### PR TITLE
remove slack notification for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 orbs:
   node: circleci/node@4.1.0
   browser-tools: circleci/browser-tools@1.2.3
-  slack: circleci/slack@4.5.1
 executors:
   docker-executor:
     # for docker you must specify an image to use for the primary container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,19 +239,7 @@ jobs:
           path: reports/
       - store_artifacts:
           path: coverage/
-      - when:
-          condition:
-            or:
-              - and:
-                - equal: [<< pipeline.project.git_url >>, << pipeline.parameters.prod_git_url >>]
-                - equal: [<< pipeline.git.branch >>, << pipeline.parameters.prod_git_branch >>]
-              - and:
-                - equal: [<< pipeline.project.git_url >>, << pipeline.parameters.staging_git_url >>]
-                - equal: [<< pipeline.git.branch >>, << pipeline.parameters.staging_git_branch >>]
-          steps:
-            - slack/notify:
-                event: fail
-                template: basic_fail_1                
+             
   test_frontend:    
     executor: docker-executor    
     steps:
@@ -269,20 +257,7 @@ jobs:
       - store_test_results:
           path: frontend/reports/
       - store_artifacts:
-          path: frontend/coverage/
-      - when:
-          condition:
-            or:
-              - and:
-                - equal: [<< pipeline.project.git_url >>, << pipeline.parameters.prod_git_url >>]
-                - equal: [<< pipeline.git.branch >>, << pipeline.parameters.prod_git_branch >>]
-              - and:
-                - equal: [<< pipeline.project.git_url >>, << pipeline.parameters.staging_git_url >>]
-                - equal: [<< pipeline.git.branch >>, << pipeline.parameters.staging_git_branch >>]
-          steps:
-            - slack/notify:
-                event: fail
-                template: basic_fail_1                
+          path: frontend/coverage/           
   cucumber_test:
     executor: docker-postgres-executor
     steps:
@@ -540,11 +515,9 @@ workflows:
     jobs:
       - build_and_lint      
       - test_backend:
-          context: ohs-eng-daily-scan-slack
           requires:
             - build_and_lint
-      - test_frontend:
-          context: ohs-eng-daily-scan-slack
+      - test_frontend: 
           requires:
             - build_and_lint
       - dynamic_security_scan:


### PR DESCRIPTION
## Description of change

Removing slack notifications from the circle ci jobs "test_frontend" and "test_backend" for now
We could enable them on for test_frontend & test_backend on every run, but not just for the daily scan, or at least that's how it looks to me

Maybe we want to do so, but I think we should discuss first in case someone is worried about channel spam
Removing them here because I've nerfed the builds to main and prod where a slack credential is not provided, as things are now

## How to test

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
