### PR TITLE
TTAHUB-548: Prevent Multiple Download Clicks

### DIFF
--- a/frontend/src/components/ActivityReportsTable/__tests__/index.js
+++ b/frontend/src/components/ActivityReportsTable/__tests__/index.js
@@ -321,6 +321,27 @@ describe('Table menus & selections', () => {
       expect(getAllReportsDownloadURL).toHaveBeenCalledWith('region.in[]=1');
     });
   });
+
+  it('disables download button while downloading', async () => {
+    const user = {
+      name: 'test@test.com',
+      permissions: [
+        {
+          scopeId: 3,
+          regionId: 1,
+        },
+      ],
+    };
+
+    renderTable(user);
+    const reportMenu = await screen.findByLabelText(/reports menu/i);
+    userEvent.click(reportMenu);
+    expect(await screen.findByRole('menuitem', { name: /export table data/i })).not.toBeDisabled();
+    const downloadButton = await screen.findByRole('menuitem', { name: /export table data/i });
+    userEvent.click(downloadButton);
+    expect(await screen.findByRole('menuitem', { name: /export table data/i })).toBeDisabled();
+    expect(getAllReportsDownloadURL).toHaveBeenCalledWith('region.in[]=1');
+  });
 });
 
 describe('Table sorting', () => {

--- a/frontend/src/components/TableHeader.js
+++ b/frontend/src/components/TableHeader.js
@@ -38,6 +38,7 @@ export default function TableHeader({
   hidePagination,
   forMyAlerts,
   downloadError,
+  isDownloading,
   dateTime,
 }) {
   return (
@@ -80,6 +81,7 @@ export default function TableHeader({
               onExportSelected={handleDownloadClick}
               count={count}
               downloadError={downloadError}
+              isDownloading={isDownloading}
             />
           )}
         </span>
@@ -140,6 +142,7 @@ TableHeader.propTypes = {
   dateTime: PropTypes.shape({
     timestamp: PropTypes.string, label: PropTypes.string,
   }),
+  isDownloading: PropTypes.bool,
 };
 
 TableHeader.defaultProps = {
@@ -160,4 +163,5 @@ TableHeader.defaultProps = {
   menuAriaLabel: 'Reports menu',
   downloadError: false,
   dateTime: { timestamp: '', label: '' },
+  isDownloading: false,
 };

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -192,6 +192,8 @@ function MyAlerts(props) {
     handleDownloadAllAlerts,
     loading,
     message,
+    isDownloadingAlerts,
+    downloadAlertsError,
   } = props;
   const getClassNamesFor = (name) => (alertsSortConfig.sortBy === name ? alertsSortConfig.direction : '');
 
@@ -239,7 +241,6 @@ function MyAlerts(props) {
     setAlertReportsCount(alertReportsCount - 1);
     updateReportAlerts(newReports);
   };
-
   return (
     <>
       {reports && reports.length === 0 && !hasFilters && (
@@ -272,6 +273,8 @@ function MyAlerts(props) {
             offset={alertsOffset}
             perPage={alertsPerPage}
             hidePagination
+            isDownloading={isDownloadingAlerts}
+            downloadError={downloadAlertsError}
           />
           <div className="usa-table-container--scrollable">
             <Table fullWidth striped>
@@ -323,6 +326,8 @@ MyAlerts.propTypes = {
     displayId: PropTypes.string,
     status: PropTypes.string,
   }),
+  isDownloadingAlerts: PropTypes.bool,
+  downloadAlertsError: PropTypes.bool,
 };
 
 MyAlerts.defaultProps = {
@@ -338,6 +343,8 @@ MyAlerts.defaultProps = {
     displayId: '',
     status: '',
   },
+  isDownloadingAlerts: false,
+  downloadAlertsError: false,
 };
 
 export default MyAlerts;

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -14,6 +14,7 @@ function ReportMenu({
   label,
   count,
   downloadError,
+  isDownloading,
 }) {
   const [open, updateOpen] = useState(false);
 
@@ -123,7 +124,7 @@ function ReportMenu({
                   role="menuitem"
                   onClick={onExportAll}
                   type="button"
-                  disabled={downloadError}
+                  disabled={downloadError || isDownloading}
                   className="usa-button usa-button--unstyled display-block smart-hub--reports-button smart-hub--button__no-margin"
                 >
                   Export table data
@@ -134,6 +135,7 @@ function ReportMenu({
                 role="menuitem"
                 onClick={onExportSelected}
                 type="button"
+                disabled={isDownloading}
                 className="usa-button usa-button--unstyled display-block smart-hub--reports-button smart-hub--button__no-margin margin-top-2"
               >
                 Export selected reports
@@ -153,6 +155,7 @@ ReportMenu.propTypes = {
   label: PropTypes.string,
   count: PropTypes.number,
   downloadError: PropTypes.bool,
+  isDownloading: PropTypes.bool,
 };
 
 ReportMenu.defaultProps = {
@@ -160,6 +163,7 @@ ReportMenu.defaultProps = {
   downloadError: false,
   label: 'Reports menu',
   onExportSelected: null,
+  isDownloading: false,
 };
 
 export default ReportMenu;

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -48,7 +48,6 @@ function ReportMenu({
   };
 
   const menuClassNames = `tta-report-menu z-400 position-absolute left-0 ${downloadError ? 'width-tablet' : 'width-mobile'}`;
-
   return (
     <span className="position-relative">
 

--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -275,6 +275,31 @@ describe('Landing page table menus & selections', () => {
         userEvent.click(downloadButton);
         expect(getAllAlertsDownloadURL).toHaveBeenCalledWith('region.in[]=1');
       });
+
+      it('disables alert download button while downloading', async () => {
+        const user = {
+          name: 'test@test.com',
+          permissions: [
+            {
+              scopeId: 3,
+              regionId: 1,
+            },
+            {
+              scopeId: 2,
+              regionId: 1,
+            },
+          ],
+        };
+
+        renderLanding(user);
+        const reportMenu = await screen.findByLabelText(/my alerts report menu/i);
+        userEvent.click(reportMenu);
+        expect(await screen.findByRole('menuitem', { name: /export table data/i })).not.toBeDisabled();
+        const downloadButton = await screen.findByRole('menuitem', { name: /export table data/i });
+        userEvent.click(downloadButton);
+        expect(await screen.findByRole('menuitem', { name: /export table data/i })).toBeDisabled();
+        expect(getAllAlertsDownloadURL).toHaveBeenCalledWith('region.in[]=1');
+      });
     });
   });
 });

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -624,6 +624,8 @@ export async function createReport(req, res) {
  */
 export async function downloadReports(req, res) {
   try {
+    console.log('\n\n\n\n\n\n\nDOWNLOADING!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+    await new Promise((r) => setTimeout(r, 4000));
     const readRegions = await getUserReadRegions(req.session.userId);
 
     const reportsWithCount = await getDownloadableActivityReportsByIds(

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -624,8 +624,6 @@ export async function createReport(req, res) {
  */
 export async function downloadReports(req, res) {
   try {
-    console.log('\n\n\n\n\n\n\nDOWNLOADING!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-    await new Promise((r) => setTimeout(r, 4000));
     const readRegions = await getUserReadRegions(req.session.userId);
 
     const reportsWithCount = await getDownloadableActivityReportsByIds(


### PR DESCRIPTION
## Description of change

Prevent Multiple Download Clicks on both the Alerts and AR grid (for all/selected).

## How to test

Go to the AR Landing page and attempt to click the download reports button while a download is in progress on both the Alerts and AR grids.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-548


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
