### PR TITLE
[TTAHUB-496] Update target populations on legacy reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ parameters:
     default: "update-node-to-14.18.1"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "kw-test-data"
+    default: "TTAHUB-496/update-legacy-ar-data"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,8 +365,8 @@ jobs:
                 app_name: tta-smarthub-sandbox
                 auth_client_id: SANDBOX_AUTH_CLIENT_ID
                 auth_client_secret: SANDBOX_AUTH_CLIENT_SECRET
-                cloudgov_username: CLOUDGOV_DEV_USERNAME
-                cloudgov_password: CLOUDGOV_DEV_PASSWORD
+                cloudgov_username: CLOUDGOV_SANDBOX_USERNAME
+                cloudgov_password: CLOUDGOV_SANDBOX_PASSWORD
                 cloudgov_space: CLOUDGOV_SANDBOX_SPACE
                 deploy_config_file: deployment_config/sandbox_vars.yml
                 new_relic_license: NEW_RELIC_LICENSE_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,8 +365,8 @@ jobs:
                 app_name: tta-smarthub-sandbox
                 auth_client_id: SANDBOX_AUTH_CLIENT_ID
                 auth_client_secret: SANDBOX_AUTH_CLIENT_SECRET
-                cloudgov_username: CLOUDGOV_SANDBOX_USERNAME
-                cloudgov_password: CLOUDGOV_SANDBOX_PASSWORD
+                cloudgov_username: CLOUDGOV_DEV_USERNAME
+                cloudgov_password: CLOUDGOV_DEV_PASSWORD
                 cloudgov_space: CLOUDGOV_SANDBOX_SPACE
                 deploy_config_file: deployment_config/sandbox_vars.yml
                 new_relic_license: NEW_RELIC_LICENSE_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ parameters:
     type: string
   sandbox_git_url:
     description: "URL of github repo that will deploy to sandbox"
-    default: "https://github.com/adhocteam/Head-Start-TTADP"
+    default: "https://github.com/HHS/Head-Start-TTADP"
     type: string
   prod_git_branch:
     description: "Name of github branch that will deploy to prod"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "addMissingGrantsToReports:local": "./node_modules/.bin/babel-node ./src/tools/addMissingGrantsToReportsCLI.js",
     "processData:local": "./node_modules/.bin/babel-node ./src/tools/processDataCLI.js",
     "changeReportStatus": "node ./build/server/tools/changeReportStatusCLI.js",
-    "changeReportStatus:local": "./node_modules/.bin/babel-node ./src/tools/changeReportStatusCLI.js"
+    "changeReportStatus:local": "./node_modules/.bin/babel-node ./src/tools/changeReportStatusCLI.js",
+    "updateLegacyPopulations": "node ./build/server/tools/updateLegacyPopulationsCLI.js",
+    "updateLegacyPopulations:local": "./node_modules/.bin/babel-node ./src/tools/updateLegacyPopulationsCLI.js"
   },
   "repository": {
     "type": "git",

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -14,7 +14,6 @@ export default async function updateLegacyPopulations() {
   `);
 
   const reports = await ActivityReport.findAll({
-    logging: console.log,
     where: {
       targetPopulations: {
         [Op.or]: [

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -8,14 +8,13 @@ const newPopulations = {
   'Affected by Homelessness': 'Children Experiencing Homelessness',
 };
 
-export default async function updateLegacyPopulations(id) {
+export default async function updateLegacyPopulations() {
   auditLogger.info(`Updating legacy target population data...
   
   `);
 
   const reports = await ActivityReport.findAll({
     where: {
-      id,
       targetPopulations: {
         [Op.or]: [
           {

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -31,14 +31,7 @@ export default async function updateLegacyPopulations() {
     },
   });
 
-  if (!reports.count) {
-    auditLogger.info(`No reports to update
-    
-    `);
-    return [];
-  }
-
-  auditLogger.info(`${reports.count} reports with affected data found...
+  auditLogger.info(`${reports.count ? reports.count : 0} reports with affected data found...
   
   `);
 

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -31,6 +31,13 @@ export default async function updateLegacyPopulations() {
     },
   });
 
