### PR TITLE
TTAHUB-514: Updates to Grantee Record Page

### DIFF
--- a/frontend/src/components/filter/FilterItem.js
+++ b/frontend/src/components/filter/FilterItem.js
@@ -129,7 +129,7 @@ export default function FilterItem({ filter, onRemoveFilter, onUpdateFilter }) {
         onChange={(e) => onUpdate(e.target.name, e.target.value)}
         className="usa-select"
       >
-        <option value="">Select a topic</option>
+        <option value="" hidden disabled selected>- Select -</option>
         {possibleFilters.map(({ id: filterId, display }) => (
           <option key={filterId} value={filterId}>{display}</option>
         ))}
@@ -146,7 +146,7 @@ export default function FilterItem({ filter, onRemoveFilter, onUpdateFilter }) {
         onChange={(e) => onUpdate(e.target.name, e.target.value)}
         className="usa-select"
       >
-        <option value="">Select a condition</option>
+        <option value="" hidden disabled selected>- Select -</option>
         {conditions.map((c) => <option key={c} value={c}>{c}</option>)}
       </select>
       { selectedTopic && condition

--- a/frontend/src/pages/GranteeRecord/components/GrantsList.js
+++ b/frontend/src/pages/GranteeRecord/components/GrantsList.js
@@ -11,7 +11,7 @@ export default function GrantsList({ summary }) {
       return summary.grants.map((grant) => (
         <tr key={grant.id}>
           <td>
-            <a style={{ display: 'table-cell' }} className="padding-y-3" href={`https://hses.ohs.acf.hhs.gov/grant-summary/?grant=${grant.number}`} target="_blank" rel="noreferrer">
+            <a style={{ display: 'table-cell' }} title="Links to HSES" className="padding-y-3" href={`https://hses.ohs.acf.hhs.gov/grant-summary/?grant=${grant.number}`} target="_blank" rel="noreferrer">
               {grant.number}
             </a>
           </td>

--- a/frontend/src/pages/GranteeRecord/components/__tests__/GrantsList.js
+++ b/frontend/src/pages/GranteeRecord/components/__tests__/GrantsList.js
@@ -62,14 +62,14 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('columnheader', { name: /project end date/i })).toBeInTheDocument();
 
     // Grant 1.
-    expect(await screen.findByRole('link', { name: /grant number 1/i })).toBeInTheDocument();
+    expect(await screen.findByText(/grant number 1/i)).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: 'Active' })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /ehs, hs/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /tim/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /sam/i })).toBeInTheDocument();
 
     // Grant 2.
-    expect(await screen.findByRole('link', { name: /grant number 2/i })).toBeInTheDocument();
+    expect(await screen.findByText(/grant number 2/i)).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: 'Inactive' })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /ehs-ccp/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /10\/02\/2020/i })).toBeInTheDocument();

--- a/src/services/grantee.js
+++ b/src/services/grantee.js
@@ -43,7 +43,7 @@ export async function granteeById(granteeId, grantScopes) {
       },
     ],
     order: [
-      [{ model: Grant, as: 'grants' }, 'endDate', 'DESC'], [{ model: Grant, as: 'grants' }, 'number', 'ASC'],
+      [{ model: Grant, as: 'grants' }, 'status', 'ASC'], [{ model: Grant, as: 'grants' }, 'endDate', 'DESC'], [{ model: Grant, as: 'grants' }, 'number', 'ASC'],
     ],
   });
 }


### PR DESCRIPTION
## Description of change

On the **Grantee Record Page**,

Profile Tab:

- When the user hovers over a grant number we display text that says "Links to HSES".
- Sort the grant list so that 'Active' grants always appear before 'Inactive' grants.

TTA History Tab:

- Update the filter items so that if a Topic or Condition has not yet been selected we show the text '- Select -'.

    NOTE: This text should NOT be select-able.


## How to test

On the **Grantee Record Page**,

On the Profile Tab:

- Hover over a grant number in the grant list. You should see text telling the user that they will be redirected to HSES.
- The grant list should always show Active grants first.

On the TTA History Tab: 

- Creating a new filter should show the value '- Select -' in both the Topic and Condition column until a value is selected.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-514


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
