### PR TITLE
Grantee search fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "update-node-to-14.18.1"
+    default: "js-478-grantee-search-fixes"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "kw-test-data"

--- a/frontend/src/pages/GranteeSearch/__tests__/index.js
+++ b/frontend/src/pages/GranteeSearch/__tests__/index.js
@@ -11,7 +11,6 @@ import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import join from 'url-join';
-import { v4 as uuidv4 } from 'uuid';
 import { act } from 'react-dom/test-utils';
 import GranteeSearch from '../index';
 import { SCOPE_IDS } from '../../../Constants';
@@ -45,121 +44,74 @@ const res = {
     {
       id: 2,
       name: 'major tom',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 3,
       name: 'major bob',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 4,
       name: 'major sara',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 5,
       name: 'major tara',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 6,
       name: 'major jim',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 7,
       name: 'major xi',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 1,
       name: 'major larry',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 8,
       name: 'major maggie',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 10,
       name: 'major brian',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 11,
       name: 'major chumley',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 12,
       name: 'major karen',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
     {
       id: 13,
       name: 'major superhero',
-      grants: [
-        {
-          programSpecialistName: 'someone else',
-          number: uuidv4(),
-        },
-      ],
+      specialists: ['someone else'],
+      regionId: 1,
     },
   ],
 };
