### PR TITLE
[TTAHUB-322/330] feature flag admin csv export, redo date picker select

### DIFF
--- a/frontend/src/components/ButtonSelect.css
+++ b/frontend/src/components/ButtonSelect.css
@@ -20,7 +20,7 @@
     display: block;
     margin-top: 1em;
     max-width: 240px;
-    padding: 0 1em;
+    padding: 0 1rem;
 }
 
 .smart-hub--button-select-range-button {
@@ -29,29 +29,49 @@
     display: block;
     outline: 0.25rem transparent;
     outline-offset: 0;
-    padding: 11px;    
+    padding: 1rem;    
     text-align: left;    
     width: 100%;
 }
 
+.smart-hub--button-select-range-button:hover{
+    background: #F8F8F8; 
+}
+
 .smart-hub--button-select-range-button[aria-pressed="true"] {
-    background: #F8F8F8;  
     color: #0166AB;
     font-weight: bold;
 }
 
 .smart-hub--button-select-checkmark {
     float: right;
-    margin-top: -9px;
-    width: 32px;
 }
-.smart-hub--button-select-menu .ttahub-date-range-picker {
-    margin: 0.5em 0;
+
+/**
+** Date range picker styles
+*/
+
+.smart-hub--button-select-menu-date-picker {
+    border-top: 1px solid #eceef1;
+    padding: 0 1rem;    
+}
+
+.smart-hub--button-select-menu-date-picker-single {
+    display: flex;
+}
+
+.smart-hub--button-select-menu-date-picker-single .SingleDatePicker{
+    flex: 2;
+}
+.smart-hub--button-select-menu-date-picker-single .SingleDatePickerInput {
+    display: block;
 }
 
 .smart-hub--button-select-menu .DateInput {
-    width: 97px;
+    width: 100%;
 }
+
+
 
 /**
 * The styles for the "style as select" prop

--- a/frontend/src/components/ButtonSelect.js
+++ b/frontend/src/components/ButtonSelect.js
@@ -1,10 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import DateRangePicker from './DateRangePicker';
+import {
+  SingleDatePicker, isInclusivelyBeforeDay,
+} from 'react-dates';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCalendar, faCheck } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@trussworks/react-uswds';
 import { CUSTOM_DATE_RANGE } from '../pages/RegionalDashboard/constants';
+import { DATE_FMT, EARLIEST_INC_FILTER_DATE } from '../Constants';
 import './ButtonSelect.css';
 import triangleDown from '../images/triange_down.png';
-import check from '../images/check.svg';
 
 function ButtonSelect(props) {
   const {
@@ -18,16 +23,21 @@ function ButtonSelect(props) {
     ariaName,
     hasDateRange,
     updateDateRange,
-    dateRangeShouldGainFocus,
-    dateRangePickerId,
+    startDatePickerId,
+    endDatePickerId,
     dateRange,
   } = props;
 
+  const [checked, setChecked] = useState(applied);
   const [selectedItem, setSelectedItem] = useState();
   const [menuIsOpen, setMenuIsOpen] = useState(false);
   const [range, setRange] = useState();
   const [showDateError, setShowDateError] = useState(false);
 
+  const [startDate, setStartDate] = useState();
+  const [startDateFocused, setStartDateFocused] = useState(false);
+  const [endDate, setEndDate] = useState();
+  const [endDateFocused, setEndDateFocused] = useState(false);
   /**
    * just so we always have something selected
    * */
@@ -38,6 +48,18 @@ function ButtonSelect(props) {
   }, [applied, initialValue, selectedItem]);
 
   /**
+   * To calculate where the checkmark should go :)
+   */
+
+  useEffect(() => {
+    if (selectedItem && selectedItem.value !== applied) {
+      setChecked(selectedItem.value);
+    } else {
+      setChecked(applied);
+    }
+  }, [applied, selectedItem]);
+
+  /**
    * we store the date range in here so that we can apply it up the chain
    * when the calendar control is updated
    */
