### PR TITLE
[TTAHUB-490] Create scopes for target population on Activity Report

### DIFF
--- a/src/scopes/activityReport/index.js
+++ b/src/scopes/activityReport/index.js
@@ -13,6 +13,7 @@ import { withoutCalculatedStatus, withCalculatedStatus } from './calculatedStatu
 import { withProgramSpecialist, withoutProgramSpecialist } from './programSpecialist';
 import { withRole, withoutRole } from './role';
 import withRegion from './region';
+import { withoutTargetPopulations, withTargetPopulations } from './targetPopulations';
 
 export const topicToQuery = {
   reportId: {
@@ -68,6 +69,10 @@ export const topicToQuery = {
   },
   region: {
     in: (query) => withRegion(query),
+  },
+  targetPopulations: {
+    in: (query) => withTargetPopulations(query),
+    nin: (query) => withoutTargetPopulations(query),
   },
 };
 

--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -41,7 +41,7 @@ const submittedReport = {
   startDate: '2000-01-01T12:00:00Z',
   requester: 'requester',
   programTypes: ['type'],
-  targetPopulations: ['pop'],
+  targetPopulations: ['Children with Disabilities', 'Pregnant Women'],
   reason: ['reason'],
   participants: ['participants'],
   topics: ['topics'],
@@ -862,6 +862,83 @@ describe('filtersToScopes', () => {
         where: { [Op.and]: [scope, { id: possibleIds }] },
       });
       expect(found.map((f) => f.id)).toStrictEqual(possibleIds);
+    });
+  });
+
+  describe('target population', () => {
+    let reportOne;
+    let reportTwo;
+    let reportThree;
+    let reportFour;
+    let possibleIds;
+
+    beforeAll(async () => {
+      reportOne = await ActivityReport.create(submittedReport);
+      reportTwo = await ActivityReport.create({
+        ...submittedReport,
+        targetPopulations: ['Pregnant Women'],
+      });
+      reportThree = await ActivityReport.create({
+        ...submittedReport,
+        targetPopulations: ['Dual-Language Learners'],
+      });
+      reportFour = await ActivityReport.create({
+        ...submittedReport,
+        targetPopulations: [],
+      });
+
+      possibleIds = [
+        reportOne.id,
+        reportTwo.id,
+        reportThree.id,
+        reportFour.id,
+      ];
+    });
+
+    afterAll(async () => {
+      await ActivityReport.destroy({
+        where: {
+          id: possibleIds,
+        },
+      });
+    });
+
+    it('filters by reports containing said population', async () => {
+      const filters = { 'targetPopulations.in': ['Pregnant Women'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+        logging: console.log,
+      });
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([reportOne.id, reportTwo.id]));
+    });
+
+    it('filters out the appropriate population', async () => {
+      const filters = { 'targetPopulations.nin': ['Pregnant Women'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+        logging: console.log,
+      });
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([reportThree.id, reportFour.id]));
+    });
+
+    it('only filters by possible population values', async () => {
+      const filters = { 'targetPopulations.in': ['(DROP SCHEMA public CASCADE)'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+        logging: console.log,
+      });
+      expect(found.length).toBe(4);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining(
+          [reportOne.id, reportTwo.id, reportThree.id, reportFour.id],
+        ));
     });
   });
 

--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -908,8 +908,8 @@ describe('filtersToScopes', () => {
       const scope = filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
-        logging: console.log,
       });
+
       expect(found.length).toBe(2);
       expect(found.map((f) => f.id))
         .toEqual(expect.arrayContaining([reportOne.id, reportTwo.id]));
@@ -920,7 +920,6 @@ describe('filtersToScopes', () => {
       const scope = filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
-        logging: console.log,
       });
       expect(found.length).toBe(2);
       expect(found.map((f) => f.id))
