### PR TITLE
Activity reports table component uses 'useDeepCompareEffect'

### DIFF
--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   Table, Checkbox, Grid, Alert,
 } from '@trussworks/react-uswds';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import { getReports, downloadReports } from '../../fetchers/activityReports';
 import { getReportsDownloadURL, getAllReportsDownloadURL } from '../../fetchers/helpers';
 import Container from '../Container';
@@ -48,7 +49,7 @@ function ActivityReportsTable({
     direction: 'desc',
   });
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     async function fetchReports() {
       setLoading(true);
       const filterQuery = filtersToQueryString(filters);


### PR DESCRIPTION
## Description of change

Props passed into the activity reports table sometimes are new objects. Use deep compare use effect to prevent multiple API calls on props that have not changed.

## How to test

Open the TTA History page on main with your network tab open. Note multiple API calls to `activity-reports`. Now reload the page with this branch, not only a single API call.
