### PR TITLE
add script to update participants

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
     "changeReportStatus": "node ./build/server/tools/changeReportStatusCLI.js",
     "changeReportStatus:local": "./node_modules/.bin/babel-node ./src/tools/changeReportStatusCLI.js",
     "updateLegacyPopulations": "node ./build/server/tools/updateLegacyPopulationsCLI.js",
-    "updateLegacyPopulations:local": "./node_modules/.bin/babel-node ./src/tools/updateLegacyPopulationsCLI.js",
+    "updateLegacyPopulations:local": "./node_modules/.bin/babel-node ./src/tools/uupdateLegacyParticipantsCLI.js",
+    "updateLegacyParticipants": "node ./build/server/tools/updateLegacyPopulationsCLI.js",
+    "updateLegacyParticipants:local": "./node_modules/.bin/babel-node ./src/tools/updateLegacyParticipantsCLI.js",
     "importActivityReportDuration": "node ./build/server/tools/importActivityReportDuration.js",
     "importActivityReportDuration:local": "./node_modules/.bin/babel-node ./src/tools/importActivityReportDuration.js"
   },

--- a/src/tools/updateLegacyParticipants.js
+++ b/src/tools/updateLegacyParticipants.js
@@ -1,0 +1,37 @@
+import { Op } from 'sequelize';
+import { ActivityReport } from '../models';
+import { auditLogger } from '../logger';
+
+export default async function updateLegacyParticipants() {
+  auditLogger.info(`Updating misspelled participants...
+  
+  `);
+
+  const reports = await ActivityReport.findAll({
+    attributes: ['id', 'participants'],
+    where: {
+      participants: {
+        [Op.or]: [
+          {
+            [Op.contains]: ['Family Chlid Care'],
+          },
+        ],
+      },
+    },
+  });
+
+  return Promise.all(reports.map(async (report) => {
+    const participants = [...report.participants];
+
+    const badSpelling = participants.findIndex((p) => p === 'Family Chlid Care');
+    if (badSpelling !== -1) {
+      participants.splice(badSpelling, 1, 'Family Child Care');
+    }
+
+    auditLogger.info(`Updating report ${report.id}'s target populations from ${report.participants} to ${participants}
+    
+    `);
+
+    return report.update({ participants });
+  }));
+}

--- a/src/tools/updateLegacyParticipants.test.js
+++ b/src/tools/updateLegacyParticipants.test.js
@@ -1,0 +1,74 @@
+import { ActivityReport, sequelize } from '../models';
+import updateLegacyParticipants from './updateLegacyParticipants';
+import { REPORT_STATUSES } from '../constants';
+
+const dumbReport = {
+  submissionStatus: REPORT_STATUSES.SUBMITTED,
+  calculatedStatus: REPORT_STATUSES.APPROVED,
+  oldApprovingManagerId: 1,
+  numberOfParticipants: 1,
+  deliveryMethod: 'method',
+  duration: 0,
+  endDate: '2020-01-01T12:00:00Z',
+  startDate: '2020-01-01T12:00:00Z',
+  requester: 'requester',
+  programTypes: ['type'],
+  reason: ['reason'],
+  topics: ['topics'],
+  ttaType: ['type'],
+  userId: 1,
+  regionId: 1,
+  targetPopulations: ['Dual-Language Learners'],
+};
+
+describe('updateLegacyParticipants', () => {
+  let reports;
+
+  beforeAll(async () => {
+    reports = await Promise.all(
+      [
+        ['Family Chlid Care'],
+        ['Family Chlid Care', 'Test'],
+        ['Test'],
+      ].map(async (participants) => ActivityReport.create({
+        ...dumbReport,
+        participants,
+      })),
+    );
+  });
+
+  afterAll(async () => {
+    await ActivityReport.destroy({
+      where: {
+        id: reports.map((r) => r.id),
+      },
+    });
+
+    await sequelize.close();
+  });
+
+  it('updates legacy population data', async () => {
+    const reportIds = reports.map((report) => report.id);
+    const before = await ActivityReport.findAll({
+      where: {
+        id: reportIds,
+      },
+    });
+
+    expect(before.length).toBe(3);
+
+    await updateLegacyParticipants();
+
+    const after = await ActivityReport.findAll({
+      where: {
+        id: reportIds,
+      },
+    });
+
+    expect(after.length).toBe(3);
+    const updatedParticipants = after.map(({ participants }) => participants);
+    expect(updatedParticipants).toContainEqual(['Family Child Care', 'Test']);
+    expect(updatedParticipants).toContainEqual(['Family Child Care']);
+    expect(updatedParticipants).toContainEqual(['Test']);
+  });
+});

--- a/src/tools/updateLegacyParticipantsCLI.js
+++ b/src/tools/updateLegacyParticipantsCLI.js
@@ -1,0 +1,7 @@
+import updateLegacyParticipants from './updateLegacyParticipants';
+import { auditLogger } from '../logger';
+
+updateLegacyParticipants().catch((e) => {
+  auditLogger.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description of change

24 Activity Reports list "Family Chlid Care" as a participant type, rather than the correctly spelled "Family Chlid Care". This script fixes this spelling error in the database

## How to test
Run script locally, checking to see if spelling errors have been corrected and the database integrity has otherwise been preserved.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-582

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
