### PR TITLE
[TTAHUB-417] Keyboard user improvements on Activity Reports table

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -127,10 +127,10 @@
   },
   "devDependencies": {
     "@sheerun/mutationobserver-shim": "^0.3.3",
-    "@testing-library/dom": "^7.28.0",
+    "@testing-library/dom": "^8.11.1",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
-    "@testing-library/user-event": "^12.2.2",
+    "@testing-library/user-event": "^13.5.0",
     "cross-env": "^7.0.2",
     "eslint": "^7.20.0",
     "eslint-config-airbnb": "^18.2.0",

--- a/frontend/src/components/ActivityReportsTable/ReportRow.css
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.css
@@ -1,0 +1,22 @@
+.tta-smarthub--report-row td:first-child {
+    position: relative;
+}
+
+.tta-smarthub--report-row .ttahub-export-reports:not(:focus) {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	width: 1px;
+}
+
+.tta-smarthub--report-row .ttahub-export-reports {
+    background: white;
+    left: 50px;  
+    top: -10px;
+    position: absolute;
+    z-index: 100000;
+}

--- a/frontend/src/components/ActivityReportsTable/ReportRow.css
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.css
@@ -2,6 +2,14 @@
     position: relative;
 }
 
+.tta-smarthub--report-row .ttahub-export-reports {
+	display: none;
+}
+
+.tta-smarthub--report-row:focus-within .ttahub-export-reports {
+	display: inline;
+}
+
 .tta-smarthub--report-row .ttahub-export-reports:not(:focus) {
 	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);

--- a/frontend/src/components/ActivityReportsTable/ReportRow.css
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.css
@@ -2,13 +2,29 @@
     position: relative;
 }
 
+/**
+* we only want 1 of these to be accessible at a time, so they are display none
+* when not in the direct path. This has the same practical effect of aria-hiding those buttons
+* but without altering any semantic values
+*/
+
 .tta-smarthub--report-row .ttahub-export-reports {
 	display: none;
 }
 
