### PR TITLE
include goals with null status

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -39,6 +39,9 @@ export async function goalsForGrants(grantIds) {
         {
           status: 'In Progress',
         },
+        {
+          status: null,
+        },
       ],
     },
     include: [

--- a/src/services/goals.test.js
+++ b/src/services/goals.test.js
@@ -213,6 +213,9 @@ describe('goalsForGrants', () => {
           {
             status: 'In Progress',
           },
+          {
+            status: null,
+          },
         ],
       },
       include: [


### PR DESCRIPTION
## Description of change

Right now, the only goals that selectable are goals with a status of Not Started or In Progress. Goals that have been created via the Hub have a status of null - therefore they should also be included.

## How to test
Create a goal in an AR. Create a second AR for the same Grantee, and confirm that this goal appears in the dropdown.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-501


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
