### PR TITLE
HotFix: Production HSES import failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "docker:db:seed": "docker-compose run --rm backend yarn db:seed",
     "docker:db:seed:undo": "docker-compose run --rm backend yarn db:seed:undo",
     "import:goals:local": "./node_modules/.bin/babel-node ./src/tools/importTTAPlanGoals.js",
-    "import:goals": "node ./build/server/tools/importTTAPlanGoals.js"
+    "import:goals": "node ./build/server/tools/importTTAPlanGoals.js",
+    "import:hses:local": "./node_modules/.bin/babel-node ./src/tools/importGrantGranteesCLI.js --skipdownload",
+    "import:hses": "node ./build/server/tools/importGrantGranteesCLI.js"
   },
   "repository": {
     "type": "git",

--- a/src/routes/admin/user.test.js
+++ b/src/routes/admin/user.test.js
@@ -1,5 +1,5 @@
 import db, {
-  User, Permission, sequelize,
+  User, Permission,
 } from '../../models';
 import getUsers, {
   getUser, deleteUser, createUser, updateUser,
@@ -59,18 +59,17 @@ describe('User route handler', () => {
   });
   afterAll(async () => {
     await User.destroy({ where: { id: 49 } });
-    await User.destroy({ where: { id: 50 } });
+    await User.destroy({ where: { id: 55 } });
     await User.destroy({ where: { id: 52 } });
     await User.destroy({ where: { id: 53 } });
-    db.sequelize.close();
+    await db.sequelize.close();
   });
 
   it('Returns a user by id', async () => {
-    await sequelize.transaction((transaction) => User.create(mockUser,
+    await User.create(mockUser,
       {
         include: [{ model: Permission, as: 'permissions' }],
-        transaction,
-      }));
+      });
     const user = await User.findOne({ where: { id: mockUser.id } });
 
     expect(user).not.toBeNull();
@@ -84,17 +83,16 @@ describe('User route handler', () => {
 
   it('Returns users', async () => {
     mockRequest.path = '/api/user';
-    mockUser.id = 50;
-    mockUser.hsesUserId = '50';
-    mockUser.email = 'test50@test.com';
+    mockUser.id = 55;
+    mockUser.hsesUserId = '55';
+    mockUser.email = 'test55@test.com';
     mockUser.permissions[0].userId = mockUser.id;
     mockUser.permissions[1].userId = mockUser.id;
 
-    await sequelize.transaction((transaction) => User.create(mockUser,
+    await User.create(mockUser,
       {
         include: [{ model: Permission, as: 'permissions' }],
-        transaction,
-      }));
+      });
 
     // Verify that once the user exists, it will be retrieved
     await getUsers(mockRequest, mockResponse);

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -31,7 +31,7 @@ const mockUserTwo = {
   id: 1002,
   homeRegionId: 1,
   name: 'a user',
-  hsesUserId: 50,
+  hsesUserId: 1002,
   hsesUsername: 'Rex',
 };
 

--- a/src/tools/importGrantGranteesCLI.js
+++ b/src/tools/importGrantGranteesCLI.js
@@ -1,0 +1,28 @@
+import {} from 'dotenv/config';
+import { option } from 'yargs';
+import updateGrantsGrantees, { processFiles } from '../lib/updateGrantsGrantees';
+import { auditLogger } from '../logger';
+
+/**
+ * importGrantGranteesCLI is a CLI option for kicking off an HSES import.
+ * Normally, this is automatically run by cron
+ */
+
+const { argv: { skipdownload } } = option('skipdownload', {
+  type: 'boolean',
+  description: 'Process files in temp without refreshing the zip file',
+})
+  .help()
+  .alias('help', 'h');
+
+if (skipdownload) {
+  processFiles().catch((e) => {
+    auditLogger.error(e);
+    return process.exit(1);
+  });
+} else {
+  updateGrantsGrantees().catch((e) => {
+    auditLogger.error(e);
+    return process.exit(1);
+  });
+}


### PR DESCRIPTION
**Description of change**

* Handle `nil` grant start and end dates
* Add ability to kick off an import via CLI

**How to test**

Production data imports successfully. Ryan tested this on GFE with a production dataset.

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/380

**Checklist**
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