@@ -45,7 +67,19 @@ function ButtonSelect(props) {
     if (!range) {
       setRange(dateRange);
     }
-  }, [range, dateRange]);
+
+    setRange(`${startDate ? startDate.format(DATE_FMT) : ''}-${endDate ? endDate.format(DATE_FMT) : ''}`);
+  }, [range, dateRange, startDate, endDate]);
+
+  /** when to focus on the start date input */
+  useEffect(() => {
+    if (hasDateRange && selectedItem && selectedItem.value === CUSTOM_DATE_RANGE) {
+      const input = document.getElementById(startDatePickerId);
+      if (input) {
+        input.focus();
+      }
+    }
+  }, [hasDateRange, selectedItem, startDatePickerId]);
 
   /**
    * apply the selected item and close the menu
@@ -59,7 +93,6 @@ function ButtonSelect(props) {
 
       if (!isValidDateRange) {
         setShowDateError(true);
-
         return;
       }
 
@@ -68,16 +101,6 @@ function ButtonSelect(props) {
 
     onApply(selectedItem);
     setMenuIsOpen(false);
-  };
-
-  /**
-   * Update the local date range when the calendar control is updated
-   * @param {string} query
-   * @param {string} date
-   */
-  const onUpdateDateRange = (query, date) => {
-    setRange(date);
-    setShowDateError(false);
   };
 
   /**
@@ -94,7 +117,7 @@ function ButtonSelect(props) {
    * Close the menu on blur, with some extenuating circumstance
    *
    * @param {Event} e
-   * @returns
+   * @returns void
    */
   const onBlur = (e) => {
     // if we're within the same menu, do nothing
@@ -103,11 +126,29 @@ function ButtonSelect(props) {
     }
 
     // if we've a date range, also do nothing on blur when we click on those
-    if (e.target.matches('.DateRangePicker_picker *')) {
+    if (e.target.matches('.CalendarDay, .DayPickerNavigation, .DayPickerNavigation_button')) {
       return;
     }
 
     setMenuIsOpen(false);
+    setShowDateError(false);
+  };
+
+  /**
+   * @param {Object} day moment object
+   * @param {String} startOrEnd either "start" or "end"
+   * returns bool
+   */
+
+  // eslint-disable-next-line no-unused-vars
+  const isOutsideRange = (day, startOrEnd) => {
+    if (startOrEnd === 'start') {
+      return isInclusivelyBeforeDay(day, EARLIEST_INC_FILTER_DATE)
+        || (endDate && day.isAfter(endDate));
+    }
+
+    return isInclusivelyBeforeDay(day, EARLIEST_INC_FILTER_DATE)
+      || (startDate && day.isBefore(startDate));
   };
 
   // get label text
@@ -134,7 +175,7 @@ function ButtonSelect(props) {
         ? (
           <div className="smart-hub--button-select-menu" role="group" aria-describedby={labelId}>
             <span className={hasDateRange ? 'smart-hub--button-select-menu-label' : 'smart-hub--button-select-menu-label sr-only'} id={labelId}><strong>{labelText}</strong></span>
-            <fieldset className="margin-0 border-0">
+            <fieldset className="margin-0 border-0 padding-0">
               { options.map((option) => (
                 <button
                   type="button"
@@ -149,30 +190,89 @@ function ButtonSelect(props) {
                   }}
                 >
                   {option.label}
-                  { option.value === applied ? <img className="smart-hub--button-select-checkmark" src={check} alt="" aria-hidden="true" /> : null }
+                  { option.value === checked ? <FontAwesomeIcon className="smart-hub--button-select-checkmark" size="1x" color="#005ea2" icon={faCheck} /> : null }
                 </button>
               ))}
 
               { hasDateRange && selectedItem && selectedItem.value === CUSTOM_DATE_RANGE
                 ? (
-                  <>
+                  <div className="smart-hub--button-select-menu-date-picker">
                     { showDateError ? (
-                      <div className="usa-alert usa-alert--error margin-1" role="alert">
-                        <div className="usa-alert__body">
-                          <p className="usa-alert__text">
-                            Please enter a valid date range
-                          </p>
-                        </div>
+                      <div className="usa-alert usa-alert--warning usa-alert--no-icon margin-top-1 margin-0" role="alert">
+                        <p className="usa-alert__text padding-1">
+                          Reports are available from 09/01/2020.
+                          <br />
+                          Use the format MM/DD/YYYY.
+                        </p>
                       </div>
                     ) : null }
-                    <DateRangePicker
-                      id={dateRangePickerId}
-                      query={dateRange}
-                      onUpdateFilter={onUpdateDateRange}
-                      classNames={['display-flex']}
-                      gainFocus={dateRangeShouldGainFocus}
-                    />
-                  </>
+                    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                    <label className="display-block margin-top-2" htmlFor={startDatePickerId}>Start Date</label>
+                    <p><small>mm/dd/yyyy</small></p>
+                    <div className="smart-hub--button-select-menu-date-picker-single">
+                      <SingleDatePicker
+                        small
+                        ariaLabel="start date"
+                        id={startDatePickerId}
+                        focused={startDateFocused}
+                        numberOfMonths={1}
+                        hideKeyboardShortcutsPanel
+                        isOutsideRange={(day) => isOutsideRange(day, 'start')}
+                        onFocusChange={({ focused }) => {
+                          if (!focused) {
+                            setStartDateFocused(focused);
+                          }
+                        }}
+                        onDateChange={(selectedDate) => {
+                          setStartDate(selectedDate);
+                          setStartDateFocused(false);
+                        }}
+                        date={startDate}
+                      />
+                      <Button
+                        onClick={() => setStartDateFocused(true)}
+                        aria-label="open start date picker calendar"
+                        type="button"
+                        unstyled
+                        className="margin-top-auto margin-bottom-auto font-sans-xs margin-left-1 smart-hub--filter-date-picker-button"
+                      >
+                        <FontAwesomeIcon size="1x" color="gray" icon={faCalendar} />
+                      </Button>
+                    </div>
+                    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                    <label className="display-block margin-top-2" htmlFor={endDatePickerId}>End Date</label>
+                    <p><small>mm/dd/yyyy</small></p>
+                    <div className="smart-hub--button-select-menu-date-picker-single">
+                      <SingleDatePicker
+                        ariaLabel="end date"
+                        small
+                        id={endDatePickerId}
+                        focused={endDateFocused}
+                        numberOfMonths={1}
+                        hideKeyboardShortcutsPanel
+                        isOutsideRange={(day) => isOutsideRange(day, 'END')}
+                        onFocusChange={({ focused }) => {
+                          if (!focused) {
+                            setEndDateFocused(focused);
+                          }
+                        }}
+                        onDateChange={(selectedDate) => {
+                          setEndDate(selectedDate);
+                          setEndDateFocused(false);
+                        }}
+                        date={endDate}
+                      />
+                      <Button
+                        onClick={() => setEndDateFocused(true)}
+                        aria-label="open end date picker calendar"
+                        type="button"
+                        unstyled
+                        className="margin-top-auto margin-bottom-auto font-sans-xs margin-left-1 smart-hub--filter-date-picker-button"
+                      >
+                        <FontAwesomeIcon size="1x" color="gray" icon={faCalendar} />
+                      </Button>
+                    </div>
+                  </div>
                 ) : null }
             </fieldset>
             <button type="button" onKeyDown={onKeyDown} className="usa-button smart-hub--button margin-2" onClick={onApplyClick} aria-label={`Apply filters for the ${ariaName}`}>Apply</button>
@@ -205,18 +305,18 @@ ButtonSelect.propTypes = {
   // props for handling the date range select
   hasDateRange: PropTypes.bool,
   updateDateRange: PropTypes.func,
-  dateRangeShouldGainFocus: PropTypes.bool,
   dateRange: PropTypes.string,
-  dateRangePickerId: PropTypes.string,
+  startDatePickerId: PropTypes.string,
+  endDatePickerId: PropTypes.string,
 };
 
 ButtonSelect.defaultProps = {
   styleAsSelect: false,
   hasDateRange: false,
-  dateRangeShouldGainFocus: false,
   updateDateRange: () => {},
   dateRange: '',
-  dateRangePickerId: '',
+  startDatePickerId: '',
+  endDatePickerId: '',
 };
 
 export default ButtonSelect;

--- a/frontend/src/components/__tests__/ButtonSelect.js
+++ b/frontend/src/components/__tests__/ButtonSelect.js
@@ -60,15 +60,23 @@ describe('The Button Select component', () => {
 
     fireEvent.click(custom);
 
-    const calendar = screen.getByRole('button', {
-      name: /open calendar/i,
+    const sdcalendar = screen.getByRole('button', {
+      name: /open start date picker calendar/i,
     });
 
-    fireEvent.click(calendar);
+    fireEvent.click(sdcalendar);
 
-    const [day1, day2] = document.querySelectorAll('.DateRangePicker_picker .CalendarDay');
+    const [day1] = document.querySelectorAll('.SingleDatePicker_picker .CalendarDay');
 
     fireEvent.click(day1);
+
+    const edcalendar = screen.getByRole('button', {
+      name: /open end date picker calendar/i,
+    });
+
+    fireEvent.click(edcalendar);
+    const [, day2] = document.querySelectorAll('.SingleDatePicker_picker .CalendarDay');
+
     fireEvent.click(day2);
 
     const startDate = screen.getByRole('textbox', {
@@ -84,6 +92,48 @@ describe('The Button Select component', () => {
     fireEvent.click(apply);
 
     expect(onApply).toHaveBeenCalled();
+  });
+
+  it('shows an error message', async () => {
+    const onApply = jest.fn();
+    renderButtonSelect(onApply);
+
+    const openMenu = screen.getByRole('button', {
+      name: /open menu/i,
+    });
+
+    fireEvent.click(openMenu);
+
+    const custom = screen.getByRole('button', {
+      name: /select to view data from custom\. select apply filters button to apply selection/i,
+    });
+
+    fireEvent.click(custom);
+
+    const sdcalendar = screen.getByRole('button', {
+      name: /open start date picker calendar/i,
+    });
+
+    fireEvent.click(sdcalendar);
+
+    const [day1] = document.querySelectorAll('.SingleDatePicker_picker .CalendarDay');
+
+    fireEvent.click(day1);
+
+    const startDate = screen.getByRole('textbox', {
+      name: /start date/i,
+    });
+
+    expect(startDate).toBeInTheDocument();
+
+    const apply = screen.getByRole('button', {
+      name: 'Apply filters for the menu',
+    });
+
+    fireEvent.click(apply);
+
+    const error = screen.getByText(/reports are available from 09\/01\/2020\.use the format mm\/dd\/yyyy\./i);
+    expect(error).toBeInTheDocument();
   });
 
   it('handles blur', () => {
@@ -107,6 +157,10 @@ describe('The Button Select component', () => {
     });
 
     // is this the best way to fire on blur? yikes
+    userEvent.tab();
+    userEvent.tab();
+    userEvent.tab();
+    userEvent.tab();
     userEvent.tab();
     userEvent.tab();
     userEvent.tab();

--- a/frontend/src/pages/RegionalDashboard/components/DateRangeSelect.js
+++ b/frontend/src/pages/RegionalDashboard/components/DateRangeSelect.js
@@ -11,7 +11,6 @@ export default function DateRangeSelect(props) {
     updateDateRange,
     dateRange,
     customDateRangeOption,
-    gainFocus,
   } = props;
 
   const initialValue = {
@@ -24,15 +23,15 @@ export default function DateRangeSelect(props) {
       onApply={onApply}
       initialValue={initialValue}
       labelId="dateRangeOptionsLabel"
-      labelText="Select the date range for TTA activities"
+      labelText="Choose activity start date range."
       options={DATE_OPTIONS}
       applied={selectedDateRangeOption}
       hasDateRange
       customDateRangeOption={customDateRangeOption}
       updateDateRange={updateDateRange}
-      dateRangeShouldGainFocus={gainFocus}
       dateRange={dateRange}
-      dateRangePickerId="dashboard-date-range-picker"
+      startDatePickerId="dashboardStartDatePicker"
+      endDatePickerId="dashboardEndDatePicker"
       ariaName="date range options menu"
     />
   );
@@ -42,7 +41,6 @@ DateRangeSelect.propTypes = {
   onApply: PropTypes.func.isRequired,
   selectedDateRangeOption: PropTypes.number.isRequired,
   updateDateRange: PropTypes.func.isRequired,
-  gainFocus: PropTypes.bool.isRequired,
   dateRange: PropTypes.string.isRequired,
   customDateRangeOption: PropTypes.number.isRequired,
 };

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -47,9 +47,7 @@ export default function RegionalDashboard({ user }) {
   // eslint-disable-next-line max-len
   const [appliedRegion, updateAppliedRegion] = useState(hasCentralOffice ? 14 : regions[0]);
   const [selectedDateRangeOption, updateSelectedDateRangeOption] = useState(1);
-
   const [dateRange, updateDateRange] = useState(defaultDate);
-  const [gainFocus, setGainFocus] = useState(false);
   const [dateTime, setDateTime] = useState(getDateTimeObject(1, defaultDate));
 
   /*
@@ -92,15 +90,9 @@ export default function RegionalDashboard({ user }) {
 
   useEffect(() => {
     const isCustom = selectedDateRangeOption === CUSTOM_DATE_RANGE;
-
     if (!isCustom) {
       const newRange = formatDateRange({ lastThirtyDays: true, forDateTime: true });
       updateDateRange(newRange);
-    }
-
-    if (isCustom) {
-      // set focus to DateRangePicker 1st input
-      setGainFocus(true);
     }
   }, [selectedDateRangeOption]);
 
@@ -154,7 +146,6 @@ export default function RegionalDashboard({ user }) {
               customDateRangeOption={CUSTOM_DATE_RANGE}
               dateRange={dateRange}
               updateDateRange={updateDateRange}
-              gainFocus={gainFocus}
               dateTime={dateTime}
             />
             <DateTime classNames="display-flex flex-align-center" timestamp={dateTime.timestamp} label={dateTime.label} />

--- a/frontend/src/widgets/__tests__/TotalHrsAndGranteeGraph.js
+++ b/frontend/src/widgets/__tests__/TotalHrsAndGranteeGraph.js
@@ -6,16 +6,16 @@ import { TotalHrsAndGranteeGraph, LegendControl } from '../TotalHrsAndGranteeGra
 
 const TEST_DATA_MONTHS = [
   {
-    name: 'Grantee Rec TTA', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [1, 2, 3, 4, 5, 6], month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    name: 'Grantee Rec TTA', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [1, 2, 3, 4, 5, 6], month: [false, false, false, false, false, false],
   },
   {
-    name: 'Hours of Training', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [7, 8, 9, 0, 0, 0], month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    name: 'Hours of Training', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [7, 8, 9, 0, 0, 0], month: [false, false, false, false, false, false],
   },
   {
-    name: 'Hours of Technical Assistance', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [0, 0, 0, 10, 11.2348732847, 12], month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    name: 'Hours of Technical Assistance', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [0, 0, 0, 10, 11.2348732847, 12], month: [false, false, false, false, false, false],
   },
   {
-    name: 'Hours of Both', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [0, 13, 0, 14, 0, 0], month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    name: 'Hours of Both', x: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'], y: [0, 13, 0, 14, 0, 0], month: [false, false, false, false, false, false],
   },
 ];
 

--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -84,6 +84,11 @@ export default class ActivityReport {
     return !_.isUndefined(adminScope);
   }
 
+  canSeeBehindFeatureFlags() {
+    // we can build upon this at some point
+    return this.isAdmin();
+  }
+
   isAuthor() {
     return this.user.id === this.activityReport.userId;
   }

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -736,7 +736,11 @@ async function getDownloadableActivityReports(where) {
   );
 }
 
-export async function getAllDownloadableActivityReports(readRegions, filters) {
+export async function getAllDownloadableActivityReports(
+  readRegions,
+  filters,
+  canSeeBehindFeatureFlags = false,
+) {
   const regions = readRegions || [];
 
   const scopes = filtersToScopes(filters);
@@ -746,9 +750,12 @@ export async function getAllDownloadableActivityReports(readRegions, filters) {
       [Op.in]: regions,
     },
     status: REPORT_STATUSES.APPROVED,
-    imported: null,
     [Op.and]: scopes,
   };
+
+  if (!canSeeBehindFeatureFlags) {
+    return getDownloadableActivityReports({ ...where, imported: null });
+  }
 
   return getDownloadableActivityReports(where);
 }
@@ -794,12 +801,16 @@ export async function getAllDownloadableActivityReportAlerts(userId, filters) {
  */
 export async function getDownloadableActivityReportsByIds(readRegions, {
   report = [],
-}) {
+}, canSeeBehindFeatureFlags = false) {
   const regions = readRegions || [];
   // Create a Set to ensure unique ordered values
   const reportSet = Array.isArray(report) ? new Set(report) : new Set([report]);
   const reportIds = [...reportSet].filter((i) => /\d+/.test(i));
-  const where = { regionId: regions, imported: null, id: { [Op.in]: reportIds } };
+  const where = { regionId: regions, id: { [Op.in]: reportIds } };
+
+  if (!canSeeBehindFeatureFlags) {
+    return getDownloadableActivityReports({ ...where, imported: null });
+  }
 
   return getDownloadableActivityReports(where);
 }

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -92,12 +92,28 @@ describe('Activity Reports DB service', () => {
 
   afterAll(async () => {
     const reports = await ActivityReport
-      .findAll({ where: { userId: [mockUser.id, mockUserTwo.id, mockUserThree.id] } });
+      .findAll({
+        where: {
+          userId:
+        [
+          mockUser.id,
+          mockUserTwo.id,
+          mockUserThree.id,
+        ],
+        },
+      });
     const ids = reports.map((report) => report.id);
     await NextStep.destroy({ where: { activityReportId: ids } });
     await ActivityRecipient.destroy({ where: { activityReportId: ids } });
     await ActivityReport.destroy({ where: { id: ids } });
-    await User.destroy({ where: { id: [mockUser.id, mockUserTwo.id] } });
+    await User.destroy({
+      where: {
+        id: [
+          mockUser.id,
+          mockUserTwo.id,
+          mockUserThree.id],
+      },
+    });
     await Permission.destroy({ where: { userId: mockUserTwo.id } });
     await NonGrantee.destroy({ where: { id: GRANTEE_ID } });
     await Grant.destroy({ where: { id: [GRANTEE_ID, GRANTEE_ID_SORTING] } });
@@ -536,6 +552,19 @@ describe('Activity Reports DB service', () => {
       const { rows } = result;
       const ids = rows.map((row) => row.id);
       expect(ids).not.toContain(legacyReport.id);
+    });
+
+    it('will return legacy reports', async () => {
+      const result = await getAllDownloadableActivityReports([14], {}, true);
+      const { rows } = result;
+      const ids = rows.map((row) => row.id);
+      expect(ids).toContain(legacyReport.id);
+
+      const secondResult = await getDownloadableActivityReportsByIds([14],
+        { report: [legacyReport.id] }, true);
+
+      expect(secondResult.rows.length).toEqual(1);
+      expect(secondResult.rows[0].id).toEqual(legacyReport.id);
     });
 
     it('excludes non-approved reports', async () => {


### PR DESCRIPTION
## Description of change
Legacy ARs have been imported into the Hub but are not included on CSV downloads. This PR allows admin users to download the CSV's with the legacy data to inspect what was missing in order to decide how to proceed with reconciliation. Non-admin users should experience no change in functionality

The date range select on the dashboard page changed significantly from an earlier, previously unseen mockup. The inputs are spaced apart and function slightly differently, the checkmark behavior has changed, and instructions have been added.

## How to test

Download CSV's from the Activity Report table (including legacy reports) as an admin. Then, download them as a non-admin. You should see reports included on the CSV as an admin; you should see them not included as a non-admin.

View the regional-dashboard. Use the region selector and the date range selector, ensure they still work and that the match the mockup in the JIRA ticket.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-322
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-330

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
