### PR TITLE
Tweak saving objectives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ parameters:
     default: "js-478-grantee-search-fixes"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "TTAHUB-496/update-legacy-ar-data"
+    default: "js-523-tweak-saving-objectives"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -30,6 +30,7 @@ const Objective = ({
   const firstInput = useRef();
   const { errors, trigger } = useFormContext();
   const isValid = !errors[parentLabel];
+  const [oldObjective, updateOldObjective] = useState(objective);
 
   useEffect(() => {
     if (firstInput.current) {
@@ -37,15 +38,14 @@ const Objective = ({
     }
   }, []);
 
-  const [editableObject, updateEditableObject] = useState(objective);
   const onChange = (e) => {
-    updateEditableObject({
-      ...editableObject,
+    onUpdate({
+      ...objective,
       [e.target.name]: e.target.value,
     });
   };
 
-  const { title, ttaProvided, status } = editableObject;
+  const { title, ttaProvided, status } = objective;
   const defaultShowEdit = !(title && (ttaProvided !== EMPTY_TEXT_BOX) && status);
   const [showEdit, updateShowEdit] = useState(defaultShowEdit);
 
@@ -54,7 +54,7 @@ const Objective = ({
       updateShowEdit(true);
     } else if (title && ttaProvided !== EMPTY_TEXT_BOX) {
       updateShowEdit(false);
-      onUpdate(editableObject);
+      updateOldObjective(objective);
     } else {
       trigger(parentLabel);
     }
@@ -66,8 +66,8 @@ const Objective = ({
 
   const onCancel = () => {
     if (objective.title || objective.ttaProvided !== EMPTY_TEXT_BOX) {
-      updateEditableObject(objective);
       updateShowEdit(false);
+      onUpdate(oldObjective);
     } else {
       onRemove();
     }
@@ -103,7 +103,7 @@ const Objective = ({
               onChange={onChange}
               inputRef={firstInput}
               value={title}
-              spellcheck="true"
+              spellCheck="true"
             />
           </ObjectiveFormItem>
           <ObjectiveFormItem
@@ -118,8 +118,8 @@ const Objective = ({
                 ariaLabel={`TTA provided for objective ${objectiveAriaLabel}`}
                 defaultValue={ttaProvided}
                 onChange={(content) => {
-                  updateEditableObject({
-                    ...editableObject,
+                  onUpdate({
+                    ...objective,
                     ttaProvided: content,
                   });
                 }}

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Goal.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Goal.js
@@ -170,11 +170,11 @@ describe('Goal', () => {
       render(<RenderGoal onUpdateObjectives={onUpdate} name="test goal" objectives={objectives} />);
 
       const title = await screen.findByRole('textbox', { name: 'title for objective 1 on goal 1' });
-      userEvent.type(title, 'title');
+      userEvent.type(title, 't');
       const button = await screen.findByRole('button', { name: 'Save objective 1 on goal 1' });
       userEvent.click(button);
       expect(onUpdate).toHaveBeenCalledWith([{
-        id: 'a', title: 'title', ttaProvided: 'test', status: 'Not Started',
+        id: 'a', title: 't', ttaProvided: 'test', status: 'Not Started',
       }]);
     });
   });

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
@@ -7,13 +7,19 @@ import Objective from '../Objective';
 
 const RenderObjective = ({
   // eslint-disable-next-line react/prop-types
-  objective, onRemove = () => {}, onUpdate = () => {},
+  defaultObjective, onRemove = () => {},
 }) => {
   const hookForm = useForm({
-    defaultValues: { goals: [] },
+    defaultValues: { objective: defaultObjective },
   });
 
   hookForm.register('goals');
+  hookForm.register('objective');
+  const objective = hookForm.watch('objective');
+
+  const onUpdate = (obj) => {
+    hookForm.setValue('objective', obj);
+  };
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -33,26 +39,37 @@ const RenderObjective = ({
 
 describe('Objective', () => {
   it('opens in edit mode if "ttaProvided" is blank', async () => {
-    render(<RenderObjective objective={{ ttaProvided: '<p></p>', title: 'title', status: 'status' }} />);
+    render(<RenderObjective defaultObjective={{ ttaProvided: '<p></p>', title: 'title', status: 'status' }} />);
     const save = await screen.findByText('Save Objective');
     expect(save).toBeVisible();
   });
 
   it('opens in edit mode if "title" is blank', async () => {
-    render(<RenderObjective objective={{ ttaProvided: 'tta', title: '', status: 'status' }} />);
+    render(<RenderObjective defaultObjective={{ ttaProvided: 'tta', title: '', status: 'status' }} />);
     const save = await screen.findByText('Save Objective');
     expect(save).toBeVisible();
   });
 
   describe('in edit mode', () => {
     it('focuses the title field', async () => {
-      render(<RenderObjective objective={{ ttaProvided: 'tta', title: '', status: 'status' }} />);
+      render(<RenderObjective defaultObjective={{ ttaProvided: 'tta', title: '', status: 'status' }} />);
       const title = await screen.findByLabelText('Objective (Required)');
       expect(document.activeElement).toEqual(title);
     });
 
+    it('saves without explicitly clicking the save button', async () => {
+      const objective = {
+        title: '', ttaProvided: 'test', status: 'Not Started',
+      };
+      render(<RenderObjective defaultObjective={objective} />);
+      const title = await screen.findByLabelText('Objective (Required)');
+      userEvent.type(title, 'this is a test');
+      const titleWithText = await screen.findByDisplayValue('this is a test');
+      expect(titleWithText).toBeVisible();
+    });
+
     it('save does not work if "objective" and "TTA Provided" are empty', async () => {
-      render(<RenderObjective objective={{}} />);
+      render(<RenderObjective defaultObjective={{}} />);
       const save = await screen.findByText('Save Objective');
       expect(save).toBeVisible();
 
@@ -64,12 +81,12 @@ describe('Objective', () => {
       const objective = {
         title: '', ttaProvided: 'test', status: 'Not Started',
       };
-      render(<RenderObjective objective={objective} />);
+      render(<RenderObjective defaultObjective={objective} />);
       const save = await screen.findByText('Save Objective');
       expect(save).toBeVisible();
 
       const title = await screen.findByLabelText('Objective (Required)');
-      userEvent.type(title, 'test');
+      userEvent.type(title, 'this is a test');
 
       userEvent.click(save);
       expect(await screen.findByTestId('tag')).toBeVisible();
@@ -77,7 +94,7 @@ describe('Objective', () => {
 
     it('calls onRemove when the cancel button is clicked with an empty objective', async () => {
       const onRemove = jest.fn();
-      render(<RenderObjective objective={{ title: '', ttaProvided: '<p></p>' }} onRemove={onRemove} />);
+      render(<RenderObjective defaultObjective={{ title: '', ttaProvided: '<p></p>', status: 'Not Started' }} onRemove={onRemove} />);
       const cancel = await screen.findByRole('button', { name: 'Cancel update of objective 1 on goal 1' });
       userEvent.click(cancel);
       expect(onRemove).toHaveBeenCalled();
@@ -85,7 +102,7 @@ describe('Objective', () => {
 
     it('cancels any edits if the objective is not empty', async () => {
       const onRemove = jest.fn();
-      render(<RenderObjective objective={{ title: 'title' }} onRemove={onRemove} />);
+      render(<RenderObjective defaultObjective={{ title: 'title', ttaProvided: '<p></p>', status: 'Not Started' }} onRemove={onRemove} />);
       const text = await screen.findByLabelText('Objective (Required)');
       userEvent.type(text, 'test');
       const cancel = await screen.findByRole('button', { name: 'Cancel update of objective 1 on goal 1' });
@@ -101,7 +118,7 @@ describe('Objective', () => {
       const objective = {
         title: 'title', ttaProvided: 'test', status: 'Not Started',
       };
-      render(<RenderObjective objective={objective} />);
+      render(<RenderObjective defaultObjective={objective} />);
       const title = await screen.findByText('title');
       const status = await screen.findByText('Not Started');
 
@@ -114,7 +131,7 @@ describe('Objective', () => {
       const objective = {
         title: 'title', ttaProvided: 'test', status: 'Not Started',
       };
-      render(<RenderObjective objective={objective} onRemove={onRemove} />);
+      render(<RenderObjective defaultObjective={objective} onRemove={onRemove} />);
       const menu = await screen.findByRole('button', { name: 'Edit or delete objective 1 on goal 1' });
       userEvent.click(menu);
 
@@ -127,7 +144,7 @@ describe('Objective', () => {
       const objective = {
         title: 'title', ttaProvided: 'test', status: 'Not Started',
       };
-      render(<RenderObjective objective={objective} />);
+      render(<RenderObjective defaultObjective={objective} />);
       const menu = await screen.findByRole('button', { name: 'Edit or delete objective 1 on goal 1' });
       userEvent.click(menu);
 

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -32,7 +32,7 @@ const NoteEntry = ({
       name={name}
       label={label}
     >
-      <TextInput name={name} onChange={onUpdate} data-testid={`${name}-input`} defaultValue={input} spellcheck="true" />
+      <TextInput name={name} onChange={onUpdate} data-testid={`${name}-input`} defaultValue={input} spellCheck="true" />
       <Button outline disabled={!(input && input.trim())} onClick={onSubmit} data-testid={`${name}-button`} type="button">Save Next Step</Button>
       {!isRequired && <Button secondary onClick={onCancel} type="button" data-testid={`${name}-cancel-button`}>Cancel</Button>}
     </FormItem>


### PR DESCRIPTION
## Description of change

Objectives will now be saved as the other fields are, without the need to explicitly click the "save objective" button. "edit" mode hasn't been removed, if a user clicks "cancel" they will get the value of the objective before they started editing (when the edit mode first was activated). Auto saves, save draft, save and continue will now save the objective as it is being editing.

## How to test

Save objectives in sandbox in the following ways 

- letting the auto save hit and refreshing
- navigating away using the navigator
- clicking the save draft button
- clicking save and continue
- adding multiple objectives on the same goal
- adding multiple objectives on different goals
- clicking the cancel button on objectives and verifying the previously saved value is used
- updating an objective and then editing it again, pressing cancel and making sure the value is correct

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-523

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
