### PR TITLE
[TTAHUB-499] filter menu should not close on blur

### DIFF
--- a/frontend/src/components/filter/FilterMenu.js
+++ b/frontend/src/components/filter/FilterMenu.js
@@ -66,19 +66,7 @@ export default function FilterMenu({ filters, onApplyFilters }) {
     setItems(newItems);
   };
 
-  const canBlur = (e) => {
-    if (e.relatedTarget && e.relatedTarget.matches('.ttahub-filter-menu')) {
-      return false;
-    }
-
-    // if we've a date range, also do nothing on blur when we click on those. this is kind of an
-    // annoyance created because we have nested dropdownmenus
-    if (e.target.matches('.CalendarDay, .DayPickerNavigation, .DayPickerNavigation_button')) {
-      return false;
-    }
-
-    return true;
-  };
+  const canBlur = () => false;
 
   return (
     <DropdownMenu


### PR DESCRIPTION
## Description of change

The filters panel shouldn't close on blur. The only ways to close it should be to successfully apply or cancel (or clicking the button again)

## How to test

Go to the Recipient record page, open the filter menu. Click around not on the menu, observe with satisfaction that the menu does not close.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-499

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
