### PR TITLE
[TTAHUB-484] Add program type scope for activity reports

### DIFF
--- a/src/scopes/activityReport/index.js
+++ b/src/scopes/activityReport/index.js
@@ -13,6 +13,7 @@ import { withoutCalculatedStatus, withCalculatedStatus } from './calculatedStatu
 import { withProgramSpecialist, withoutProgramSpecialist } from './programSpecialist';
 import { withRole, withoutRole } from './role';
 import withRegion from './region';
+import { withoutProgramTypes, withProgramTypes } from './programType';
 
 export const topicToQuery = {
   reportId: {
@@ -65,6 +66,10 @@ export const topicToQuery = {
   programSpecialist: {
     in: (query) => withProgramSpecialist(query),
     nin: (query) => withoutProgramSpecialist(query),
+  },
+  programType: {
+    in: (query) => withProgramTypes(query),
+    nin: (query) => withoutProgramTypes(query),
   },
   region: {
     in: (query) => withRegion(query),

--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -976,9 +976,9 @@ describe('filtersToScopes', () => {
   });
 
   describe('programType', () => {
-    let reportIncluded1;
-    let reportIncluded2;
-    let reportExcluded;
+    let reportOne;
+    let reportTwo;
+    let reportThree;
 
     let granteeIncluded1;
     let granteeIncluded2;
@@ -991,6 +991,10 @@ describe('filtersToScopes', () => {
     let activityRecipientIncluded1;
     let activityRecipientIncluded2;
     let activityRecipientExcluded;
+
+    let programOne;
+    let programTwo;
+    let programThree;
 
     let possibleIds;
 
@@ -1033,21 +1037,21 @@ describe('filtersToScopes', () => {
         updatedAt: new Date(),
       };
 
-      await Program.create({
+      programOne = await Program.create({
         ...dummyProgram,
         id: grantIncluded1.id,
         name: faker.name.findName(),
         grantId: grantIncluded1.id,
         programType: 'EHS',
       });
-      await Program.create({
+      programTwo = await Program.create({
         ...dummyProgram,
         id: grantIncluded2.id,
         name: faker.name.findName(),
         grantId: grantIncluded2.id,
         programType: 'EHS',
       });
-      await Program.create({
+      programThree = await Program.create({
         ...dummyProgram,
         id: grantExcluded.id,
         name: faker.name.findName(),
@@ -1055,27 +1059,27 @@ describe('filtersToScopes', () => {
         programType: 'HS',
       });
 
-      reportIncluded1 = await ActivityReport.create({ ...draftReport });
-      reportIncluded2 = await ActivityReport.create({ ...draftReport });
-      reportExcluded = await ActivityReport.create({ ...draftReport });
+      reportOne = await ActivityReport.create({ ...draftReport });
+      reportTwo = await ActivityReport.create({ ...draftReport });
+      reportThree = await ActivityReport.create({ ...draftReport });
 
       activityRecipientIncluded1 = await ActivityRecipient.create({
-        activityReportId: reportIncluded1.id,
+        activityReportId: reportOne.id,
         grantId: grantIncluded1.id,
       });
       activityRecipientIncluded2 = await ActivityRecipient.create({
-        activityReportId: reportIncluded2.id,
+        activityReportId: reportTwo.id,
         grantId: grantIncluded2.id,
       });
       activityRecipientExcluded = await ActivityRecipient.create({
-        activityReportId: reportExcluded.id,
+        activityReportId: reportThree.id,
         grantId: grantExcluded.id,
       });
 
       possibleIds = [
-        reportIncluded1.id,
-        reportIncluded2.id,
-        reportExcluded.id,
+        reportOne.id,
+        reportTwo.id,
+        reportThree.id,
         globallyExcludedReport.id,
       ];
     });
@@ -1091,11 +1095,11 @@ describe('filtersToScopes', () => {
         },
       });
       await ActivityReport.destroy({
-        where: { id: [reportIncluded1.id, reportIncluded2.id, reportExcluded.id] },
+        where: { id: [reportOne.id, reportTwo.id, reportThree.id] },
       });
 
       await Program.destroy({
-        where: { id: [grantIncluded1.id, grantIncluded2.id, grantExcluded.id] },
+        where: { id: [programOne.id, programTwo.id, programThree.id] },
       });
 
       await Grant.destroy({
@@ -1107,14 +1111,14 @@ describe('filtersToScopes', () => {
     });
 
     it('includes program type', async () => {
-      const filters = { 'programType.in': ['EHS'] };
+      const filters = { 'programType.in': ['EHS', 'HS'] };
       const scope = filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
       });
-      expect(found.length).toBe(2);
+      expect(found.length).toBe(3);
       expect(found.map((f) => f.id))
-        .toEqual(expect.arrayContaining([reportIncluded1.id, reportIncluded2.id]));
+        .toEqual(expect.arrayContaining([reportOne.id, reportTwo.id, reportThree.id]));
     });
 
     it('excludes program type', async () => {
@@ -1125,7 +1129,7 @@ describe('filtersToScopes', () => {
       });
       expect(found.length).toBe(2);
       expect(found.map((f) => f.id))
-        .toEqual(expect.arrayContaining([reportExcluded.id, globallyExcludedReport.id]));
+        .toEqual(expect.arrayContaining([reportThree.id, globallyExcludedReport.id]));
     });
   });
 

--- a/src/scopes/activityReport/programType.js
+++ b/src/scopes/activityReport/programType.js
@@ -1,3 +1,4 @@
+import { Op } from 'sequelize';
 import { filterAssociation } from './utils';
 
 const programTypes = `
@@ -7,9 +8,9 @@ const programTypes = `
     WHERE "Programs"."programType"`;
 
 export function withProgramTypes(types) {
-  return filterAssociation(programTypes, types, false);
+  return filterAssociation(programTypes, types, false, '~*', Op.or);
 }
 
 export function withoutProgramTypes(types) {
-  return filterAssociation(programTypes, types, true);
+  return filterAssociation(programTypes, types, true, '~*', Op.or);
 }

--- a/src/scopes/activityReport/programType.js
+++ b/src/scopes/activityReport/programType.js
@@ -1,16 +1,31 @@
-import { Op } from 'sequelize';
 import { filterAssociation } from './utils';
 
+// this should return an array of activityReport ids. That where clause will be finished when the
+// function is called
 const programTypes = `
     SELECT "ActivityRecipients"."activityReportId" FROM "ActivityRecipients"
     INNER JOIN "Grants" ON "Grants".id = "ActivityRecipients"."grantId"
     INNER JOIN "Programs" ON "Programs"."grantId" = "Grants"."id" 
     WHERE "Programs"."programType"`;
 
+/**
+ *
+ * - in the two functions below, type is expected to be an array of Program Types
+ * - The filter association function takes a partial SQL statement and then creates an array of
+ * SQL statements joined by an AND or an OR depending on which function is called
+ * - see the ./utils.js file for more details
+
+ * @param {*} types an array of strings
+ * @returns an object with a where clause in the sequelize syntax
+ */
 export function withProgramTypes(types) {
-  return filterAssociation(programTypes, types, false, '~*', Op.or);
+  return filterAssociation(programTypes, types, false, '~*');
 }
 
+/**
+ * @param {*} types an array of strings
+ * @returns an object with a where clause in the sequelize syntax
+ */
 export function withoutProgramTypes(types) {
-  return filterAssociation(programTypes, types, true, '~*', Op.or);
+  return filterAssociation(programTypes, types, true, '~*');
 }

--- a/src/scopes/activityReport/programType.js
+++ b/src/scopes/activityReport/programType.js
@@ -1,0 +1,15 @@
+import { filterAssociation } from './utils';
+
+const programTypes = `
+    SELECT "ActivityRecipients"."activityReportId" FROM "ActivityRecipients"
+    INNER JOIN "Grants" ON "Grants".id = "ActivityRecipients"."grantId"
+    INNER JOIN "Programs" ON "Programs"."grantId" = "Grants"."id" 
+    WHERE "Programs"."programType"`;
+
+export function withProgramTypes(types) {
+  return filterAssociation(programTypes, types, false);
+}
+
+export function withoutProgramTypes(types) {
+  return filterAssociation(programTypes, types, true);
+}

--- a/src/scopes/activityReport/utils.js
+++ b/src/scopes/activityReport/utils.js
@@ -23,15 +23,15 @@ export default function filterArray(column, searchTerms, exclude) {
   };
 }
 
-export function filterAssociation(baseQuery, searchTerms, exclude, comparator = '~*') {
+export function filterAssociation(baseQuery, searchTerms, exclude, comparator = '~*', operator = Op.and) {
   if (exclude) {
     return {
-      [Op.and]:
+      [operator]:
         reportInSubQuery(baseQuery, searchTerms, 'NOT IN', comparator),
     };
   }
 
   return {
-    [Op.and]: reportInSubQuery(baseQuery, searchTerms, 'IN', comparator),
+    [operator]: reportInSubQuery(baseQuery, searchTerms, 'IN', comparator),
   };
 }


### PR DESCRIPTION
## Description of change
Create two scopes on the backend that can be applied to activity reports, one to include activity reports on a given program type, one to exclude the same.

## How to test
This functionality is not implemented on the front end as of yet - read the code and the tests, make sure that the tests are written in a way as to actually test the scope, and that they pass

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-484

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
