### PR TITLE
[TTAHUB-571] Add Last Thirty Days Filter to AR Landing

### DIFF
--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -8,24 +8,42 @@ import { MemoryRouter } from 'react-router';
 import fetchMock from 'fetch-mock';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
+import { v4 as uuidv4 } from 'uuid';
 import UserContext from '../../../UserContext';
 import AriaLiveContext from '../../../AriaLiveContext';
 import Landing from '../index';
 import activityReports, { activityReportsSorted, generateXFakeReports, overviewRegionOne } from '../mocks';
 import { getAllAlertsDownloadURL } from '../../../fetchers/helpers';
+import { formatDateRange } from '../../../components/DateRangeSelect';
+import { filtersToQueryString } from '../../../utils';
 
 jest.mock('../../../fetchers/helpers');
 
 const mockAnnounce = jest.fn();
 
-const base = '/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10';
-const baseAlerts = '/api/activity-reports/alerts?sortBy=startDate&sortDir=desc&offset=0&limit=10';
+// Get last 30 day filter.
+const defaultDate = formatDateRange({
+  lastThirtyDays: true,
+  forDateTime: true,
+});
+
+const filters = [{
+  id: uuidv4(),
+  topic: 'startDate',
+  condition: 'Is within',
+  query: defaultDate,
+}];
+
+const dateFilter = filtersToQueryString(filters);
+
+const base = `/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${dateFilter}`;
+const baseAlerts = `/api/activity-reports/alerts?sortBy=startDate&sortDir=desc&offset=0&limit=10&${dateFilter}`;
 
 const withRegionOne = '&region.in[]=1';
 const baseAlertsWithRegionOne = `${baseAlerts}${withRegionOne}`;
 const baseWithRegionOne = `${base}${withRegionOne}`;
 
-const defaultOverviewUrl = '/api/widgets/overview?';
+const defaultOverviewUrl = `/api/widgets/overview?${dateFilter}`;
 const defaultOverviewUrlWithRegionOne = `${defaultOverviewUrl}${withRegionOne}`;
 const overviewUrlWithRegionOne = `${defaultOverviewUrl}?region.in[]=1`;
 
@@ -272,7 +290,7 @@ describe('Landing page table menus & selections', () => {
         userEvent.click(reportMenu);
         const downloadButton = await screen.findByRole('menuitem', { name: /export table data/i });
         userEvent.click(downloadButton);
-        expect(getAllAlertsDownloadURL).toHaveBeenCalledWith('');
+        expect(getAllAlertsDownloadURL).toHaveBeenCalledWith(dateFilter);
       });
 
       it('disables alert download button while downloading', async () => {
@@ -298,7 +316,7 @@ describe('Landing page table menus & selections', () => {
         const downloadButton = await screen.findByRole('menuitem', { name: /export table data/i });
         userEvent.click(downloadButton);
         expect(await screen.findByRole('menuitem', { name: /export table data/i })).toBeDisabled();
-        expect(getAllAlertsDownloadURL).toHaveBeenCalledWith('');
+        expect(getAllAlertsDownloadURL).toHaveBeenCalledWith(dateFilter);
       });
     });
   });
