### PR TITLE
Lock minio to a specific version on docker hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-01-16T02-19-44Z
     env_file: .env
     ports:
       - "9000:9000"


### PR DESCRIPTION
## Description of change
Recently ran into varying behavior on different versions of minio images. This PR specifies an agreed upon release tag that we know works as expected.

## How to test
Rebuild docker, check to see that you can view the minio UI and run commands within the container

## Issue(s)


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
