### PR TITLE
Add annual funding month to the database

### DIFF
--- a/src/lib/updateGrantsRecipients.js
+++ b/src/lib/updateGrantsRecipients.js
@@ -105,6 +105,7 @@ export async function processFiles() {
         programSpecialistEmail: valueFromXML(g.program_specialist_email),
         grantSpecialistName,
         grantSpecialistEmail: valueFromXML(g.grants_specialist_email),
+        annualFundingMonth: valueFromXML(g.annual_funding_month),
       };
     });
 
@@ -136,14 +137,14 @@ export async function processFiles() {
     await Grant.bulkCreate(
       nonCdiGrants,
       {
-        updateOnDuplicate: ['number', 'regionId', 'recipientId', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode'],
+        updateOnDuplicate: ['number', 'regionId', 'recipientId', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode', 'annualFundingMonth'],
       },
     );
 
     await Grant.bulkCreate(
       cdiGrants,
       {
-        updateOnDuplicate: ['number', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode'],
+        updateOnDuplicate: ['number', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode', 'annualFundingMonth'],
       },
     );
 

--- a/src/lib/updateGrantsRecipients.test.js
+++ b/src/lib/updateGrantsRecipients.test.js
@@ -109,6 +109,18 @@ describe('Update grants and recipients', () => {
     expect(grantWithStateCode.stateCode).toEqual('CT');
   });
 
+  it('includes the annual funding month', async () => {
+    await processFiles();
+    const grant = await Grant.findOne({ where: { id: 11630 } });
+    // simulate updating an existing grant with null stateCode
+    await grant.update({ annualFundingMonth: null });
+    const grantWithNullAfm = await Grant.findOne({ where: { id: 11630 } });
+    expect(grantWithNullAfm.annualFundingMonth).toBeNull();
+    await processFiles();
+    const grantWithAfm = await Grant.findOne({ where: { id: 11630 } });
+    expect(grantWithAfm.annualFundingMonth).toEqual('February');
+  });
+
   it('handles nil states codes', async () => {
     await processFiles();
     const grant = await Grant.findOne({ where: { id: 10448 } });

--- a/src/migrations/20220114214532-add_grant_annual_funding_month.js
+++ b/src/migrations/20220114214532-add_grant_annual_funding_month.js
@@ -1,0 +1,5 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => queryInterface.addColumn('Grants', 'annualFundingMonth', { type: Sequelize.STRING }),
+
+  down: async (queryInterface) => queryInterface.removeColumn('Grants', 'annualFundingMonth'),
+};

--- a/src/models/grant.js
+++ b/src/models/grant.js
@@ -35,6 +35,7 @@ module.exports = (sequelize, DataTypes) => {
         unique: true,
       */
     },
+    annualFundingMonth: DataTypes.STRING,
     cdi: DataTypes.BOOLEAN,
     status: DataTypes.STRING,
     grantSpecialistName: DataTypes.STRING,


### PR DESCRIPTION
## Description of change
Adds the annual funding month to the database and populates values from the HSES XML


## How to test
Make sure tests pass

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-569


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
