### PR TITLE
[TTAHUB-314] Remove included model that changed counts 

### DIFF
--- a/frontend/src/fetchers/Widgets.js
+++ b/frontend/src/fetchers/Widgets.js
@@ -1,10 +1,11 @@
 import join from 'url-join';
 import { get } from './index';
 
-const fetchWidget = async (widgetId, region, dateRange = '') => {
+const fetchWidget = async (widgetId, region, dateRange = '', roles = '') => {
   const regionStr = region ? `&region.in[]=${region}` : '';
+  const rolesStr = roles ? `&role.in[]=${roles}` : '';
   const dateRangeStr = dateRange !== '' ? `&startDate.win=${dateRange}` : '';
-  const res = await get(join('/', 'api', 'widgets', widgetId, '?', regionStr, dateRangeStr));
+  const res = await get(join('/', 'api', 'widgets', widgetId, '?', regionStr, dateRangeStr, rolesStr));
   return res.json();
 };
 

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -7,7 +7,7 @@ import Container from '../../components/Container';
 import RegionalSelect from '../../components/RegionalSelect';
 import DateRangeSelect from './components/DateRangeSelect';
 import DashboardOverview from '../../widgets/DashboardOverview';
-import TopicFrequencyGraph from '../../widgets/TopicFrequencyGraph';
+import TopicFrequencyGraph, { ROLES_MAP } from '../../widgets/TopicFrequencyGraph';
 import DateTime from '../../components/DateTime';
 import { getUserRegions } from '../../permissions';
 import { CUSTOM_DATE_RANGE } from './constants';
@@ -38,6 +38,7 @@ export default function RegionalDashboard({ user }) {
     */
 
   const [filters, updateFilters] = useState([]);
+  const [roleFilter, updateRoleFilter] = useState('');
 
   useEffect(() => {
     /**
@@ -101,6 +102,10 @@ export default function RegionalDashboard({ user }) {
   const onApplyRegion = (region) => {
     const regionId = region ? region.value : appliedRegion;
     updateAppliedRegion(regionId);
+  };
+
+  const updateRoles = (selectedRoles) => {
+    updateRoleFilter(selectedRoles.map((role) => ROLES_MAP.find((r) => r.selectValue === role)).map((r) => r.value).join(','));
   };
 
   const onApplyDateRange = (range) => {
@@ -184,10 +189,12 @@ export default function RegionalDashboard({ user }) {
           </Grid>
           <Grid row>
             <TopicFrequencyGraph
-              filters={filters}
+              filters={[...filters, roleFilter]}
               region={appliedRegion}
               allRegions={regions}
               dateRange={dateRange}
+              roles={roleFilter}
+              updateRoles={updateRoles}
               skipLoading
               dateTime={dateTime}
             />

--- a/frontend/src/widgets/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/TopicFrequencyGraph.js
@@ -10,11 +10,6 @@ import './TopicFrequencyGraph.css';
 import ButtonSelect from '../components/ButtonSelect';
 import CheckboxSelect from '../components/CheckboxSelect';
 
-export const SORT_ORDER = {
-  DESC: 1,
-  ALPHA: 2,
-};
-
 export const ROLES_MAP = [
   {
     selectValue: 1,
@@ -43,34 +38,14 @@ export const ROLES_MAP = [
   },
 ];
 
-export function filterData(data, roles) {
-  const selectedRoles = roles.map((role) => ROLES_MAP.find((r) => r.selectValue === role));
-
-  const copyOfData = data.map((object) => ({ ...object }));
-
-  return copyOfData.map((dataPoint) => {
-    let setToZero = true;
-
-    if (selectedRoles.length > 0) {
-      selectedRoles.forEach((selectedRole) => {
-        if (dataPoint.roles.includes(selectedRole.value)) {
-          setToZero = false;
-        }
-      });
-    }
-
-    if (setToZero) {
-      // eslint-disable-next-line no-param-reassign
-      dataPoint.count = 0;
-    }
-
-    return dataPoint;
-  });
-}
+export const SORT_ORDER = {
+  DESC: 1,
+  ALPHA: 2,
+};
 
 export function sortData(data, order) {
   if (order === SORT_ORDER.ALPHA) {
-    data.sort((a, b) => a.reason.localeCompare(b.reason));
+    data.sort((a, b) => a.topic.localeCompare(b.topic));
   } else {
     data.sort((a, b) => b.count - a.count);
   }
@@ -82,13 +57,13 @@ export function sortData(data, order) {
  * provided for an activity report and intersperses it with line breaks
  * depending on the length
  *
- * @param {string} reason
+ * @param {string} topic
  * @returns string with line breaks
  */
-export function reasonsWithLineBreaks(reason) {
-  const arrayOfReasons = reason.split(' ');
+export function topicsWithLineBreaks(reason) {
+  const arrayOfTopics = reason.split(' ');
 
-  return arrayOfReasons.reduce((accumulator, currentValue) => {
+  return arrayOfTopics.reduce((accumulator, currentValue) => {
     const lineBreaks = accumulator.match(/<br \/>/g);
     const allowedLength = lineBreaks ? lineBreaks.length * 6 : 6;
 
@@ -105,7 +80,7 @@ export function reasonsWithLineBreaks(reason) {
   }, '');
 }
 
-export function TopicFrequencyGraphWidget({ data, dateTime }) {
+export function TopicFrequencyGraphWidget({ data, dateTime, updateRoles }) {
   // whether to show the data as accessible widget data or not
   const [showAccessibleData, setShowAccessibleData] = useState(false);
 
@@ -116,9 +91,6 @@ export function TopicFrequencyGraphWidget({ data, dateTime }) {
   // the order the data is displayed in the chart
   const [order, setOrder] = useState(SORT_ORDER.DESC);
 
-  // this is roles selected in the multiselect
-  const [roles, setRoles] = useState(ROLES_MAP.map((r) => r.selectValue));
-
   // the dom el for drawing the chart
   const bars = useRef();
 
@@ -127,23 +99,20 @@ export function TopicFrequencyGraphWidget({ data, dateTime }) {
       return;
     }
 
-    // here is where we can filter array for participants
-    const filteredData = filterData(data, roles);
-
     // sort the api response based on the dropdown choices
-    sortData(filteredData, order);
+    sortData(data, order);
 
-    const reasons = [];
+    const topics = [];
     const counts = [];
     const rows = [];
 
-    filteredData.forEach((dataPoint) => {
+    data.forEach((dataPoint) => {
       if (!showAccessibleData) {
-        reasons.push(dataPoint.reason);
+        topics.push(dataPoint.topic);
         counts.push(dataPoint.count);
       } else {
         rows.push({
-          data: [dataPoint.reason, dataPoint.count],
+          data: [dataPoint.topic, dataPoint.count],
         });
       }
     });
@@ -156,12 +125,12 @@ export function TopicFrequencyGraphWidget({ data, dateTime }) {
 
     const trace = {
       type: 'bar',
-      x: reasons.map((reason) => reasonsWithLineBreaks(reason)),
+      x: topics.map((topic) => topicsWithLineBreaks(topic)),
       y: counts,
       hoverinfo: 'y',
     };
 
-    const width = reasons.length * 180;
+    const width = topics.length * 180;
 
     const layout = {
       bargap: 0.5,
@@ -196,7 +165,7 @@ export function TopicFrequencyGraphWidget({ data, dateTime }) {
 
     // draw the plot
     Plotly.newPlot(bars.current, [trace], layout, { displayModeBar: false, hovermode: 'none' });
-  }, [data, order, roles, showAccessibleData]);
+  }, [data, order, setOrder, showAccessibleData]);
 
   if (!data) {
     return <p>Loading...</p>;
@@ -216,7 +185,7 @@ export function TopicFrequencyGraphWidget({ data, dateTime }) {
 
   const onApplyRoles = (selected) => {
     // we may get these as a string, so we cast them to ints
-    setRoles(selected.map((s) => parseInt(s, 10)));
+    updateRoles(selected.map((s) => parseInt(s, 10)));
   };
 
   // toggle the data table
@@ -294,12 +263,12 @@ TopicFrequencyGraphWidget.propTypes = {
   data: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.shape({
-        reason: PropTypes.string,
+        topic: PropTypes.string,
         count: PropTypes.number,
-        roles: PropTypes.arrayOf(PropTypes.string),
       }),
     ), PropTypes.shape({}),
   ]).isRequired,
+  updateRoles: PropTypes.func.isRequired,
 };
 
 TopicFrequencyGraphWidget.defaultProps = {

--- a/frontend/src/widgets/__tests__/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/__tests__/TopicFrequencyGraph.js
@@ -8,42 +8,34 @@ import {
 import userEvent from '@testing-library/user-event';
 import {
   TopicFrequencyGraphWidget,
-  reasonsWithLineBreaks,
-  filterData,
+  topicsWithLineBreaks,
   sortData,
   SORT_ORDER,
-  ROLES_MAP,
 } from '../TopicFrequencyGraph';
 
 const TEST_DATA = [{
-  reason: 'CLASS: Instructional Support',
+  topic: 'CLASS: Instructional Support',
   count: 12,
-  roles: [],
 },
 {
-  reason: 'Community and Self-Assessment',
+  topic: 'Community and Self-Assessment',
   count: 155,
-  roles: ['System Specialist'],
 },
 {
-  reason: 'Family Support Services',
+  topic: 'Family Support Services',
   count: 53,
-  roles: [],
 },
 {
-  reason: 'Fiscal / Budget',
+  topic: 'Fiscal / Budget',
   count: 0,
-  roles: [],
 },
 {
-  reason: 'Five-Year Grant',
+  topic: 'Five-Year Grant',
   count: 33,
-  roles: [],
 },
 {
-  reason: 'Human Resources',
+  topic: 'Human Resources',
   count: 0,
-  roles: ['System Specialist'],
 }];
 
 const renderArGraphOverview = async (props) => (
@@ -60,77 +52,34 @@ describe('Topic & Frequency Graph Widget', () => {
     await expect(document.querySelector('svg')).toBeInTheDocument();
   });
 
-  it('correctly filters data', () => {
-    const data = [...TEST_DATA];
-
-    const filter = [ROLES_MAP.find((role) => role.value === 'System Specialist').selectValue];
-    const filteredData = filterData(data, filter);
-    expect(filteredData).toStrictEqual([{
-      reason: 'CLASS: Instructional Support',
-      count: 0,
-      roles: [],
-    },
-    {
-      reason: 'Community and Self-Assessment',
-      count: 155,
-      roles: ['System Specialist'],
-    },
-    {
-      reason: 'Family Support Services',
-      count: 0,
-      roles: [],
-    },
-    {
-      reason: 'Fiscal / Budget',
-      count: 0,
-      roles: [],
-    },
-    {
-      reason: 'Five-Year Grant',
-      count: 0,
-      roles: [],
-    },
-    {
-      reason: 'Human Resources',
-      count: 0,
-      roles: ['System Specialist'],
-    }]);
-  });
-
   it('correctly sorts data by count', () => {
     const data = [...TEST_DATA];
     sortData(data, SORT_ORDER.DESC);
 
     expect(data).toStrictEqual([
       {
-        reason: 'Community and Self-Assessment',
+        topic: 'Community and Self-Assessment',
         count: 155,
-        roles: ['System Specialist'],
       },
       {
-        reason: 'Family Support Services',
+        topic: 'Family Support Services',
         count: 53,
-        roles: [],
       },
       {
-        reason: 'Five-Year Grant',
+        topic: 'Five-Year Grant',
         count: 33,
-        roles: [],
       },
       {
-        reason: 'CLASS: Instructional Support',
+        topic: 'CLASS: Instructional Support',
         count: 12,
-        roles: [],
       },
       {
-        reason: 'Fiscal / Budget',
+        topic: 'Fiscal / Budget',
         count: 0,
-        roles: [],
       },
       {
-        reason: 'Human Resources',
+        topic: 'Human Resources',
         count: 0,
-        roles: ['System Specialist'],
       },
 
     ]);
@@ -143,34 +92,28 @@ describe('Topic & Frequency Graph Widget', () => {
 
     expect(data).toStrictEqual([
       {
-        reason: 'CLASS: Instructional Support',
+        topic: 'CLASS: Instructional Support',
         count: 12,
-        roles: [],
       },
       {
-        reason: 'Community and Self-Assessment',
+        topic: 'Community and Self-Assessment',
         count: 155,
-        roles: ['System Specialist'],
       },
       {
-        reason: 'Family Support Services',
+        topic: 'Family Support Services',
         count: 53,
-        roles: [],
       },
       {
-        reason: 'Fiscal / Budget',
+        topic: 'Fiscal / Budget',
         count: 0,
-        roles: [],
       },
       {
-        reason: 'Five-Year Grant',
+        topic: 'Five-Year Grant',
         count: 33,
-        roles: [],
       },
       {
-        reason: 'Human Resources',
+        topic: 'Human Resources',
         count: 0,
-        roles: ['System Specialist'],
       },
     ]);
   });
@@ -183,32 +126,8 @@ describe('Topic & Frequency Graph Widget', () => {
   });
 
   it('correctly inserts line breaks', () => {
-    const formattedReason = reasonsWithLineBreaks('Equity, Culture &amp; Language');
-    expect(formattedReason).toBe(' Equity,<br />Culture<br />&amp;<br />Language');
-  });
-
-  it('the filter control works', async () => {
-    renderArGraphOverview({ data: [...TEST_DATA] });
-
-    const button = screen.getByRole('button', { name: /change filter by specialists/i });
-    userEvent.click(button);
-
-    const barSelector = 'g.point';
-
-    // eslint-disable-next-line no-underscore-dangle
-    let height = document.querySelectorAll(barSelector)[0].__data__.y;
-    expect(height).toBe(155);
-
-    const systemSpecialist = screen.getByRole('checkbox', { name: /select system specialist \(ss\)/i });
-
-    userEvent.click(systemSpecialist);
-
-    const apply = screen.getByRole('button', { name: /apply filters/i });
-    userEvent.click(apply);
-
-    // eslint-disable-next-line no-underscore-dangle
-    height = document.querySelectorAll(barSelector)[0].__data__.y;
-    expect(height).toBe(0);
+    const formattedtopic = topicsWithLineBreaks('Equity, Culture &amp; Language');
+    expect(formattedtopic).toBe(' Equity,<br />Culture<br />&amp;<br />Language');
   });
 
   it('the sort control works', async () => {

--- a/frontend/src/widgets/withWidgetData.js
+++ b/frontend/src/widgets/withWidgetData.js
@@ -16,7 +16,7 @@ const withWidgetData = (Widget, widgetId) => {
     const [data, updateData] = useState({});
 
     const {
-      dateRange, region, allRegions, loadingOverride, skipLoading, errorOverride,
+      dateRange, region, allRegions, loadingOverride, skipLoading, errorOverride, roles,
     } = props;
 
     const selectedRegion = region || allRegions[0];
@@ -25,7 +25,7 @@ const withWidgetData = (Widget, widgetId) => {
       const fetch = async () => {
         try {
           updateLoading(true);
-          const fetchedData = await fetchWidget(widgetId, selectedRegion, dateRange);
+          const fetchedData = await fetchWidget(widgetId, selectedRegion, dateRange, roles);
           updateData(fetchedData);
           updateError('');
         } catch (e) {
@@ -36,7 +36,7 @@ const withWidgetData = (Widget, widgetId) => {
       };
 
       fetch();
-    }, [selectedRegion, dateRange]);
+    }, [selectedRegion, dateRange, roles]);
 
     if ((loading || loadingOverride) && !skipLoading) {
       return (
@@ -65,6 +65,7 @@ const withWidgetData = (Widget, widgetId) => {
     skipLoading: PropTypes.bool,
     startDate: PropTypes.string,
     dateRange: PropTypes.string,
+    roles: PropTypes.string,
   };
 
   WidgetWrapper.defaultProps = {
@@ -74,6 +75,7 @@ const withWidgetData = (Widget, widgetId) => {
     region: 0,
     startDate: '',
     dateRange: '',
+    roles: '',
   };
 
   return WidgetWrapper;


### PR DESCRIPTION
## Description of change
Discovered via testing that the raw:true attribute seemed to add an unpredictable number to the count returned for the Topic/Frequency graph. Testing found that duplicate reports were being included in the query results. The query was modified after some research. I verified the correct number was being returned via direct SQL queries and proceeded from there.

This change to the query necessitated moving the role filtering from the frontend to the backend. This also improves the data after you filter, since the role query is added to the query that actually counts the results.

## How to test
Visit the regional dashboard. View the topic/frequency graph and check the numbers against CSV export or your local database. Likewise, check with the roles filter.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-314


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
