### PR TITLE
[TTAHUB-222] reduce data submission size when creating an activity report

### DIFF
--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -458,7 +458,7 @@ export async function saveReport(req, res) {
 
     newReport.lastUpdatedById = userId;
 
-    const savedReport = await createOrUpdate(newReport, report);
+    const savedReport = await createOrUpdate({ ...report, ...newReport }, report);
     if (savedReport.collaborators) {
     // only include collaborators that aren't already in the report
       const newCollaborators = savedReport.collaborators.filter((c) => {

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -576,9 +576,22 @@ export async function createOrUpdate(newActivityReport, report) {
       await saveNotes(id, specialistNextSteps, false, transaction);
     }
 
-    if (allFields.activityRecipientType === 'non-grantee' && objectivesWithoutGoals) {
+    const recipientType = () => {
+      if (allFields.activityRecipientType) {
+        return allFields.activityRecipientType;
+      }
+      if (report.activityRecipientType) {
+        return report.activityRecipientType;
+      }
+
+      return '';
+    };
+
+    const activityRecipientType = recipientType();
+
+    if (activityRecipientType === 'non-grantee' && objectivesWithoutGoals) {
       await saveObjectivesForReport(objectivesWithoutGoals, savedReport, transaction);
-    } else if (allFields.activityRecipientType === 'grantee' && goals) {
+    } else if (activityRecipientType === 'grantee' && goals) {
       await saveGoalsForReport(goals, savedReport, transaction);
     }
   });


### PR DESCRIPTION
## Description of change
PUT requests when saving an activity report now only pass the fields which have changed. Minor adjustments were made to the backend code to accept these smaller request bodies.

## How to test
Create an activity report, fill it out, save it, exit it, return to it. If possible, inspect the packet sizes in the network pane in your developer tools of choice and admire those tiny little numbers.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-222


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
