### PR TITLE
Remove unique constraint from Grant.number

### DIFF
--- a/src/models/grant.js
+++ b/src/models/grant.js
@@ -17,10 +17,16 @@ module.exports = (sequelize, DataTypes) => {
     }
   }
   Grant.init({
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: null,
+      primaryKey: true,
+      autoIncrement: false,
+    },
     number: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: true,
     },
     status: DataTypes.STRING,
     startDate: DataTypes.DATE,


### PR DESCRIPTION
**Description of change**

Sequelize's `bulkCreate` `updateOnDuplicate` matches rows on `unique` columns rather than `ID` when unique constraints exist.

This removes the model validation, but leaves the DB constraint, so our data should be as consistent as we expect, at the cost of potentially worse error messages.

**How to test**

1) Run `processFiles()` locally with the test data.
2) Ask Ryan for a current zip file of staging data and run against those files
3) Grants import will complete successfully. Previous to this change, the grantees would properly import, but not the grants

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/329

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
