### PR TITLE
TTAHUB-548: Put the Focus Back on the Download Buttons

### DIFF
--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Table, Checkbox, Grid, Alert,
@@ -49,6 +49,9 @@ function ActivityReportsTable({
     sortBy: 'updatedAt',
     direction: 'desc',
   });
+
+  const downloadAllButtonRef = useRef();
+  const downloadSelectedButtonRef = useRef();
 
   useEffect(() => {
     async function fetchReports() {
@@ -153,6 +156,7 @@ function ActivityReportsTable({
       setDownloadError(true);
     } finally {
       setIsDownloading(false);
+      downloadAllButtonRef.current.focus();
     }
   };
 
@@ -179,6 +183,7 @@ function ActivityReportsTable({
         setDownloadError(true);
       } finally {
         setIsDownloading(false);
+        downloadSelectedButtonRef.current.focus();
       }
     }
   };
@@ -247,6 +252,8 @@ function ActivityReportsTable({
           downloadError={downloadError}
           dateTime={dateTime}
           isDownloading={isDownloading}
+          downloadAllButtonRef={downloadAllButtonRef}
+          downloadSelectedButtonRef={downloadSelectedButtonRef}
         />
         <div className="usa-table-container--scrollable">
           <Table fullWidth striped>

--- a/frontend/src/components/TableHeader.js
+++ b/frontend/src/components/TableHeader.js
@@ -40,6 +40,8 @@ export default function TableHeader({
   downloadError,
   isDownloading,
   dateTime,
+  downloadAllButtonRef,
+  downloadSelectedButtonRef,
 }) {
   return (
     <div className="desktop:display-flex">
@@ -82,6 +84,8 @@ export default function TableHeader({
               count={count}
               downloadError={downloadError}
               isDownloading={isDownloading}
+              downloadAllButtonRef={downloadAllButtonRef}
+              downloadSelectedButtonRef={downloadSelectedButtonRef}
             />
           )}
         </span>
@@ -143,6 +147,14 @@ TableHeader.propTypes = {
     timestamp: PropTypes.string, label: PropTypes.string,
   }),
   isDownloading: PropTypes.bool,
+  downloadAllButtonRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+  downloadSelectedButtonRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 TableHeader.defaultProps = {
@@ -164,4 +176,6 @@ TableHeader.defaultProps = {
   downloadError: false,
   dateTime: { timestamp: '', label: '' },
   isDownloading: false,
+  downloadAllButtonRef: () => {},
+  downloadSelectedButtonRef: () => {},
 };

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -194,6 +194,8 @@ function MyAlerts(props) {
     message,
     isDownloadingAlerts,
     downloadAlertsError,
+    downloadAllAlertsButtonRef,
+    downloadSelectedAlertsButtonRef,
   } = props;
   const getClassNamesFor = (name) => (alertsSortConfig.sortBy === name ? alertsSortConfig.direction : '');
 
@@ -275,6 +277,8 @@ function MyAlerts(props) {
             hidePagination
             isDownloading={isDownloadingAlerts}
             downloadError={downloadAlertsError}
+            downloadAllButtonRef={downloadAllAlertsButtonRef}
+            downloadSelectedButtonRef={downloadSelectedAlertsButtonRef}
           />
           <div className="usa-table-container--scrollable">
             <Table fullWidth striped>
@@ -328,6 +332,14 @@ MyAlerts.propTypes = {
   }),
   isDownloadingAlerts: PropTypes.bool,
   downloadAlertsError: PropTypes.bool,
+  downloadAllAlertsButtonRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+  downloadSelectedAlertsButtonRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 MyAlerts.defaultProps = {
@@ -345,6 +357,8 @@ MyAlerts.defaultProps = {
   },
   isDownloadingAlerts: false,
   downloadAlertsError: false,
+  downloadAllAlertsButtonRef: () => {},
+  downloadSelectedAlertsButtonRef: () => {},
 };
 
 export default MyAlerts;

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -15,6 +15,8 @@ function ReportMenu({
   count,
   downloadError,
   isDownloading,
+  downloadAllButtonRef,
+  downloadSelectedButtonRef,
 }) {
   const [open, updateOpen] = useState(false);
 
@@ -120,6 +122,7 @@ function ReportMenu({
             )
               : (
                 <button
+                  ref={downloadAllButtonRef}
                   role="menuitem"
                   onClick={onExportAll}
                   type="button"
@@ -131,6 +134,7 @@ function ReportMenu({
               ) }
             {hasSelectedReports && onExportSelected && (
               <button
+                ref={downloadSelectedButtonRef}
                 role="menuitem"
                 onClick={onExportSelected}
                 type="button"
@@ -155,6 +159,14 @@ ReportMenu.propTypes = {
   count: PropTypes.number,
   downloadError: PropTypes.bool,
   isDownloading: PropTypes.bool,
+  downloadAllButtonRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+  downloadSelectedButtonRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 ReportMenu.defaultProps = {
@@ -163,6 +175,8 @@ ReportMenu.defaultProps = {
   label: 'Reports menu',
   onExportSelected: null,
   isDownloading: false,
+  downloadAllButtonRef: () => {},
+  downloadSelectedButtonRef: () => {},
 };
 
 export default ReportMenu;

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -3,6 +3,7 @@ import React, {
   useState,
   useEffect,
   useContext,
+  useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -67,6 +68,8 @@ function Landing({ user }) {
   const [alertFilters, setAlertFilters] = useState([]);
   const [isDownloadingAlerts, setIsDownloadingAlerts] = useState(false);
   const [downloadAlertsError, setDownloadAlertsError] = useState(false);
+
+  const downloadAllAlertsButtonRef = useRef();
 
   const defaultRegion = regions[0] || user.homeRegionId || 0;
 
@@ -165,6 +168,7 @@ function Landing({ user }) {
       setDownloadAlertsError(true);
     } finally {
       setIsDownloadingAlerts(false);
+      downloadAllAlertsButtonRef.current.focus();
     }
   };
 
@@ -301,6 +305,7 @@ function Landing({ user }) {
           message={message}
           isDownloadingAlerts={isDownloadingAlerts}
           downloadAlertsError={downloadAlertsError}
+          downloadAllAlertsButtonRef={downloadAllAlertsButtonRef}
         />
         <ActivityReportsTable
           filters={filters}


### PR DESCRIPTION
## Description of change

Put focus back on the download buttons once download completes.

## How to test

Download Alerts or AR's from the landing. Once the download finishes the button should get focus back so the user can click off.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-548


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