-.tta-smarthub--report-row:focus-within .ttahub-export-reports {
+/**
+** Wish we didn't have to support IE 11, cause then we could just use
+* :focus-within and we wouldn't need to be managing classes with javascript as well
+*/
+
+.tta-smarthub--report-row.focused .ttahub-export-reports {
 	display: inline;
 }
+
+/**
+* even if it's display: inline, we still want to hide the button visually unless it's focused. 
+* that's what the code does below (handles focus and not focused states)
+*/
 
 .tta-smarthub--report-row .ttahub-export-reports:not(:focus) {
 	border: 0;

--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -8,9 +8,15 @@ import { getReportsDownloadURL } from '../../fetchers/helpers';
 import TooltipWithCollection from '../TooltipWithCollection';
 import Tooltip from '../Tooltip';
 import { DATE_DISPLAY_FORMAT } from '../../Constants';
+import './ReportRow.css';
 
 function ReportRow({
-  report, openMenuUp, handleReportSelect, isChecked,
+  report,
+  openMenuUp,
+  handleReportSelect,
+  isChecked,
+  numberOfSelectedReports,
+  exportSelected,
 }) {
   const {
     id,
@@ -71,9 +77,22 @@ function ReportRow({
   const selectId = `report-${id}`;
 
   return (
-    <tr key={`landing_${id}`}>
+    <tr className="tta-smarthub--report-row" key={`landing_${id}`}>
       <td className="width-8">
         <Checkbox id={selectId} label="" value={id} checked={isChecked} onChange={handleReportSelect} aria-label={`Select ${displayId}`} />
+        { numberOfSelectedReports > 0 && (
+        <button
+          type="button"
+          className="usa-button usa-button--outline ttahub-export-reports"
+          onClick={exportSelected}
+        >
+          Export
+          {' '}
+          {numberOfSelectedReports}
+          {' '}
+          selected reports
+        </button>
+        ) }
       </td>
       <th scope="row" className="smart-hub--blue">
         <Link
@@ -109,41 +128,47 @@ function ReportRow({
   );
 }
 
-export const reportPropTypes = {
-  report: PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    displayId: PropTypes.string.isRequired,
-    activityRecipients: PropTypes.arrayOf(PropTypes.shape({
-      name: PropTypes.string,
-      grant: PropTypes.shape({
-        grantee: PropTypes.shape({
-          name: PropTypes.string,
-        }),
+export const reportPropTypes = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  displayId: PropTypes.string.isRequired,
+  activityRecipients: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    grant: PropTypes.shape({
+      grantee: PropTypes.shape({
+        name: PropTypes.string,
       }),
-    })).isRequired,
-    approvedAt: PropTypes.string,
-    createdAt: PropTypes.string,
-    startDate: PropTypes.string.isRequired,
-    author: PropTypes.shape({
-      fullName: PropTypes.string,
-      homeRegionId: PropTypes.number,
-      name: PropTypes.string,
-    }).isRequired,
-    topics: PropTypes.arrayOf(PropTypes.string).isRequired,
-    collaborators: PropTypes.arrayOf(
-      PropTypes.shape({
-        fullName: PropTypes.string,
-      }),
-    ).isRequired,
-    lastSaved: PropTypes.string.isRequired,
-    calculatedStatus: PropTypes.string.isRequired,
-    legacyId: PropTypes.string,
+    }),
+  })).isRequired,
+  approvedAt: PropTypes.string,
+  createdAt: PropTypes.string,
+  startDate: PropTypes.string.isRequired,
+  author: PropTypes.shape({
+    fullName: PropTypes.string,
+    homeRegionId: PropTypes.number,
+    name: PropTypes.string,
   }).isRequired,
+  topics: PropTypes.arrayOf(PropTypes.string).isRequired,
+  collaborators: PropTypes.arrayOf(
+    PropTypes.shape({
+      fullName: PropTypes.string,
+    }),
+  ),
+  lastSaved: PropTypes.string,
+  calculatedStatus: PropTypes.instanceOf(moment),
+  legacyId: PropTypes.string,
+});
+
+ReportRow.propTypes = {
+  report: reportPropTypes.isRequired,
   openMenuUp: PropTypes.bool.isRequired,
   handleReportSelect: PropTypes.func.isRequired,
   isChecked: PropTypes.bool.isRequired,
+  numberOfSelectedReports: PropTypes.number,
+  exportSelected: PropTypes.func.isRequired,
 };
 
-ReportRow.propTypes = reportPropTypes;
+ReportRow.defaultProps = {
+  numberOfSelectedReports: 0,
+};
 
 export default ReportRow;

--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox } from '@trussworks/react-uswds';
 import { Link, useHistory } from 'react-router-dom';
@@ -32,6 +32,9 @@ function ReportRow({
     createdAt,
     legacyId,
   } = report;
+
+  // eslint-disable-next-line no-unused-vars
+  const [trClassname, setTrClassname] = useState('tta-smarthub--report-row');
 
   const history = useHistory();
   const authorName = author ? author.fullName : '';
@@ -76,8 +79,15 @@ function ReportRow({
 
   const selectId = `report-${id}`;
 
+  const onFocus = () => setTrClassname('tta-smarthub--report-row focused');
+
+  const onBlur = (e) => {
+    console.log(e);
+    // setTrClassname
+  };
+
   return (
-    <tr className="tta-smarthub--report-row" key={`landing_${id}`}>
+    <tr onFocus={onFocus} onBlur={onBlur} className="tta-smarthub--report-row" key={`landing_${id}`}>
       <td className="width-8">
         <Checkbox id={selectId} label="" value={id} checked={isChecked} onChange={handleReportSelect} aria-label={`Select ${displayId}`} />
         { numberOfSelectedReports > 0 && (
@@ -85,7 +95,6 @@ function ReportRow({
           type="button"
           className="usa-button usa-button--outline ttahub-export-reports"
           onClick={exportSelected}
-          aria-hidden="true"
         >
           Export
           {' '}

--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -85,6 +85,7 @@ function ReportRow({
           type="button"
           className="usa-button usa-button--outline ttahub-export-reports"
           onClick={exportSelected}
+          aria-hidden="true"
         >
           Export
           {' '}

--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -33,7 +33,6 @@ function ReportRow({
     legacyId,
   } = report;
 
-  // eslint-disable-next-line no-unused-vars
   const [trClassname, setTrClassname] = useState('tta-smarthub--report-row');
 
   const history = useHistory();
@@ -79,15 +78,23 @@ function ReportRow({
 
   const selectId = `report-${id}`;
 
+  /**
+   * we manage the class of the row as a sort of "focus-within" workaround
+   * this is entirely to show/hide the export reports button to keyboard users but
+   * not blast screen-reader only users with a bunch of redundant buttons
+   */
+
   const onFocus = () => setTrClassname('tta-smarthub--report-row focused');
 
   const onBlur = (e) => {
-    console.log(e);
-    // setTrClassname
+    if (e.relatedTarget && e.relatedTarget.matches('.tta-smarthub--report-row *')) {
+      return;
+    }
+    setTrClassname('tta-smarthub--report-row');
   };
 
   return (
-    <tr onFocus={onFocus} onBlur={onBlur} className="tta-smarthub--report-row" key={`landing_${id}`}>
+    <tr onFocus={onFocus} onBlur={onBlur} className={trClassname} key={`landing_${id}`}>
       <td className="width-8">
         <Checkbox id={selectId} label="" value={id} checked={isChecked} onChange={handleReportSelect} aria-label={`Select ${displayId}`} />
         { numberOfSelectedReports > 0 && (

--- a/frontend/src/components/ActivityReportsTable/__tests__/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/__tests__/ReportRow.js
@@ -14,7 +14,7 @@ const history = createMemoryHistory();
 const [report] = generateXFakeReports(1);
 
 describe('ReportRow', () => {
-  const renderReportRow = () => (
+  const renderReportRow = (numberOfSelectedReports = 0, exportSelected = jest.fn()) => (
     render(
       <Router history={history}>
         <ReportRow
@@ -22,6 +22,8 @@ describe('ReportRow', () => {
           openMenuUp={false}
           handleReportSelect={jest.fn()}
           isChecked={false}
+          numberOfSelectedReports={numberOfSelectedReports}
+          exportSelected={exportSelected}
         />
       </Router>,
     )
@@ -51,5 +53,15 @@ describe('ReportRow', () => {
     userEvent.click(await screen.findByRole('button', { name: /copy url/i }));
 
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
+  });
+
+  it('the export all button appears when a report is selected', () => {
+    const exportSelected = jest.fn();
+    renderReportRow(1, exportSelected);
+
+    userEvent.tab();
+    userEvent.tab();
+    userEvent.keyboard('{enter}');
+    expect(exportSelected).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -330,6 +330,8 @@ function ActivityReportsTable({
                   handleReportSelect={handleReportSelect}
                   isChecked={reportCheckboxes[report.id] || false}
                   openMenuUp={index > displayReports.length - 1}
+                  numberOfSelectedReports={numberOfSelectedReports}
+                  exportSelected={handleDownloadClick}
                 />
               ))}
             </tbody>

--- a/frontend/src/components/__tests__/Filter.js
+++ b/frontend/src/components/__tests__/Filter.js
@@ -36,14 +36,15 @@ describe('filter', () => {
     let menu;
 
     render(<RenderFilterItem />);
-    const button = await screen.findByRole('button');
+    const button = await screen.findByRole('button', { name: /filters menu/i });
     expect(button).not.toHaveClass('smart-hub--menu-button__open');
     userEvent.click(button);
     expect(button).toHaveClass('smart-hub--menu-button__open');
     menu = screen.queryByRole('menu');
     expect(menu).toBeInTheDocument();
 
-    button.focus();
+    userEvent.tab();
+    userEvent.tab();
     menu = screen.queryByRole('menu');
     expect(menu).not.toBeInTheDocument();
   });

--- a/frontend/src/widgets/__tests__/FrequencyGraph.js
+++ b/frontend/src/widgets/__tests__/FrequencyGraph.js
@@ -4,6 +4,7 @@ import React from 'react';
 import {
   render,
   screen,
+  act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FreqGraph } from '../FrequencyGraph';
@@ -53,13 +54,12 @@ describe('Frequency Graph', () => {
   it('can switch to show reasons', async () => {
     renderFrequencyGraph();
     const topics = await screen.findByRole('button', { name: 'toggle change graph type menu' });
-
+    expect(topics.textContent).toBe('Topics');
     userEvent.click(topics);
-    const reasonBtn = await screen.findByText('Reasons');
-    userEvent.click(reasonBtn);
-    const apply = await screen.findByText('Apply');
+    const reasonBtn = await screen.findByRole('button', { name: /Select to view data from Reasons/i });
+    act(() => userEvent.click(reasonBtn));
+    const apply = await screen.findByRole('button', { name: /Apply filters for the change graph type menu/i });
     userEvent.click(apply);
-
     const reasons = await screen.findByRole('button', { name: 'toggle change graph type menu' });
     expect(reasons.textContent).toBe('Reasons');
   });

--- a/frontend/src/widgets/__tests__/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/__tests__/TopicFrequencyGraph.js
@@ -4,6 +4,7 @@ import React from 'react';
 import {
   render,
   screen,
+  act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -138,15 +139,15 @@ describe('Topic & Frequency Graph Widget', () => {
   it('the sort control works', async () => {
     renderArGraphOverview({ data: [...TEST_DATA] });
     const button = screen.getByRole('button', { name: /change topic graph order/i });
-    userEvent.click(button);
+    act(() => userEvent.click(button));
     const aZ = screen.getByRole('button', { name: /select to view data from a to z\. select apply filters button to apply selection/i });
-    userEvent.click(aZ);
+    act(() => userEvent.click(aZ));
     const apply = screen.getByRole('button', { name: 'Apply filters for the Change topic graph order menu' });
 
     const point1 = document.querySelector('g.xtick');
     // eslint-disable-next-line no-underscore-dangle
     expect(point1.__data__.text).toBe(' Community<br />and<br />Self-Assessment');
-    userEvent.click(apply);
+    act(() => userEvent.click(apply));
 
     const point2 = document.querySelector('g.xtick');
     // eslint-disable-next-line no-underscore-dangle
@@ -155,19 +156,19 @@ describe('Topic & Frequency Graph Widget', () => {
 
   it('handles switching display contexts', async () => {
     renderArGraphOverview({ data: [...TEST_DATA] });
-    const button = screen.getByRole('button', { name: 'display number of activity reports by topic data as table' });
-    userEvent.click(button);
+    const button = await screen.findByRole('button', { name: 'display number of activity reports by topic data as table' });
+    act(() => userEvent.click(button));
 
-    const firstRowHeader = screen.getByRole('cell', {
+    const firstRowHeader = await screen.findByRole('cell', {
       name: /community and self-assessment/i,
     });
     expect(firstRowHeader).toBeInTheDocument();
 
-    const firstTableCell = screen.getByRole('cell', { name: /155/i });
+    const firstTableCell = await screen.findByRole('cell', { name: /155/i });
     expect(firstTableCell).toBeInTheDocument();
 
-    const viewGraph = screen.getByRole('button', { name: 'display number of activity reports by topic data as graph' });
-    userEvent.click(viewGraph);
+    const viewGraph = await screen.findByRole('button', { name: 'display number of activity reports by topic data as graph' });
+    act(() => userEvent.click(viewGraph));
 
     expect(firstRowHeader).not.toBeInTheDocument();
     expect(firstTableCell).not.toBeInTheDocument();

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2033,7 +2033,7 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
-"@testing-library/dom@^7.28.0", "@testing-library/dom@^7.28.1":
+"@testing-library/dom@^7.28.1":
   version "7.31.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
   integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
@@ -2046,6 +2046,20 @@
     dom-accessibility-api "^0.5.6"
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
+
+"@testing-library/dom@^8.11.1":
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.1.tgz#03fa2684aa09ade589b460db46b4c7be9fc69753"
+  integrity sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
 
 "@testing-library/jest-dom@^5.11.9":
   version "5.14.1"
@@ -2070,10 +2084,10 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
-"@testing-library/user-event@^12.2.2":
-  version "12.8.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.3.tgz#1aa3ed4b9f79340a1e1836bc7f57c501e838704a"
-  integrity sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==
+"@testing-library/user-event@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -2923,6 +2937,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -5341,6 +5360,11 @@ dom-accessibility-api@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz#8c2aa6325968f2933160a0b7dbb380893ddf3e7d"
   integrity sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
+  integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
 
 dom-converter@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Description of change
Previously, if a keyboard user wanted to export selected reports, it would require **a lot** of tabbing if one of those reports were in the middle of the table.

Hidden tab stops were created directly after the selection checkbox. These are "aria-hidden" since a bunch of buttons with identical text would be confusing to screen-reader-only users, and they have additional navigational options.

## How to test
Select a report and tab through the document. Observe that you can tab to focus one of the hidden buttons (directly after the report checkbox) and hit enter to initiate a download of selected reports.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-417

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