@@ -928,11 +927,22 @@ describe('filtersToScopes', () => {
     });
 
     it('only filters by possible population values', async () => {
+      const filters = { 'targetPopulations.in': ['(DROP SCHEMA public CASCADE)', 'Pregnant Women'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([reportOne.id, reportTwo.id]));
+    });
+
+    it('filters out bad population values', async () => {
       const filters = { 'targetPopulations.in': ['(DROP SCHEMA public CASCADE)'] };
       const scope = filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
-        logging: console.log,
       });
       expect(found.length).toBe(4);
       expect(found.map((f) => f.id))

--- a/src/scopes/activityReport/targetPopulations.js
+++ b/src/scopes/activityReport/targetPopulations.js
@@ -1,45 +1,30 @@
 import filterArray from './utils';
+import { TARGET_POPULATIONS } from '../../constants';
+
+export function allowedPopulations(populations) {
+  function filterPopulations(population) {
+    return TARGET_POPULATIONS.includes(population);
+  }
+
+  if (!Array.isArray(populations)) {
+    return [populations].filter((population) => filterPopulations(population));
+  }
+
+  return populations.filter((population) => filterPopulations(population));
+}
 
 export function withTargetPopulations(targetPopulations) {
-  return filterArray('ARRAY_TO_STRING("ActivityReport"."targetPopulations", \',\')', targetPopulations, false);
+  const populations = allowedPopulations(targetPopulations);
+  if (populations.length < 1) {
+    return {};
+  }
+  return filterArray('ARRAY_TO_STRING("ActivityReport"."targetPopulations", \',\')', populations, false);
 }
 
 export function withoutTargetPopulations(targetPopulations) {
-  return filterArray('ARRAY_TO_STRING("ActivityReport"."targetPopulations", \',\')', targetPopulations, true);
+  const populations = allowedPopulations(targetPopulations);
+  if (populations.length < 1) {
+    return {};
+  }
+  return filterArray('ARRAY_TO_STRING("ActivityReport"."targetPopulations", \',\')', populations, true);
 }
-
-// import { Op } from 'sequelize';
-// import { TARGET_POPULATIONS } from '../../constants';
-
-// export function allowedPopulations(populations) {
-//   function filterPopulations(population) {
-//     return TARGET_POPULATIONS.includes(population);
-//   }
-
-//   if (!Array.isArray(populations)) {
-//     return [populations].filter((population) => filterPopulations(population));
-//   }
-
-//   return populations.filter((population) => filterPopulations(population));
-// }
-
-// export function withTargetPopulations(populations) {
-//   const allowed = allowedPopulations(populations);
-
-//   // if we don't have any allowed populations, don't apply a filter at all
-//   if (allowed.length < 1) {
-//     return {};
-//   }
-
-//   return {
-//     targetPopulations: {
-//       [Op.overlap]: allowed,
-//     },
-//   };
-// }
-
-// export function withoutTargetPopulations(populations) {
-//   return {
-//     [Op.not]: withTargetPopulations(populations),
-//   };
-// }

--- a/src/scopes/activityReport/targetPopulations.js
+++ b/src/scopes/activityReport/targetPopulations.js
@@ -1,0 +1,45 @@
+import filterArray from './utils';
+
+export function withTargetPopulations(targetPopulations) {
+  return filterArray('ARRAY_TO_STRING("ActivityReport"."targetPopulations", \',\')', targetPopulations, false);
+}
+
+export function withoutTargetPopulations(targetPopulations) {
+  return filterArray('ARRAY_TO_STRING("ActivityReport"."targetPopulations", \',\')', targetPopulations, true);
+}
+
+// import { Op } from 'sequelize';
+// import { TARGET_POPULATIONS } from '../../constants';
+
+// export function allowedPopulations(populations) {
+//   function filterPopulations(population) {
+//     return TARGET_POPULATIONS.includes(population);
+//   }
+
+//   if (!Array.isArray(populations)) {
+//     return [populations].filter((population) => filterPopulations(population));
+//   }
+
+//   return populations.filter((population) => filterPopulations(population));
+// }
+
+// export function withTargetPopulations(populations) {
+//   const allowed = allowedPopulations(populations);
+
+//   // if we don't have any allowed populations, don't apply a filter at all
+//   if (allowed.length < 1) {
+//     return {};
+//   }
+
+//   return {
+//     targetPopulations: {
+//       [Op.overlap]: allowed,
+//     },
+//   };
+// }
+
+// export function withoutTargetPopulations(populations) {
+//   return {
+//     [Op.not]: withTargetPopulations(populations),
+//   };
+// }


### PR DESCRIPTION
## Description of change
Create two scopes on the backend that can be applied to activity reports, one to include activity reports on a given target population, one to exclude the same.

## How to test
This functionality is not implemented on the front end as of yet - read the code and the tests, make sure that the tests are written in a way as to actually test the scope, and that they pass

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-490

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