@@ -187,7 +139,7 @@ describe('the grantee search page', () => {
       homeRegionId: 14,
     };
 
-    fetchMock.get('/api/grantee/search?s=&region.in[]=1&region.in[]=2&sortBy=name&direction=asc&offset=0', res);
+    fetchMock.get('/api/grantee/search?s=&region.in[]=1&region.in[]=2&sortBy=regionId&direction=asc&offset=0', res);
     renderGranteeSearch(user);
     expect(screen.getByRole('heading', { name: /grantee records/i })).toBeInTheDocument();
     const regionalSelect = screen.getByRole('button', { name: 'toggle regional select menu' });
@@ -280,10 +232,10 @@ describe('the grantee search page', () => {
   it('the regional select works with all regions', async () => {
     const user = { ...userBluePrint, homeRegionId: 14 };
 
-    fetchMock.get('/api/grantee/search?s=&region.in[]=1&region.in[]=2&sortBy=name&direction=asc&offset=0', res);
+    fetchMock.get('/api/grantee/search?s=&region.in[]=1&region.in[]=2&sortBy=regionId&direction=asc&offset=0', res);
 
     renderGranteeSearch(user);
-    const url = join(granteeUrl, 'search?s=ground%20control&region.in[]=1&region.in[]=2&sortBy=name&direction=asc&offset=0');
+    const url = join(granteeUrl, 'search?s=ground%20control&region.in[]=1&region.in[]=2&sortBy=regionId&direction=asc&offset=0');
     fetchMock.get(url, res);
 
     const searchBox = screen.getByRole('searchbox');
@@ -399,12 +351,8 @@ describe('the grantee search page', () => {
           {
             id: 14,
             name: 'major barack',
-            grants: [
-              {
-                programSpecialistName: 'someone else',
-                number: uuidv4(),
-              },
-            ],
+            regionId: 1,
+            specialists: ['someone else'],
           },
         ],
       });

--- a/frontend/src/pages/GranteeSearch/components/GranteeResults.js
+++ b/frontend/src/pages/GranteeSearch/components/GranteeResults.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Container from '../../../components/Container';
 import './GranteeResults.css';
 import TableHeader from '../../../components/TableHeader';
-import { getDistinctSortedArray } from '../../../utils';
 
 export default function GranteeResults(
   {
@@ -23,17 +22,13 @@ export default function GranteeResults(
 
   const renderGrantee = (grantee) => {
     // Get a unique sorted list of Program Specialists.
-    const valueArray = grantee.grants.map((p) => p.programSpecialistName);
-    const psList = getDistinctSortedArray(valueArray).join(', ');
-    const grant = grantee.grants[0];
-
-    const { number, regionId } = grant;
+    const { regionId, programSpecialists } = grantee;
 
     return (
-      <tr key={grantee.id + number}>
+      <tr key={`${grantee.id} ${regionId}`}>
         <td>{regionId}</td>
         <td><Link to={`/grantee/${grantee.id}/profile?region=${regionId}`}>{grantee.name}</Link></td>
-        <td className="maxw-3">{psList}</td>
+        <td className="maxw-3">{programSpecialists}</td>
       </tr>
     );
   };

--- a/frontend/src/pages/GranteeSearch/components/__tests__/GranteeResults.js
+++ b/frontend/src/pages/GranteeSearch/components/__tests__/GranteeResults.js
@@ -15,57 +15,49 @@ const history = createMemoryHistory();
 const grantees = [
   {
     id: 11,
+    granteeType: '',
     name: 'Agency 2 in region 1, Inc.',
-    createdAt: '2021-09-21T19:16:15.842Z',
-    updatedAt: '2021-09-21T19:16:15.842Z',
-    grants: [
-      {
-        id: 12,
-        number: '09HP01111',
-        regionId: 1,
-        programSpecialistName: 'Candyman',
-      },
-      {
-        id: 13,
-        number: '09HP0112',
-        regionId: 2,
-        programSpecialistName: 'Tony Todd',
-      },
-      {
-        id: 14,
-        number: '09HP01113',
-        regionId: 3,
-        programSpecialistName: 'Doug Bradley',
-      },
+    regionId: 1,
+    specialists: [
+      'Tony Todd',
+      'Candyman',
+    ],
+  },
+  {
+    id: 11,
+    granteeType: '',
+    name: 'Agency 2 in region 1, Inc.',
+    regionId: 2,
+    specialists: [
+      'Tony Todd',
+    ],
+  },
+  {
+    id: 11,
+    granteeType: '',
+    name: 'Agency 2 in region 1, Inc.',
+    regionId: 2,
+    specialists: [
+      'Doug Bradley',
     ],
   },
   {
     id: 10,
+    granteeType: '',
     name: 'Agency 1.b in region 1, Inc.',
+    regionId: 1,
     createdAt: '2021-09-21T19:16:15.842Z',
     updatedAt: '2021-09-21T19:16:15.842Z',
-    grants: [
-      {
-        id: 11,
-        number: '01HP022222',
-        regionId: 1,
-        programSpecialistName: null,
-      },
-    ],
+    specialists: [],
   },
   {
     id: 9,
+    granteeType: '',
     name: 'Agency 1.a in region 1, Inc.',
+    regionId: 1,
     createdAt: '2021-09-21T19:16:15.842Z',
     updatedAt: '2021-09-21T19:16:15.842Z',
-    grants: [
-      {
-        id: 10,
-        number: '01HP044444',
-        regionId: 1,
-        programSpecialistName: null,
-      },
-    ],
+    specialists: [],
   },
 ];
 
@@ -109,7 +101,7 @@ describe('Grantee Search > GranteeResults', () => {
     expect(screen.getByRole('link', {
       name: /agency 1\.a in region 1, inc\./i,
     })).toBeInTheDocument();
-    expect(screen.getByRole('cell', { name: /candyman, Doug Bradley, tony todd/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /candyman, tony todd/i })).toBeInTheDocument();
   });
 
   it('calls the sort function', async () => {

--- a/frontend/src/pages/GranteeSearch/components/__tests__/GranteeResults.js
+++ b/frontend/src/pages/GranteeSearch/components/__tests__/GranteeResults.js
@@ -18,28 +18,21 @@ const grantees = [
     granteeType: '',
     name: 'Agency 2 in region 1, Inc.',
     regionId: 1,
-    specialists: [
-      'Tony Todd',
-      'Candyman',
-    ],
+    programSpecialists: 'Candyman, Tony Todd',
   },
   {
     id: 11,
     granteeType: '',
     name: 'Agency 2 in region 1, Inc.',
     regionId: 2,
-    specialists: [
-      'Tony Todd',
-    ],
+    programSpecialists: 'Tony Todd',
   },
   {
     id: 11,
     granteeType: '',
     name: 'Agency 2 in region 1, Inc.',
-    regionId: 2,
-    specialists: [
-      'Doug Bradley',
-    ],
+    regionId: 3,
+    programSpecialists: 'Doug Bradley',
   },
   {
     id: 10,
@@ -48,7 +41,7 @@ const grantees = [
     regionId: 1,
     createdAt: '2021-09-21T19:16:15.842Z',
     updatedAt: '2021-09-21T19:16:15.842Z',
-    specialists: [],
+    programSpecialists: [],
   },
   {
     id: 9,
@@ -57,7 +50,7 @@ const grantees = [
     regionId: 1,
     createdAt: '2021-09-21T19:16:15.842Z',
     updatedAt: '2021-09-21T19:16:15.842Z',
-    specialists: [],
+    programSpecialists: [],
   },
 ];
 

--- a/frontend/src/pages/GranteeSearch/index.js
+++ b/frontend/src/pages/GranteeSearch/index.js
@@ -13,6 +13,16 @@ import { searchGrantees } from '../../fetchers/grantee';
 import { GRANTEES_PER_PAGE } from '../../Constants';
 import './index.css';
 
+const DEFAULT_SORT = {
+  sortBy: 'name',
+  direction: 'asc',
+};
+
+const DEFAULT_CENTRAL_OFFICE_SORT = {
+  sortBy: 'regionId',
+  direction: 'asc',
+};
+
 function GranteeSearch({ user }) {
   const hasCentralOffice = user && user.homeRegionId && user.homeRegionId === 14;
   const regions = getUserRegions(user);
@@ -21,10 +31,9 @@ function GranteeSearch({ user }) {
   const [results, setResults] = useState({ count: 0, rows: [] });
   const [activePage, setActivePage] = useState(1);
   const [loading, setLoading] = useState(false);
-  const [sortConfig, setSortConfig] = useState({
-    sortBy: 'name',
-    direction: 'asc',
-  });
+  const [sortConfig, setSortConfig] = useState(
+    hasCentralOffice ? DEFAULT_CENTRAL_OFFICE_SORT : DEFAULT_SORT,
+  );
 
   const inputRef = useRef();
 

--- a/src/lib/orderGranteesBy.js
+++ b/src/lib/orderGranteesBy.js
@@ -1,3 +1,5 @@
+import { sequelize } from '../models';
+
 const orderGranteesBy = (sortBy, sortDir) => {
   let result = '';
   switch (sortBy) {
@@ -13,7 +15,7 @@ const orderGranteesBy = (sortBy, sortDir) => {
           'grants', 'regionId', sortDir,
         ],
         [
-          'id',
+          'name',
           sortDir,
         ],
       ];
@@ -21,7 +23,14 @@ const orderGranteesBy = (sortBy, sortDir) => {
     case 'programSpecialist':
       result = [
         [
-          'grants', 'programSpecialistName', sortDir,
+          sequelize.literal('"programSpecialists"'), sortDir,
+        ],
+      ];
+      break;
+    case 'grantSpecialist':
+      result = [
+        [
+          sequelize.literal('"grantSpecialists"'), sortDir,
         ],
       ];
       break;

--- a/src/lib/orderGranteesBy.test.js
+++ b/src/lib/orderGranteesBy.test.js
@@ -1,4 +1,5 @@
 import orderGranteesBy from './orderGranteesBy';
+import { sequelize } from '../models';
 
 describe('orderGranteesBy', () => {
   it('returns the correct values', () => {
@@ -14,7 +15,7 @@ describe('orderGranteesBy', () => {
         'grants', 'regionId', 'desc',
       ],
       [
-        'id',
+        'name',
         'desc',
       ],
     ]);
@@ -23,7 +24,7 @@ describe('orderGranteesBy', () => {
 
     expect(three).toStrictEqual([
       [
-        'grants', 'programSpecialistName', 'asc',
+        sequelize.literal('"programSpecialists"'), 'asc',
       ],
     ]);
 

--- a/src/services/grantee.js
+++ b/src/services/grantee.js
@@ -64,8 +64,8 @@ export async function granteesByName(query, scopes, sortBy, direction, offset) {
   const rows = await Grantee.findAll({
     attributes: [
       [sequelize.literal('DISTINCT COUNT(*) OVER()'), 'count'],
-      [sequelize.fn('STRING_AGG', sequelize.fn('DISTINCT', sequelize.col('grants.programSpecialistName')), ', '), 'programSpecialists'],
-      [sequelize.fn('STRING_AGG', sequelize.fn('DISTINCT', sequelize.col('grants.grantSpecialistName')), ', '), 'grantSpecialists'],
+      sequelize.literal('STRING_AGG(DISTINCT "grants"."programSpecialistName", \', \' order by "grants"."programSpecialistName") as "programSpecialists"'),
+      sequelize.literal('STRING_AGG(DISTINCT "grants"."grantSpecialistName", \', \' order by "grants"."grantSpecialistName") as "grantSpecialists"'),
       [sequelize.col('grants.regionId'), 'regionId'],
       'id',
       'name',

--- a/src/services/grantee.test.js
+++ b/src/services/grantee.test.js
@@ -257,18 +257,23 @@ describe('Grantee DB service', () => {
       },
     ];
 
-    beforeEach(async () => {
+    function regionToScope(regionId) {
+      const query = { 'region.in': [regionId] };
+      return filtersToScopes(query, 'grant');
+    }
+
+    beforeAll(async () => {
       await Promise.all(granteesToSearch.map((g) => Grantee.create(g)));
       await Promise.all(grants.map((g) => Grant.create(g)));
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
       await Grant.destroy({ where: { granteeId: granteesToSearch.map((g) => g.id) } });
       await Grantee.destroy({ where: { id: granteesToSearch.map((g) => g.id) } });
     });
 
     it('finds based on grantee name', async () => {
-      const foundGrantees = await granteesByName('apple', 1, 'name', 'asc', 0);
+      const foundGrantees = await granteesByName('apple', regionToScope(1), 'name', 'asc', 0);
       expect(foundGrantees.rows.length).toBe(3);
       expect(foundGrantees.rows.map((g) => g.id)).toContain(63);
       expect(foundGrantees.rows.map((g) => g.id)).toContain(66);
@@ -276,43 +281,43 @@ describe('Grantee DB service', () => {
     });
 
     it('finds based on grantee id', async () => {
-      const foundGrantees = await granteesByName('5555', 1, 'name', 'asc', 0);
+      const foundGrantees = await granteesByName('5555', regionToScope(1), 'name', 'asc', 0);
       expect(foundGrantees.rows.length).toBe(1);
       expect(foundGrantees.rows.map((g) => g.id)).toContain(64);
     });
 
     it('finds based on region', async () => {
-      const foundGrantees = await granteesByName('banana', 2, 'name', 'asc', 0);
+      const foundGrantees = await granteesByName('banana', regionToScope(2), 'name', 'asc', 0);
       expect(foundGrantees.rows.length).toBe(1);
       expect(foundGrantees.rows.map((g) => g.id)).toContain(65);
     });
 
     it('sorts based on name', async () => {
-      const foundGrantees = await granteesByName('apple', 1, 'name', 'asc', 0);
+      const foundGrantees = await granteesByName('apple', regionToScope(1), 'name', 'asc', 0);
       expect(foundGrantees.rows.length).toBe(3);
       expect(foundGrantees.rows.map((g) => g.id)).toStrictEqual([68, 63, 66]);
     });
 
     it('sorts based on program specialist', async () => {
-      const foundGrantees = await granteesByName('apple', 1, 'programSpecialist', 'asc', 0);
+      const foundGrantees = await granteesByName('apple', regionToScope(1), 'programSpecialist', 'asc', 0);
       expect(foundGrantees.rows.length).toBe(3);
       expect(foundGrantees.rows.map((g) => g.id)).toStrictEqual([66, 63, 68]);
     });
 
     it('sorts based on grant specialist', async () => {
-      const foundGrantees = await granteesByName('apple', 1, 'grantSpecialistName', 'desc', 0);
+      const foundGrantees = await granteesByName('apple', regionToScope(1), 'grantSpecialist', 'asc', 0);
       expect(foundGrantees.rows.length).toBe(3);
-      expect(foundGrantees.rows.map((g) => g.id)).toStrictEqual([63, 66, 68]);
+      expect(foundGrantees.rows.map((g) => g.id)).toStrictEqual([68, 63, 66]);
     });
 
     it('respects sort order', async () => {
-      const foundGrantees = await granteesByName('apple', 1, 'name', 'desc', 0);
+      const foundGrantees = await granteesByName('apple', regionToScope(1), 'name', 'desc', 0);
       expect(foundGrantees.rows.length).toBe(3);
       expect(foundGrantees.rows.map((g) => g.id)).toStrictEqual([66, 63, 68]);
     });
 
     it('respects the offset passed in', async () => {
-      const foundGrantees = await granteesByName('apple', 1, 'name', 'asc', 1);
+      const foundGrantees = await granteesByName('apple', regionToScope(1), 'name', 'asc', 1);
       expect(foundGrantees.rows.length).toBe(2);
       expect(foundGrantees.rows.map((g) => g.id)).toStrictEqual([63, 66]);
     });


### PR DESCRIPTION
## Description of change
 
 * Single SQL query hits the DB
 * Grouping by `regionId` allows recipients to be split on region
 * Sorting by region now has a secondary sort on name. Regional office defaults to sorting by region
 * Program/Grant specialists are ordered and put in a comma separated string in SQL
 * Updated frontend to just display result from the API

## How to test

View the grantee search page. This branch is deploying to dev so you should be able to search/sort using "real" program specialists.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-478

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
