### PR TITLE
[TTAHUB-572] Make large export errors dismissable

### DIFF
--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -250,6 +250,7 @@ function ActivityReportsTable({
           perPage={perPage}
           handlePageChange={handlePageChange}
           downloadError={downloadError}
+          setDownloadError={setDownloadError}
           dateTime={dateTime}
           isDownloading={isDownloading}
           downloadAllButtonRef={downloadAllButtonRef}

--- a/frontend/src/components/TableHeader.js
+++ b/frontend/src/components/TableHeader.js
@@ -38,6 +38,7 @@ export default function TableHeader({
   hidePagination,
   forMyAlerts,
   downloadError,
+  setDownloadError,
   isDownloading,
   dateTime,
   downloadAllButtonRef,
@@ -83,6 +84,7 @@ export default function TableHeader({
               onExportSelected={handleDownloadClick}
               count={count}
               downloadError={downloadError}
+              setDownloadError={setDownloadError}
               isDownloading={isDownloading}
               downloadAllButtonRef={downloadAllButtonRef}
               downloadSelectedButtonRef={downloadSelectedButtonRef}
@@ -142,6 +144,7 @@ TableHeader.propTypes = {
   handlePageChange: PropTypes.func,
   hideMenu: PropTypes.bool,
   menuAriaLabel: PropTypes.string,
+  setDownloadError: PropTypes.func,
   downloadError: PropTypes.bool,
   dateTime: PropTypes.shape({
     timestamp: PropTypes.string, label: PropTypes.string,
@@ -174,6 +177,7 @@ TableHeader.defaultProps = {
   hideMenu: false,
   menuAriaLabel: 'Reports menu',
   downloadError: false,
+  setDownloadError: () => {},
   dateTime: { timestamp: '', label: '' },
   isDownloading: false,
   downloadAllButtonRef: () => {},

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -194,6 +194,7 @@ function MyAlerts(props) {
     message,
     isDownloadingAlerts,
     downloadAlertsError,
+    setDownloadAlertsError,
     downloadAllAlertsButtonRef,
     downloadSelectedAlertsButtonRef,
   } = props;
@@ -277,6 +278,7 @@ function MyAlerts(props) {
             hidePagination
             isDownloading={isDownloadingAlerts}
             downloadError={downloadAlertsError}
+            setDownloadError={setDownloadAlertsError}
             downloadAllButtonRef={downloadAllAlertsButtonRef}
             downloadSelectedButtonRef={downloadSelectedAlertsButtonRef}
           />
@@ -332,6 +334,7 @@ MyAlerts.propTypes = {
   }),
   isDownloadingAlerts: PropTypes.bool,
   downloadAlertsError: PropTypes.bool,
+  setDownloadAlertsError: PropTypes.func.isRequired,
   downloadAllAlertsButtonRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { faSortDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Alert } from '@trussworks/react-uswds';
+import { Alert, Button } from '@trussworks/react-uswds';
 import Container from '../../components/Container';
 
 export const MAXIMUM_EXPORTED_REPORTS = 2000;
@@ -14,6 +14,7 @@ function ReportMenu({
   label,
   count,
   downloadError,
+  setDownloadError,
   isDownloading,
   downloadAllButtonRef,
   downloadSelectedButtonRef,
@@ -75,21 +76,34 @@ function ReportMenu({
         <div role="menu" tabIndex={-1} onBlur={onMenuBlur} onKeyDown={onMenuKeyDown} ref={menuRef} className={menuClassNames}>
           <Container padding={2} className="margin-bottom-0">
             {downloadError && (
-              <Alert noIcon slim type="error" className="margin-bottom-3" role="alert">
+              <Alert
+                noIcon
+                slim
+                type="error"
+                className="margin-bottom-3"
+                role="alert"
+                cta={(
+                  <Button
+                    outline
+                    onClick={() => setDownloadError(false)}
+                  >
+                    Dismiss
+                  </Button>
+                )}
+              >
                 Sorry, something went wrong. Please try your request again.
                 <br />
                 You may export up to
-                {' '}
-                {MAXIMUM_EXPORTED_REPORTS.toLocaleString('en-us')}
-                {' '}
+                  {' '}
+                  {MAXIMUM_EXPORTED_REPORTS.toLocaleString('en-us')}
+                  {' '}
                 reports at a time.
-                {' '}
+                  {' '}
                 <br />
                 For assistance, please
                   {' '}
                 <a href="https://app.smartsheetgov.com/b/form/f0b4725683f04f349a939bd2e3f5425a">contact support</a>
                 .
-
               </Alert>
             )}
             {count > MAXIMUM_EXPORTED_REPORTS ? (
@@ -167,6 +181,7 @@ ReportMenu.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   ]),
+  setDownloadError: PropTypes.func.isRequired,
 };
 
 ReportMenu.defaultProps = {

--- a/frontend/src/pages/Landing/__tests__/ReportMenu.js
+++ b/frontend/src/pages/Landing/__tests__/ReportMenu.js
@@ -11,12 +11,16 @@ const RenderReportMenu = ({
   onExportSelected = () => {},
   hasSelectedReports = true,
   count = 12,
+  downloadError = false,
+  setDownloadError = jest.fn(),
 }) => (
   <ReportMenu
     count={count}
     onExportAll={onExportAll}
     onExportSelected={onExportSelected}
     hasSelectedReports={hasSelectedReports}
+    downloadError={downloadError}
+    setDownloadError={setDownloadError}
   />
 );
 
@@ -78,6 +82,21 @@ describe('ReportMenu', () => {
     userEvent.click(button);
     const label = `This export has ${(MAXIMUM_EXPORTED_REPORTS + 1).toLocaleString('en-us')} reports. You can only export ${MAXIMUM_EXPORTED_REPORTS.toLocaleString('en-us')} reports at a time.`;
     expect(await screen.findByText(label)).toBeVisible();
+  });
+
+  it('shows and dismisses a download error message', async () => {
+    const setDownloadError = jest.fn();
+    const downloadError = true;
+    render(<RenderReportMenu downloadError={downloadError} setDownloadError={setDownloadError} />);
+
+    const button = await screen.findByRole('button');
+    userEvent.click(button);
+
+    await screen.findByText(/sorry, something went wrong. Please try your request again/i);
+    const dismiss = await screen.findByRole('button', { name: /dismiss/i });
+    userEvent.click(dismiss);
+
+    expect(setDownloadError).toHaveBeenCalledWith(false);
   });
 
   it('closes when the Escape key is pressed', async () => {

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -305,6 +305,7 @@ function Landing({ user }) {
           message={message}
           isDownloadingAlerts={isDownloadingAlerts}
           downloadAlertsError={downloadAlertsError}
+          setDownloadAlertsError={setDownloadAlertsError}
           downloadAllAlertsButtonRef={downloadAllAlertsButtonRef}
         />
         <ActivityReportsTable


### PR DESCRIPTION
## Description of change
In the case of an request error when downloading reports, a message is shown explaining that "something went wrong." This is pretty much only caused by trying a large download in an environment that can't support it. This is all fine, however, once the download error has occurred, there wasn't a way to clear the error and try another download. 

## How to test
Try a large export that you know will fail (you may have to disable the shields preventing you from doing so), or force the error to appear. Get an error - and then clear it.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-572


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
