### PR TITLE
TTAHUB-415: Remove aria announcements on total tta graph and fix CSS select

### DIFF
--- a/frontend/src/pages/GranteeSearch/components/GranteeResults.css
+++ b/frontend/src/pages/GranteeSearch/components/GranteeResults.css
@@ -5,6 +5,6 @@
     text-decoration: none;
 }
 
-.ttahub-grantee-results .usa-table td {
+.ttahub-grantee-results .usa-table tbody td {
     white-space: unset;
 }

--- a/frontend/src/widgets/TotalHrsAndGranteeGraph.js
+++ b/frontend/src/widgets/TotalHrsAndGranteeGraph.js
@@ -217,7 +217,7 @@ export function TotalHrsAndGranteeGraph({ data, dateTime, loading }) {
         { showAccessibleData
           ? <AccessibleWidgetData caption="Total TTA Hours by Date and Type" columnHeadings={columnHeadings} rows={tableRows} />
           : (
-            <>
+            <div aria-hidden="true">
               <fieldset className="grid-row ttahub--total-hrs-grantee-graph-legend text-align-center margin-bottom-3 border-0 padding-0">
                 <legend className="margin-bottom-1">Toggle individual lines by checking or unchecking a legend item.</legend>
                 <LegendControl id="show-ta-checkbox" label="Technical Assistance" selected={showTA} setSelected={setShowTA} shape="circle" />
@@ -226,7 +226,7 @@ export function TotalHrsAndGranteeGraph({ data, dateTime, loading }) {
               </fieldset>
 
               <div data-testid="lines" ref={lines} />
-            </>
+            </div>
           )}
       </div>
     </Container>

--- a/frontend/src/widgets/__tests__/TotalHrsAndGranteeGraph.js
+++ b/frontend/src/widgets/__tests__/TotalHrsAndGranteeGraph.js
@@ -90,7 +90,7 @@ describe('Total Hrs And Grantee Graph Widget', () => {
     await expect(nodes[0].childNodes[2].childNodes[3].childNodes.length).toEqual(4);
 
     expect(document.querySelectorAll('.plot .scatterlayer .point').length).toBe(12);
-    const training = screen.getByRole('checkbox', { name: /training/i });
+    const training = screen.getByRole('checkbox', { name: /training/i, hidden: true });
 
     fireEvent.click(training);
     expect(document.querySelectorAll('.plot .scatterlayer .point').length).toBe(8);


### PR DESCRIPTION
## Description of change

Remove aria announcements on Total TTA Hrs Graph.

Also updated CSS select for Grantee Results to ensure Program Specialist column is set to white-space 'unset'.

## How to test

View the Dashboard page the Total TTA Hours should only read the heading, dates and Display Table text.

View the Grantee search results. The Program Specialist column should wrap correctly.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-415


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
`- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
