### PR TITLE
Handle unexpected multiple values in queries

### DIFF
--- a/src/scopes/activityReport/createDate.js
+++ b/src/scopes/activityReport/createDate.js
@@ -1,31 +1,26 @@
 import { Op } from 'sequelize';
+import { withinDateRange, compareDate } from '../utils';
 
 export function beforeCreateDate(date) {
   return {
-    createdAt: {
-      [Op.lt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'createdAt', Op.lt),
     },
   };
 }
 
 export function afterCreateDate(date) {
   return {
-    createdAt: {
-      [Op.gt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'createdAt', Op.gt),
     },
   };
 }
 
-export function withinCreateDate(startDate, endDate) {
-  if (!startDate || !endDate) {
-    return {
-      startDate: {},
-    };
-  }
+export function withinCreateDate(dates) {
   return {
-
-    createdAt: {
-      [Op.between]: [new Date(startDate), new Date(endDate)],
+    [Op.and]: {
+      [Op.or]: withinDateRange(dates, 'createdAt'),
     },
   };
 }

--- a/src/scopes/activityReport/index.js
+++ b/src/scopes/activityReport/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/prefer-default-export */
 import { map, pickBy } from 'lodash';
-
 import { withRecipientName, withoutRecipientName } from './recipient';
 import withRecipientId from './recipientId';
 import { withoutReportIds, withReportIds } from './reportId';
@@ -35,18 +34,12 @@ export const topicToQuery = {
   startDate: {
     bef: (query) => beforeStartDate(query),
     aft: (query) => afterStartDate(query),
-    win: (query) => {
-      const [startDate, endDate] = query.split('-');
-      return withinStartDates(startDate, endDate);
-    },
+    win: (query) => withinStartDates(query),
   },
   lastSaved: {
     bef: (query) => beforeLastSaveDate(query),
     aft: (query) => afterLastSaveDate(query),
-    win: (query) => {
-      const [startDate, endDate] = query.split('-');
-      return withinLastSaveDates(startDate, endDate);
-    },
+    win: (query) => withinLastSaveDates(query),
   },
   role: {
     in: (query) => withRole(query),
@@ -97,10 +90,7 @@ export const topicToQuery = {
   createDate: {
     bef: (query) => beforeCreateDate(query),
     aft: (query) => afterCreateDate(query),
-    win: (query) => {
-      const [startDate, endDate] = query.split('-');
-      return withinCreateDate(startDate, endDate);
-    },
+    win: (query) => withinCreateDate(query),
   },
 };
 
@@ -112,6 +102,6 @@ export function activityReportsFiltersToScopes(filters) {
 
   return map(validFilters, (query, topicAndCondition) => {
     const [topic, condition] = topicAndCondition.split('.');
-    return topicToQuery[topic][condition](query);
+    return topicToQuery[topic][condition]([query].flat());
   });
 }

--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -523,6 +523,17 @@ describe('filtersToScopes', () => {
       expect(found.map((f) => f.id))
         .toEqual(expect.arrayContaining([secondReport.id, thirdReport.id]));
     });
+
+    it('within returns reports with start dates when the filters are an array', async () => {
+      const filters = { 'startDate.win': ['2020/06/06-2022/06/06', '2020/06/05-2021/06/05'] };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([secondReport.id, thirdReport.id]));
+    });
   });
 
   describe('lastSaved', () => {
@@ -566,6 +577,17 @@ describe('filtersToScopes', () => {
 
     it('after returns reports with updated ats before the given date', async () => {
       const filters = { 'lastSaved.aft': '2021/06/06' };
+      const scope = filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([thirdReport.id, fourthReport.id]));
+    });
+
+    it('handles an array of querys', async () => {
+      const filters = { 'lastSaved.aft': ['2021/06/06', '2021/06/05'] };
       const scope = filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },

--- a/src/scopes/activityReport/startDate.js
+++ b/src/scopes/activityReport/startDate.js
@@ -1,31 +1,26 @@
 import { Op } from 'sequelize';
+import { withinDateRange, compareDate } from '../utils';
 
 export function beforeStartDate(date) {
   return {
-    startDate: {
-      [Op.lt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'startDate', Op.lt),
     },
   };
 }
 
 export function afterStartDate(date) {
   return {
-    startDate: {
-      [Op.gt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'startDate', Op.gt),
     },
   };
 }
 
-export function withinStartDates(startDate, endDate) {
-  if (!startDate || !endDate) {
-    return {
-      startDate: {},
-    };
-  }
-
+export function withinStartDates(dates) {
   return {
-    startDate: {
-      [Op.between]: [new Date(startDate), new Date(endDate)],
+    [Op.and]: {
+      [Op.or]: withinDateRange(dates, 'startDate'),
     },
   };
 }

--- a/src/scopes/activityReport/updatedAt.js
+++ b/src/scopes/activityReport/updatedAt.js
@@ -1,25 +1,26 @@
 import { Op } from 'sequelize';
+import { withinDateRange, compareDate } from '../utils';
 
 export function beforeLastSaveDate(date) {
   return {
-    updatedAt: {
-      [Op.lt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'updatedAt', Op.lt),
     },
   };
 }
 
 export function afterLastSaveDate(date) {
   return {
-    updatedAt: {
-      [Op.gt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'updatedAt', Op.gt),
     },
   };
 }
 
-export function withinLastSaveDates(startDate, endDate) {
+export function withinLastSaveDates(dates) {
   return {
-    updatedAt: {
-      [Op.between]: [new Date(startDate), new Date(endDate)],
+    [Op.and]: {
+      [Op.or]: withinDateRange(dates, 'updatedAt'),
     },
   };
 }

--- a/src/scopes/grants/index.js
+++ b/src/scopes/grants/index.js
@@ -7,10 +7,7 @@ export const topicToQuery = {
   startDate: {
     bef: (query) => beforeGrantStartDate(query),
     aft: (query) => afterGrantStartDate(query),
-    win: (query) => {
-      const [startDate, endDate] = query.split('-');
-      return withinGrantStartDates(startDate, endDate);
-    },
+    win: (query) => withinGrantStartDates(query),
   },
   region: {
     in: (query) => withGrantsRegion(query),
@@ -25,6 +22,6 @@ export function grantsReportFiltersToScopes(filters) {
 
   return map(validFilters, (query, topicAndCondition) => {
     const [topic, condition] = topicAndCondition.split('.');
-    return topicToQuery[topic][condition](query);
+    return topicToQuery[topic][condition]([query].flat());
   });
 }

--- a/src/scopes/grants/startDate.js
+++ b/src/scopes/grants/startDate.js
@@ -1,31 +1,26 @@
 import { Op } from 'sequelize';
+import { withinDateRange, compareDate } from '../utils';
 
 export function beforeGrantStartDate(date) {
   return {
-    startDate: {
-      [Op.lt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'startDate', Op.lt),
     },
   };
 }
 
 export function afterGrantStartDate(date) {
   return {
-    startDate: {
-      [Op.gt]: new Date(date),
+    [Op.and]: {
+      [Op.or]: compareDate(date, 'startDate', Op.gt),
     },
   };
 }
 
-export function withinGrantStartDates(startDate, endDate) {
-  if (!startDate || !endDate) {
-    return {
-      startDate: {},
-    };
-  }
-
+export function withinGrantStartDates(dates) {
   return {
-    startDate: {
-      [Op.between]: [new Date(startDate), new Date(endDate)],
+    [Op.and]: {
+      [Op.or]: withinDateRange(dates, 'startDate'),
     },
   };
 }

--- a/src/scopes/utils.js
+++ b/src/scopes/utils.js
@@ -1,0 +1,52 @@
+/* eslint-disable import/prefer-default-export */
+import { Op } from 'sequelize';
+
+/**
+ * Takes an array of string date ranges (2020/09/01-2021/10/02, for example)
+ * and attempts to turn them into something sequelize can understand
+ *
+ * @param {String[]} dates
+ * @param {String} property
+ * @param {Op.gt || Op.lt} Operator (a sequelize date operator)
+ * @returns an array meant to be folded in an Op.and/Op.or sequelize expression
+ */
+export function compareDate(dates, property, operator) {
+  return dates.reduce((acc, date) => [
+    ...acc,
+    {
+      [property]: {
+        [operator]: new Date(date),
+      },
+    },
+  ], []);
+}
+
+/**
+ * Takes an array of string date ranges (2020/09/01-2021/10/02, for example)
+ * and attempts to turn them into something sequelize can understand
+ *
+ * @param {String[]} dates
+ * @param {String} property
+ * @returns an array meant to be folded in an Op.and/Op.or sequelize expression
+ */
+export function withinDateRange(dates, property) {
+  return dates.reduce((acc, range) => {
+    if (!range.split) {
+      return acc;
+    }
+
+    const [startDate, endDate] = range.split('-');
+    if (!startDate || !endDate) {
+      return acc;
+    }
+
+    return [
+      ...acc,
+      {
+        [property]: {
+          [Op.between]: [new Date(startDate), new Date(endDate)],
+        },
+      },
+    ];
+  }, []);
+}


### PR DESCRIPTION
## Description of change
The jira explains the behavior but essentially something like ```?startDate.win=2020/10/01-2020/10/02&startDate.win=2021/10/01-2021/11/01``` would cause an error on the backend historically.  Date queries/scopes have been modified to accept such things

## How to test
The unit tests pass (and make sense). If you add multiple startDate within filters on the activity reports page, the backend handles it gracefully.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-441

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
