### PR TITLE
[TTAHUB-600] Add annual funding month to recipient TTA record page

### DIFF
--- a/frontend/src/pages/RecipientRecord/components/GrantsList.css
+++ b/frontend/src/pages/RecipientRecord/components/GrantsList.css
@@ -5,9 +5,3 @@
 .ttahub-recipient-record--grants-list th {
   vertical-align: bottom;
 }
-
-.ttahub-recipient-record--grants-list th,
-.ttahub-recipient-record--grants-list td {
-  padding-left: 24px;
-  padding-right: 24px;
-}

--- a/frontend/src/pages/RecipientRecord/components/GrantsList.js
+++ b/frontend/src/pages/RecipientRecord/components/GrantsList.js
@@ -29,6 +29,9 @@ export default function GrantsList({ summary }) {
           <td>
             {grant.endDate ? moment(grant.endDate).format('MM/DD/yyyy') : null}
           </td>
+          <td>
+            {grant.annualFundingMonth}
+          </td>
         </tr>
       ));
     }
@@ -45,13 +48,14 @@ export default function GrantsList({ summary }) {
           </caption>
           <thead>
             <tr>
-              <th scope="col">Grant Number</th>
+              <th scope="col">Grant number</th>
               <th scope="col">Status</th>
-              <th scope="col">Program Type(s)</th>
-              <th scope="col">Program Specialist</th>
-              <th scope="col">Grant Specialist</th>
-              <th scope="col">Project Start Date</th>
-              <th scope="col">Project End Date</th>
+              <th scope="col">Program type(s)</th>
+              <th scope="col">Program specialist</th>
+              <th scope="col">Grant specialist</th>
+              <th scope="col">Project start date</th>
+              <th scope="col">Project end date</th>
+              <th scope="col">AFM</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/pages/RecipientRecord/components/GrantsList.js
+++ b/frontend/src/pages/RecipientRecord/components/GrantsList.js
@@ -43,14 +43,14 @@ export default function GrantsList({ summary }) {
       <h2 className="ttahub-recipient-record--card-header padding-x-3 padding-y-3 margin-bottom-0">Grants</h2>
       <div className="usa-table-container--scrollable margin-0 ttahub-recipient-record-table-container">
         <table className="usa-table usa-table--striped ttahub-recipient-record--table ttahub--recipient-summary-table usa-table--borderless width-full margin-y-1">
-          <caption className="padding-x-3 padding-y-1 sr-only">
+          <caption className="sr-only">
             Grants summary table data
           </caption>
           <thead>
             <tr>
               <th scope="col">Grant number</th>
               <th scope="col">Status</th>
-              <th scope="col">Program type(s)</th>
+              <th scope="col">Programs</th>
               <th scope="col">Program specialist</th>
               <th scope="col">Grant specialist</th>
               <th scope="col">Project start date</th>

--- a/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
+++ b/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
@@ -13,7 +13,7 @@ describe('Grants List Widget', () => {
     renderGrantsList({ summaryData });
     expect(await screen.findByRole('heading', { name: /grants/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /status/i })).toBeInTheDocument();
-    expect(await screen.findByRole('columnheader', { name: /program type\(s\)/i })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: /programs/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /project start date/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /project end date/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /program specialist/i })).toBeInTheDocument();

--- a/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
+++ b/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
@@ -61,7 +61,7 @@ describe('Grants List Widget', () => {
     renderGrantsList(summary);
     expect(await screen.findByRole('heading', { name: /grants/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /status/i })).toBeInTheDocument();
-    expect(await screen.findByRole('columnheader', { name: /program type\(s\)/i })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: /programs/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /project end date/i })).toBeInTheDocument();
 
     // Grant 1.

--- a/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
+++ b/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
@@ -18,6 +18,7 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('columnheader', { name: /project end date/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /program specialist/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /grant specialist/i })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: /afm/i })).toBeInTheDocument();
   });
   it('renders correctly with data', async () => {
     const summary = {
@@ -38,6 +39,7 @@ describe('Grants List Widget', () => {
           id: 1,
           programSpecialistName: 'Tim',
           grantSpecialistName: 'Sam',
+          annualFundingMonth: 'January',
         },
         {
           name: 'Grant Name 2',
@@ -52,6 +54,7 @@ describe('Grants List Widget', () => {
           endDate: '2021-10-01',
           programSpecialistName: 'Jim',
           grantSpecialistName: 'Joe',
+          annualFundingMonth: null,
         },
       ],
     };
@@ -67,6 +70,7 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('cell', { name: /ehs, hs/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /tim/i })).toBeInTheDocument();
     expect(await screen.findByRole('cell', { name: /sam/i })).toBeInTheDocument();
+    expect(await screen.findByRole('cell', { name: /january/i })).toBeInTheDocument();
 
     // Grant 2.
     expect(await screen.findByText(/grant number 2/i)).toBeInTheDocument();

--- a/frontend/src/pages/RecipientRecord/index.js
+++ b/frontend/src/pages/RecipientRecord/index.js
@@ -22,6 +22,7 @@ export default function RecipientRecord({ match }) {
     'grants.startDate': '',
     'grants.endDate': '',
     'grants.number': '',
+    'grants.annualFundingMonth': '',
     recipientId,
     regionId,
     recipientName: '',

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -28,7 +28,18 @@ export async function recipientById(recipientId, grantScopes) {
     },
     include: [
       {
-        attributes: ['id', 'number', 'regionId', 'status', 'startDate', 'endDate', 'programSpecialistName', 'grantSpecialistName', 'recipientId'],
+        attributes: [
+          'id',
+          'number',
+          'regionId',
+          'status',
+          'startDate',
+          'endDate',
+          'programSpecialistName',
+          'grantSpecialistName',
+          'recipientId',
+          'annualFundingMonth',
+        ],
         model: Grant,
         as: 'grants',
         where: [{

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -381,7 +381,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Eugene',
         status: 'Active',
         grantSpecialistName: 'Eric',
-        annualFundingMonth: 'October',
+        annualFundingMonth: 'January',
       },
       {
         id: 55,
@@ -391,7 +391,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Farrah',
         status: 'Active',
         grantSpecialistName: 'Frank',
-        annualFundingMonth: 'October',
+        annualFundingMonth: null,
       },
       {
         id: 56,
@@ -421,7 +421,7 @@ describe('Recipient DB service', () => {
         status: 'Inactive',
         endDate: new Date(2020, 10, 31),
         grantSpecialistName: 'Allen',
-        annualFundingMonth: 'October',
+        annualFundingMonth: 'November',
       },
       {
         id: 59,

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -341,6 +341,7 @@ describe('Recipient DB service', () => {
         status: 'Active',
         endDate: new Date(2020, 10, 2),
         grantSpecialistName: 'Glen',
+        annualFundingMonth: 'October',
       },
       {
         id: 51,
@@ -350,6 +351,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Belle',
         status: 'Active',
         grantSpecialistName: 'Ben',
+        annualFundingMonth: 'October',
       },
       {
         id: 52,
@@ -359,6 +361,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Caesar',
         status: 'Active',
         grantSpecialistName: 'Cassie',
+        annualFundingMonth: 'October',
       },
       {
         id: 53,
@@ -368,6 +371,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Doris',
         status: 'Active',
         grantSpecialistName: 'David',
+        annualFundingMonth: 'October',
       },
       {
         id: 54,
@@ -377,6 +381,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Eugene',
         status: 'Active',
         grantSpecialistName: 'Eric',
+        annualFundingMonth: 'October',
       },
       {
         id: 55,
@@ -386,6 +391,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Farrah',
         status: 'Active',
         grantSpecialistName: 'Frank',
+        annualFundingMonth: 'October',
       },
       {
         id: 56,
@@ -395,6 +401,7 @@ describe('Recipient DB service', () => {
         programSpecialistName: 'Aaron',
         status: 'Active',
         grantSpecialistName: 'Brom',
+        annualFundingMonth: 'October',
       },
       {
         id: 57,
@@ -403,6 +410,7 @@ describe('Recipient DB service', () => {
         number: '12352',
         programSpecialistName: 'Jim',
         status: 'Inactive',
+        annualFundingMonth: 'October',
       },
       {
         id: 58,
@@ -413,8 +421,8 @@ describe('Recipient DB service', () => {
         status: 'Inactive',
         endDate: new Date(2020, 10, 31),
         grantSpecialistName: 'Allen',
+        annualFundingMonth: 'October',
       },
-
       {
         id: 59,
         recipientId: 69,
@@ -424,6 +432,7 @@ describe('Recipient DB service', () => {
         status: 'Inactive',
         endDate: new Date(moment().add(2, 'days').format('MM/DD/yyyy')),
         grantSpecialistName: 'Bill Smith',
+        annualFundingMonth: 'October',
       },
       {
         id: 60,
@@ -434,6 +443,7 @@ describe('Recipient DB service', () => {
         status: 'Inactive',
         endDate: new Date(moment().format('MM/DD/yyyy')),
         grantSpecialistName: 'Bill Smith',
+        annualFundingMonth: 'October',
       },
       {
         id: 61,
@@ -444,6 +454,7 @@ describe('Recipient DB service', () => {
         status: 'Inactive',
         endDate: new Date('09/01/2020'),
         grantSpecialistName: 'Joe Allen',
+        annualFundingMonth: 'October',
       },
     ];
 


### PR DESCRIPTION
## Description of change

Adding annual funding month to data is returned from API, surfaced it on the grants table in the frontend. Also made some minor CSS changes to the table to make it flow a little more naturally based on the content provided.

## How to test
View the table, provided you have annualFundingMonth on your grants, and make sure the column appears.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-600

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [n/a] Staging smoke test completed

### After merge/deploy

- [n/a] Update JIRA ticket status
