### PR TITLE
[TTAHUB-485] Create scopes for reason on Activity Report

### DIFF
--- a/src/scopes/activityReport/index.js
+++ b/src/scopes/activityReport/index.js
@@ -13,6 +13,7 @@ import { withoutCalculatedStatus, withCalculatedStatus } from './calculatedStatu
 import { withProgramSpecialist, withoutProgramSpecialist } from './programSpecialist';
 import { withRole, withoutRole } from './role';
 import withRegion from './region';
+import { withoutReason, withReason } from './reason';
 
 export const topicToQuery = {
   reportId: {
@@ -68,6 +69,10 @@ export const topicToQuery = {
   },
   region: {
     in: (query) => withRegion(query),
+  },
+  reason: {
+    in: (query) => withReason(query),
+    nin: (query) => withoutReason(query),
   },
 };
 

--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -865,6 +865,69 @@ describe('filtersToScopes', () => {
     });
   });
 
+  describe('reason', () => {
+    let possibleIds;
+    let reportOne;
+    let reportTwo;
+    let reportThree;
+    let reportFour;
+
+    beforeAll(async () => {
+      reportOne = await ActivityReport.create({ ...approvedReport, reason: ['School Readiness Goals', 'Child Incidents'] });
+      reportTwo = await ActivityReport.create({ ...approvedReport, reason: ['School Readiness Goals', 'Ongoing Quality Improvement'] });
+      reportThree = await ActivityReport.create({ ...approvedReport, reason: ['COVID-19 response'] });
+      reportFour = await ActivityReport.create({ ...approvedReport, reason: [] });
+
+      possibleIds = [
+        reportOne.id,
+        reportTwo.id,
+        reportThree.id,
+        reportFour.id,
+      ];
+    });
+
+    afterAll(async () => {
+      await ActivityReport.destroy({
+        where: {
+          id: possibleIds,
+        },
+      });
+    });
+
+    it('returns reports with a specific reason', async () => {
+      const filters = { 'reason.in': ['School Readiness Goals'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id)).toEqual(expect.arrayContaining([reportOne.id, reportTwo.id]));
+    });
+
+    it('returns reports without a specific reason', async () => {
+      const filters = { 'reason.nin': ['School Readiness Goals'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([reportThree.id, reportFour.id]));
+    });
+
+    it('only searches by allowed reasons', async () => {
+      const filters = { 'reason.in': ['Pesky the Clown'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+
+      expect(found.length).toBe(4);
+    });
+  });
+
   describe('program specialist', () => {
     let reportIncluded1;
     let reportIncluded2;

--- a/src/scopes/activityReport/reason.js
+++ b/src/scopes/activityReport/reason.js
@@ -1,0 +1,27 @@
+import filterArray from './utils';
+import { REASONS } from '../../constants';
+
+function onlyValidReasons(query) {
+  if (!Array.isArray(query)) {
+    return [query].filter((reason) => REASONS.includes(reason));
+  }
+
+  return query.filter((reason) => REASONS.includes(reason));
+}
+
+export function withReason(query) {
+  const reason = onlyValidReasons(query);
+  if (!reason.length) {
+    return {};
+  }
+
+  return filterArray('ARRAY_TO_STRING(reason, \',\')', reason, false);
+}
+
+export function withoutReason(query) {
+  const reason = onlyValidReasons(query);
+  if (!reason.length) {
+    return {};
+  }
+  return filterArray('ARRAY_TO_STRING(reason, \',\')', reason, true);
+}


### PR DESCRIPTION
## Description of change
Create two scopes on the backend that can be applied to activity reports, one to include activity reports on a given reason, one to exclude the same.

## How to test
This functionality is not implemented on the front end as of yet - read the code and the tests, make sure that the tests are written in a way as to actually test the scope, and that they pass

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-485

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
