### PR TITLE
TTAHUB-193: Clear Condition on Topic Change (#431)

### DIFF
--- a/frontend/src/pages/Landing/Filter.js
+++ b/frontend/src/pages/Landing/Filter.js
@@ -54,6 +54,11 @@ function Filter({ applyFilters, forMyAlerts }) {
     // Topic or condition has changed so we need to clear out the query
     if (name !== 'query') {
       filter.query = '';
+
+      // We need to also clear the condition if the topic changes.
+      if (name === 'topic') {
+        filter.condition = '';
+      }
     }
 
     filter[name] = value;

--- a/frontend/src/pages/Landing/__tests__/Filter.js
+++ b/frontend/src/pages/Landing/__tests__/Filter.js
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 import Filter, { filtersToQueryString } from '../Filter';
 
-const RenderFilterItem = ({ applyFilters = () => {} }) => (
+const RenderFilterItem = ({ applyFilters = () => { } }) => (
   <Filter applyFilters={applyFilters} />
 );
 
@@ -111,6 +111,40 @@ describe('filter', () => {
         topic: 'reportId',
         condition: 'Contains',
         query: 'test',
+      },
+    ]);
+  });
+
+  it('condition is reset when the topic is changed', async () => {
+    const applyFilters = jest.fn();
+    render(<RenderFilterItem applyFilters={applyFilters} />);
+    const button = await screen.findByRole('button');
+    userEvent.click(button);
+
+    const addFilter = await screen.findByRole('button', { name: 'Add New Filter' });
+    userEvent.click(addFilter);
+
+    let topic = await screen.findByRole('combobox', { name: 'topic' });
+    userEvent.selectOptions(topic, 'startDate');
+
+    const condition = await screen.findByRole('combobox', { name: 'condition' });
+    userEvent.selectOptions(condition, 'Is before');
+
+    const query = await screen.findByRole('textbox', { name: /date/i });
+    userEvent.type(query, '09/15/2021');
+
+    topic = await screen.findByRole('combobox', { name: 'topic' });
+    userEvent.selectOptions(topic, 'reportId');
+
+    const apply = await screen.findByRole('button', { name: 'Apply Filters' });
+    userEvent.click(apply);
+
+    expect(applyFilters).toHaveBeenCalledWith([
+      {
+        id: expect.anything(),
+        topic: 'reportId',
+        condition: '',
+        query: '',
       },
     ]);
   });


### PR DESCRIPTION
## Description of change

We need to make sure that if the filter topic changes that we also clear the condition. The reason is that if they user is switching between date and string filters the previous date filters are NOT valid for strings (BEFORE, IN, AFTER).

## How to test

Create a report filter for 'Start Date' with the 'before' condition and any date then apply. 

Now switch the topic of the filter to 'Creator'. The condition field should now be cleared as 'before' is not valid for a string field like creator. 


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-193


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

~- [ ] Staging smoke test completed~

### After merge/deploy

- [x] Update JIRA ticket status