+  if (!reports.count) {
+    auditLogger.info(`No reports to update
+    
+    `);
+    return [];
+  }
+
   auditLogger.info(`${reports.count} reports with affected data found...
   
   `);

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -19,10 +19,10 @@ export default async function updateLegacyPopulations(id) {
       targetPopulations: {
         [Op.or]: [
           {
-            [Op.contains]: ['Infants/Toddlers'],
+            [Op.contains]: ['Infant/Toddlers'],
           },
           {
-            [Op.contains]: ['Preschoolers'],
+            [Op.contains]: ['Preschool'],
           },
           {
             [Op.contains]: ['Affected by Homelessness'],

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -1,0 +1,58 @@
+import { Op } from 'sequelize';
+import { ActivityReport } from '../models';
+import { auditLogger } from '../logger';
+
+const newPopulations = {
+  'Infant/Toddlers': 'Infants and Toddlers (ages birth to 3)',
+  Preschool: 'Preschool (ages 3-5)',
+  'Affected by Homelessness': 'Children Experiencing Homelessness',
+};
+
+export default async function updateLegacyPopulations(id) {
+  auditLogger.info(`Updating legacy target population data...
+  
+  `);
+
+  const reports = await ActivityReport.findAll({
+    where: {
+      id,
+      targetPopulations: {
+        [Op.or]: [
+          {
+            [Op.contains]: ['Infants/Toddlers'],
+          },
+          {
+            [Op.contains]: ['Preschoolers'],
+          },
+          {
+            [Op.contains]: ['Affected by Homelessness'],
+          },
+        ],
+      },
+    },
+  });
+
+  auditLogger.info(`${reports.count} reports with affected data found...
+  
+  `);
+
+  return Promise.all(reports.map(async (report) => {
+    const populations = [...report.targetPopulations];
+    populations.forEach((population, index) => {
+      const newPopulation = newPopulations[population];
+      if (!newPopulation) {
+        return;
+      }
+
+      populations.splice(index, 1, newPopulation);
+    });
+
+    auditLogger.info(`Updating report ${report.id}'s target populations from ${report.targetPopulations} to ${populations}
+    
+    `);
+
+    return report.update({
+      targetPopulations: populations,
+    });
+  }));
+}

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -14,6 +14,7 @@ export default async function updateLegacyPopulations() {
   `);
 
   const reports = await ActivityReport.findAll({
+    logging: console.log,
     where: {
       targetPopulations: {
         [Op.or]: [

--- a/src/tools/updateLegacyPopulations.js
+++ b/src/tools/updateLegacyPopulations.js
@@ -8,7 +8,7 @@ const newPopulations = {
   'Affected by Homelessness': 'Children Experiencing Homelessness',
 };
 
-export default async function updateLegacyPopulations(id) {
+export default async function updateLegacyPopulations() {
   auditLogger.info(`Updating legacy target population data...
   
   `);
@@ -16,7 +16,6 @@ export default async function updateLegacyPopulations(id) {
   const reports = await ActivityReport.findAll({
     attributes: ['id', 'targetPopulations', 'imported'],
     where: {
-      id,
       [Op.or]: [
         {
           targetPopulations: {

--- a/src/tools/updateLegacyPopulations.test.js
+++ b/src/tools/updateLegacyPopulations.test.js
@@ -81,7 +81,7 @@ describe('updateLegacyPopulations', () => {
 
     expect(before.length).toBe(3);
 
-    await updateLegacyPopulations(reportIds);
+    await updateLegacyPopulations();
 
     const after = await ActivityReport.findAll({
       where: {

--- a/src/tools/updateLegacyPopulations.test.js
+++ b/src/tools/updateLegacyPopulations.test.js
@@ -1,0 +1,41 @@
+import faker from 'faker';
+import updateLegacyPopulations from './updateLegacyPopulations';
+import { createReport, destroyReport } from '../testUtils';
+
+describe('updateLegacyPopulations', () => {
+  const reports = [];
+  beforeAll(() => {
+    const populationData = [
+      ['Infants/Toddlers', 'Preschool', 'Affected by Homelessness'],
+      ['Infants and Toddlers (ages birth to 3)', 'Preschool', 'Affected by Homelessness'],
+      ['Infants and Toddlers (ages birth to 3)', 'Preschool', 'Children Experiencing Homelessness'],
+      ['Infants and Toddlers (ages birth to 3)'],
+      ['Dual-Language Learners'],
+      [],
+    ];
+
+    populationData.forEach(async (targetPopulations) => {
+      const report = await createReport({
+        activityRecipients: [
+          {
+            grantId: faker.datatype.number(),
+          },
+        ],
+        targetPopulations,
+      });
+
+      reports.push(report);
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all(reports.map(async (report) => {
+      await destroyReport(report);
+    }));
+  });
+
+  it('updates legacy population data', async () => {
+    const reportIds = reports.map((report) => report.id);
+    await updateLegacyPopulations(reportIds);
+  });
+});

--- a/src/tools/updateLegacyPopulations.test.js
+++ b/src/tools/updateLegacyPopulations.test.js
@@ -1,12 +1,33 @@
-import faker from 'faker';
+import { Op } from 'sequelize';
+import { ActivityReport, sequelize } from '../models';
 import updateLegacyPopulations from './updateLegacyPopulations';
-import { createReport, destroyReport } from '../testUtils';
+import { REPORT_STATUSES } from '../constants';
+
+const dumbReport = {
+  submissionStatus: REPORT_STATUSES.SUBMITTED,
+  calculatedStatus: REPORT_STATUSES.APPROVED,
+  oldApprovingManagerId: 1,
+  numberOfParticipants: 1,
+  deliveryMethod: 'method',
+  duration: 0,
+  endDate: '2020-01-01T12:00:00Z',
+  startDate: '2020-01-01T12:00:00Z',
+  requester: 'requester',
+  programTypes: ['type'],
+  reason: ['reason'],
+  participants: ['participants'],
+  topics: ['topics'],
+  ttaType: ['type'],
+  userId: 1,
+  regionId: 1,
+};
 
 describe('updateLegacyPopulations', () => {
-  const reports = [];
-  beforeAll(() => {
+  let reports;
+
+  beforeAll(async () => {
     const populationData = [
-      ['Infants/Toddlers', 'Preschool', 'Affected by Homelessness'],
+      ['Infant/Toddlers', 'Preschool', 'Affected by Homelessness'],
       ['Infants and Toddlers (ages birth to 3)', 'Preschool', 'Affected by Homelessness'],
       ['Infants and Toddlers (ages birth to 3)', 'Preschool', 'Children Experiencing Homelessness'],
       ['Infants and Toddlers (ages birth to 3)'],
@@ -14,28 +35,70 @@ describe('updateLegacyPopulations', () => {
       [],
     ];
 
-    populationData.forEach(async (targetPopulations) => {
-      const report = await createReport({
-        activityRecipients: [
-          {
-            grantId: faker.datatype.number(),
-          },
-        ],
-        targetPopulations,
-      });
-
-      reports.push(report);
-    });
+    reports = await Promise.all(
+      populationData.map(
+        async (targetPopulations) => ActivityReport.create({
+          ...dumbReport,
+          targetPopulations,
+        }),
+      ),
+    );
   });
 
   afterAll(async () => {
-    await Promise.all(reports.map(async (report) => {
-      await destroyReport(report);
-    }));
+    await ActivityReport.destroy({
+      where: {
+        id: reports.map((r) => r.id),
+      },
+    });
+
+    await sequelize.close();
   });
 
   it('updates legacy population data', async () => {
     const reportIds = reports.map((report) => report.id);
+
+    const where = {
+      id: reportIds,
+      targetPopulations: {
+        [Op.or]: [
+          {
+            [Op.contains]: ['Infant/Toddlers'],
+          },
+          {
+            [Op.contains]: ['Preschool'],
+          },
+          {
+            [Op.contains]: ['Affected by Homelessness'],
+          },
+        ],
+      },
+    };
+
+    const before = await ActivityReport.findAll({
+      where,
+    });
+
+    expect(before.length).toBe(3);
+
     await updateLegacyPopulations(reportIds);
+
+    const after = await ActivityReport.findAll({
+      where: {
+        id: reportIds,
+      },
+    });
+
+    expect(after.length).toBe(6);
+
+    const populations = after.map((report) => report.targetPopulations);
+    expect(populations).toEqual(expect.arrayContaining([['Infants and Toddlers (ages birth to 3)', 'Preschool (ages 3-5)', 'Children Experiencing Homelessness']]));
+    expect(populations).toEqual(expect.arrayContaining([['Infants and Toddlers (ages birth to 3)']]));
+    expect(populations).toEqual(expect.arrayContaining([['Dual-Language Learners']]));
+    expect(populations).toEqual(expect.arrayContaining([[]]));
+
+    const sanityCheck = await ActivityReport.findAll({ where });
+
+    expect(sanityCheck.length).toBe(0);
   });
 });

--- a/src/tools/updateLegacyPopulations.test.js
+++ b/src/tools/updateLegacyPopulations.test.js
@@ -118,7 +118,7 @@ describe('updateLegacyPopulations', () => {
 
     expect(before.length).toBe(5);
 
-    await updateLegacyPopulations(reportIds);
+    await updateLegacyPopulations();
 
     const after = await ActivityReport.findAll({
       where: {

--- a/src/tools/updateLegacyPopulationsCLI.js
+++ b/src/tools/updateLegacyPopulationsCLI.js
@@ -1,0 +1,7 @@
+import updateLegacyPopulations from './updateLegacyPopulations';
+import { auditLogger } from '../logger';
+
+updateLegacyPopulations().catch((e) => {
+  auditLogger.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description of change
Create script to update legacy report target populations
Specifically
- Infant/Toddlers to Infants and Toddlers (ages birth to 3)
- Preschool to Preschool (ages 3-5)
- Affected by Homelessness to Children Experiencing Homelessness

This will remove duplicated values in analytics widgets like on the recipient record page

## How to test
- (Locally) Verify that you have legacy data that needs updating. Note some reports that you can check after running the script. 
- Run ```yarn updateLegacyPopulations:local```. 
- Check those reports you noted earlier.
- Run the script again. It should find no reports to update.
- All tests pass.

### Successful run on sandbox
![Screen Shot 2021-12-02 at 9 46 16 AM](https://user-images.githubusercontent.com/3288586/144444668-0e52dc21-667f-42b4-9e95-e9b89e6728ac.png)

You can also compare the recipient Absaroka Head Start - Region 8 on sandbox and dev to further verify success

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-496


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
