### PR TITLE
Set UTF-8 BOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "js-443-rename-grantee-recipient-on-fe"
+    default: "js-521-set-utf8-BOM"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "js-523-tweak-saving-objectives"

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -197,7 +197,7 @@ async function sendActivityReportCSV(reports, res) {
   );
 
   res.attachment('activity-reports.csv');
-  res.send(`${warning}${csvData}`);
+  res.send(`\ufeff${warning}${csvData}`);
 }
 
 export async function updateLegacyFields(req, res) {

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -771,7 +771,7 @@ describe('Activity Report handlers', () => {
       expect(mockResponse.send).toHaveBeenCalled();
 
       const [[value]] = mockResponse.send.mock.calls;
-      expect(value).toEqual('');
+      expect(value).toEqual('\ufeff');
     });
   });
 });


### PR DESCRIPTION
## Description of change

Lots of discussion of BOM and if it is good to add to CSV files. See

https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-without-bom
https://stackoverflow.com/questions/17879198/adding-utf-8-bom-to-string-blob/27975629#27975629

The quick explanation is excel doesn't auto detect that our files are UTF-8 without the BOM set. We set the BOM for UTF-16 which node translates to the UTF-8 BOM (didn't work when I tried to directly set the UTF-8 BOM). See the second link above for a possible explanation. BOM can mess with scripts and combining files together, but I don't think there is going to be direct manipulation of our CSV files so I think we are okay setting the BOM.

## How to test

Download CSVs in dev with single quotes on windows, open in excel. Report ID 12025 should have some offending characters in the context, check the ticket for specifics. Verify no goofy characters. Also check the resulting files for the correct encoding. Find the expected values in [wikipedia](https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding)

`file activity-reports.csv` - should say "UTF-8 Unicode (with BOM)"
`hexdump -n 3 -C activity-reports.csv` - should see the values "ef bb bf"

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-521

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
