### PR TITLE
[TTAHUB-258]Topic/Frequency Graph filters on specialist roles instead of participants

### DIFF
--- a/frontend/src/pages/Dashboard/__tests__/index.js
+++ b/frontend/src/pages/Dashboard/__tests__/index.js
@@ -17,7 +17,7 @@ describe('Dashboard page', () => {
 
   it('shows a heading', async () => {
     renderDashboard(user);
-    const heading = await screen.findByText(/regional tta activity dashboard/i);
+    const heading = await screen.findByText(/regional tta activity analytics/i);
     expect(heading).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/Dashboard/index.js
+++ b/frontend/src/pages/Dashboard/index.js
@@ -156,7 +156,6 @@ function Dashboard({ user }) {
   return (
     <div className="ttahub-dashboard">
       <Helmet titleTemplate="%s - Dashboard - TTA Smart Hub" defaultTitle="TTA Smart Hub - Dashboard" />
-
       <>
         <Helmet titleTemplate="%s - Dashboard - TTA Smart Hub" defaultTitle="TTA Smart Hub - Dashboard" />
         <Grid className="ttahub-dashboard--filter-row flex-fill display-flex flex-align-center flex-align-self-center flex-row flex-wrap margin-bottom-2">
@@ -164,7 +163,7 @@ function Dashboard({ user }) {
             <h1 className="ttahub--dashboard-title">
               {appliedRegion === 14 ? 'Regional' : `Region ${appliedRegion}` }
               {' '}
-              TTA Activity Dashboard
+              TTA Activity Analytics
             </h1>
           </Grid>
           <Grid className="ttahub-dashboard--filters display-flex flex-wrap flex-align-center margin-top-2 desktop:margin-top-0">

--- a/frontend/src/widgets/TopicFrequencyGraph.css
+++ b/frontend/src/widgets/TopicFrequencyGraph.css
@@ -26,8 +26,26 @@
     left: 33%;
 }
 
+
+.tta-dashboard--topic-frequency-graph-apply-filters {
+    height: 40px;
+    min-width: 120px;
+}
+
 .tta-dashboard--bar-graph-container::after {
     content: 'Topics';
     display: block;
     padding-left: 10em;
+}
+
+@media(max-width: 768px) {
+    .ttahub--topic-frequency-graph-control-row {
+        display: block;
+        width: 100%;
+    }
+
+    .ttahub--topic-frequency-graph-control-row .usa-select, 
+    .tta-dashboard--topic-frequency-graph-apply-filters {
+        width: 180px;
+    }
 }

--- a/frontend/src/widgets/__tests__/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/__tests__/TopicFrequencyGraph.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   TopicFrequencyGraphWidget, reasonsWithLineBreaks, filterData, sortData, Tooltip,
@@ -9,32 +9,32 @@ import {
 const TEST_DATA = [{
   reason: 'CLASS: Instructional Support',
   count: 12,
-  participants: [],
+  roles: [],
 },
 {
   reason: 'Community and Self-Assessment',
   count: 155,
-  participants: [],
+  roles: [],
 },
 {
   reason: 'Family Support Services',
   count: 53,
-  participants: [],
+  roles: [],
 },
 {
   reason: 'Fiscal / Budget',
   count: 0,
-  participants: ['Louise'],
+  roles: [],
 },
 {
   reason: 'Five-Year Grant',
   count: 33,
-  participants: ['Bob'],
+  roles: [],
 },
 {
   reason: 'Human Resources',
   count: 0,
-  participants: ['Gene'],
+  roles: ['System Specialist'],
 }];
 
 const renderArGraphOverview = async (props) => (
@@ -43,7 +43,7 @@ const renderArGraphOverview = async (props) => (
   )
 );
 
-describe('AR Graph Widget', () => {
+describe('Topic & Frequency Graph Widget', () => {
   it('shows the correct data', async () => {
     renderArGraphOverview({ data: TEST_DATA });
     const graphTitle = screen.getByRole('heading', { name: /number of activity reports by topic/i });
@@ -53,13 +53,13 @@ describe('AR Graph Widget', () => {
 
   it('correctly filters data', () => {
     const data = [...TEST_DATA];
-    const filteredData = filterData(data, [{ label: 'Gene' }]);
+    const filteredData = filterData(data, [{ value: 'System Specialist' }]);
 
     expect(filteredData).toStrictEqual([
       {
         reason: 'Human Resources',
         count: 0,
-        participants: ['Gene'],
+        roles: ['System Specialist'],
       },
     ]);
   });
@@ -73,38 +73,32 @@ describe('AR Graph Widget', () => {
       {
         reason: 'Fiscal / Budget',
         count: 0,
-        participants: [
-          'Louise',
-        ],
+        roles: [],
       },
       {
         reason: 'Human Resources',
         count: 0,
-        participants: [
-          'Gene',
-        ],
+        roles: ['System Specialist'],
       },
       {
         reason: 'CLASS: Instructional Support',
         count: 12,
-        participants: [],
+        roles: [],
       },
       {
         reason: 'Five-Year Grant',
         count: 33,
-        participants: [
-          'Bob',
-        ],
+        roles: [],
       },
       {
         reason: 'Family Support Services',
         count: 53,
-        participants: [],
+        roles: [],
       },
       {
         reason: 'Community and Self-Assessment',
         count: 155,
-        participants: [],
+        roles: [],
       },
     ]);
 
@@ -114,38 +108,32 @@ describe('AR Graph Widget', () => {
       {
         reason: 'Community and Self-Assessment',
         count: 155,
-        participants: [],
+        roles: [],
       },
       {
         reason: 'Family Support Services',
         count: 53,
-        participants: [],
+        roles: [],
       },
       {
         reason: 'Five-Year Grant',
         count: 33,
-        participants: [
-          'Bob',
-        ],
+        roles: [],
       },
       {
         reason: 'CLASS: Instructional Support',
         count: 12,
-        participants: [],
+        roles: [],
       },
       {
         reason: 'Fiscal / Budget',
         count: 0,
-        participants: [
-          'Louise',
-        ],
+        roles: [],
       },
       {
         reason: 'Human Resources',
         count: 0,
-        participants: [
-          'Gene',
-        ],
+        roles: ['System Specialist'],
       },
     ]);
   });
@@ -168,6 +156,9 @@ describe('AR Graph Widget', () => {
     const order = screen.getByRole('combobox', { name: /change topic data order/i });
     userEvent.selectOptions(order, ['asc']);
 
+    const applyFiltersButton = screen.getByRole('button', { name: 'Apply filters' });
+    fireEvent.click(applyFiltersButton);
+
     expect(order.value).toBe('asc');
   });
 
@@ -186,11 +177,11 @@ describe('AR Graph Widget', () => {
 
     expect(select.classList.contains('ar__control--is-focused')).toBe(true);
 
-    let louise = screen.getByText(/louise/i);
+    let louise = screen.getByText(/system specialist/i);
 
     userEvent.click(louise);
 
-    louise = screen.getByText(/louise/i);
+    louise = screen.getByText(/system specialist/i);
 
     expect(louise.classList.contains('ar__multi-value__label')).toBe(true);
   });

--- a/src/widgets/topicFrequencyGraph.test.js
+++ b/src/widgets/topicFrequencyGraph.test.js
@@ -9,17 +9,18 @@ import topicFrequencyGraph, { topics } from './topicFrequencyGraph';
 const BASE_REASONS = topics.map((topic) => ({
   reason: topic,
   count: 0,
-  participants: [],
+  roles: [],
 }));
 
 const GRANTEE_ID = 30;
 
 const mockUser = {
-  id: 1000,
+  id: 2000,
   homeRegionId: 1,
   name: 'user1000',
   hsesUsername: 'user1000',
   hsesUserId: '1000',
+  role: ['Grants Specialist'],
 };
 
 const reportObject = {
@@ -63,9 +64,9 @@ const regionTwoReport = {
   regionId: 18,
 };
 
-describe('AR Graph widget', () => {
+describe('Topics and frequency graph widget', () => {
   beforeAll(async () => {
-    await User.findOrCreate({ where: mockUser });
+    await User.create(mockUser);
     await Grantee.findOrCreate({ where: { name: 'grantee', id: GRANTEE_ID } });
     await Region.create({ name: 'office 17', id: 17 });
     await Region.create({ name: 'office 18', id: 18 });
@@ -119,7 +120,7 @@ describe('AR Graph widget', () => {
     const reasonToModify = reasons.find((reason) => reason.reason === 'Program Planning and Services');
 
     reasonToModify.count = 1;
-    reasonToModify.participants = ['participants', 'genies'];
+    reasonToModify.roles = ['Grants Specialist'];
 
     expect(data).toStrictEqual(reasons);
   });
@@ -131,7 +132,7 @@ describe('AR Graph widget', () => {
     const reasons = [...BASE_REASONS];
     const reasonToModify = reasons.find((reason) => reason.reason === 'Program Planning and Services');
     reasonToModify.count = 1;
-    reasonToModify.participants = ['participants', 'genies'];
+    reasonToModify.roles = ['Grants Specialist'];
 
     expect(data).toStrictEqual(reasons);
   });
@@ -145,14 +146,12 @@ describe('AR Graph widget', () => {
     const reasonToModify = reasons.find((reason) => reason.reason === 'Program Planning and Services');
 
     reasonToModify.count = 2;
-    reasonToModify.participants = ['participants', 'genies'];
+    reasonToModify.roles = ['Grants Specialist'];
 
     const secondReasonToModify = reasons.find((reason) => reason.reason === 'Recordkeeping and Reporting');
     secondReasonToModify.count = 1;
-    secondReasonToModify.participants = ['participants', 'genies'];
+    secondReasonToModify.roles = ['Grants Specialist'];
 
     expect(data).toStrictEqual(reasons);
   });
-
-  // todo - write test with dummy reason
 });


### PR DESCRIPTION
## Description of change

The dropdown at the top of the Topic/frequency graph was populated with the wrong information. It now extracts roles from the users and collaborators rather than the participant roles.

Feedback from accessibility design review was also incorporated, adding a button to apply the sorting options.

The title was also changed on the page to use the new "analytics" language.

## How to test

Verify that the topic/frequency graph now contains appropriate values, and that the data can be appropriately filtered.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-258

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
