### PR TITLE
TTAHUB-22: Change unlock report button CSS to outline

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -329,7 +329,7 @@ export default function ApprovedActivityReport({ match, user }) {
           : null}
         <button type="button" className="usa-button no-print" disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false} onClick={() => window.print()}>Print to PDF</button>
         {user && user.permissions && canUnlockReports(user)
-          ? <ModalToggleButton type="button" className="usa-button usa-button--accent-warm no-print" modalRef={modalRef} opener>Unlock Report</ModalToggleButton>
+          ? <ModalToggleButton type="button" className="usa-button usa-button--outline no-print" modalRef={modalRef} opener>Unlock report</ModalToggleButton>
           : null}
       </Grid>
       <Modal


### PR DESCRIPTION
## Description of change

Change unlock report button CSS to outline.


## How to test

View any approved report the "Unlock report" button should now be outline.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-22


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

~- [ ] Staging smoke test completed~

### After merge/deploy

- [x] Update JIRA ticket status
