### PR TITLE
Lower prod memory and reinstate export limit

### DIFF
--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -1,6 +1,6 @@
 env: prod
 web_instances: 3
-web_memory: 4GB
+web_memory: 2GB
 worker_instances: 1
 worker_memory: 512M
 LOG_LEVEL: info

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Alert } from '@trussworks/react-uswds';
 import Container from '../../components/Container';
 
-export const MAXIMUM_EXPORTED_REPORTS = 12000;
+export const MAXIMUM_EXPORTED_REPORTS = 2000;
 
 function ReportMenu({
   onExportAll,


### PR DESCRIPTION
## Description of change
We don't have enough free-floating memory to give prod 4GB/instance. This PR reinstates the previous memory and export limit cap to give us time to assess and test how our memory should be allocated while unblocking the deployment pipeline.

## How to test

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
