### PR TITLE
Remove 2021 from frontend UI test

### DIFF
--- a/frontend/src/pages/RecipientRecord/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/__tests__/index.js
@@ -155,7 +155,7 @@ describe('recipient record page', () => {
     });
 
     const remove = screen.getByRole('button', {
-      name: /this button removes the filter: date range is within 01\/01\/2021/i,
+      name: /this button removes the filter: date range is within/i,
     });
 
     act(() => userEvent.click(remove));


### PR DESCRIPTION
## Description of change
There was a rogue UI test with 2021 hardcoded into it. I did it. Happy New Year!

## How to test
Frontend tests pass in the CI

## Issue(s)
no ticket

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
