### PR TITLE
add focus to header on nav

### DIFF
--- a/frontend/src/components/Navigator/components/NavigatorHeader.js
+++ b/frontend/src/components/Navigator/components/NavigatorHeader.js
@@ -2,16 +2,24 @@
   USWDS step indicator header, grabbed from https://designsystem.digital.gov/components/step-indicator/
   The uswds react library we use doesn't have this component yet.
 */
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-const NavigatorHeader = ({ label }) => (
-  <div className="usa-step-indicator__header">
-    <h2 className="usa-step-indicator__heading">
-      <span className="usa-step-indicator__heading-text">{label}</span>
-    </h2>
-  </div>
-);
+const NavigatorHeader = ({ label }) => {
+  useEffect(() => {
+    document.getElementsByClassName('usa-step-indicator__heading-text')[0].focus();
+  });
+
+  return (
+    <div className="usa-step-indicator__header">
+      {/* <style>{`:focus{ outline: solid 1px red}`}</style> */}
+      <h2 className="usa-step-indicator__heading">
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <span tabIndex="0" className="usa-step-indicator__heading-text">{label}</span>
+      </h2>
+    </div>
+  );
+};
 
 NavigatorHeader.propTypes = {
   label: PropTypes.string.isRequired,


### PR DESCRIPTION
**Description of change**
added focus to header on nav.

**How to test**
Verify that when moving through pages of a report, focus is set to the header.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/212

**Checklist**
<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
