### PR TITLE
TTAHUB-555: Exclude grants if its inactive and has an end date greater than today

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "js-443-rename-grantee-recipient-on-fe"
+    default: "TTAHUB-555-exclude-inactive-grants-with-end-date-greater-than-today"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "js-523-tweak-saving-objectives"

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -1,4 +1,5 @@
 import { Op } from 'sequelize';
+import moment from 'moment';
 import {
   Grant, Recipient, Program, sequelize,
 } from '../models';
@@ -18,6 +19,7 @@ export async function allRecipients() {
 }
 
 export async function recipientById(recipientId, grantScopes) {
+  const todaysDate = moment().format('MM/DD/yyyy');
   return Recipient.findOne({
     attributes: ['id', 'name', 'recipientType'],
     where: {
@@ -38,7 +40,7 @@ export async function recipientById(recipientId, grantScopes) {
                 },
                 {
                   endDate: {
-                    [Op.gte]: '2020-09-01',
+                    [Op.between]: ['2020-09-01', todaysDate],
                   },
                 },
               ],

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -18,8 +18,9 @@ export async function allRecipients() {
   });
 }
 
+const todaysDate = moment().format('MM/DD/yyyy');
+
 export async function recipientById(recipientId, grantScopes) {
-  const todaysDate = moment().format('MM/DD/yyyy');
   return Recipient.findOne({
     attributes: ['id', 'name', 'recipientType'],
     where: {
@@ -114,7 +115,7 @@ export async function recipientsByName(query, scopes, sortBy, direction, offset)
               },
               {
                 endDate: {
-                  [Op.gte]: '2020-09-01',
+                  [Op.between]: ['2020-09-01', todaysDate],
                 },
               },
             ],

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import {
   Recipient, Grant, Program, sequelize,
 } from '../models';
@@ -86,6 +87,26 @@ describe('Recipient DB service', () => {
         startDate: new Date('2020-01-01'),
         endDate: new Date('2020-01-15'),
       }),
+
+      Grant.create({
+        id: 80,
+        number: '3145355',
+        regionId: 1,
+        recipientId: 76,
+        status: 'Inactive',
+        startDate: new Date(moment().add(1, 'days').format('MM/DD/yyyy')),
+        endDate: new Date(moment().add(2, 'days').format('MM/DD/yyyy')),
+      }),
+      Grant.create({
+        id: 81,
+        number: '3145399',
+        regionId: 1,
+        recipientId: 76,
+        status: 'Inactive',
+        startDate: new Date(moment().subtract(5, 'days').format('MM/DD/yyyy')),
+        endDate: new Date(moment().format('MM/DD/yyyy')),
+      }),
+
     ]);
     await Promise.all([
       Program.create({
@@ -148,12 +169,32 @@ describe('Recipient DB service', () => {
         startDate: 'today',
         endDate: 'tomorrow',
       }),
+      Program.create({
+        id: 80,
+        grantId: 80,
+        name: 'type',
+        programType: 'HS',
+        startYear: 'The murky depths of time',
+        status: 'active',
+        startDate: 'today',
+        endDate: 'tomorrow',
+      }),
+      Program.create({
+        id: 81,
+        grantId: 81,
+        name: 'type',
+        programType: 'HS',
+        startYear: 'The murky depths of time',
+        status: 'active',
+        startDate: 'today',
+        endDate: 'tomorrow',
+      }),
     ]);
   });
 
   afterAll(async () => {
-    await Program.destroy({ where: { id: [74, 75, 76, 77, 78, 79] } });
-    await Grant.destroy({ where: { id: [74, 75, 76, 77, 78, 79] } });
+    await Program.destroy({ where: { id: [74, 75, 76, 77, 78, 79, 80, 81] } });
+    await Grant.destroy({ where: { id: [74, 75, 76, 77, 78, 79, 80, 81] } });
     await Recipient.destroy({ where: { id: [73, 74, 75, 76] } });
     await sequelize.close();
   });
@@ -231,7 +272,7 @@ describe('Recipient DB service', () => {
       const recipient = await recipientById(76, grantScopes);
 
       expect(recipient.name).toBe('recipient 4');
-      expect(recipient.grants.length).toBe(3);
+      expect(recipient.grants.length).toBe(4);
 
       // Active After Cut Off Date.
       expect(recipient.grants[0].id).toBe(76);
@@ -241,9 +282,13 @@ describe('Recipient DB service', () => {
       expect(recipient.grants[1].id).toBe(77);
       expect(recipient.grants[1].status).toBe('Active');
 
-      // Inactive After Cut Off Date.
-      expect(recipient.grants[2].id).toBe(78);
+      // Inactive with End Date of Today.
+      expect(recipient.grants[2].id).toBe(81);
       expect(recipient.grants[2].status).toBe('Inactive');
+
+      // Inactive After Cut Off Date.
+      expect(recipient.grants[3].id).toBe(78);
+      expect(recipient.grants[3].status).toBe('Inactive');
     });
   });
 

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -87,7 +87,6 @@ describe('Recipient DB service', () => {
         startDate: new Date('2020-01-01'),
         endDate: new Date('2020-01-15'),
       }),
-
       Grant.create({
         id: 80,
         number: '3145355',
@@ -318,6 +317,18 @@ describe('Recipient DB service', () => {
         id: 68,
         name: 'Apple Crisp',
       },
+      {
+        id: 69,
+        name: 'Pumpkin Pie',
+      },
+      {
+        id: 70,
+        name: 'Pumpkin Bread',
+      },
+      {
+        id: 71,
+        name: 'Pumpkin Coffee',
+      },
     ];
 
     const grants = [
@@ -403,6 +414,37 @@ describe('Recipient DB service', () => {
         endDate: new Date(2020, 10, 31),
         grantSpecialistName: 'Allen',
       },
+
+      {
+        id: 59,
+        recipientId: 69,
+        regionId: 1,
+        number: '582353',
+        programSpecialistName: 'John Tom',
+        status: 'Inactive',
+        endDate: new Date(moment().add(2, 'days').format('MM/DD/yyyy')),
+        grantSpecialistName: 'Bill Smith',
+      },
+      {
+        id: 60,
+        recipientId: 70,
+        regionId: 1,
+        number: '582354',
+        programSpecialistName: 'John Tom',
+        status: 'Inactive',
+        endDate: new Date(moment().format('MM/DD/yyyy')),
+        grantSpecialistName: 'Bill Smith',
+      },
+      {
+        id: 61,
+        recipientId: 71,
+        regionId: 1,
+        number: '582355',
+        programSpecialistName: 'Grant West',
+        status: 'Inactive',
+        endDate: new Date('09/01/2020'),
+        grantSpecialistName: 'Joe Allen',
+      },
     ];
 
     function regionToScope(regionId) {
@@ -468,6 +510,13 @@ describe('Recipient DB service', () => {
       const foundRecipients = await recipientsByName('apple', regionToScope(1), 'name', 'asc', 1);
       expect(foundRecipients.rows.length).toBe(2);
       expect(foundRecipients.rows.map((g) => g.id)).toStrictEqual([63, 66]);
+    });
+
+    it('finds inactive grants that fall in the accepted range', async () => {
+      const foundRecipients = await recipientsByName('Pumpkin', regionToScope(1), 'name', 'asc', 0);
+      expect(foundRecipients.rows.length).toBe(2);
+      expect(foundRecipients.rows.map((g) => g.id)).toContain(70);
+      expect(foundRecipients.rows.map((g) => g.id)).toContain(71);
     });
   });
 });


### PR DESCRIPTION
## Description of change

Exclude grants if its inactive and has an end date greater than today.


## How to test

View a recipient, only ACTIVE grants and INACTIVE grants between '09/01/2020' and today's date should show.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-555


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