@@ -366,7 +384,7 @@ describe('My alerts sorting', () => {
     await waitFor(() => expect(screen.getAllByRole('cell')[7]).toHaveTextContent(/draft/i));
     await waitFor(() => expect(screen.getAllByRole('cell')[16]).toHaveTextContent(/needs action/i));
 
-    fetchMock.get('/api/activity-reports/alerts?sortBy=calculatedStatus&sortDir=desc&offset=0&limit=10',
+    fetchMock.get(`/api/activity-reports/alerts?sortBy=calculatedStatus&sortDir=desc&offset=0&limit=10&${dateFilter}`,
       { alertsCount: 2, alerts: activityReportsSorted });
 
     fireEvent.click(statusColumnHeaders[0]);
@@ -378,7 +396,7 @@ describe('My alerts sorting', () => {
     const reportIdHeaders = await screen.findAllByRole('columnheader', { name: /report id/i });
     expect(reportIdHeaders.length).toBe(2);
     fetchMock.reset();
-    fetchMock.get('/api/activity-reports/alerts?sortBy=regionId&sortDir=asc&offset=0&limit=10',
+    fetchMock.get(`/api/activity-reports/alerts?sortBy=regionId&sortDir=asc&offset=0&limit=10&${dateFilter}`,
       { alertsCount: 2, alerts: activityReports });
     fetchMock.get(
       base,
@@ -396,7 +414,7 @@ describe('My alerts sorting', () => {
     });
     expect(columnHeaders.length).toBe(2);
     fetchMock.reset();
-    fetchMock.get('/api/activity-reports/alerts?sortBy=activityRecipients&sortDir=asc&offset=0&limit=10',
+    fetchMock.get(`/api/activity-reports/alerts?sortBy=activityRecipients&sortDir=asc&offset=0&limit=10&${dateFilter}`,
       { alertsCount: 2, alerts: activityReports });
     fetchMock.get(
       base,
@@ -411,11 +429,10 @@ describe('My alerts sorting', () => {
   });
 
   it('is enabled for Start date', async () => {
-    const columnHeaders = await screen.findAllByText(/start date/i);
-
+    const columnHeaders = await screen.findAllByRole('button', { name: /start date\. activate to sort ascending/i });
     expect(columnHeaders.length).toBe(2);
     fetchMock.reset();
-    fetchMock.get('/api/activity-reports/alerts?sortBy=startDate&sortDir=asc&offset=0&limit=10',
+    fetchMock.get(`/api/activity-reports/alerts?sortBy=startDate&sortDir=asc&offset=0&limit=10&${dateFilter}`,
       { alertsCount: 2, alerts: activityReportsSorted });
     fetchMock.get(
       base,
@@ -433,7 +450,7 @@ describe('My alerts sorting', () => {
 
     expect(columnHeaders.length).toBe(2);
     fetchMock.reset();
-    fetchMock.get('/api/activity-reports/alerts?sortBy=author&sortDir=asc&offset=0&limit=10',
+    fetchMock.get(`/api/activity-reports/alerts?sortBy=author&sortDir=asc&offset=0&limit=10&${dateFilter}`,
       { alertsCount: 2, alerts: activityReportsSorted });
     fetchMock.get(
       base,
@@ -451,7 +468,7 @@ describe('My alerts sorting', () => {
     expect(columnHeaders.length).toBe(2);
     fetchMock.reset();
 
-    fetchMock.get('/api/activity-reports/alerts?sortBy=collaborators&sortDir=asc&offset=0&limit=10',
+    fetchMock.get(`/api/activity-reports/alerts?sortBy=collaborators&sortDir=asc&offset=0&limit=10&${dateFilter}`,
       { alertsCount: 2, alerts: activityReportsSorted });
     fetchMock.get(`${base}`, { count: 0, rows: [] });
 
@@ -563,13 +580,9 @@ describe('handleApplyFilters', () => {
     const filterMenuButton = await screen.findByRole('button', { name: /filters/i });
     fireEvent.click(filterMenuButton);
 
-    // Add new filter
-    const addNewFilterButton = await screen.findByRole('button', { name: /add new filter/i });
-    fireEvent.click(addNewFilterButton);
-
     // Get filter group.
-    const topic = await screen.findAllByRole('combobox', { name: /topic/i });
-    userEvent.selectOptions(topic[0], 'reportId');
+    const topic = await screen.findByRole('combobox', { name: /topic/i });
+    userEvent.selectOptions(topic, 'reportId');
 
     const condition = await screen.findByRole('combobox', { name: 'condition' });
     userEvent.selectOptions(condition, 'Contains');
@@ -595,7 +608,6 @@ describe('handleApplyAlertFilters', () => {
   beforeEach(() => {
     delete window.location;
     window.location = new URL('https://www.test.gov');
-
     fetchMock.get(baseAlerts, {
       count: 10,
       alerts: generateXFakeReports(10),
@@ -629,10 +641,6 @@ describe('handleApplyAlertFilters', () => {
 
     const filterMenuButton = allFilterButtons[0];
     fireEvent.click(filterMenuButton);
-
-    // Add new filter
-    const addFilter = await screen.findByRole('button', { name: /add new filter/i });
-    fireEvent.click(addFilter);
 
     const topic = await screen.findByRole('combobox', { name: 'topic' });
     userEvent.selectOptions(topic, 'reportId');

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -33,6 +33,11 @@ import FilterPanel from '../../components/filter/FilterPanel';
 import useUrlFilters from '../../hooks/useUrlFilters';
 import { formatDateRange } from '../../components/DateRangeSelect';
 
+const defaultDate = formatDateRange({
+  lastThirtyDays: true,
+  forDateTime: true,
+});
+
 export function renderTotal(offset, perPage, activePage, reportsCount) {
   const from = offset >= reportsCount ? 0 : offset + 1;
   const offsetTo = perPage * activePage;
@@ -61,7 +66,18 @@ function Landing({ user }) {
         condition: 'Is',
         query: defaultRegion,
       },
-      ] : [],
+      {
+        id: uuidv4(),
+        topic: 'startDate',
+        condition: 'Is within',
+        query: defaultDate,
+      }]
+      : [{
+        id: uuidv4(),
+        topic: 'startDate',
+        condition: 'Is within',
+        query: defaultDate,
+      }],
   );
 
   const history = useHistory();


### PR DESCRIPTION
## Description of change

By default we always want the AR Landing page to have a default filter of "the last thirty days".


## How to test

If the user has permission for more than one region. The AR Landing should have both the Region and LTD filter.

If the user only has permission to one region. The AR Landing should only have the LTD fiter.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-571


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
