### PR TITLE
Remove script from non-local environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "kw-delete-reports-script"
+    default: "kw-remove-script"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "kw-delete-reports-script"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "updateReasonNames:local": "./node_modules/.bin/babel-node ./src/tools/updateReasonNamesCLI.js",
     "addMissingGrantsToReports": "node ./build/server/tools/addMissingGrantsToReportsCLI.js",
     "addMissingGrantsToReports:local": "./node_modules/.bin/babel-node ./src/tools/addMissingGrantsToReportsCLI.js",
-    "processData": "node ./build/server/tools/processDataCLI.js",
     "processData:local": "./node_modules/.bin/babel-node ./src/tools/processDataCLI.js",
     "changeReportStatus": "node ./build/server/tools/changeReportStatusCLI.js",
     "changeReportStatus:local": "./node_modules/.bin/babel-node ./src/tools/changeReportStatusCLI.js"


### PR DESCRIPTION
## Description of change
This PR removes the ability to run a script that works on data. The runs are limited to the local ones only. This will prevent accidental runs.


## How to test
Nothing to test in the UI.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-408


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a ] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [x] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status