### PR TITLE
CI: Fix deploy requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,7 +470,6 @@ workflows:
             - build_and_lint
       - deploy:
           requires:
-            - build_and_lint
             - test_backend
             - test_frontend
             - cucumber_test


### PR DESCRIPTION
## Description of change
During testing of the multiple approvers code, I was limiting with the deploy pipeline requirements to make something deploy faster and I accidentally left this in the code.

We don't need to require the `build_and_lint` step for deploy directly, because it is a requirement of other jobs that are required by deploy.


## How to test


## Issue(s)

None


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [na] Meets issue criteria
- [na] JIRA ticket status updated
- [na] Code is meaningfully tested
- [na] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [na] API Documentation updated
- [na] Boundary diagram updated
- [na] Logical Data Model updated
- [na] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
