### PR TITLE
[TTAHUB-205] notify engineers in slack of daily scan failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   node: circleci/node@4.1.0
   browser-tools: circleci/browser-tools@1.2.3
+  slack: circleci/slack@4.5.1
 executors:
   docker-executor:
     # for docker you must specify an image to use for the primary container
@@ -169,7 +170,7 @@ parameters:
     default: "TTAHUB-555-exclude-inactive-grants-with-end-date-greater-than-today"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "js-523-tweak-saving-objectives"
+    default: "TTAHUB-205/notify-daily-scan-failure"
     type: string
   prod_new_relic_app_id:
     default: "877570491"
@@ -384,6 +385,10 @@ jobs:
                 env_name: sandbox
                 new_relic_app_id: << pipeline.parameters.sandbox_new_relic_app_id >>
                 new_relic_api_key: $NEW_RELIC_REST_API_KEY
+            - slack/notify:
+                channel: -mb-test-channel
+                event: always
+                template: basic_fail_1
       - when:  # dev
           condition:
             and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,6 @@ jobs:
                 new_relic_app_id: << pipeline.parameters.sandbox_new_relic_app_id >>
                 new_relic_api_key: $NEW_RELIC_REST_API_KEY
             - slack/notify:
-                channel: -mb-test-channel
                 event: always
                 template: basic_fail_1
       - when:  # dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,7 @@ workflows:
           requires:
             - build_and_lint
       - deploy:
+          context: ohs-eng-daily-scan-slack
           requires:
             - test_backend
             - test_frontend
@@ -505,7 +506,7 @@ workflows:
                 - << pipeline.parameters.dev_git_branch >>
                 - << pipeline.parameters.staging_git_branch >>
                 - << pipeline.parameters.prod_git_branch >>
-  daily_scan:
+  daily_scan:    
     triggers:
       - schedule:
           cron: "0 12 * * 1-5"
@@ -516,7 +517,7 @@ workflows:
                 - << pipeline.parameters.staging_git_branch >>
                 - << pipeline.parameters.prod_git_branch >>
     jobs:
-      - build_and_lint
+      - build_and_lint      
       - test_backend:
           requires:
             - build_and_lint
@@ -526,3 +527,8 @@ workflows:
       - dynamic_security_scan:
           requires:
             - build_and_lint
+      - slack/notify:
+          channel: -mb-test-channel
+          event: fail
+          template: basic_fail_1
+          context: ohs-eng-daily-scan-slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
     description: "Notify acf-eng on daily scan fail"    
     steps:
       - slack/notify:
-          event: always
+          event: fail
           template: basic_fail_1
   build_and_lint:
     executor: docker-executor
@@ -518,7 +518,6 @@ workflows:
                 - << pipeline.parameters.dev_git_branch >>
                 - << pipeline.parameters.staging_git_branch >>
                 - << pipeline.parameters.prod_git_branch >>
-                - << pipeline.parameters.sandbox_git_branch >>
     jobs:
       - build_and_lint      
       - test_backend:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,7 +515,6 @@ workflows:
           filters:
             branches:
               only:
-                - << pipeline.parameters.sandbox_git_branch >>
                 - << pipeline.parameters.dev_git_branch >>
                 - << pipeline.parameters.staging_git_branch >>
                 - << pipeline.parameters.prod_git_branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,6 +515,7 @@ workflows:
           filters:
             branches:
               only:
+                - << pipeline.parameters.sandbox_git_branch >>
                 - << pipeline.parameters.dev_git_branch >>
                 - << pipeline.parameters.staging_git_branch >>
                 - << pipeline.parameters.prod_git_branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,8 +527,3 @@ workflows:
       - dynamic_security_scan:
           requires:
             - build_and_lint
-      - slack/notify:
-          channel: -mb-test-channel
-          event: fail
-          template: basic_fail_1
-          context: ohs-eng-daily-scan-slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,8 +494,7 @@ workflows:
       - accessibility_scan:
           requires:
             - build_and_lint
-      - deploy:
-          
+      - deploy:          
           requires:
             - test_backend
             - test_frontend
