### PR TITLE
Fix z-index for multiselect, again

### DIFF
--- a/frontend/src/components/MultiSelect.js
+++ b/frontend/src/components/MultiSelect.js
@@ -63,7 +63,6 @@ function MultiSelect({
       return {
         ...provided,
         outline,
-        zIndex: 2,
       };
     },
     groupHeading: (provided) => ({
@@ -93,6 +92,10 @@ function MultiSelect({
       marginRight: '4px',
     }),
     indicatorSeparator: () => ({ display: 'none' }),
+    menu: (provided) => ({
+      ...provided,
+      zIndex: 2,
+    }),
   };
 
   /*


### PR DESCRIPTION
## Description of change
Modified the z-index on the wrong part of the multiselect. Instead of the container, the dropdown will have a z-index of 2. This prevents a situation where if there are multiple multiselects in a column, the dropdown will sometimes be hidden under the one beneath.

## How to test
Create a new activity report. Select a grantee. Note that the dropdowns appear normal. Move on to the goals page. Note that the context/goals problem is still fixed and you can select any goal from a list of 3-4 goals even when it might be underneath the context area.

## Issue(s)
## Checklists

### Every PR

<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [n/a] JIRA ticket status updated
- [n/a] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
