### PR TITLE
Leave redundant backend route in place

### DIFF
--- a/src/widgets/dashboardOverview.js
+++ b/src/widgets/dashboardOverview.js
@@ -1,0 +1,3 @@
+import overview from './overview';
+
+export default overview;

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -1,5 +1,6 @@
 import example from './example';
 import overview from './overview';
+import dashboardOverview from './dashboardOverview';
 import totalHrsAndGranteeGraph from './totalHrsAndGranteeGraph';
 import reasonList from './reasonList';
 import topicFrequencyGraph from './topicFrequencyGraph';
@@ -10,6 +11,7 @@ import topicFrequencyGraph from './topicFrequencyGraph';
 export default {
   example,
   overview,
+  dashboardOverview,
   totalHrsAndGranteeGraph,
   reasonList,
   topicFrequencyGraph,

--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -5,7 +5,7 @@ import {
 } from '../models';
 import { REPORT_STATUSES } from '../constants';
 
-export default async function dashboardOverview(scopes) {
+export default async function overview(scopes) {
   /**
    * this looks a little strange... why create two SQL queries?
    *


### PR DESCRIPTION
## Description of change

From @jasalisbury on https://github.com/HHS/Head-Start-TTADP/pull/598

> Oh another thing to be aware of, we are removing a widget route. If a user has their browser open when we deploy they will have a broken frontend that asks for a widget that no longer exists. It seems like we have a built in refresh on the frontend with the inactivity timeout. They will have to re-login (and pull in new frontend code) at least every morning (I'm sort of assuming that). We should probably keep the old route around for a couple of deploys so people will have time to pull in the new frontend code.

Also fixed the naming on "dashboardOverview"/"overview" widget handlers

## How to test


## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
