### PR TITLE
Add some fields to the report

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/ActivitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/ActivitySummary.js
@@ -8,6 +8,9 @@ import {
 
 import DatePicker from '../../../components/DatePicker';
 import MultiSelect from '../../../components/MultiSelect';
+import {
+  reasons, granteeParticipants, nonGranteeParticipants, targetPopulations,
+} from '../constants';
 
 const grantees = [
   'Grantee Name 1',
@@ -29,11 +32,6 @@ const nonGrantees = [
   'State Professional Development / Continuing Education',
 ];
 
-const reasons = [
-  'reason 1',
-  'reason 2',
-];
-
 const otherUsers = [
   'User 1',
   'User 2',
@@ -48,14 +46,6 @@ const programTypes = [
   'program type 5',
 ];
 
-const targetPopulations = [
-  'target pop 1',
-  'target pop 2',
-  'target pop 3',
-  'target pop 4',
-  'target pop 5',
-];
-
 const ActivitySummary = ({
   register,
   watch,
@@ -66,12 +56,16 @@ const ActivitySummary = ({
   const participantSelection = watch('participant-category');
   const startDate = watch('start-date');
   const endDate = watch('end-date');
+  const previousParticipantSelection = useRef(participantSelection);
 
   const disableParticipant = participantSelection === '';
   const nonGranteeSelected = participantSelection === 'non-grantee';
-  const participants = nonGranteeSelected ? nonGrantees : grantees;
-  const previousParticipantSelection = useRef(participantSelection);
-  const participantLabel = nonGranteeSelected ? 'Non-grantee name(s)' : 'Grantee name(s)';
+
+  const subjects = nonGranteeSelected ? nonGrantees : grantees;
+  const subjectsLabel = nonGranteeSelected ? 'Non-grantee name(s)' : 'Grantee name(s)';
+
+  const participants = nonGranteeSelected ? nonGranteeParticipants : granteeParticipants;
+  const participantsLabel = nonGranteeSelected ? 'Non-grantee participants' : 'Grantee participants';
 
   useEffect(() => {
     if (previousParticipantSelection.current !== participantSelection) {
@@ -122,11 +116,11 @@ const ActivitySummary = ({
         <div className="smart-hub--form-section">
           <MultiSelect
             name="grantees"
-            label={participantLabel}
+            label={subjectsLabel}
             disabled={disableParticipant}
             control={control}
             options={
-              participants.map((participant) => ({ value: participant, label: participant }))
+              subjects.map((participant) => ({ value: participant, label: participant }))
             }
           />
         </div>
@@ -276,9 +270,8 @@ const ActivitySummary = ({
         <div className="smart-hub--form-section">
           <MultiSelect
             name="participants"
-            label="Grantee participant(s) involved"
+            label={participantsLabel}
             control={control}
-            placeholder="Select a particgetValuesipant..."
             options={
               participants.map((participant) => ({ value: participant, label: participant }))
             }

--- a/frontend/src/pages/ActivityReport/Pages/GoalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/GoalsObjectives.js
@@ -1,17 +1,25 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 
-const GoalsObjectives = () => (
+import {
+  Fieldset, Label, Textarea,
+} from '@trussworks/react-uswds';
+
+const GoalsObjectives = ({ register }) => (
   <>
     <Helmet>
       <title>Goals and objectives</title>
     </Helmet>
-    <div>
-      Goals and objectives
-    </div>
+    <Fieldset className="smart-hub--report-legend smart-hub--form-section" legend="Context">
+      <Label htmlFor="context">OPTIONAL: Provide background or context for this activity</Label>
+      <Textarea id="context" name="context" inputRef={register()} />
+    </Fieldset>
   </>
 );
 
-GoalsObjectives.propTypes = {};
+GoalsObjectives.propTypes = {
+  register: PropTypes.func.isRequired,
+};
 
 export default GoalsObjectives;

--- a/frontend/src/pages/ActivityReport/constants.js
+++ b/frontend/src/pages/ActivityReport/constants.js
@@ -1,0 +1,55 @@
+export const reasons = [
+  'Below Competitive Threshold (CLASS)',
+  'Below Quality Threshold (CLASS)',
+  'Change in Scope',
+  'Full Enrollment',
+  'New Grantee',
+  'New Director or Management',
+  'New Program Option',
+  'New Staff / Turnover',
+  'Ongoing Quality Improvement',
+  'Planning/Coordination (also TTA Plan Agreement)',
+  'School Readiness Goals',
+  'Monitoring | Area of Concern',
+  'Monitoring | Noncompliance',
+  'Monitoring | Deficiency',
+];
+
+export const granteeParticipants = [
+  'CEO / CFO / Executive',
+  'Center Director / Site Director',
+  'Coach',
+  'Direct Service: Other',
+  'Family Service Worker / Case Manager',
+  'Fiscal Manager/Team',
+  'Governing Body / Tribal Council / Policy Council',
+  'Home Visitor',
+  'Manager / Coordinator / Specialist',
+  'Parent / Guardian',
+  'Program Director (HS / EHS)',
+  'Program Support / Administrative Assistant',
+  'Teacher / Infant-Toddler Caregiver',
+  'Volunteer',
+];
+
+export const nonGranteeParticipants = [
+  'Local/State Agency(ies)',
+  'HSCO',
+  'OCC Regional Office',
+  'OHS Regional Office',
+  'Regional Head Start Association',
+  'Regional TTA Team / Specialists',
+  'State Early Learning System',
+  'State Head Start Association',
+  'Other',
+];
+
+export const targetPopulations = [
+  'Affected by Child Welfare Involvement',
+  'Affected by Disaster',
+  'Affected by Substance Use',
+  'Children with Disabilities',
+  'Children Experiencing Homelessness',
+  'Dual-Language Learners',
+  'Pregnant Women',
+];

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -60,9 +60,10 @@ const pages = [
     position: 3,
     label: 'Goals and objectives',
     path: 'goals-objectives',
-    render: () => (
-      <GoalsObjectives />
-    ),
+    render: (hookForm) => {
+      const { register } = hookForm;
+      return <GoalsObjectives register={register} />;
+    },
   },
   {
     position: 4,


### PR DESCRIPTION
**Description of change**

Added some fields to the report:

 * Activity summary: participants, reasons and target populations
 * Goals & Objectives: context

Keeping as draft until these fields can be saved to the database. Wanted to get this up before the break so I have an easier time picking up where I left off.

**How to test**

These fields do not currently save to the database.

1) Pull down
2) Fill out the report. Note participants, reasons and target population options are the "finalized" options

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/172
* https://github.com/HHS/Head-Start-TTADP/issues/173
* https://github.com/HHS/Head-Start-TTADP/issues/218
* https://github.com/HHS/Head-Start-TTADP/issues/171

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
