### PR TITLE
Expand annual funding month label in table

### DIFF
--- a/frontend/src/pages/RecipientRecord/components/GrantsList.js
+++ b/frontend/src/pages/RecipientRecord/components/GrantsList.js
@@ -55,7 +55,7 @@ export default function GrantsList({ summary }) {
               <th scope="col">Grant specialist</th>
               <th scope="col">Project start date</th>
               <th scope="col">Project end date</th>
-              <th scope="col">AFM</th>
+              <th scope="col">Annual funding month</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
+++ b/frontend/src/pages/RecipientRecord/components/__tests__/GrantsList.js
@@ -18,7 +18,7 @@ describe('Grants List Widget', () => {
     expect(await screen.findByRole('columnheader', { name: /project end date/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /program specialist/i })).toBeInTheDocument();
     expect(await screen.findByRole('columnheader', { name: /grant specialist/i })).toBeInTheDocument();
-    expect(await screen.findByRole('columnheader', { name: /afm/i })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: /annual funding month/i })).toBeInTheDocument();
   });
   it('renders correctly with data', async () => {
     const summary = {


### PR DESCRIPTION
## Description of change

I forgot to push my change writing out "Annual Funding Month" from AFM before I closed my previous branch.

## How to test
Table on recipient record says "Annual Funding Month," not AFM.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-600


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
