### PR TITLE
Dcloud/ttahub 35 download ar as csv

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "statements": 90,
         "functions": 90,
         "branches": 81,
-        "lines": 90 
+        "lines": 90
       }
     }
   },
@@ -162,6 +162,7 @@
     "cookie-session": "^1.4.0",
     "cron": "^1.8.2",
     "csv-parse": "^4.14.1",
+    "csv-stringify": "^5.6.2",
     "cucumber-html-reporter": "^5.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -1,0 +1,91 @@
+async function getAuthorEmail(report) {
+  const authorRecord = await report.getAuthor();
+  const author = authorRecord ? authorRecord.get('email') : '';
+  return { author };
+}
+
+async function getApprovingManagerName(report) {
+  const managerRecord = await report.getApprovingManager();
+  const approvingManager = managerRecord ? managerRecord.get('name') : '';
+  return { approvingManager };
+}
+
+async function getLastUpdatedBy(report) {
+  const lastUpdatedByRecord = await report.getLastUpdatedBy();
+  const lastUpdatedBy = lastUpdatedByRecord ? lastUpdatedByRecord.get('name') : '';
+  return { lastUpdatedBy };
+}
+
+function sortObjectives(a, b) {
+  if (b.goal.id < a.goal.id) {
+    return 1;
+  }
+  if (b.id < a.id) {
+    return 1;
+  }
+  return -1;
+}
+
+async function getGoalsAndObjectives(report) {
+  const objectiveRecords = await report.get('objectives');
+  objectiveRecords.sort(sortObjectives);
+  let objectiveNum = 1;
+  let goalNum = 0;
+
+  const goalsAndObjectives = objectiveRecords.reduce((accum, objective) => {
+    const {
+      goal, title, status, ttaProvided,
+    } = objective;
+    const goalName = goal.get('name') || null;
+    const newGoal = goalName && !Object.values(accum).includes(goalName);
+
+    if (newGoal) {
+      goalNum += 1;
+      Object.defineProperty(accum, `goal-${goalNum}`, {
+        value: goalName,
+        enumerable: true,
+      });
+      Object.defineProperty(accum, `goal-${goalNum}-status`, {
+        value: goal.get('status'),
+        enumerable: true,
+      });
+      objectiveNum = 1;
+    }
+
+    const objectiveId = `${goalNum}.${objectiveNum}`;
+
+    Object.defineProperty(accum, `objective-${objectiveId}`, {
+      value: title,
+      enumerable: true,
+    });
+    Object.defineProperty(accum, `objective-${objectiveId}-status`, {
+      value: status,
+      enumerable: true,
+    });
+    Object.defineProperty(accum, `objective-${objectiveId}-ttaProvided`, {
+      value: ttaProvided,
+      enumerable: true,
+    });
+    objectiveNum += 1;
+    return accum;
+  }, {});
+
+  return goalsAndObjectives;
+}
+
+const arBuilders = [
+  getAuthorEmail,
+  getApprovingManagerName,
+  getLastUpdatedBy,
+  getGoalsAndObjectives,
+];
+
+async function activityReportToCsvRecord(report) {
+  const recordObjects = await Promise.all(arBuilders.map((f) => f(report)));
+  const record = recordObjects.reduce((obj, value) => Object.assign(obj, value), {});
+  return record;
+}
+
+export {
+  activityReportToCsvRecord,
+};

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -1,21 +1,53 @@
-async function getAuthorEmail(report) {
+/**
+ * @param {string} field name to be retrieved
+ * @returns {function} Function that will return a simple value wrapped in a Promise
+ */
+function transformSimpleValue(instance, field) {
+  let value = instance.get(field);
+  if (value && Array.isArray(value)) {
+    value = value.join('\n');
+  }
+  const obj = {};
+  Object.defineProperty(obj, field, {
+    value,
+    enumerable: true,
+  });
+  return Promise.resolve(obj);
+}
+
+/*
+ * @param {ActivityReport} ActivityReport instance
+ * @returns {Promise<object>} author email
+ */
+async function transformAuthorEmail(report) {
   const authorRecord = await report.getAuthor();
   const author = authorRecord ? authorRecord.get('email') : '';
   return { author };
 }
 
-async function getApprovingManagerName(report) {
+/*
+ * @param {ActivityReport} ActivityReport instance
+ * @returns {Promise<object>} approving manager name
+ */
+async function transformApprovingManagerName(report) {
   const managerRecord = await report.getApprovingManager();
   const approvingManager = managerRecord ? managerRecord.get('name') : '';
   return { approvingManager };
 }
 
-async function getLastUpdatedBy(report) {
+/*
+ * @param {ActivityReport} ActivityReport instance
+ * @returns {Promise<object>} Name of user who last updated report
+ */
+async function transformLastUpdatedBy(report) {
   const lastUpdatedByRecord = await report.getLastUpdatedBy();
   const lastUpdatedBy = lastUpdatedByRecord ? lastUpdatedByRecord.get('name') : '';
   return { lastUpdatedBy };
 }
 
+/*
+ * Helper function for transformGoalsAndObjectives
+ */
 function sortObjectives(a, b) {
   if (b.goal.id < a.goal.id) {
     return 1;
@@ -26,7 +58,12 @@ function sortObjectives(a, b) {
   return -1;
 }
 
-async function getGoalsAndObjectives(report) {
+/*
+ * Transform goals and objectives into a format suitable for a CSV
+ * @param {ActivityReport} ActivityReport instance
+ * @returns {Promise<object>} Object with key-values for goals and objectives
+ */
+async function transformGoalsAndObjectives(report) {
   const objectiveRecords = await report.get('objectives');
   objectiveRecords.sort(sortObjectives);
   let objectiveNum = 1;
@@ -67,21 +104,86 @@ async function getGoalsAndObjectives(report) {
       enumerable: true,
     });
     objectiveNum += 1;
+
     return accum;
   }, {});
 
   return goalsAndObjectives;
 }
 
+// function transformManyModel(field, prop) {
+//   async function transformer(instance) {
+//     const records = await instance.get(field);
+//     const value = records.map((r) => (({}).hasOwnProperty.call(r, prop) ? r[prop] : '')).join('\n');
+//     const obj = {};
+//     Object.defineProperty(obj, field, {
+//       value,
+//       enumerable: true,
+//     });
+//     return Promise.resolve(obj);
+//   }
+//   return transformer;
+// }
+
+async function transformActivityRecipients(report) {
+  const records = await report.get('activityRecipients');
+  const activityRecipients = records.map((r) => r.name || '').join('\n');
+  return { activityRecipients };
+}
+
+async function transformCollaborators(report) {
+  const records = await report.get('collaborators');
+  const collaborators = records.map((r) => r.name || '').join('\n');
+  return { collaborators };
+}
+
+// 'attachments\n' +
+// 'specialistNextSteps\n' +
+// 'granteeNextSteps\n' +
 const arBuilders = [
-  getAuthorEmail,
-  getApprovingManagerName,
-  getLastUpdatedBy,
-  getGoalsAndObjectives,
+  'displayId',
+  transformAuthorEmail,
+  transformApprovingManagerName,
+  transformLastUpdatedBy,
+  'requester',
+  transformCollaborators,
+  'programTypes',
+  'targetPopulations',
+  'virtualDeliveryType',
+  'reason',
+  'participants',
+  'topics',
+  'status',
+  'ttaType',
+  'numberOfParticipants',
+  'deliveryMethod',
+  'duration',
+  'endDate',
+  'startDate',
+  transformActivityRecipients,
+  'activityRecipientType',
+  'ECLKCResourcesUsed',
+  'nonECLKCResourcesUsed',
+  transformGoalsAndObjectives,
+  // transformManyModel('granteeNextSteps', 'note'),
+  // transformManyModel('specialistNextSteps', 'note'),
+  'context',
+  'managerNotes',
+  'additionalNotes',
+  'lastSaved',
 ];
 
 async function activityReportToCsvRecord(report) {
-  const recordObjects = await Promise.all(arBuilders.map((f) => f(report)));
+  const callFunctionOrValueGetter = (x) => {
+    if (typeof x === 'function') {
+      return x(report);
+    }
+    if (typeof x === 'string') {
+      return transformSimpleValue(report, x);
+    }
+    return {};
+  };
+  const recordObjects = await Promise.all(arBuilders.map(callFunctionOrValueGetter));
   const record = recordObjects.reduce((obj, value) => Object.assign(obj, value), {});
   return record;
 }

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -188,7 +188,7 @@ async function activityReportToCsvRecord(report) {
     if (typeof x === 'function') {
       return x(report);
     }
-    if (typeof x === 'string' && ({}).hasOwnProperty.call(report.dataValues, x)) {
+    if (typeof x === 'string') {
       return transformSimpleValue(report, x);
     }
     return {};

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -116,7 +116,7 @@ async function transformGoalsAndObjectives(report) {
   return obj;
 }
 
-const arBuilders = [
+const arTransformers = [
   'displayId',
   transformRelatedModel('author', 'name'),
   transformRelatedModel('approvingManager', 'name'),
@@ -150,7 +150,7 @@ const arBuilders = [
   'lastSaved',
 ];
 
-async function activityReportToCsvRecord(report) {
+async function activityReportToCsvRecord(report, transformers = arTransformers) {
   const callFunctionOrValueGetter = (x) => {
     if (typeof x === 'function') {
       return x(report);
@@ -160,11 +160,13 @@ async function activityReportToCsvRecord(report) {
     }
     return {};
   };
-  const recordObjects = await Promise.all(arBuilders.map(callFunctionOrValueGetter));
+  const recordObjects = await Promise.all(transformers.map(callFunctionOrValueGetter));
   const record = recordObjects.reduce((obj, value) => Object.assign(obj, value), {});
   return record;
 }
 
 export {
-  activityReportToCsvRecord as default,
+  activityReportToCsvRecord,
+  arTransformers,
+  makeGoalsAndObjectivesObject,
 };

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -111,19 +111,19 @@ async function transformGoalsAndObjectives(report) {
   return goalsAndObjectives;
 }
 
-// function transformManyModel(field, prop) {
-//   async function transformer(instance) {
-//     const records = await instance.get(field);
-//     const value = records.map((r) => (({}).hasOwnProperty.call(r, prop) ? r[prop] : '')).join('\n');
-//     const obj = {};
-//     Object.defineProperty(obj, field, {
-//       value,
-//       enumerable: true,
-//     });
-//     return Promise.resolve(obj);
-//   }
-//   return transformer;
-// }
+function transformManyModel(field, prop) {
+  async function transformer(instance) {
+    const records = await instance.get(field);
+    const value = records.map((r) => (r[prop] || '')).join('\n');
+    const obj = {};
+    Object.defineProperty(obj, field, {
+      value,
+      enumerable: true,
+    });
+    return Promise.resolve(obj);
+  }
+  return transformer;
+}
 
 async function transformActivityRecipients(report) {
   const records = await report.get('activityRecipients');
@@ -165,8 +165,8 @@ const arBuilders = [
   'ECLKCResourcesUsed',
   'nonECLKCResourcesUsed',
   transformGoalsAndObjectives,
-  // transformManyModel('granteeNextSteps', 'note'),
-  // transformManyModel('specialistNextSteps', 'note'),
+  transformManyModel('granteeNextSteps', 'note'),
+  transformManyModel('specialistNextSteps', 'note'),
   'context',
   'managerNotes',
   'additionalNotes',

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -1,0 +1,48 @@
+import { ActivityReport, User, sequelize } from '../models';
+import activityReportToCsvRecord from './transform';
+
+describe('activityReportToCsvRecord', () => {
+  const mockAuthor = {
+    id: 2099,
+    name: 'Arthur',
+    hsesUserId: '2099',
+    hsesUsername: 'arthur.author',
+  };
+
+  const mockReport = {
+    id: 209914,
+    regionId: 14,
+    reason: 'Test CSV Export',
+    status: 'approved',
+    numberOfParticipants: 12,
+    deliveryMethod: 'virtual',
+    duration: 4.5,
+    startDate: '2021-10-31',
+    endSDate: '2021-11-31',
+    ECLKCResourcesUsed: ['https://one.test', 'https://two.test'],
+    nonECLKCResourcesUsed: ['one', 'two'],
+    author: mockAuthor,
+    lastUpdatedBy: mockAuthor,
+  };
+
+  it('transforms arrays of strings into strings', async () => {
+    const report = ActivityReport.build({
+      ECLKCResourcesUsed: ['https://one.test', 'https://two.test'],
+      nonECLKCResourcesUsed: ['one', 'two'],
+    });
+    const output = await activityReportToCsvRecord(report);
+    const expectedOutput = {
+      ECLKCResourcesUsed: 'https://one.test\nhttps://two.test',
+      nonECLKCResourcesUsed: 'one\ntwo',
+    };
+    expect(output).toMatchObject(expectedOutput);
+  });
+
+  it('transforms related models into string values', async () => {
+    const report = await ActivityReport.build(mockReport, { include: [{ model: User, as: 'author' }, { model: User, as: 'lastUpdatedBy' }] });
+    const output = await activityReportToCsvRecord(report);
+    const { author: authorOutput, lastUpdatedBy: lastUpdatedByOutput } = output;
+    expect(authorOutput).toEqual('Arthur');
+    expect(lastUpdatedByOutput).toEqual('Arthur');
+  });
+});

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -1,5 +1,10 @@
-import { ActivityReport, User, sequelize } from '../models';
-import activityReportToCsvRecord from './transform';
+import {
+  ActivityReport,
+  Goal,
+  Objective,
+  User,
+} from '../models';
+import { activityReportToCsvRecord, makeGoalsAndObjectivesObject } from './transform';
 
 describe('activityReportToCsvRecord', () => {
   const mockAuthor = {
@@ -8,6 +13,87 @@ describe('activityReportToCsvRecord', () => {
     hsesUserId: '2099',
     hsesUsername: 'arthur.author',
   };
+
+  const mockCollaborators = [
+    {
+      id: 2100,
+      name: 'Collaborator 1',
+      hsesUserId: '2100',
+      hsesUsername: 'collaborator.one',
+    },
+    {
+      id: 2101,
+      name: 'Collaborator 2',
+      hsesUserId: '2101',
+      hsesUsername: 'collaborator.two',
+    },
+  ];
+
+  const mockGoals = [
+    {
+      name: 'Goal 1',
+      id: 2080,
+      status: 'Fake',
+      timeframe: 'None',
+    },
+    {
+      name: 'Goal 2',
+      id: 2081,
+      status: 'Fake',
+      timeframe: 'None',
+    },
+    {
+      name: 'Goal 3',
+      id: 2082,
+      status: 'Fake',
+      timeframe: 'None',
+    },
+  ];
+
+  const mockObjectives = [
+    {
+      id: 11,
+      title: 'Objective 1.1',
+      ttaProvided: 'Training',
+      status: 'Fake',
+      goal: mockGoals[0],
+    },
+    {
+      id: 12,
+      title: 'Objective 1.2',
+      ttaProvided: 'Training',
+      status: 'Fake',
+      goal: mockGoals[0],
+    },
+    {
+      id: 13,
+      title: 'Objective 2.1',
+      ttaProvided: 'Training',
+      status: '',
+      goal: mockGoals[1],
+    },
+    {
+      id: 14,
+      title: 'Objective 2.2',
+      ttaProvided: 'Training',
+      status: '',
+      goal: mockGoals[1],
+    },
+    {
+      id: 15,
+      title: 'Objective 2.3',
+      ttaProvided: 'Training',
+      status: '',
+      goal: mockGoals[1],
+    },
+    {
+      id: 16,
+      title: 'Objective 3.1',
+      ttaProvided: 'Training',
+      status: '',
+      goal: mockGoals[2],
+    },
+  ];
 
   const mockReport = {
     id: 209914,
@@ -18,11 +104,12 @@ describe('activityReportToCsvRecord', () => {
     deliveryMethod: 'virtual',
     duration: 4.5,
     startDate: '2021-10-31',
-    endSDate: '2021-11-31',
+    endDate: '2021-11-03',
     ECLKCResourcesUsed: ['https://one.test', 'https://two.test'],
     nonECLKCResourcesUsed: ['one', 'two'],
     author: mockAuthor,
     lastUpdatedBy: mockAuthor,
+    collaborators: mockCollaborators,
   };
 
   it('transforms arrays of strings into strings', async () => {
@@ -39,10 +126,50 @@ describe('activityReportToCsvRecord', () => {
   });
 
   it('transforms related models into string values', async () => {
-    const report = await ActivityReport.build(mockReport, { include: [{ model: User, as: 'author' }, { model: User, as: 'lastUpdatedBy' }] });
+    const report = await ActivityReport.build(mockReport, {
+      include: [{ model: User, as: 'author' }, { model: User, as: 'lastUpdatedBy' }, { model: User, as: 'collaborators' }],
+    });
     const output = await activityReportToCsvRecord(report);
-    const { author: authorOutput, lastUpdatedBy: lastUpdatedByOutput } = output;
-    expect(authorOutput).toEqual('Arthur');
-    expect(lastUpdatedByOutput).toEqual('Arthur');
+    const { author, lastUpdatedBy, collaborators } = output;
+    expect(author).toEqual('Arthur');
+    expect(lastUpdatedBy).toEqual('Arthur');
+    expect(collaborators).toEqual('Collaborator 1\nCollaborator 2');
+  });
+
+  it('transforms goals and objectives into many values', async () => {
+    const objectives = await Objective.build(mockObjectives, { include: [{ model: Goal, as: 'goal' }] });
+    const output = makeGoalsAndObjectivesObject(objectives);
+    expect(output).toEqual({
+      'goal-1': 'Goal 1',
+      'goal-1-status': 'Fake',
+      'objective-1.1': 'Objective 1.1',
+      'objective-1.1-ttaProvided': 'Training',
+      'objective-1.1-status': 'Fake',
+      'objective-1.2': 'Objective 1.2',
+      'objective-1.2-ttaProvided': 'Training',
+      'objective-1.2-status': 'Fake',
+      'goal-2': 'Goal 2',
+      'goal-2-status': 'Fake',
+      'objective-2.1': 'Objective 2.1',
+      'objective-2.1-ttaProvided': 'Training',
+      'objective-2.1-status': '',
+      'objective-2.2': 'Objective 2.2',
+      'objective-2.2-ttaProvided': 'Training',
+      'objective-2.2-status': '',
+      'objective-2.3': 'Objective 2.3',
+      'objective-2.3-ttaProvided': 'Training',
+      'objective-2.3-status': '',
+      'goal-3': 'Goal 3',
+      'goal-3-status': 'Fake',
+      'objective-3.1': 'Objective 3.1',
+      'objective-3.1-ttaProvided': 'Training',
+      'objective-3.1-status': '',
+    });
+  });
+
+  it('does not provide values for builders that are not strings or functions', async () => {
+    const report = await ActivityReport.build(mockReport, { include: [{ model: User, as: 'author' }, { model: User, as: 'lastUpdatedBy' }] });
+    const output = await activityReportToCsvRecord(report, [1, true, 'regionId']);
+    expect(output).toMatchObject({ regionId: 14 });
   });
 });

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -1,3 +1,4 @@
+import stringify from 'csv-stringify/lib/sync';
 import handleErrors from '../../lib/apiErrorHandler';
 import SCOPES from '../../middleware/scopeConstants';
 import ActivityReport from '../../policies/activityReport';
@@ -11,11 +12,13 @@ import {
   setStatus,
   activityReportAlerts,
   activityReportByLegacyId,
+  getDownloadableActivityReports,
 } from '../../services/activityReports';
 import { goalsForGrants } from '../../services/goals';
 import { userById, usersWithPermissions } from '../../services/users';
 import { REPORT_STATUSES, DECIMAL_BASE } from '../../constants';
 import { getUserReadRegions } from '../../services/accessValidation';
+import activityReportToCsvRecord from '../../lib/transform';
 
 const { APPROVE_REPORTS } = SCOPES;
 
@@ -290,6 +293,41 @@ export async function createReport(req, res) {
 
     const report = await createOrUpdate(newReport);
     res.json(report);
+  } catch (error) {
+    await handleErrors(req, res, error, logContext);
+  }
+}
+
+/**
+ * Download activity reports
+ *
+ * @param {*} req - request
+ * @param {*} res - response
+ */
+export async function downloadReports(req, res) {
+  try {
+    const readRegions = await getUserReadRegions(req.session.userId);
+    const reportsWithCount = await getDownloadableActivityReports(readRegions, req.query);
+    const { format = 'json' } = req.query;
+
+    if (!reportsWithCount) {
+      res.sendStatus(404);
+    } else if (format === 'csv') {
+      const { rows } = reportsWithCount;
+      const csvRows = await Promise.all(rows.map((r) => activityReportToCsvRecord(r)));
+      const csvData = stringify(
+        csvRows,
+        {
+          header: true,
+          quoted: true,
+          quoted_empty: true,
+        },
+      );
+      res.attachment('activity-reports.csv');
+      res.send(csvData);
+    } else {
+      res.json(reportsWithCount);
+    }
   } catch (error) {
     await handleErrors(req, res, error, logContext);
   }

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -18,7 +18,7 @@ import { goalsForGrants } from '../../services/goals';
 import { userById, usersWithPermissions } from '../../services/users';
 import { REPORT_STATUSES, DECIMAL_BASE } from '../../constants';
 import { getUserReadRegions } from '../../services/accessValidation';
-import activityReportToCsvRecord from '../../lib/transform';
+import { activityReportToCsvRecord } from '../../lib/transform';
 
 const { APPROVE_REPORTS } = SCOPES;
 

--- a/src/routes/activityReports/index.js
+++ b/src/routes/activityReports/index.js
@@ -12,6 +12,7 @@ import {
   reviewReport,
   resetToDraft,
   getLegacyReport,
+  downloadReports,
 } from './handlers';
 
 const router = express.Router();
@@ -26,6 +27,7 @@ router.get('/activity-recipients', getActivityRecipients);
 router.get('/goals', getGoals);
 router.get('/alerts', getReportAlerts);
 router.get('/legacy/:legacyReportId', getLegacyReport);
+router.get('/download', downloadReports);
 router.get('/:activityReportId', getReport);
 router.get('/', getReports);
 router.put('/:activityReportId', saveReport);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,6 +3358,11 @@ csv-parse@^4.14.1:
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.15.3.tgz#8a62759617a920c328cb31c351b05053b8f92b10"
   integrity sha512-jlTqDvLdHnYMSr08ynNfk4IAUSJgJjTKy2U5CQBSu4cN9vQOJonLVZP4Qo4gKKrIgIQ5dr07UwOJdi+lRqT12w==
 
+csv-stringify@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.6.2.tgz#e653783e2189c4c797fbb12abf7f4943c787caa9"
+  integrity sha512-n3rIVbX6ylm1YsX2NEug9IaPV8xRnT+9/NNZbrA/bcHgOSSeqtWla6XnI/xmyu57wIw+ASCAoX1oM6EZtqJV0A==
+
 cucumber-html-reporter@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/cucumber-html-reporter/-/cucumber-html-reporter-5.3.0.tgz#831d21e2ad64c10949bf2bab920343f1d01ef3ee"


### PR DESCRIPTION
**Description of change**

Backend/API changes to enable downloading Activity Report records as a CSV file.

**How to test**


**Issue(s)**
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-35

**Checklist**
<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] Documentation updated
    - API methods
    - Boundary and Data Flow Diagrams
    - [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions with the [Nygard template](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md)
    - OSCAL templates completed when security controls are implemented or modified
