### PR TITLE
TTAHUB-491: Add Approvers to CSV Output

### DIFF
--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -62,6 +62,29 @@ function transformRelatedModel(field, prop) {
   return transformer;
 }
 
+function transformApproversModel(prop) {
+  async function transformer(instance) {
+    const obj = {};
+    const values = await instance.approvers;
+    if (values) {
+      const distinctValues = [
+        ...new Set(
+          values.filter(
+            (approver) => approver.User && approver.User[prop] !== null,
+          ).map((r) => r.User[prop]).flat(),
+        ),
+      ];
+      const approversList = distinctValues.sort().join('\n');
+      Object.defineProperty(obj, 'approvers', {
+        value: approversList,
+        enumerable: true,
+      });
+    }
+    return Promise.resolve(obj);
+  }
+  return transformer;
+}
+
 function transformGrantModel(prop) {
   async function transformer(instance) {
     const obj = {};
@@ -187,6 +210,7 @@ const arTransformers = [
   transformRelatedModel('lastUpdatedBy', 'name'),
   'requester',
   transformRelatedModel('collaborators', 'fullName'),
+  transformApproversModel('name'),
   'targetPopulations',
   'virtualDeliveryType',
   'reason',

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -4,6 +4,7 @@ import {
   Objective,
   User,
   ActivityRecipient,
+  ActivityReportApprover,
   Grant,
   Grantee,
 } from '../models';
@@ -101,6 +102,37 @@ describe('activityReportToCsvRecord', () => {
     },
   ];
 
+  const mockApprovers = [
+    {
+      activityReportId: 209914,
+      status: 'approved',
+      userId: 3,
+      User: {
+        name: 'Test Approver 1',
+
+      },
+    },
+    {
+      activityReportId: 209914,
+      status: 'approved',
+      userId: 4,
+      User: {
+        name: 'Test Approver 3',
+
+      },
+    },
+    {
+
+      activityReportId: 209914,
+      status: 'approved',
+      userId: 5,
+      User: {
+        name: 'Test Approver 2',
+
+      },
+    },
+  ];
+
   const mockActivityRecipients = [
     {
       id: 4,
@@ -149,6 +181,7 @@ describe('activityReportToCsvRecord', () => {
     collaborators: mockCollaborators,
     approvedAt: new Date(),
     activityRecipients: mockActivityRecipients,
+    approvers: mockApprovers,
   };
 
   it('transforms arrays of strings into strings', async () => {
@@ -173,16 +206,22 @@ describe('activityReportToCsvRecord', () => {
           model: ActivityRecipient,
           as: 'activityRecipients',
           include: [{ model: Grant, as: 'grant', include: [{ model: Grantee, as: 'grantee' }] }],
+        },
+        {
+          model: ActivityReportApprover,
+          as: 'approvers',
+          include: [{ model: User }],
         }],
     });
     const output = await activityReportToCsvRecord(report);
     const {
-      author, lastUpdatedBy, collaborators, programSpecialistName,
+      author, lastUpdatedBy, collaborators, programSpecialistName, approvers,
     } = output;
     expect(author).toEqual('Arthur, GS');
     expect(lastUpdatedBy).toEqual('Arthur');
     expect(collaborators).toEqual('Collaborator 1, GS, HS\nCollaborator 2');
     expect(programSpecialistName).toEqual('Program Specialist 1\nProgram Specialist 2\nProgram Specialist 4');
+    expect(approvers).toEqual('Test Approver 1\nTest Approver 2\nTest Approver 3');
   });
 
   it('transforms goals and objectives into many values', async () => {

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -75,6 +75,10 @@ async function sendActivityReportCSV(reports, res) {
           header: 'Collaborators',
         },
         {
+          key: 'approvers',
+          header: 'Approvers',
+        },
+        {
           key: 'programSpecialistName',
           header: 'Program Specialists',
         },

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -785,6 +785,12 @@ async function getDownloadableActivityReports(where) {
           attributes: ['userId'],
           as: 'approvers',
           required: false,
+          include: [
+            {
+              model: User,
+              attributes: ['name'],
+            },
+          ],
         },
       ],
       distinct: true,


### PR DESCRIPTION
## Description of change
Add Approvers to CSV Output.


## How to test

Export the report CSV it should now contain a list of Approving managers separated by carriage returns.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-491


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
