### PR TITLE
Add full state names to state filter

### DIFF
--- a/frontend/src/components/filter/FilterSelect.js
+++ b/frontend/src/components/filter/FilterSelect.js
@@ -9,6 +9,7 @@ export default function FilterSelect({
   inputId,
   options,
   selectedValues,
+  mapByValue,
 }) {
   /**
    * unfortunately, given our support for ie11, we can't
@@ -19,8 +20,10 @@ export default function FilterSelect({
 
   useSpellCheck(inputId);
 
+  const key = mapByValue ? 'value' : 'label';
+
   const value = [selectedValues].flat().map((selection) => (
-    options.find((option) => option.label === selection)
+    options.find((option) => option[key] === selection)
   ));
 
   const styles = {
@@ -73,7 +76,7 @@ export default function FilterSelect({
   };
 
   const onChange = (selected) => {
-    onApply(selected.map((selection) => selection.label));
+    onApply(selected.map((selection) => selection[key]));
   };
 
   return (
@@ -106,4 +109,9 @@ FilterSelect.propTypes = {
   options: PropTypes.arrayOf(option).isRequired,
   inputId: PropTypes.string.isRequired,
   selectedValues: PropTypes.arrayOf(PropTypes.string).isRequired,
+  mapByValue: PropTypes.bool,
+};
+
+FilterSelect.defaultProps = {
+  mapByValue: false,
 };

--- a/frontend/src/components/filter/FilterStateSelect.js
+++ b/frontend/src/components/filter/FilterStateSelect.js
@@ -9,26 +9,99 @@ import { allRegionsUserHasPermissionTo } from '../../permissions';
 // see: https://www.acf.hhs.gov/oro/regional-offices
 const ALL_STATES = [
   // Region 1 States
-  ['MA', 'ME', 'CT', 'RI', 'VT', 'NH'],
+  [
+    { label: 'Massachusetts (MA)', value: 'MA' },
+    { label: 'Maine (ME)', value: 'ME' },
+    { label: 'Conneticut (CT)', value: 'CT' },
+    { label: 'Rhode Island (RI)', value: 'RI' },
+    { label: 'Vermont (VT)', value: 'VT' },
+    { label: 'New Hampshire (NH)', value: 'NH' },
+  ],
   // Region 2 States
-  ['NY', 'NJ', 'PR'],
+  [
+    { label: 'New York (NY)', value: 'NY' },
+    { label: 'New Jersey (NJ)', value: 'NJ' },
+    { label: 'Puerto Rico (PR)', value: 'PR' },
+  ],
   // Region 3 States
-  ['PA', 'WV', 'MD', 'DE', 'VA', 'DC'],
+  [
+    { label: 'Pennsylvania (PA)', value: 'PA' },
+    { label: 'West Virginia (WV)', value: 'WV' },
+    { label: 'Maryland (MD)', value: 'MD' },
+    { label: 'Delaware (DE)', value: 'DE' },
+    { label: 'Virginia (VA)', value: 'VA' },
+    { label: 'District of Columbia (DC)', value: 'DC' },
+  ],
   // Region 4 States
-  ['KY', 'TN', 'NC', 'AL', 'MS', 'GA', 'SC', 'FL'],
+  [
+    { label: 'Kentucky (KY)', value: 'KY' },
+    { label: 'Tennessee (TN)', value: 'TN' },
+    { label: 'North Carolina (NC)', value: 'NC' },
+    { label: 'Alabama (AL)', value: 'AL' },
+    { label: 'Mississippi (MS)', value: 'MS' },
+    { label: 'Georgia (GA)', value: 'GA' },
+    { label: 'South Carolina (SC)', value: 'SC' },
+    { label: 'Florida (FL)', value: 'FL' },
+  ],
   // Region 5 States
-  ['MN', 'WI', 'IL', 'IN', 'MI', 'OH'],
+  [
+    { label: 'Minnesota (MN)', value: 'MN' },
+    { label: 'Wisconsin (WI)', value: 'WI' },
+    { label: 'Illinois (IL)', value: 'IL' },
+    { label: 'Indiana (IN)', value: 'AL' },
+    { label: 'Michigan (MI)', value: 'MI' },
+    { label: 'Ohio (OH)', value: 'OH' },
+  ],
   // Region 6 States
-  ['NM', 'OK', 'AR', 'TX', 'LA'],
+  [
+    { label: 'New Mexico (NM)', value: 'NM' },
+    { label: 'Oklahoma (OK)', value: 'OK' },
+    { label: 'Arkansas (AR)', value: 'AR' },
+    { label: 'Texas (TX)', value: 'TX' },
+    { label: 'Louisiana (LA)', value: 'LA' },
+  ],
   // Region 7 States
-  ['NE', 'IA', 'KS', 'MO'],
+  [
+    { label: 'Nebraska (NE)', value: 'NE' },
+    { label: 'Iowa (IA)', value: 'IA' },
+    { label: 'Kansas (KS)', value: 'KS' },
+    { label: 'Missouri (MO)', value: 'MO' },
+  ],
   // Region 8 States
-  ['MT', 'ND', 'SD', 'WY', 'UT', 'CO'],
+  [
+    { label: 'Montana (MT)', value: 'MT' },
+    { label: 'North Dakota (ND)', value: 'ND' },
+    { label: 'South Dakota (SD)', value: 'SD' },
+    { label: 'Wyoming (WY)', value: 'WY' },
+    { label: 'Utah (UT)', value: 'UT' },
+    { label: 'Colorado (CO)', value: 'CO' },
+  ],
   // Region 9 States
-  ['NV', 'CA', 'AZ', 'HI', 'GU', 'AS', 'VI', 'MP', 'FM', 'MH', 'PW'],
+  [
+    { label: 'Nevada (NV)', value: 'NV' },
+    { label: 'California (CA)', value: 'CA' },
+    { label: 'Arizona (AZ)', value: 'AZ' },
+    { label: 'Hawaii (HI)', value: 'HI' },
+    { label: 'Guam (GU)', value: 'GU' },
+    { label: 'American Samoa (AS)', value: 'AS' },
+    { label: 'Virgin Islands (VI)', value: 'VI' },
+    { label: 'Northern Mariana Islands (MP)', value: 'MP' },
+    { label: 'Northern Mariana Islands (FC)', value: 'FC' },
+    { label: 'Federated States of Micronesia (FM)', value: 'FM' },
+    { label: 'Marshall Islands (MH)', value: 'MH' },
+    { label: 'Republic of Palau (PW)', value: 'PW' },
+  ],
   // 'Region 10 States
-  ['WA', 'OR', 'ID', 'AK'],
+  [
+    { label: 'Washington (WA)', value: 'WA' },
+    { label: 'Oregon (OR)', value: 'OR' },
+    { label: 'Idaho (ID)', value: 'ID' },
+    { label: 'Alaska (AK)', value: 'AK' },
+  ],
 ];
+
+const ALL_STATES_FLATTENED = ALL_STATES.flat();
+
 export default function FilterStateSelect({
   onApply,
   inputId,
@@ -47,9 +120,20 @@ export default function FilterStateSelect({
       // build the list of state codes for our user
       if (allowedRegions.includes(11) || allowedRegions.includes(12)) {
         try {
-          codes = await getStateCodes();
+          const response = await getStateCodes();
+          codes = response.map((code) => {
+            const found = ALL_STATES_FLATTENED.find((c) => c.value === code);
+            if (found) {
+              return found;
+            }
+
+            return {
+              value: code,
+              label: code,
+            };
+          });
         } catch (err) {
-          codes = ALL_STATES.flat();
+          codes = ALL_STATES_FLATTENED;
         }
       }
 
@@ -76,8 +160,19 @@ export default function FilterStateSelect({
       // de-dupe state codes
       codes = Array.from(new Set(codes));
 
+      codes = codes.sort((firstCode, secondCode) => {
+        if (firstCode.value < secondCode.value) {
+          return -1;
+        }
+        if (firstCode.value > secondCode.value) {
+          return 1;
+        }
+
+        return 0;
+      });
+
       // return list sorted alphabetically
-      setStateCodes(codes.sort());
+      setStateCodes(codes);
     }
 
     // we're only fetching these once
@@ -86,11 +181,8 @@ export default function FilterStateSelect({
     }
   }, [stateCodes, user]);
 
-  const options = stateCodes.map((label, value) => ({
-    value, label,
-  }));
-
   const onApplyClick = (selected) => {
+    // console.log(selected);
     onApply(selected);
   };
 
@@ -99,8 +191,9 @@ export default function FilterStateSelect({
       onApply={onApplyClick}
       inputId={inputId}
       labelText="Select state to filter by"
-      options={options}
+      options={stateCodes}
       selectedValues={query}
+      mapByValue
     />
   );
 }

--- a/frontend/src/components/filter/FilterStateSelect.js
+++ b/frontend/src/components/filter/FilterStateSelect.js
@@ -48,7 +48,7 @@ const ALL_STATES = [
     { label: 'Minnesota (MN)', value: 'MN' },
     { label: 'Wisconsin (WI)', value: 'WI' },
     { label: 'Illinois (IL)', value: 'IL' },
-    { label: 'Indiana (IN)', value: 'AL' },
+    { label: 'Indiana (IN)', value: 'IN' },
     { label: 'Michigan (MI)', value: 'MI' },
     { label: 'Ohio (OH)', value: 'OH' },
   ],

--- a/frontend/src/components/filter/FilterStateSelect.js
+++ b/frontend/src/components/filter/FilterStateSelect.js
@@ -86,7 +86,6 @@ const ALL_STATES = [
     { label: 'American Samoa (AS)', value: 'AS' },
     { label: 'Virgin Islands (VI)', value: 'VI' },
     { label: 'Northern Mariana Islands (MP)', value: 'MP' },
-    { label: 'Northern Mariana Islands (FC)', value: 'FC' },
     { label: 'Federated States of Micronesia (FM)', value: 'FM' },
     { label: 'Marshall Islands (MH)', value: 'MH' },
     { label: 'Republic of Palau (PW)', value: 'PW' },

--- a/frontend/src/components/filter/FilterStateSelect.js
+++ b/frontend/src/components/filter/FilterStateSelect.js
@@ -12,7 +12,7 @@ const ALL_STATES = [
   [
     { label: 'Massachusetts (MA)', value: 'MA' },
     { label: 'Maine (ME)', value: 'ME' },
-    { label: 'Conneticut (CT)', value: 'CT' },
+    { label: 'Connecticut (CT)', value: 'CT' },
     { label: 'Rhode Island (RI)', value: 'RI' },
     { label: 'Vermont (VT)', value: 'VT' },
     { label: 'New Hampshire (NH)', value: 'NH' },

--- a/frontend/src/components/filter/__tests__/FilterStateSelect.js
+++ b/frontend/src/components/filter/__tests__/FilterStateSelect.js
@@ -42,7 +42,7 @@ describe('FilterStateSelect', () => {
     renderStateSelect(user, onApply);
 
     const select = await findByText(/Select state to filter by/i);
-    await selectEvent.select(select, ['MA']);
+    await selectEvent.select(select, ['Massachusetts (MA)']);
     expect(onApply).toHaveBeenCalledWith(['MA']);
   });
 
@@ -60,7 +60,7 @@ describe('FilterStateSelect', () => {
 
     renderStateSelect(user, onApply);
     const select = await findByText(/Select state to filter by/i);
-    await selectEvent.select(select, ['PR']);
+    await selectEvent.select(select, ['Puerto Rico (PR)']);
     const options = document.querySelectorAll('div[class$="-option"]');
     expect(options.length).toBe(2);
     expect(onApply).toHaveBeenCalledWith(['PR']);
@@ -80,7 +80,7 @@ describe('FilterStateSelect', () => {
 
     renderStateSelect(user, onApply);
     const select = await findByText(/Select state to filter by/i);
-    await selectEvent.select(select, ['GU']);
+    await selectEvent.select(select, ['Guam (GU)']);
     const options = document.querySelectorAll('div[class$="-option"]');
     expect(options.length).toBe(2);
     expect(onApply).toHaveBeenCalledWith(['GU']);
@@ -100,9 +100,9 @@ describe('FilterStateSelect', () => {
 
     renderStateSelect(user, onApply);
     const select = await findByText(/Select state to filter by/i);
-    await selectEvent.select(select, ['GU']);
+    await selectEvent.select(select, ['Guam (GU)']);
     const options = document.querySelectorAll('div[class$="-option"]');
-    expect(options.length).toBe(59);
+    expect(options.length).toBe(60);
     expect(onApply).toHaveBeenCalledWith(['GU']);
   });
 });

--- a/frontend/src/components/filter/__tests__/FilterStateSelect.js
+++ b/frontend/src/components/filter/__tests__/FilterStateSelect.js
@@ -47,7 +47,7 @@ describe('FilterStateSelect', () => {
   });
 
   it('handles a user with permissions to region 11', async () => {
-    fetchMock.get('/api/users/stateCodes', ['AZ', 'PR']);
+    fetchMock.get('/api/users/stateCodes', ['AZ', 'PR', 'FC']);
     const onApply = jest.fn();
     const user = {
       permissions: [
@@ -60,10 +60,11 @@ describe('FilterStateSelect', () => {
 
     renderStateSelect(user, onApply);
     const select = await findByText(/Select state to filter by/i);
-    await selectEvent.select(select, ['Puerto Rico (PR)']);
+    await selectEvent.select(select, ['Puerto Rico (PR)', 'FC']);
     const options = document.querySelectorAll('div[class$="-option"]');
-    expect(options.length).toBe(2);
+    expect(options.length).toBe(3);
     expect(onApply).toHaveBeenCalledWith(['PR']);
+    expect(onApply).toHaveBeenCalledWith(['FC']);
   });
 
   it('handles a user with permissions to region 12', async () => {
@@ -102,7 +103,7 @@ describe('FilterStateSelect', () => {
     const select = await findByText(/Select state to filter by/i);
     await selectEvent.select(select, ['Guam (GU)']);
     const options = document.querySelectorAll('div[class$="-option"]');
-    expect(options.length).toBe(60);
+    expect(options.length).toBe(59);
     expect(onApply).toHaveBeenCalledWith(['GU']);
   });
 });


### PR DESCRIPTION
## Description of change
Per discussion at standup, change the state names in the state filter to make the type-ahead more robust.

## How to test
Make sure you can still select states, make sure as best you can that everything is spelled correctly

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-534

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
