### PR TITLE
[TTAHUB-240] Include goals and objectives in CSV download (#360)

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Approved.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Approved.js
@@ -13,7 +13,7 @@ const Approved = ({
   const managerNotesState = getEditorState(managerNotes || 'No manager notes');
 
   return (
-    <>
+    <div className="no-print">
       <h2>Report approved</h2>
       <div className="smart-hub--creator-notes">
         <p>
@@ -30,7 +30,7 @@ const Approved = ({
       <div className="margin-top-3">
         <ApproverStatusList approverStatus={approverStatusList} />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Approved.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Approved.js
@@ -13,7 +13,7 @@ const Approved = ({
   const managerNotesState = getEditorState(managerNotes || 'No manager notes');
 
   return (
-    <>
+    <div className="no-print">
       <h2>Report approved</h2>
       <div className="smart-hub--creator-notes">
         <p>
@@ -30,7 +30,7 @@ const Approved = ({
       <div className="margin-top-3">
         <ApproverStatusList approverStatus={approverStatusList} />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -4,7 +4,7 @@ import {
   Objective,
   User,
 } from '../models';
-import { activityReportToCsvRecord, makeGoalsAndObjectivesObject } from './transform';
+import { activityReportToCsvRecord, makeGoalsAndObjectivesObject, extractListOfGoalsAndObjectives } from './transform';
 
 describe('activityReportToCsvRecord', () => {
   const mockAuthor = {
@@ -141,7 +141,6 @@ describe('activityReportToCsvRecord', () => {
     const output = makeGoalsAndObjectivesObject(objectives);
     expect(output).toEqual({
       'goal-1': 'Goal 1',
-      'goal-1-status': 'Fake',
       'objective-1.1': 'Objective 1.1',
       'objective-1.1-ttaProvided': 'Training',
       'objective-1.1-status': 'Fake',
@@ -149,7 +148,6 @@ describe('activityReportToCsvRecord', () => {
       'objective-1.2-ttaProvided': 'Training',
       'objective-1.2-status': 'Fake',
       'goal-2': 'Goal 2',
-      'goal-2-status': 'Fake',
       'objective-2.1': 'Objective 2.1',
       'objective-2.1-ttaProvided': 'Training',
       'objective-2.1-status': '',
@@ -160,11 +158,38 @@ describe('activityReportToCsvRecord', () => {
       'objective-2.3-ttaProvided': 'Training',
       'objective-2.3-status': '',
       'goal-3': 'Goal 3',
-      'goal-3-status': 'Fake',
       'objective-3.1': 'Objective 3.1',
       'objective-3.1-ttaProvided': 'Training',
       'objective-3.1-status': '',
     });
+  });
+
+  it('return a list of all keys that are a goal or objective and in the proper order', () => {
+    const csvData = [
+      {
+        'goal-1': 'butter',
+        'objective-1': 'cream',
+      },
+      {
+        'goal-1': 'butter',
+        'objective-1': 'cream',
+        'goal-2': 'cream',
+        'goal-2-status': 'butter',
+        'objective-2.1': 'eggs',
+        'objective-2.1-ttaProvided': 'cream',
+      },
+      {
+        'goal-3': 'butter',
+        'objective-3.1-status': 'cream',
+        kitchen: 'test',
+      },
+    ];
+
+    const validated = extractListOfGoalsAndObjectives(csvData);
+
+    expect(validated).toStrictEqual([
+      'goal-1', 'objective-1', 'goal-2', 'goal-2-status', 'objective-2.1', 'objective-2.1-ttaProvided', 'goal-3', 'objective-3.1-status',
+    ]);
   });
 
   it('does not provide values for builders that are not strings or functions', async () => {

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -28,9 +28,9 @@ import {
   reportApprovedNotification,
   collaboratorAddedNotification,
 } from '../../lib/mailer';
-import { activityReportToCsvRecord } from '../../lib/transform';
+import { activityReportToCsvRecord, extractListOfGoalsAndObjectives } from '../../lib/transform';
 
-const { APPROVE_REPORTS } = SCOPES;
+const { APPROVE_REPORTS, ADMIN } = SCOPES;
 
 const namespace = 'SERVICE:ACTIVITY_REPORTS';
 
@@ -38,15 +38,146 @@ const logContext = {
   namespace,
 };
 
-async function sendActivityReportCSV(reports, res) {
+async function sendActivityReportCSV(reports, res, userId) {
   const csvRows = await Promise.all(reports.map((r) => activityReportToCsvRecord(r)));
+
+  // base options
+  let options = {
+    header: true,
+    quoted: true,
+    quoted_empty: true,
+  };
+
+  // if we have some rows, we need to extract a list of goals and objectives and format the columns
+  if (csvRows.length > 0) {
+    const goalsAndObjectives = extractListOfGoalsAndObjectives(csvRows);
+    const user = await userById(userId);
+    const isAdmin = user.permissions.find((permission) => permission.scopeId === ADMIN);
+
+    options = {
+      ...options,
+      columns: [
+        {
+          key: 'displayId',
+          header: 'Report ID',
+        },
+        {
+          key: 'author',
+          header: 'Creator',
+        },
+        {
+          key: 'collaborators',
+          header: 'Collaborators',
+        },
+        {
+          key: 'requester',
+          header: 'Requester',
+        },
+        {
+          key: 'activityRecipientType',
+          header: 'Grantee or non-grantee',
+        },
+        {
+          key: 'activityRecipients',
+          header: 'Grantee name/non-grantee name',
+        },
+        {
+          key: 'programTypes',
+          header: 'Program type',
+        },
+        {
+          key: 'reason',
+          header: 'Reason',
+        },
+        {
+          key: 'targetPopulations',
+          header: 'Target population',
+        },
+        {
+          key: 'startDate',
+          header: 'Start date',
+        },
+        {
+          key: 'endDate',
+          header: 'End date',
+        },
+        {
+          key: 'ttaType',
+          header: 'TTA type',
+        },
+        {
+          key: 'deliveryMethod',
+          header: 'Delivery method',
+        },
+        {
+          key: 'virtualDeliveryType',
+          header: 'Virtual delivery type',
+        },
+        {
+          key: 'duration',
+          header: 'Duration',
+        },
+        {
+          key: 'participants',
+          header: 'Participant roles',
+        },
+        {
+          key: 'numberOfParticipants',
+          header: 'Number of participants',
+        },
+        {
+          key: 'topics',
+          header: 'Topics covered',
+        },
+        {
+          key: 'ECLKCResourcesUsed',
+          header: 'ECLKC resources',
+        },
+        {
+          key: 'nonECLKCResourcesUsed',
+          header: 'Non-ECLKC resources',
+        },
+        {
+          key: 'attachments',
+          header: 'Attachments',
+        },
+        {
+          key: 'context',
+          header: 'Context',
+        },
+        {
+          key: 'specialistNextSteps',
+          header: 'Specialist next steps',
+        },
+        {
+          key: 'granteeNextSteps',
+          header: 'Grantee next steps',
+        },
+        {
+          key: 'lastSaved',
+          header: 'Last saved',
+        },
+
+      ],
+    };
+
+    // Feature flag (goal fields for admins only)...
+    if (isAdmin) {
+      const contextPosition = 22;
+
+      goalsAndObjectives.forEach((obj, index) => {
+        options.columns.splice(contextPosition + index, 0, {
+          key: obj,
+          // capitalize each word and space them out (no '-' in there)
+          header: obj.split('-').map((w) => `${w.charAt(0).toUpperCase()}${w.slice(1)}`).join(' '),
+        });
+      });
+    }
+  }
+
   const csvData = stringify(
     csvRows,
-    {
-      header: true,
-      quoted: true,
-      quoted_empty: true,
-    },
+    options,
   );
 
   res.attachment('activity-reports.csv');
@@ -402,7 +533,7 @@ export async function downloadReports(req, res) {
     if (!reportsWithCount) {
       res.sendStatus(404);
     } else if (format === 'csv') {
-      await sendActivityReportCSV(reportsWithCount.rows, res);
+      await sendActivityReportCSV(reportsWithCount.rows, res, req.session.userId);
     } else {
       res.json(reportsWithCount);
     }
@@ -417,12 +548,12 @@ export async function downloadAllReports(req, res) {
 
     const reportsWithCount = await getAllDownloadableActivityReports(
       readRegions['region.in'],
-      { readRegions, limit: null },
+      { ...readRegions, limit: null },
       true,
     );
 
     const rows = reportsWithCount ? reportsWithCount.rows : [];
-    await sendActivityReportCSV(rows, res);
+    await sendActivityReportCSV(rows, res, req.session.userId);
   } catch (error) {
     await handleErrors(req, res, error, logContext);
   }
@@ -435,7 +566,8 @@ export async function downloadAllAlerts(req, res) {
     const alertsWithCount = await getAllDownloadableActivityReportAlerts(userId, query);
 
     const rows = alertsWithCount ? alertsWithCount.rows : [];
-    await sendActivityReportCSV(rows, res);
+
+    await sendActivityReportCSV(rows, res, userId);
   } catch (error) {
     await handleErrors(req, res, error, logContext);
   }

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -100,6 +100,7 @@ const report = {
   userId: mockUser.id,
   approvingManager: mockManager,
   displayId: 'mockreport-1',
+  regionId: 1,
 };
 
 describe('Activity Report handlers', () => {
@@ -532,7 +533,7 @@ describe('Activity Report handlers', () => {
     it('returns a csv', async () => {
       getAllDownloadableActivityReports.mockResolvedValue({ count: 1, rows: [report] });
       setReadRegions.mockResolvedValue([1]);
-
+      userById.mockResolvedValue({ permissions: [{ scopeId: 50 }] });
       await downloadAllReports(request, mockResponse);
       expect(mockResponse.attachment).toHaveBeenCalledWith('activity-reports.csv');
     });
@@ -555,6 +556,7 @@ describe('Activity Report handlers', () => {
     it('returns a csv', async () => {
       getAllDownloadableActivityReportAlerts.mockResolvedValue({ count: 1, rows: [report] });
       getUserReadRegions.mockResolvedValue([1]);
+      userById.mockResolvedValue({ permissions: [{ scopeId: 50 }] });
 
       await downloadAllAlerts(request, mockResponse);
       expect(mockResponse.attachment).toHaveBeenCalledWith('activity-reports.csv');
@@ -570,7 +572,7 @@ describe('Activity Report handlers', () => {
   });
 
   describe('downloadReports', () => {
-    it('returns a csv with appopriate headers when format=csv', async () => {
+    it('returns a csv with appropriate headers when format=csv', async () => {
       const request = {
         ...mockRequest,
         query: { format: 'csv' },
@@ -583,6 +585,7 @@ describe('Activity Report handlers', () => {
         },
       };
 
+      userById.mockResolvedValue({ permissions: [{ scopeId: 50 }] });
       getDownloadableActivityReportsByIds.mockResolvedValue({
         count: 1, rows: [downloadableReport],
       });
@@ -592,8 +595,8 @@ describe('Activity Report handlers', () => {
       expect(mockResponse.send).toHaveBeenCalled();
       const [[value]] = mockResponse.send.mock.calls;
       /* eslint-disable no-useless-escape */
-      expect(value).toMatch('\"displayId\"');
-      expect(value).toMatch('\"Arty\"');
+      expect(value).toContain('\"Creator\"');
+      expect(value).toContain('\"Arty\"');
       /* eslint-enable no-useless-escape */
     });
 

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -631,8 +631,17 @@ async function getDownloadableActivityReports(where) {
   return ActivityReport.findAndCountAll(
     {
       where,
-      attributes: { include: ['displayId'], exclude: ['imported', 'legacyId'] },
+      attributes: { include: ['displayId'], exclude: ['imported', 'legacyId', 'managerNotes', 'additionalNotes'] },
       include: [
+        {
+          model: Objective,
+          as: 'objectives',
+          include: [{
+            model: Goal,
+            as: 'goal',
+          }],
+          attributes: ['title', 'status', 'ttaProvided'],
+        },
         {
           model: ActivityRecipient,
           attributes: ['id', 'name', 'activityRecipientId', 'grantId', 'nonGranteeId'],


### PR DESCRIPTION
## Description of change

**TTAHUB-240:**
Updated the column headers for the CSV to be more human-readable
**Admins only** will also now see the goals and objectives with the CSV output.

**TTAHUB-86:**
Always hide the Creator and Manager notes when printing an approved report.

## How to test

**TTAHUB-240:**
Export a CSV. Confirm the column data has changed. If possible, confirm admins see goals and objectives and non-admins do not.

**TTAHUB-86:**
Print a approved report the Creator and Manager notes section should no longer be visible in the print out.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-240
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-86


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a ] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
