### PR TITLE
Activity report pages are navigable via url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ parameters:
     default: "main"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-140-add-navigator"
+    default: "js-135-activity-report-uses-urls"
     type: string
 jobs:
   build:

--- a/axe-urls
+++ b/axe-urls
@@ -1,0 +1,7 @@
+http://localhost:3000,
+http://localhost:3000/activity-reports/activity-summary,
+http://localhost:3000/activity-reports/topics-resources,
+http://localhost:3000/activity-reports/goals-objectives,
+http://localhost:3000/activity-reports/next-steps,
+http://localhost:3000/activity-reports/review,
+http://localhost:3000/admin

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -78,9 +78,9 @@ function App() {
           )}
         />
         <Route
-          path="/activity-reports"
-          render={() => (
-            <ActivityReport />
+          path="/activity-reports/:currentPage?"
+          render={({ match }) => (
+            <ActivityReport match={match} />
           )}
         />
         <Route

--- a/frontend/src/components/Navigator/__tests__/index.js
+++ b/frontend/src/components/Navigator/__tests__/index.js
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 import userEvent from '@testing-library/user-event';
 import {
   render, screen, waitFor, within,
@@ -10,8 +11,10 @@ import { NOT_STARTED } from '../constants';
 
 const pages = [
   {
+    position: 1,
+    path: 'first',
     label: 'first page',
-    renderForm: (hookForm) => (
+    render: (hookForm) => (
       <input
         type="radio"
         data-testid="first"
@@ -21,8 +24,10 @@ const pages = [
     ),
   },
   {
+    position: 2,
+    path: 'second',
     label: 'second page',
-    renderForm: (hookForm) => (
+    render: (hookForm) => (
       <input
         type="radio"
         data-testid="second"
@@ -31,25 +36,34 @@ const pages = [
       />
     ),
   },
+  {
+    position: 3,
+    path: 'review',
+    label: 'review page',
+    review: true,
+    render: (allComplete, onSubmit) => (
+      <div>
+        <button type="button" data-testid="review" onClick={onSubmit}>Continue</button>
+      </div>
+    ),
+  },
 ];
 
-const renderReview = (allComplete, onSubmit) => (
-  <div>
-    <button type="button" data-testid="review" onClick={onSubmit}>button</button>
-  </div>
-);
-
 describe('Navigator', () => {
-  const renderNavigator = (onSubmit = () => {}) => {
+  // eslint-disable-next-line arrow-body-style
+  const renderNavigator = (currentPage = 'first', onSubmit = () => {}, updatePage = () => {}) => {
     render(
-      <Navigator
-        submitted={false}
-        initialPageState={[NOT_STARTED, NOT_STARTED]}
-        defaultValues={{ first: '', second: '' }}
-        pages={pages}
-        onFormSubmit={onSubmit}
-        renderReview={renderReview}
-      />,
+      <MemoryRouter>
+        <Navigator
+          submitted={false}
+          initialPageState={{ 1: NOT_STARTED, 2: NOT_STARTED }}
+          defaultValues={{ first: '', second: '' }}
+          pages={pages}
+          updatePage={updatePage}
+          currentPage={currentPage}
+          onFormSubmit={onSubmit}
+        />
+      </MemoryRouter>,
     );
   };
 
@@ -57,36 +71,28 @@ describe('Navigator', () => {
     renderNavigator();
     const firstInput = screen.getByTestId('first');
     userEvent.click(firstInput);
-    const second = await screen.findByText('second page');
-    userEvent.click(second);
-    const first = screen.getByText('first page');
-    await waitFor(() => expect(within(first.nextSibling).getByText('In progress')).toBeVisible());
+    const first = await screen.findByRole('link', { name: 'first page' });
+    await waitFor(() => expect(within(first).getByText('In progress')).toBeVisible());
   });
 
-  it('shows the review page after showing the last form page', async () => {
-    renderNavigator();
+  it('onContinue calls update page with correct page position', async () => {
+    const updatePage = jest.fn();
+    renderNavigator('second', () => {}, updatePage);
     userEvent.click(screen.getByRole('button', { name: 'Continue' }));
-    await screen.findByTestId('second');
-    userEvent.click(screen.getByRole('button', { name: 'Continue' }));
-    await waitFor(() => expect(screen.getByTestId('review')).toBeVisible());
+    await waitFor(() => expect(updatePage).toHaveBeenCalledWith(3));
   });
 
   it('submits data when "continuing" from the review page', async () => {
     const onSubmit = jest.fn();
-    renderNavigator(onSubmit);
+    renderNavigator('review', onSubmit);
     userEvent.click(screen.getByRole('button', { name: 'Continue' }));
-    await screen.findByTestId('second');
-    userEvent.click(screen.getByRole('button', { name: 'Continue' }));
-    await screen.findByTestId('review');
-    userEvent.click(screen.getByTestId('review'));
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
   });
 
   it('changes navigator state to complete when "continuing"', async () => {
     renderNavigator();
     userEvent.click(screen.getByRole('button', { name: 'Continue' }));
-    await screen.findByTestId('second');
-    const navItem = await screen.findByText('first page');
-    await waitFor(() => expect(within(navItem.nextSibling).getByText('Complete')).toBeVisible());
+    const first = await screen.findByRole('link', { name: 'first page' });
+    await waitFor(() => expect(within(first).getByText('Complete')).toBeVisible());
   });
 });

--- a/frontend/src/components/Navigator/components/SideNav.css
+++ b/frontend/src/components/Navigator/components/SideNav.css
@@ -41,7 +41,7 @@
 
 .smart-hub--tag-complete {
   background-color: #e6faedb0;
-  color: #467e5a;
+  color: #3a7e5a;
 }
 
 .smart-hub--tag-submitted {

--- a/frontend/src/components/Navigator/components/SideNav.js
+++ b/frontend/src/components/Navigator/components/SideNav.js
@@ -6,8 +6,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Sticky from 'react-stickynode';
-import { Button, Tag } from '@trussworks/react-uswds';
+import { Tag } from '@trussworks/react-uswds';
 import { useMediaQuery } from 'react-responsive';
+import { NavLink } from 'react-router-dom';
 
 import Container from '../../Container';
 import './SideNav.css';
@@ -36,11 +37,11 @@ function SideNav({
   const isMobile = useMediaQuery({ maxWidth: 640 });
   const navItems = () => pages.map((page) => (
     <li key={page.label} className="smart-hub--navigator-item">
-      <Button
-        onClick={page.onClick}
-        unstyled
-        role="button"
-        className={`smart-hub--navigator-link ${page.current ? 'smart-hub--navigator-link-active' : ''}`}
+      <NavLink
+        to={`${page.path}`}
+        activeClassName="smart-hub--navigator-link-active"
+        className="smart-hub--navigator-link"
+        aria-label={page.label}
       >
         <span className="margin-left-2">{page.label}</span>
         <span className="margin-left-auto margin-right-2">
@@ -51,7 +52,7 @@ function SideNav({
             </Tag>
             )}
         </span>
-      </Button>
+      </NavLink>
     </li>
   ));
 
@@ -71,8 +72,8 @@ SideNav.propTypes = {
   pages: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
-      current: PropTypes.bool.isRequired,
       state: PropTypes.string,
+      path: PropTypes.string.isRequired,
     }),
   ).isRequired,
   skipTo: PropTypes.string.isRequired,

--- a/frontend/src/components/Navigator/components/__tests__/SideNav.js
+++ b/frontend/src/components/Navigator/components/__tests__/SideNav.js
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -11,71 +13,73 @@ import {
 } from '../../constants';
 
 describe('SideNav', () => {
-  const renderNav = (state, current, onNavigation = () => {}) => {
+  const renderNav = (state, path = '/path') => {
+    const history = createMemoryHistory();
     const pages = [
       {
         label: 'test',
-        current,
         state,
-        onClick: () => onNavigation(0),
+        path: 'test',
       },
       {
         label: 'second',
-        current: false,
         state: '',
-        onClick: () => onNavigation(1),
+        path: 'second',
       },
     ];
+    history.push(path);
     render(
-      <SideNav
-        pages={pages}
-        skipTo="skip"
-        skipToMessage="message"
-      />,
+      <Router history={history} initialEntries={path}>
+        <SideNav
+          pages={pages}
+          skipTo="skip"
+          skipToMessage="message"
+        />
+      </Router>,
     );
+    return history;
   };
 
   describe('displays the correct status', () => {
     it('not started', () => {
-      renderNav(NOT_STARTED, false);
+      renderNav(NOT_STARTED);
       const notStarted = screen.getByText('Not started');
       expect(notStarted).toHaveClass('smart-hub--tag-not-started');
       expect(notStarted).toBeVisible();
     });
 
     it('in progress', () => {
-      renderNav(IN_PROGRESS, false);
+      renderNav(IN_PROGRESS);
       const inProgress = screen.getByText('In progress');
       expect(inProgress).toHaveClass('smart-hub--tag-in-progress');
       expect(inProgress).toBeVisible();
     });
 
     it('complete', () => {
-      renderNav(COMPLETE, false);
+      renderNav(COMPLETE);
       const complete = screen.getByText('Complete');
       expect(complete).toHaveClass('smart-hub--tag-complete');
       expect(complete).toBeVisible();
     });
 
     it('submitted', () => {
-      renderNav(SUBMITTED, false);
+      renderNav(SUBMITTED);
       const submitted = screen.getByText('Submitted');
       expect(submitted).toHaveClass('smart-hub--tag-submitted');
       expect(submitted).toBeVisible();
     });
   });
 
-  it('clicking a nav item calls "onNavigation" with the selected index', () => {
-    const onNavigation = jest.fn();
-    renderNav(NOT_STARTED, false, onNavigation);
+  it('clicking a nav item navigates to that item', () => {
+    const history = renderNav(NOT_STARTED);
     const notStarted = screen.getByText('Not started');
     userEvent.click(notStarted);
-    expect(onNavigation).toHaveBeenCalledWith(0);
+    expect(history.location.pathname).toBe('/test');
   });
 
   it('the currently selected page has the current class', () => {
-    renderNav(SUBMITTED, true);
-    const submitted = screen.getByRole('button', { name: 'test Submitted' });
+    renderNav(SUBMITTED, '/test');
+    const submitted = screen.getByRole('link', { name: 'test' });
     expect(submitted).toHaveClass('smart-hub--navigator-link-active');
   });
 });

--- a/frontend/src/components/__tests__/IdleModal.js
+++ b/frontend/src/components/__tests__/IdleModal.js
@@ -1,7 +1,8 @@
 import '@testing-library/jest-dom';
 import { act } from 'react-dom/test-utils';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import IdleModal from '../IdleModal';
 
@@ -44,17 +45,17 @@ describe('IdleModal', () => {
     expect(logout).toHaveBeenCalled();
   });
 
-  it('modal is not shown after modalTimeout if there is activity', () => {
+  it('modal is not shown after modalTimeout if there is activity', async () => {
     const logout = jest.fn();
     renderIdleModal(20, 10, logout);
     act(() => {
       jest.advanceTimersByTime(7);
       const testDiv = screen.getByTestId('test');
-      fireEvent.keyDown(testDiv, { key: 'Enter', code: 'Enter' });
+      userEvent.type(testDiv, 'test');
       jest.advanceTimersByTime(7);
     });
     expect(logout).not.toHaveBeenCalled();
-    expect(screen.queryByTestId('modal')).toBeNull();
+    await waitFor(() => expect(screen.queryByTestId('modal')).toBeNull());
   });
 
   it('a shown modal is removed after action is taken', () => {
@@ -64,7 +65,7 @@ describe('IdleModal', () => {
       jest.advanceTimersByTime(12);
       expect(screen.getByTestId('modal')).toBeVisible();
       const testDiv = screen.getByTestId('test');
-      fireEvent.keyDown(testDiv, { key: 'Enter', code: 'Enter' });
+      userEvent.type(testDiv, 'test');
     });
     expect(logout).not.toHaveBeenCalled();
     expect(screen.queryByTestId('modal')).toBeNull();

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
 import reactSelectEvent from 'react-select-event';
 import {
   render, screen, fireEvent, waitFor, within,
@@ -25,12 +27,29 @@ const formData = () => ({
   'target-populations': ['target 1'],
   topics: 'first',
 });
+const history = createMemoryHistory();
+
+const renderActivityReport = (data = {}, location = 'activity-summary') => {
+  render(
+    <Router history={history}>
+      <ActivityReport
+        initialData={data}
+        match={{ params: { currentPage: location }, path: '', url: '' }}
+      />
+    </Router>,
+  );
+};
 
 describe('ActivityReport', () => {
+  it('defaults to activity summary if no page is in the url', () => {
+    renderActivityReport({}, null);
+    expect(history.location.pathname).toEqual('/activity-reports/activity-summary');
+  });
+
   describe('grantee select', () => {
     describe('changes the participant selection to', () => {
       it('Grantee', async () => {
-        render(<ActivityReport />);
+        renderActivityReport();
         const information = await screen.findByRole('group', { name: 'Who was the activity for?' });
         const grantee = within(information).getByLabelText('Grantee');
         fireEvent.click(grantee);
@@ -40,7 +59,7 @@ describe('ActivityReport', () => {
       });
 
       it('Non-grantee', async () => {
-        render(<ActivityReport />);
+        renderActivityReport();
         const information = await screen.findByRole('group', { name: 'Who was the activity for?' });
         const nonGrantee = within(information).getByLabelText('Non-Grantee');
         fireEvent.click(nonGrantee);
@@ -51,7 +70,7 @@ describe('ActivityReport', () => {
     });
 
     it('when non-grantee is selected', async () => {
-      render(<ActivityReport />);
+      renderActivityReport();
       const enabled = screen.getByRole('textbox', { name: 'Grantee name(s)' });
       expect(enabled).toBeDisabled();
       const information = await screen.findByRole('group', { name: 'Who was the activity for?' });
@@ -67,7 +86,7 @@ describe('ActivityReport', () => {
       const data = formData();
       delete data['activity-method'];
 
-      render(<ActivityReport initialData={data} />);
+      renderActivityReport(data);
       expect(await screen.findByText('Continue')).toBeDisabled();
       const box = await screen.findByLabelText('Virtual');
       fireEvent.click(box);
@@ -80,7 +99,7 @@ describe('ActivityReport', () => {
       const data = formData();
       delete data['activity-type'];
 
-      render(<ActivityReport initialData={data} />);
+      renderActivityReport(data);
       expect(await screen.findByText('Continue')).toBeDisabled();
       const box = await screen.findByLabelText('Training');
       fireEvent.click(box);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "12.19.0"
   },
   "scripts": {
-    "axe:ci": "axe --exit --load-delay 1000 http://localhost:3000, http://localhost:3000/activity-reports, http://localhost:3000/admin --dir ./reports/ --chromedriver-path=\"node_modules/chromedriver/bin/chromedriver\"",
+    "axe:ci": "axe --exit --load-delay 1000 `cat axe-urls` --dir ./reports/ --chromedriver-path=\"node_modules/chromedriver/bin/chromedriver\"",
     "build": "./node_modules/.bin/babel src -d ./build/server  && ./node_modules/.bin/babel config -d build/config",
     "deps:local": "yarn install && yarn --cwd frontend install",
     "deps": "yarn install --frozen-lockfile && yarn --cwd frontend install --frozen-lockfile",


### PR DESCRIPTION
**Description of change**
The current activity reports page shown is determined by the url. Being able to browse to specific report pages via URL has two main advantages:
 * A user can share/bookmark a specific page
 * We are setup to directly link to specific sections of the pages

Also I added the report pages to the axe testing, and added a file with the urls axe should test. Note the `axe:ci` command no longer works on windows. Also fixed a color contrast accessibility issue in the activity report side nav when a page is selected and has a state of `Complete`.

**How to test**

Browse to [sandbox](https://tta-smarthub-sandbox.app.cloud.gov/activity-reports). Browsing to different pages will change the url. You can also directly go to specific pages of the report (https://tta-smarthub-sandbox.app.cloud.gov/activity-reports/review)

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/135

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
