### PR TITLE
Fix deployed UI frontend issues (#39)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "sj-add-callback-to-manifest"
+    default: "js-fix-deployed-ui-login"
     type: string
 jobs:
   build:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build:local": "react-scripts build",
-    "build": "react-scripts build && mv build/ ../build/server/client",
+    "build:local": "INLINE_RUNTIME_CHUNK=false react-scripts build",
+    "build": "INLINE_RUNTIME_CHUNK=false react-scripts build && mv build/ ../build/server/client",
     "eject": "react-scripts eject",
     "test": "react-scripts test",
     "test:ci": "cross-env JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml CI=true yarn test --coverage --reporters=default --reporters=jest-junit",

--- a/frontend/src/__tests__/App.js
+++ b/frontend/src/__tests__/App.js
@@ -37,7 +37,7 @@ describe('App', () => {
       render(<App />);
     });
 
-    it('displays the logout button', async () => {
+    it('displays the login button', async () => {
       expect(await waitFor(() => screen.getByText('HSES Login'))).toBeVisible();
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,10 @@ app.use(session({
   resave: false,
 }));
 
+if (process.env.NODE_ENV === 'production') {
+  app.use(express.static(path.join(__dirname, 'client')));
+}
+
 authMiddleware.unless = unless;
 // TODO: update unless to replace `oauth1CallbackPath with `join('/api', oauth2CallbackPath)`
 // once our oauth callback has been updated
@@ -85,10 +89,6 @@ app.get(oauth2CallbackPath, async (req, res) => {
 });
 
 app.use('/api', router);
-
-if (process.env.NODE_ENV === 'production') {
-  app.use(express.static(path.join(__dirname, 'client')));
-}
 
 const server = app.listen(process.env.PORT || 8080, () => {
   logger.info('listening on 8080');

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,7 +2,7 @@ import request from 'supertest';
 import server from './index';
 
 describe('Root', () => {
-  test('Redirects to login if user is not logged in', async () => {
+  test('Responds with a 401 (Unauthorized) if user is not logged in', async () => {
     const response = await request(server).get('/');
     expect(response.status).toBe(401);
   });


### PR DESCRIPTION
**Description of change**
 * Serve the static frontend before applying the auth middleware
 * The CSP of the backend (via [helmet](https://helmetjs.github.io/)) forces us to set [INLINE_RUNTIME_CHUNK](https://create-react-app.dev/docs/advanced-configuration/) to false.

**How to test**

1) Login to the sandbox env https://tta-smarthub-sandbox.app.cloud.gov/

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/4

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
