### PR TITLE
[TTAHUB-553] remove grantee_record_page feature flag from users/backend

### DIFF
--- a/src/migrations/20220103142419-remove-grantee-record-flag.js
+++ b/src/migrations/20220103142419-remove-grantee-record-flag.js
@@ -1,0 +1,12 @@
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await queryInterface.bulkUpdate('Users', {
+        flags: [],
+      }, {}, { transaction });
+    },
+  ),
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    // whoops, don't think this can be rolled back
+  ),
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -19,9 +19,7 @@ const roles = [
   'System Specialist',
 ];
 
-export const featureFlags = [
-  'grantee_record_page',
-];
+export const featureFlags = [];
 
 const generateFullName = (name, role) => {
   const combinedRoles = Array.isArray(role) ? role.reduce((result, val) => {


### PR DESCRIPTION
## Description of change
Remove the grantee record page feature flag from the user model, and bulk update all users to remove that feature flag. (It's already been removed from the frontend)

## How to test
Run the migration. Ensure you have no users with the feature flag, that the feature flag cannot be assigned, and that everything else works as expected

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-553

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
