### PR TITLE
[TTAHUB-313] Remove Static Dates from Overview Widget

### DIFF
--- a/frontend/src/widgets/Overview.css
+++ b/frontend/src/widgets/Overview.css
@@ -1,8 +1,3 @@
-.smart-hub--overview-period {
-  padding: 22px;
-  font-size: 15px;
-}
-
 .smart-hub--overview-header {
   margin-top: -35px;
   margin-left: -20px;
@@ -26,4 +21,4 @@
 
 .smart-hub--overview-border {
   border: 3px solid #0166ab;
-}
+} 

--- a/frontend/src/widgets/Overview.js
+++ b/frontend/src/widgets/Overview.js
@@ -55,7 +55,6 @@ function Overview({
         <h2>
           {title}
         </h2>
-        <span className="smart-hub--overview-period"> 9/01/2020 to Today</span>
       </Grid>
       <Grid row gap className="smart-hub--overview-data">
         <Field col="fill" tablet={{ col: true }} label="Grants served " data={data.numGrants} />


### PR DESCRIPTION
## Description of change

Because the user can now filter dates from the new filter control on the AR Landing page. We should no longer show the static date value of "09/01/2021 to Present".


## How to test

View the AR landing, the overview widget should no longer show the static dates. If a date filter is applied it should show in the filter pills.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-313


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [x] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
