### PR TITLE
Remove feature flag preventing access to the recipient record page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,7 +28,6 @@ import LandingLayout from './components/LandingLayout';
 import RequestPermissions from './components/RequestPermissions';
 import AriaLiveContext from './AriaLiveContext';
 import AriaLiveRegion from './components/AriaLiveRegion';
-import FeatureFlag from './components/FeatureFlag';
 import ApprovedActivityReport from './pages/ApprovedActivityReport';
 import RecipientRecord from './pages/RecipientRecord';
 import RecipientSearch from './pages/RecipientSearch';
@@ -130,9 +129,7 @@ function App() {
           path="/recipient-tta-records/:recipientId([0-9]*)"
           render={({ match, location }) => (
             <AppWrapper authenticated logout={logout} padded={false}>
-              <FeatureFlag user={user} flag="grantee_record_page" admin={admin} renderNotFound>
-                <RecipientRecord location={location} match={match} user={user} />
-              </FeatureFlag>
+              <RecipientRecord location={location} match={match} user={user} />
             </AppWrapper>
           )}
         />
@@ -156,7 +153,7 @@ function App() {
           path="/recipient-tta-records"
           render={() => (
             <AppWrapper authenticated logout={logout}>
-              <FeatureFlag user={user} flag="grantee_record_page" admin={admin} renderNotFound><RecipientSearch user={user} /></FeatureFlag>
+              <RecipientSearch user={user} />
             </AppWrapper>
           )}
         />

--- a/frontend/src/components/SiteNav.js
+++ b/frontend/src/components/SiteNav.js
@@ -4,9 +4,7 @@ import PropTypes from 'prop-types';
 import { NavLink as Link, withRouter } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChartBar, faBorderAll, faUserFriends } from '@fortawesome/free-solid-svg-icons';
-
 import './SiteNav.css';
-import FeatureFlag from './FeatureFlag';
 
 const navLinkClasses = [
   'display-block',
@@ -97,18 +95,16 @@ const SiteNav = ({
                       Regional Dashboard
                     </NavLink>
                   </li>
-                  <FeatureFlag user={user} flag="grantee_record_page" admin={admin} renderNotFound={false}>
-                    <li>
-                      <NavLink
-                        to="/recipient-tta-records"
-                      >
-                        <span className="display-none tablet:display-inline padding-right-105">
-                          <FontAwesomeIcon color="white" icon={faUserFriends} />
-                        </span>
-                        Recipient TTA Records
-                      </NavLink>
-                    </li>
-                  </FeatureFlag>
+                  <li>
+                    <NavLink
+                      to="/recipient-tta-records"
+                    >
+                      <span className="display-none tablet:display-inline padding-right-105">
+                        <FontAwesomeIcon color="white" icon={faUserFriends} />
+                      </span>
+                      Recipient TTA Records
+                    </NavLink>
+                  </li>
                 </ul>
               </div>
               <div className="width-full padding-bottom-5 smart-hub-sitenav-separator--before opacity-70">


### PR DESCRIPTION
## Description of change
- Remove the feature flag from the frontend
- This leaves the flag in place in the backend for now. I think we'd have to write a migration to 1) alter the enum_Users_flags so that "grantee_record_page" is not an option and 2) remove it from all users that have it. This feels like a separate task (to me).

## How to test
View the site as a user (who is not an admin or a possessor of the feature flag). You should be able to view the recipient search and the recipient record page

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-552


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
