### PR TITLE
TTAHUB-474: Move context text field above goals /w fix for goal check box vertical alignment

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.css
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.css
@@ -1,7 +1,3 @@
 #goals .usa-checkbox {
     background: transparent;
 }
-
-#goals .usa-checkbox__label::before {
-    margin-top: -12px;
-}

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectivePicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectivePicker.js
@@ -37,7 +37,7 @@ const ObjectivePicker = () => {
   const singleObjective = objectives.length <= 1;
 
   return (
-    <div className="margin-top-4">
+    <div>
       <FormItem
         label='Because goals are associated with grantees, there is no "goal" field in this section. You must create at least one objective for this activity.'
         name={OBJECTIVE_LABEL}

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -45,7 +45,7 @@ const GoalsObjectives = () => {
         <title>Goals and objectives</title>
       </Helmet>
       <Fieldset className="smart-hub--report-legend margin-top-4" legend="Context">
-        <Label htmlFor="context">OPTIONAL: Provide background or context for this activity</Label>
+        <Label htmlFor="context">Provide background or context for this activity</Label>
         <div className="smart-hub--text-area__resize-vertical margin-top-1">
           <HookFormRichEditor ariaLabel="Context" name="context" id="context" />
         </div>

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -44,6 +44,12 @@ const GoalsObjectives = () => {
       <Helmet>
         <title>Goals and objectives</title>
       </Helmet>
+      <Fieldset className="smart-hub--report-legend margin-top-4" legend="Context">
+        <Label htmlFor="context">OPTIONAL: Provide background or context for this activity</Label>
+        <div className="smart-hub--text-area__resize-vertical margin-top-1">
+          <HookFormRichEditor ariaLabel="Context" name="context" id="context" />
+        </div>
+      </Fieldset>
       {!recipientGrantee && (
         <Fieldset className="smart-hub--report-legend margin-top-4" legend="Objectives for non-grantee TTA">
           <ObjectivePicker />
@@ -58,12 +64,6 @@ const GoalsObjectives = () => {
           />
         </Fieldset>
         )}
-      <Fieldset className="smart-hub--report-legend margin-top-4" legend="Context">
-        <Label htmlFor="context">OPTIONAL: Provide background or context for this activity</Label>
-        <div className="smart-hub--text-area__resize-vertical margin-top-1">
-          <HookFormRichEditor ariaLabel="Context" name="context" id="context" />
-        </div>
-      </Fieldset>
     </>
   );
 };


### PR DESCRIPTION
## Description of change
- When creating a new AR the context text field now appears above the goals section.
- Entering a new goal the check box now aligns vertically with the text.


## How to test
- Create a new AR the Context text field should now appear above the goals.
- When adding a new goal the check box to the left of the text should be aligned vertically.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-474


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
