### PR TITLE
[TTAHUB-160] final changes to export message from accessibility spec. and lowering limit

### DIFF
--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -6,7 +6,7 @@ import Container from '../../components/Container';
 
 import './ReportMenu.css';
 
-const MAXIMUM_EXPORTED_REPORTS = 4000;
+const MAXIMUM_EXPORTED_REPORTS = 2000;
 
 function ReportMenu({
   onExportAll,

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -56,7 +56,7 @@ function ReportMenu({
         aria-label={label}
         onClick={() => updateOpen((current) => !current)}
       >
-        Reports
+        Export reports
         {' '}
         <FontAwesomeIcon
           size="1x"
@@ -71,18 +71,6 @@ function ReportMenu({
           <Container padding={2} className="margin-bottom-0">
             {count > MAXIMUM_EXPORTED_REPORTS ? (
               <>
-                <div className="display-flex">
-                  <button
-                    role="menuitem"
-                    onClick={onExportAll}
-                    type="button"
-                    disabled
-                    className="usa-button usa-button--unstyled smart-hub--reports-button margin-bottom-1"
-                    aria-labelledby="no-exports-please"
-                  >
-                    Export table data
-                  </button>
-                </div>
                 <div className="usa-hint" id="no-exports-please">
                   <p>
                     This export has
@@ -116,7 +104,7 @@ function ReportMenu({
                   type="button"
                   className="usa-button usa-button--unstyled smart-hub--reports-button smart-hub--button__no-margin"
                 >
-                  Export table data...
+                  Export table data
                 </button>
               ) }
             {hasSelectedReports && onExportSelected && (
@@ -126,7 +114,7 @@ function ReportMenu({
                 type="button"
                 className="usa-button usa-button--unstyled smart-hub--reports-button smart-hub--button__no-margin margin-top-2"
               >
-                Export selected reports...
+                Export selected reports
               </button>
             )}
           </Container>

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -6,7 +6,7 @@ import Container from '../../components/Container';
 
 import './ReportMenu.css';
 
-const MAXIMUM_EXPORTED_REPORTS = 5000;
+const MAXIMUM_EXPORTED_REPORTS = 4000;
 
 function ReportMenu({
   onExportAll,

--- a/frontend/src/pages/Landing/__tests__/ReportMenu.js
+++ b/frontend/src/pages/Landing/__tests__/ReportMenu.js
@@ -76,7 +76,7 @@ describe('ReportMenu', () => {
     render(<RenderReportMenu count={5001} hasSelectedReports={false} />);
     const button = await screen.findByRole('button');
     userEvent.click(button);
-    const label = /this export has 5,001 reports\. you can only export 5,000 reports at a time\./i;
+    const label = /this export has 5,001 reports\. you can only export 4,000 reports at a time\./i;
     expect(screen.getByText(label)).toBeVisible();
   });
 

--- a/frontend/src/pages/Landing/__tests__/ReportMenu.js
+++ b/frontend/src/pages/Landing/__tests__/ReportMenu.js
@@ -25,7 +25,7 @@ describe('ReportMenu', () => {
     render(<RenderReportMenu />);
     const button = await screen.findByRole('button');
     userEvent.click(button);
-    const report = await screen.findByText('Reports');
+    const report = await screen.findByText('Export reports');
     expect(report).toHaveClass('smart-hub--menu-button__open');
   });
 
@@ -34,7 +34,7 @@ describe('ReportMenu', () => {
     render(<RenderReportMenu onExportAll={onExport} />);
     const button = await screen.findByRole('button');
     userEvent.click(button);
-    const exportButton = await screen.findByRole('menuitem', { name: 'Export table data...' });
+    const exportButton = await screen.findByRole('menuitem', { name: 'Export table data' });
     userEvent.click(exportButton);
     expect(onExport).toHaveBeenCalled();
   });
@@ -45,7 +45,7 @@ describe('ReportMenu', () => {
       render(<RenderReportMenu onExportSelected={onExport} hasSelectedReports />);
       const button = await screen.findByRole('button');
       userEvent.click(button);
-      const exportButton = await screen.findByRole('menuitem', { name: 'Export selected reports...' });
+      const exportButton = await screen.findByRole('menuitem', { name: 'Export selected reports' });
       userEvent.click(exportButton);
       expect(onExport).toHaveBeenCalled();
     });
@@ -59,26 +59,25 @@ describe('ReportMenu', () => {
     // first, open the menu
     const button = await screen.findByRole('button');
     userEvent.click(button);
-    report = await screen.findByText('Reports');
+    report = await screen.findByText('Export reports');
     expect(report).toHaveClass('smart-hub--menu-button__open');
     menu = screen.queryByRole('menu');
     expect(menu).toBeInTheDocument();
 
     // Focus on the menu button should close the menu
     button.focus();
-    report = await screen.findByText('Reports');
+    report = await screen.findByText('Export reports');
     expect(report).not.toHaveClass('smart-hub--menu-button__open');
     menu = screen.queryByRole('menu');
     expect(menu).not.toBeInTheDocument();
   });
 
-  it('disables the button and shows the error message when there are too many reports', async () => {
+  it('shows the error message when there are too many reports', async () => {
     render(<RenderReportMenu count={5001} hasSelectedReports={false} />);
     const button = await screen.findByRole('button');
     userEvent.click(button);
     const label = /this export has 5,001 reports\. you can only export 5,000 reports at a time\./i;
-    const exportButton = await screen.findByRole('menuitem', { name: label });
-    expect(exportButton).toBeDisabled();
+    expect(screen.getByText(label)).toBeVisible();
   });
 
   it('closes when the Escape key is pressed', async () => {
@@ -89,21 +88,21 @@ describe('ReportMenu', () => {
     // first, open the menu
     const button = await screen.findByRole('button');
     userEvent.click(button);
-    report = await screen.findByText('Reports');
+    report = await screen.findByText('Export reports');
     expect(report).toHaveClass('smart-hub--menu-button__open');
     menu = screen.queryByRole('menu');
     expect(menu).toBeInTheDocument();
 
     // Keypress with the keys other than 'Escape' should NOT close the menu
     fireEvent.keyDown(document.activeElement || document.body, { key: ' ' });
-    report = await screen.findByText('Reports');
+    report = await screen.findByText('Export reports');
     expect(report).toHaveClass('smart-hub--menu-button__open');
     menu = screen.queryByRole('menu');
     expect(menu).toBeInTheDocument();
 
     // Keypress with the escape key should close the menu
     fireEvent.keyDown(document.activeElement || document.body, { key: 'Escape' });
-    report = await screen.findByText('Reports');
+    report = await screen.findByText('Export reports');
     expect(report).not.toHaveClass('smart-hub--menu-button__open');
     menu = screen.queryByRole('menu');
     expect(menu).not.toBeInTheDocument();

--- a/frontend/src/pages/Landing/__tests__/ReportMenu.js
+++ b/frontend/src/pages/Landing/__tests__/ReportMenu.js
@@ -76,7 +76,8 @@ describe('ReportMenu', () => {
     render(<RenderReportMenu count={5001} hasSelectedReports={false} />);
     const button = await screen.findByRole('button');
     userEvent.click(button);
-    const label = /this export has 5,001 reports\. you can only export 4,000 reports at a time\./i;
+
+    const label = /this export has 5,001 reports\. you can only export 2,000 reports at a time\./i;
     expect(screen.getByText(label)).toBeVisible();
   });
 


### PR DESCRIPTION
## Description of change
Changes to the "over-the-limit" export menu 
- Out of accessibility review, we rethought having a disabled button at all, since the user experience for a disabled control like that can be quite poor. Instead of disabling the button, we remove it. In order to give additional context to the menu's functionality that the button was previously providing, we change the dropdown from "Reports" to "Export reports"
- Removed ellipsis on those menu actions, also as per UI/accessibility review
- Reports from users indicate that 5000 might be too high of a limit. We have lowered it to 4000.

## How to test
Attempt to export more than 5000 reports. Confirm that the error message appears, and the button does not. Attempt to export less and confirm it works as normal.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-160


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