@@ -519,6 +518,7 @@ workflows:
                 - << pipeline.parameters.dev_git_branch >>
                 - << pipeline.parameters.staging_git_branch >>
                 - << pipeline.parameters.prod_git_branch >>
+                - << pipeline.parameters.sandbox_git_branch >>
     jobs:
       - build_and_lint      
       - test_backend:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,13 @@ commands:
       - run:
           name: Combine package-lock.json files to single file
           command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
+  notify_daily_scan_fail:
+    description: "Notify acf-eng on daily scan fail"
+    context: ohs-eng-daily-scan-slack
+    steps:
+      - slack/notify:
+          event: always
+          template: basic_fail_1
   notify_new_relic:
     description: "Notify new relic of a deploy"
     parameters:
@@ -385,9 +392,6 @@ jobs:
                 env_name: sandbox
                 new_relic_app_id: << pipeline.parameters.sandbox_new_relic_app_id >>
                 new_relic_api_key: $NEW_RELIC_REST_API_KEY
-            - slack/notify:
-                event: always
-                template: basic_fail_1
       - when:  # dev
           condition:
             and:
@@ -491,7 +495,7 @@ workflows:
           requires:
             - build_and_lint
       - deploy:
-          context: ohs-eng-daily-scan-slack
+          
           requires:
             - test_backend
             - test_frontend
@@ -526,3 +530,8 @@ workflows:
       - dynamic_security_scan:
           requires:
             - build_and_lint
+      - notify_daily_scan_fail:
+          requires:
+            - dynamic_security_scan
+            - test_backend
+            - test_frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,7 @@ commands:
           name: Combine package-lock.json files to single file
           command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
   notify_daily_scan_fail:
-    description: "Notify acf-eng on daily scan fail"
-    context: ohs-eng-daily-scan-slack
+    description: "Notify acf-eng on daily scan fail"    
     steps:
       - slack/notify:
           event: always
@@ -509,7 +508,7 @@ workflows:
                 - << pipeline.parameters.dev_git_branch >>
                 - << pipeline.parameters.staging_git_branch >>
                 - << pipeline.parameters.prod_git_branch >>
-  daily_scan:    
+  daily_scan:   
     triggers:
       - schedule:
           cron: "0 12 * * 1-5"
@@ -531,6 +530,7 @@ workflows:
           requires:
             - build_and_lint
       - notify_daily_scan_fail:
+          context: ohs-eng-daily-scan-slack 
           requires:
             - dynamic_security_scan
             - test_backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,6 @@ commands:
       - run:
           name: Combine package-lock.json files to single file
           command: cat yarn.lock frontend/yarn.lock > << parameters.filename >>
-  notify_daily_scan_fail:
-    description: "Notify acf-eng on daily scan fail"    
-    steps:
-      - slack/notify:
-          event: always
-          template: basic_fail_1
   notify_new_relic:
     description: "Notify new relic of a deploy"
     parameters:
@@ -191,6 +185,13 @@ parameters:
     default: "867346799"
     type: string
 jobs:
+  notify_daily_scan_fail:
+    executor: docker-executor
+    description: "Notify acf-eng on daily scan fail"    
+    steps:
+      - slack/notify:
+          event: always
+          template: basic_fail_1
   build_and_lint:
     executor: docker-executor
     steps:

--- a/frontend/src/pages/RecipientRecord/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/__tests__/index.js
@@ -155,7 +155,7 @@ describe('recipient record page', () => {
     });
 
     const remove = screen.getByRole('button', {
-      name: /this button removes the filter: date range is within 01\/01\/2021/i,
+      name: /this button removes the filter: date range is within/i,
     });
 
     act(() => userEvent.click(remove));


### PR DESCRIPTION
## Description of change

Uses circleci's slack orb to post a generic failure message in the acf-head-start-engineers channel should the daily scan job fail. The channel name and slack api key are stored in Circle CI in the contexts panel for HHS.

## How to test
I've created a slack channel (-mb-test-channel) and I've had the messages posted there. Let me know if you want to review and I'll add you to view the sample failure message that's been posted.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-205


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
