### PR TITLE
TTAHUB-325: Add Program Specialists to CSV output

### DIFF
--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -67,7 +67,8 @@ function transformGrantModel(field) {
     const obj = {};
     const activityRecipients = await instance.activityRecipients;
     if (activityRecipients) {
-      const programSpecialistNames = activityRecipients.map((recipient) => (recipient.grant && recipient.grant[field] !== null ? recipient.grant[field] : '')).sort().join('\n');
+      const distinctPS = [...new Set(activityRecipients.map((recipient) => (recipient.grant && recipient.grant[field] !== null ? recipient.grant[field] : '')))];
+      const programSpecialistNames = distinctPS.sort().join('\n');
       Object.defineProperty(obj, field, {
         value: programSpecialistNames,
         enumerable: true,

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -62,6 +62,22 @@ function transformRelatedModel(field, prop) {
   return transformer;
 }
 
+function transformGrantModel(field) {
+  async function transformer(instance) {
+    const obj = {};
+    const activityRecipients = await instance.activityRecipients;
+    if (activityRecipients) {
+      const programSpecialistNames = activityRecipients.map((recipient) => (recipient.grant && recipient.grant[field] !== null ? recipient.grant[field] : '')).sort().join('\n');
+      Object.defineProperty(obj, field, {
+        value: programSpecialistNames,
+        enumerable: true,
+      });
+    }
+    return Promise.resolve(obj);
+  }
+  return transformer;
+}
+
 /*
  * Helper function for transformGoalsAndObjectives
  */
@@ -189,6 +205,7 @@ const arTransformers = [
   'lastSaved',
   transformDate('createdAt'),
   transformDate('approvedAt'),
+  transformGrantModel('programSpecialistName'),
 ];
 
 /**

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -149,7 +149,7 @@ describe('activityReportToCsvRecord', () => {
     };
     expect(output).toMatchObject(expectedOutput);
   });
-  // ActivityRecipient
+
   it('transforms related models into string values', async () => {
     const report = await ActivityReport.build(mockReport, {
       include: [{ model: User, as: 'author' },

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -3,6 +3,9 @@ import {
   Goal,
   Objective,
   User,
+  ActivityRecipient,
+  Grant,
+  Grantee,
 } from '../models';
 import { activityReportToCsvRecord, makeGoalsAndObjectivesObject, extractListOfGoalsAndObjectives } from './transform';
 
@@ -98,6 +101,23 @@ describe('activityReportToCsvRecord', () => {
     },
   ];
 
+  const mockActivityRecipients = [
+    {
+      id: 1,
+      grantId: 1,
+      grant: {
+        name: 'test1', programSpecialistName: 'Program Specialist 1', granteeId: 1, grantee: { name: 'test1' },
+      },
+    },
+    {
+      id: 2,
+      grantId: 2,
+      grant: {
+        name: 'test2', programSpecialistName: 'Program Specialist 2', granteeId: 2, grantee: { name: 'test2' },
+      },
+    },
+  ];
+
   const mockReport = {
     id: 209914,
     regionId: 14,
@@ -114,6 +134,7 @@ describe('activityReportToCsvRecord', () => {
     lastUpdatedBy: mockAuthor,
     collaborators: mockCollaborators,
     approvedAt: new Date(),
+    activityRecipients: mockActivityRecipients,
   };
 
   it('transforms arrays of strings into strings', async () => {
@@ -128,16 +149,26 @@ describe('activityReportToCsvRecord', () => {
     };
     expect(output).toMatchObject(expectedOutput);
   });
-
+  // ActivityRecipient
   it('transforms related models into string values', async () => {
     const report = await ActivityReport.build(mockReport, {
-      include: [{ model: User, as: 'author' }, { model: User, as: 'lastUpdatedBy' }, { model: User, as: 'collaborators' }],
+      include: [{ model: User, as: 'author' },
+        { model: User, as: 'lastUpdatedBy' },
+        { model: User, as: 'collaborators' },
+        {
+          model: ActivityRecipient,
+          as: 'activityRecipients',
+          include: [{ model: Grant, as: 'grant', include: [{ model: Grantee, as: 'grantee' }] }],
+        }],
     });
     const output = await activityReportToCsvRecord(report);
-    const { author, lastUpdatedBy, collaborators } = output;
+    const {
+      author, lastUpdatedBy, collaborators, programSpecialistName,
+    } = output;
     expect(author).toEqual('Arthur, GS');
     expect(lastUpdatedBy).toEqual('Arthur');
     expect(collaborators).toEqual('Collaborator 1, GS, HS\nCollaborator 2');
+    expect(programSpecialistName).toEqual('Program Specialist 1\nProgram Specialist 2');
   });
 
   it('transforms goals and objectives into many values', async () => {

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -103,6 +103,13 @@ describe('activityReportToCsvRecord', () => {
 
   const mockActivityRecipients = [
     {
+      id: 4,
+      grantId: 4,
+      grant: {
+        name: 'test4', programSpecialistName: 'Program Specialist 4', granteeId: 4, grantee: { name: 'test4' },
+      },
+    },
+    {
       id: 1,
       grantId: 1,
       grant: {
@@ -114,6 +121,13 @@ describe('activityReportToCsvRecord', () => {
       grantId: 2,
       grant: {
         name: 'test2', programSpecialistName: 'Program Specialist 2', granteeId: 2, grantee: { name: 'test2' },
+      },
+    },
+    {
+      id: 3,
+      grantId: 3,
+      grant: {
+        name: 'test3', programSpecialistName: 'Program Specialist 1', granteeId: 3, grantee: { name: 'test3' },
       },
     },
   ];
@@ -168,7 +182,7 @@ describe('activityReportToCsvRecord', () => {
     expect(author).toEqual('Arthur, GS');
     expect(lastUpdatedBy).toEqual('Arthur');
     expect(collaborators).toEqual('Collaborator 1, GS, HS\nCollaborator 2');
-    expect(programSpecialistName).toEqual('Program Specialist 1\nProgram Specialist 2');
+    expect(programSpecialistName).toEqual('Program Specialist 1\nProgram Specialist 2\nProgram Specialist 4');
   });
 
   it('transforms goals and objectives into many values', async () => {

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -75,6 +75,10 @@ async function sendActivityReportCSV(reports, res) {
           header: 'Collaborators',
         },
         {
+          key: 'programSpecialistName',
+          header: 'Program Specialists',
+        },
+        {
           key: 'requester',
           header: 'Requester',
         },

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -699,7 +699,7 @@ async function getDownloadableActivityReports(where) {
           include: [
             {
               model: Grant,
-              attributes: ['id', 'number'],
+              attributes: ['id', 'number', 'programSpecialistName'],
               as: 'grant',
               required: false,
               include: [


### PR DESCRIPTION
## Description of change

Add Program Specialists to CSV output.

## How to test

Exporting the CSV of approved reports should add all Program Specialist names.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-325


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
