### PR TITLE
fix bug when saving with no AR type selected

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -582,10 +582,10 @@ export async function createOrUpdate(newActivityReport, report) {
      */
 
     const recipientType = () => {
-      if (allFields.activityRecipientType) {
+      if (allFields && allFields.activityRecipientType) {
         return allFields.activityRecipientType;
       }
-      if (report.activityRecipientType) {
+      if (report && report.activityRecipientType) {
         return report.activityRecipientType;
       }
 

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -160,6 +160,53 @@ describe('Activity Reports DB service', () => {
       expect(report.id).toEqual(3334);
     });
 
+    it('creates a report with no recipient type', async () => {
+      const emptyReport = {
+        ECLKCResourcesUsed: [{ value: '' }],
+        activityRecipientType: null,
+        activityRecipients: [],
+        activityType: [],
+        additionalNotes: null,
+        approvingManagerId: null,
+        attachments: [],
+        collaborators: [],
+        context: '',
+        deliveryMethod: null,
+        duration: null,
+        endDate: null,
+        goals: [],
+        granteeNextSteps: [],
+        grantees: [],
+        nonECLKCResourcesUsed: [{ value: '' }],
+        numberOfParticipants: null,
+        objectivesWithoutGoals: [],
+        otherResources: [],
+        participantCategory: '',
+        participants: [],
+        programTypes: [],
+        reason: [],
+        requester: null,
+        specialistNextSteps: [],
+        startDate: null,
+        status: 'draft',
+        targetPopulations: [],
+        topics: [],
+        pageState: {
+          1: 'Not started',
+          2: 'Not started',
+          3: 'Not started',
+          4: 'Not started',
+        },
+        userId: mockUser.id,
+        regionId: 1,
+        ttaType: [],
+        lastUpdatedById: 1,
+      };
+
+      const report = await createOrUpdate(emptyReport);
+      expect(report.status).toEqual('draft');
+    });
+
     it('creates a new report', async () => {
       const beginningARCount = await ActivityReport.findAll({ where: { userId: mockUser.id } });
       const report = await createOrUpdate(reportObject);


### PR DESCRIPTION
## Description of change
Due to recent changes, if a user attempts to save a report with first selecting recipient type, they will encounter an error. This is a fix for that.

## How to test
Start a new report. Jump to "Next Steps" without saving. The report should save.

## Issue(s)


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [n/a] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
