### PR TITLE
Change Edit option

### DIFF
--- a/frontend/src/pages/Landing/index.css
+++ b/frontend/src/pages/Landing/index.css
@@ -147,7 +147,7 @@ h1.landing {
   background-color: #148439;
 }
 
-.landing > .smart-hub--context-menu-button:hover {
+.landing .smart-hub--context-menu-button {
   max-width: 20px;
   padding: 2px;
 }

--- a/frontend/src/pages/Landing/index.css
+++ b/frontend/src/pages/Landing/index.css
@@ -147,6 +147,11 @@ h1.landing {
   background-color: #148439;
 }
 
+.landing > .smart-hub--context-menu-button:hover {
+  max-width: 20px;
+  padding: 2px;
+}
+
 .usa-table tr:nth-child(odd) {
   background-color:#F8F8F8;
 }
@@ -199,7 +204,7 @@ h1.landing {
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
-  width: 180px;
+  width: 173.5px;
   vertical-align: middle;
 }
 

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -97,15 +97,14 @@ function renderReports(reports, history) {
       </Tag>
     ));
 
+    const linkTarget = legacyId ? `/activity-reports/legacy/${legacyId}` : `/activity-reports/${id}`;
     const menuItems = [
       {
-        label: 'Edit',
-        onClick: () => { history.push(`/activity-reports/${id}`); },
+        label: 'View',
+        onClick: () => { history.push(linkTarget); },
       },
     ];
-    const contextMenuLabel = `Edit activity report ${displayId}`;
-
-    const linkTarget = legacyId ? `/activity-reports/legacy/${legacyId}` : `/activity-reports/${id}`;
+    const contextMenuLabel = `View activity report ${displayId}`;
 
     return (
       <tr key={`landing_${id}`}>


### PR DESCRIPTION
**Description of change**
Changes the "Edit" option of the context menu in the list of reports to "View". Fixes link for legacy reports.

**How to test**
- pull changes
- click on "meatballs"
- verify that a report can be viewed

**Issue(s)**
* https://github.com/HHS/Head-Start-TTADP/issues/0

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
