### PR TITLE
[TTAHUB-165/169] include roles w/author & collaborators on CSV & fix issue where reason list test would sometimes fail. 

### DIFF
--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -19,7 +19,7 @@ function transformSimpleValue(instance, field) {
 /*
  * Generates a function that can transform values of a related model
  * @param {string} field The field of the related model
- * @param {string} key The key on the related model to transform
+ * @param {string[]} props The key on the related model to transform
  * @returns {function} A function that will perform the transformation
  */
 function transformRelatedModel(field, prop) {
@@ -140,11 +140,11 @@ async function transformGoalsAndObjectives(report) {
 
 const arTransformers = [
   'displayId',
-  transformRelatedModel('author', 'name'),
+  transformRelatedModel('author', 'fullName'),
   transformRelatedModel('approvingManager', 'name'),
   transformRelatedModel('lastUpdatedBy', 'name'),
   'requester',
-  transformRelatedModel('collaborators', 'name'),
+  transformRelatedModel('collaborators', 'fullName'),
   'programTypes',
   'targetPopulations',
   'virtualDeliveryType',

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -12,6 +12,7 @@ describe('activityReportToCsvRecord', () => {
     name: 'Arthur',
     hsesUserId: '2099',
     hsesUsername: 'arthur.author',
+    role: ['Grantee Specialist'],
   };
 
   const mockCollaborators = [
@@ -20,12 +21,14 @@ describe('activityReportToCsvRecord', () => {
       name: 'Collaborator 1',
       hsesUserId: '2100',
       hsesUsername: 'collaborator.one',
+      role: ['Grantee Specialist', 'Health Specialist'],
     },
     {
       id: 2101,
       name: 'Collaborator 2',
       hsesUserId: '2101',
       hsesUsername: 'collaborator.two',
+      role: [],
     },
   ];
 
@@ -131,9 +134,9 @@ describe('activityReportToCsvRecord', () => {
     });
     const output = await activityReportToCsvRecord(report);
     const { author, lastUpdatedBy, collaborators } = output;
-    expect(author).toEqual('Arthur');
+    expect(author).toEqual('Arthur, GS');
     expect(lastUpdatedBy).toEqual('Arthur');
-    expect(collaborators).toEqual('Collaborator 1\nCollaborator 2');
+    expect(collaborators).toEqual('Collaborator 1, GS, HS\nCollaborator 2');
   });
 
   it('transforms goals and objectives into many values', async () => {

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -597,7 +597,16 @@ describe('Activity Report handlers', () => {
         id: 616,
         author: {
           name: 'Arty',
+          role: ['Grantee Specialist'],
+          fullName: 'Arty, GS',
         },
+        collaborators: [
+          {
+            name: 'Jarty',
+            role: ['System Specialist', 'Grantee Specialist'],
+            fullName: 'Jarty, SS, GS',
+          },
+        ],
       };
 
       userById.mockResolvedValue({ permissions: [{ scopeId: 50 }] });
@@ -612,7 +621,9 @@ describe('Activity Report handlers', () => {
       const [[value]] = mockResponse.send.mock.calls;
       /* eslint-disable no-useless-escape */
       expect(value).toContain('\"Creator\"');
-      expect(value).toContain('\"Arty\"');
+      expect(value).toContain('\"Arty, GS\"');
+      expect(value).toContain('\"Collaborators\"');
+      expect(value).toContain('\"Jarty, SS, GS\"');
       /* eslint-enable no-useless-escape */
     });
 

--- a/src/widgets/reasonList.js
+++ b/src/widgets/reasonList.js
@@ -32,7 +32,20 @@ export default async function reasonList(scopes) {
   });
 
   // Sort By Reason Count largest to smallest.
-  reasons.sort((r1, r2) => r2.count - r1.count);
+  reasons.sort((r1, r2) => {
+    if (r2.count - r1.count === 0) {
+      // Break tie on Reason name.
+      const reasonName1 = r1.name.toUpperCase().replace(' ', ''); // ignore upper and lowercase
+      const reasonName2 = r2.name.toUpperCase().replace(' ', ''); // ignore upper and lowercase
+      if (reasonName1 < reasonName2) {
+        return -1;
+      }
+      if (reasonName1 > reasonName2) {
+        return 1;
+      }
+    }
+    return r2.count - r1.count;
+  });
 
   // Return only top 14.
   return reasons.slice(0, 13);

--- a/src/widgets/reasonList.test.js
+++ b/src/widgets/reasonList.test.js
@@ -200,9 +200,9 @@ describe('Reason list widget', () => {
 
     expect(res[0].name).toBe('Second Reason');
     expect(res[0].count).toBe(2);
-    expect(res[1].name).toBe('Third Reason');
+    expect(res[1].name).toBe('Fourth Reason');
     expect(res[1].count).toBe(1);
-    expect(res[2].name).toBe('Fourth Reason');
+    expect(res[2].name).toBe('Third Reason');
     expect(res[2].count).toBe(1);
 
     scopes = filtersToScopes({ 'region.in': ['1'], 'startDate.win': '2021/02/01-2021/04/30' });


### PR DESCRIPTION
## Description of change
This is a fix where a sorting tie would sometimes cause the Reason List unit test to fail.

Used the calculated "fullName" field on the User model to populate the CSV exports. This field includes abbreviated roles, which are now included on the Creator & Collaborator fields on the CSV.

## How to test
Run the Reason list unit test.

Export a CSV, preferably one with collaborators. The Creator and Collaborators should be formatted as below.
- In CSV download, the Creator field contains [First Name] [Last Name], [role 1], [role...] 
- In CSV download, the Collaborators field contains [First Name][Last Name], [role 1], [role...] 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-165
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-169


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
~-[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

~- [ ] Staging smoke test completed~

### After merge/deploy

~- [ ] Update JIRA ticket status~
