### PR TITLE
[TTAHUB-494] add specialists to grants table

### DIFF
--- a/frontend/src/pages/GranteeRecord/components/GrantsList.js
+++ b/frontend/src/pages/GranteeRecord/components/GrantsList.js
@@ -21,6 +21,8 @@ export default function GrantsList({ summary }) {
           <td>
             {grant.programs ? getDistinctSortedArray(grant.programs.map((program) => program.programType)).join(', ') : ''}
           </td>
+          <td>{grant.programSpecialistName}</td>
+          <td>{grant.grantSpecialistName}</td>
           <td>
             {grant.endDate ? moment(grant.endDate).format('MM/DD/yyyy') : null}
           </td>
@@ -43,6 +45,8 @@ export default function GrantsList({ summary }) {
               <th scope="col">Grant Number</th>
               <th scope="col">Status</th>
               <th scope="col">Program Type(s)</th>
+              <th scope="col">Program Specialist</th>
+              <th scope="col">Grant Specialist</th>
               <th scope="col">Project End Date</th>
             </tr>
           </thead>
@@ -65,8 +69,9 @@ GrantsList.propTypes = {
           number: PropTypes.string,
           status: PropTypes.string,
           endDate: PropTypes.string,
+          programSpecialistName: PropTypes.string,
+          grantSpecialistName: PropTypes.string,
         }),
       ),
     }).isRequired,
-
 };

--- a/frontend/src/pages/GranteeRecord/components/GrantsList.js
+++ b/frontend/src/pages/GranteeRecord/components/GrantsList.js
@@ -24,6 +24,9 @@ export default function GrantsList({ summary }) {
           <td>{grant.programSpecialistName}</td>
           <td>{grant.grantSpecialistName}</td>
           <td>
+            {grant.startDate ? moment(grant.startDate).format('MM/DD/yyyy') : null}
+          </td>
+          <td>
             {grant.endDate ? moment(grant.endDate).format('MM/DD/yyyy') : null}
           </td>
         </tr>
@@ -47,6 +50,7 @@ export default function GrantsList({ summary }) {
               <th scope="col">Program Type(s)</th>
               <th scope="col">Program Specialist</th>
               <th scope="col">Grant Specialist</th>
+              <th scope="col">Project Start Date</th>
               <th scope="col">Project End Date</th>
             </tr>
           </thead>

--- a/frontend/src/pages/GranteeRecord/components/__tests__/GrantsList.js
+++ b/frontend/src/pages/GranteeRecord/components/__tests__/GrantsList.js
@@ -15,6 +15,8 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('columnheader', { name: /status/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /program type\(s\)/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /project end date/i })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: /program specialist/i })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: /grant specialist/i })).toBeInTheDocument();
   });
   it('renders correctly with data', async () => {
     const summary = {
@@ -34,6 +36,8 @@ describe('Grants List Widget', () => {
           ],
           endDate: '2021-09-28',
           id: 1,
+          programSpecialistName: 'Tim',
+          grantSpecialistName: 'Sam',
         },
         {
           name: 'Grant Name 2',
@@ -45,6 +49,8 @@ describe('Grants List Widget', () => {
             },
           ],
           endDate: '2021-10-01',
+          programSpecialistName: 'Jim',
+          grantSpecialistName: 'Joe',
         },
       ],
     };
@@ -58,12 +64,15 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('link', { name: /grant number 1/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: 'Active' })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /ehs, hs/i })).toBeInTheDocument();
-    expect(await screen.findByRole('cell', { name: /09\/28\/2021/i })).toBeInTheDocument();
+    expect(await screen.findByRole('cell', { name: /tim/i })).toBeInTheDocument();
+    expect(await screen.findByRole('cell', { name: /sam/i })).toBeInTheDocument();
 
     // Grant 2.
     expect(await screen.findByRole('link', { name: /grant number 2/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: 'Inactive' })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /ehs-ccp/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /10\/01\/2021/i })).toBeInTheDocument();
+    expect(await screen.findByRole('cell', { name: /jim/i })).toBeInTheDocument();
+    expect(await screen.findByRole('cell', { name: /joe/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/GranteeRecord/components/__tests__/GrantsList.js
+++ b/frontend/src/pages/GranteeRecord/components/__tests__/GrantsList.js
@@ -14,6 +14,7 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('heading', { name: /grants/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /status/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /program type\(s\)/i })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: /project start date/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /project end date/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /program specialist/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /grant specialist/i })).toBeInTheDocument();
@@ -34,7 +35,6 @@ describe('Grants List Widget', () => {
               programType: 'HS',
             },
           ],
-          endDate: '2021-09-28',
           id: 1,
           programSpecialistName: 'Tim',
           grantSpecialistName: 'Sam',
@@ -48,6 +48,7 @@ describe('Grants List Widget', () => {
               programType: 'EHS-CCP',
             },
           ],
+          startDate: '2020-10-02',
           endDate: '2021-10-01',
           programSpecialistName: 'Jim',
           grantSpecialistName: 'Joe',
@@ -71,6 +72,7 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('link', { name: /grant number 2/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: 'Inactive' })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /ehs-ccp/i })).toBeInTheDocument();
+    expect(await screen.findByRole('cell', { name: /10\/02\/2020/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /10\/01\/2021/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /jim/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /joe/i })).toBeInTheDocument();


### PR DESCRIPTION
## Description of change
Add program specialist and grant specialist to Grants list on Grantee Record Profile tab

## How to test
Visit a grantee record and view the grants table. Note the presence of the program specialist and grant specialist.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-494

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
