### PR TITLE
Remove server side session cookie timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,6 @@ POSTGRES_HOST=localhost
 AUTH_CLIENT_ID=clientId
 AUTH_CLIENT_SECRET=clientSecret
 SESSION_SECRET=secret
-# In milliseconds, 30 minutes
-SESSION_TIMEOUT=1800000
 TTA_SMART_HUB_URI=http://localhost:3000
 AUTH_BASE=https://uat.hsesinfo.org
 # This env variable should go away soon in favor of TTA_SMART_HUB_URI

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,7 +23,6 @@ There are yarn commands for starting/testing/linting the frontend defined a dire
 | Variable | Description |
 |-|-|
 | `REACT_APP_INACTIVE_MODAL_TIMEOUT` | Amount of time before the "Idle Logout" modal is shown to a user, in milliseconds |
-| `REACT_APP_SESSION_TIMEOUT` | Amount of time before an inactive user is automatically logged out |
 
 ## Create React App
 

--- a/src/app.js
+++ b/src/app.js
@@ -26,7 +26,6 @@ app.use(session({
   cookie: {
     httpOnly: true,
     sameSite: 'lax',
-    maxAge: Number(process.env.SESSION_TIMEOUT),
   },
   rolling: true,
   store: new MemoryStore({ // Potentially change this to a different store


### PR DESCRIPTION
**Description of change**

Having no cookie timeout defined causes the cookie to expire only when the user closes their browser, instead of their cookie expiring after a set amount of time. This prevents an edge case where the user is active on the site without hitting the server and having their session expire on the backend but not the frontend.

**How to test**

1) Pull down, and login.
2) Look at the cookie sent from the server, it should be a listed as a `session` cookie in the `expires at` field.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/132

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [n/a] Code tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
