### PR TITLE
[TTAHUB-624] dashboard heading should not change

### DIFF
--- a/frontend/src/components/filter/FilterPanel.js
+++ b/frontend/src/components/filter/FilterPanel.js
@@ -8,7 +8,7 @@ export default function FilterPanel(props) {
   const { onRemoveFilter, filters, filterConfig } = props;
 
   return (
-    <div data-testid="filter-panel">
+    <>
       <FilterMenu
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
@@ -18,7 +18,7 @@ export default function FilterPanel(props) {
         filters={filters}
         onRemoveFilter={onRemoveFilter}
       />
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/components/filter/FilterPanel.js
+++ b/frontend/src/components/filter/FilterPanel.js
@@ -8,7 +8,7 @@ export default function FilterPanel(props) {
   const { onRemoveFilter, filters, filterConfig } = props;
 
   return (
-    <>
+    <div data-testid="filter-panel">
       <FilterMenu
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
@@ -18,7 +18,7 @@ export default function FilterPanel(props) {
         filters={filters}
         onRemoveFilter={onRemoveFilter}
       />
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/components/filter/props.js
+++ b/frontend/src/components/filter/props.js
@@ -9,24 +9,13 @@ export const filterSelectProps = {
 export const filterConfigProp = PropTypes.shape({
   id: PropTypes.string,
   display: PropTypes.string,
-  conditions: PropTypes.shape({
-    Is: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
-    'Is not': PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
-    Contains: PropTypes.string,
-    'Does not contain': PropTypes.string,
-  }),
-  defaultValues: {
+  conditions: PropTypes.arrayOf(PropTypes.string),
+  defaultValues: PropTypes.shape({
     'Is within': PropTypes.string,
     'Is after': PropTypes.string,
     'Is before': PropTypes.string,
     In: PropTypes.string,
-  },
+  }),
   displayQuery: PropTypes.func,
   renderInput: PropTypes.func,
 });

--- a/frontend/src/pages/RegionalDashboard/__tests__/index.js
+++ b/frontend/src/pages/RegionalDashboard/__tests__/index.js
@@ -4,8 +4,9 @@ import join from 'url-join';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import {
-  render, screen,
+  act, render, screen,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 
 import RegionalDashboard from '../index';
@@ -79,8 +80,41 @@ describe('Regional Dashboard page', () => {
     fetchMock.get(`${topicFrequencyGraphUrl}?${lastThirtyDaysParams}`, topicFrequencyResponse);
     fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${lastThirtyDaysParams}`, activityReportsResponse);
 
+    fetchMock.get(`${overViewUrl}?${regionInParams}`, overViewResponse);
+    fetchMock.get(`${reasonListUrl}?${regionInParams}`, reasonListResponse);
+    fetchMock.get(`${totalHrsAndRecipientGraphUrl}?${regionInParams}`, totalHoursResponse);
+    fetchMock.get(`${topicFrequencyGraphUrl}?${regionInParams}`, topicFrequencyResponse);
+    fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${regionInParams}`, activityReportsResponse);
+
     renderDashboard(user);
-    const heading = await screen.findByText(/regional tta activity dashboard/i);
+    let heading = await screen.findByText(/regional tta activity dashboard/i);
+    expect(heading).toBeVisible();
+
+    const remove = await screen.findByRole('button', { name: /This button removes the filter/i });
+    act(() => userEvent.click(remove));
+
+    const open = await screen.findByRole('button', { name: /open filters for this page/i });
+    act(() => userEvent.click(open));
+
+    const [lastTopic] = Array.from(document.querySelectorAll('[name="topic"]')).slice(-1);
+    act(() => userEvent.selectOptions(lastTopic, 'region'));
+
+    const [lastCondition] = Array.from(document.querySelectorAll('[name="condition"]')).slice(-1);
+    act(() => userEvent.selectOptions(lastCondition, 'Is'));
+
+    const select = await screen.findByRole('combobox', { name: 'Select region to filter by' });
+    act(() => userEvent.selectOptions(select, 'Region 1'));
+
+    const apply = await screen.findByRole('button', { name: /apply filters for regional dashboard/i });
+    act(() => userEvent.click(apply));
+
+    heading = await screen.findByText(/regional tta activity dashboard/i);
+    expect(heading).toBeVisible();
+
+    const removeRegion = await screen.findByRole('button', { name: /this button removes the filter: region is 1/i });
+    act(() => userEvent.click(removeRegion));
+
+    heading = await screen.findByText(/regional tta activity dashboard/i);
     expect(heading).toBeVisible();
   });
 

--- a/frontend/src/pages/RegionalDashboard/__tests__/index.js
+++ b/frontend/src/pages/RegionalDashboard/__tests__/index.js
@@ -4,11 +4,10 @@ import join from 'url-join';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import {
-  act,
   render, screen,
 } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
-import userEvent from '@testing-library/user-event';
+
 import RegionalDashboard from '../index';
 import { formatDateRange } from '../../../utils';
 import { SCOPE_IDS } from '../../../Constants';
@@ -44,16 +43,12 @@ const lastThirtyDaysParams = `startDate.win=${encodeURIComponent(lastThirtyDays)
 const regionInParams = 'region.in[]=1';
 
 describe('Regional Dashboard page', () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     fetchMock.get(overViewUrl, overViewResponse);
     fetchMock.get(reasonListUrl, reasonListResponse);
     fetchMock.get(totalHrsAndRecipientGraphUrl, totalHoursResponse);
     fetchMock.get(topicFrequencyGraphUrl, topicFrequencyResponse);
     fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10`, activityReportsResponse);
-  });
-
-  afterEach(async () => {
-    fetchMock.restore();
   });
 
   const renderDashboard = (user) => {
@@ -66,7 +61,7 @@ describe('Regional Dashboard page', () => {
     );
   };
 
-  it('shows a heading', async () => {
+  it('shows proper heading for user with more than one region', async () => {
     const user = {
       homeRegionId: 14,
       permissions: [{
@@ -84,51 +79,12 @@ describe('Regional Dashboard page', () => {
     fetchMock.get(`${topicFrequencyGraphUrl}?${lastThirtyDaysParams}`, topicFrequencyResponse);
     fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${lastThirtyDaysParams}`, activityReportsResponse);
 
-    fetchMock.get(`${overViewUrl}?${regionInParams}`, overViewResponse);
-    fetchMock.get(`${reasonListUrl}?${regionInParams}`, reasonListResponse);
-    fetchMock.get(`${totalHrsAndRecipientGraphUrl}?${regionInParams}`, totalHoursResponse);
-    fetchMock.get(`${topicFrequencyGraphUrl}?${regionInParams}`, topicFrequencyResponse);
-    fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${regionInParams}`, activityReportsResponse);
-
     renderDashboard(user);
-    let heading = await screen.findByText(/regional tta activity dashboard/i);
-    expect(heading).toBeVisible();
-
-    const remove = await screen.findByRole('button', { name: /This button removes the filter/i });
-    act(() => userEvent.click(remove));
-
-    const open = await screen.findByRole('button', { name: /open filters for this page/i });
-    act(() => userEvent.click(open));
-
-    const [lastTopic] = Array.from(document.querySelectorAll('[name="topic"]')).slice(-1);
-    act(() => userEvent.selectOptions(lastTopic, 'region'));
-
-    const [lastCondition] = Array.from(document.querySelectorAll('[name="condition"]')).slice(-1);
-    act(() => userEvent.selectOptions(lastCondition, 'Is'));
-
-    const select = await screen.findByRole('combobox', { name: 'Select region to filter by' });
-    act(() => userEvent.selectOptions(select, 'Region 1'));
-
-    const apply = await screen.findByRole('button', { name: /apply filters for regional dashboard/i });
-    act(() => userEvent.click(apply));
-
-    heading = await screen.findByText(/region 1 tta activity dashboard/i);
+    const heading = await screen.findByText(/regional tta activity dashboard/i);
     expect(heading).toBeVisible();
   });
 
-  it('shows the reason list widget', async () => {
-    fetchMock.get(`${overViewUrl}?${regionInParams}`, overViewResponse);
-    fetchMock.get(`${reasonListUrl}?${regionInParams}`, reasonListResponse);
-    fetchMock.get(`${totalHrsAndRecipientGraphUrl}?${regionInParams}`, totalHoursResponse);
-    fetchMock.get(`${topicFrequencyGraphUrl}?${regionInParams}`, topicFrequencyResponse);
-    fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${regionInParams}`, activityReportsResponse);
-
-    fetchMock.get(`${overViewUrl}?${lastThirtyDaysParams}`, overViewResponse);
-    fetchMock.get(`${reasonListUrl}?${lastThirtyDaysParams}`, reasonListResponse);
-    fetchMock.get(`${totalHrsAndRecipientGraphUrl}?${lastThirtyDaysParams}`, totalHoursResponse);
-    fetchMock.get(`${topicFrequencyGraphUrl}?${lastThirtyDaysParams}`, topicFrequencyResponse);
-    fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${lastThirtyDaysParams}`, activityReportsResponse);
-
+  it('shows proper heading for user with one region', async () => {
     const user = {
       homeRegionId: 1,
       permissions: [{
@@ -136,8 +92,15 @@ describe('Regional Dashboard page', () => {
         scopeId: SCOPE_IDS.READ_ACTIVITY_REPORTS,
       }],
     };
-    renderDashboard(user);
 
-    expect(await screen.findByText(/reasons in activity reports/i)).toBeInTheDocument();
+    fetchMock.get(`${overViewUrl}?${regionInParams}&${lastThirtyDaysParams}`, overViewResponse);
+    fetchMock.get(`${reasonListUrl}?${regionInParams}&${lastThirtyDaysParams}`, reasonListResponse);
+    fetchMock.get(`${totalHrsAndRecipientGraphUrl}?${regionInParams}&${lastThirtyDaysParams}`, totalHoursResponse);
+    fetchMock.get(`${topicFrequencyGraphUrl}?${regionInParams}&${lastThirtyDaysParams}`, topicFrequencyResponse);
+    fetchMock.get(`${activityReportsUrl}?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&${regionInParams}&${lastThirtyDaysParams}`, activityReportsResponse);
+
+    renderDashboard(user);
+    const heading = await screen.findByText(/region 1 tta activity dashboard/i);
+    expect(heading).toBeVisible();
   });
 });

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -33,6 +33,7 @@ export default function RegionalDashboard() {
     user && user.homeRegionId && user.homeRegionId === 14
   ), [user]);
   const regions = useMemo(() => getUserRegions(user), [user]);
+  const userHasOnlyOneRegion = useMemo(() => regions.length === 1, [regions]);
   const defaultRegion = useMemo(() => regions[0].toString(), [regions]);
 
   const defaultFilters = useMemo(() => {
@@ -65,9 +66,6 @@ export default function RegionalDashboard() {
 
   const [filters, setFilters] = useUrlFilters(defaultFilters);
 
-  const regionFilter = filters.find((filter) => filter.topic === 'region');
-  const appliedRegion = regionFilter ? regionFilter.query : false;
-
   const onApplyFilters = (newFilters) => {
     setFilters(newFilters);
   };
@@ -89,7 +87,7 @@ export default function RegionalDashboard() {
       <>
         <Helmet titleTemplate="%s - Dashboard - TTA Hub" defaultTitle="TTA Hub - Dashboard" />
         <h1 className="ttahub--dashboard-title">
-          {appliedRegion ? `Region ${appliedRegion}` : 'Regional'}
+          {userHasOnlyOneRegion ? `Region ${defaultRegion}` : 'Regional'}
           {' '}
           TTA Activity Dashboard
         </h1>


### PR DESCRIPTION
## Description of change

Design feedback has indicated that the heading on the dashboard should not update as we have the filters in place with the pills to indicate what's applied. There are two scenarios: A user has one region, and sees a heading like "Region 1 TTA Activity Dashboard" or a user can view different regions, in which case they'd see "Regional TTA Activity Dashboard"

## How to test

View the dashboard with each test case. Ensure that everything is working as intended.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-624

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [N/A] API Documentation updated
- [N/A] Boundary diagram updated
- [N/A] Logical Data Model updated
- [N/A] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
