### PR TITLE
CI: Use one image for dynamic security scan (#54)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs:
               -v $(pwd)/reports:/zap/wrk:rw \
               --rm \
               --network="project_smarthub" \
-              -t owasp/zap2docker-stable zap-baseline.py \
+              -t owasp/zap2docker-weekly zap-baseline.py \
               -t http://server:8080 \
               -c zap.conf -I -i
   deploy:


### PR DESCRIPTION
**Description of change**
Target the docker image we already pulled

**How to test**
See how [only one docker image is pulled](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/466/workflows/724e564e-bc1a-429a-9caf-cf87aa6850d4/jobs/1797), vs [earlier](https://app.circleci.com/pipelines/github/adhocteam/Head-Start-TTADP/464/workflows/aa08ff8c-2169-4a21-bda1-1b7fa71fb792/jobs/1782), when we were pulling one docker image for the "Pull OWASP ZAP docker image" step and a second image for the "Run OWASP ZAP" step

**Issue(s)**
* closes https://github.com/HHS/Head-Start-TTADP/issues/114

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
