### PR TITLE
[TTAHUB-252] save AR ordering and sorting

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "draftjs-to-html": "^0.9.1",
     "html-to-draftjs": "^1.5.0",
     "http-proxy-middleware": "^2.0.1",
+    "js-cookie": "^3.0.1",
     "lodash": "^4.17.20",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",
@@ -68,7 +69,7 @@
     "ansi-regex": "^5.0.1",
     "nanoid": "^3.2.0",
     "node-fetch": "^2.6.7",
-    "follow-redirects":"^1.14.7"
+    "follow-redirects": "^1.14.7"
   },
   "eslintConfig": {
     "root": true,

--- a/frontend/src/components/ActivityReportsTable/__tests__/index.js
+++ b/frontend/src/components/ActivityReportsTable/__tests__/index.js
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
+import Cookies from 'js-cookie';
 import {
   render, screen, fireEvent, waitFor, act,
 } from '@testing-library/react';
@@ -368,13 +369,17 @@ describe('Table sorting', () => {
   it('clicking Topics column header will sort by topics', async () => {
     const columnHeader = await screen.findByText(/topic\(s\)/i);
 
+    const mockSet = jest.fn();
+    Cookies.set = mockSet;
+
     fetchMock.get(
       '/api/activity-reports?sortBy=topics&sortDir=asc&offset=0&limit=10&region.in[]=1',
       { count: 2, rows: activityReportsSorted },
     );
 
-    await act(async () => fireEvent.click(columnHeader));
+    act(async () => fireEvent.click(columnHeader));
     await waitFor(() => expect(screen.getAllByRole('cell')[15]).toHaveTextContent(/Behavioral \/ Mental Health CLASS: Instructional Support click to visually reveal the topics for R14-AR-1$/i));
+    expect(mockSet).toHaveBeenCalled();
   });
 
   it('clicking Creator column header will sort by author', async () => {

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -11,8 +11,10 @@ import { filtersToQueryString } from '../../utils';
 import TableHeader from '../TableHeader';
 import ReportRow from './ReportRow';
 import { REPORTS_PER_PAGE } from '../../Constants';
+import useCookieSorting from '../../hooks/useCookieSorting';
 
 import './index.css';
+import useCookiePage from '../../hooks/useCookiePage';
 
 function ActivityReportsTable({
   filters,
@@ -24,16 +26,17 @@ function ActivityReportsTable({
   const [error, setError] = useState('');
   const [reportCheckboxes, setReportCheckboxes] = useState({});
   const [allReportsChecked, setAllReportsChecked] = useState(false);
-  const [offset, setOffset] = useState(0);
   const [perPage] = useState(REPORTS_PER_PAGE);
-  const [activePage, setActivePage] = useState(1);
+  // const [activePage, setActivePage] = useState(1);
+  const [activePage, setActivePage] = useCookiePage(1, 'activityReportsTable');
+  const [offset, setOffset] = useState((activePage - 1) * perPage);
   const [reportsCount, setReportsCount] = useState(0);
   const [downloadError, setDownloadError] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
-  const [sortConfig, setSortConfig] = React.useState({
+  const [sortConfig, setSortConfig] = useCookieSorting({
     sortBy: 'updatedAt',
     direction: 'desc',
-  });
+  }, 'activityReportsTable');
 
   const downloadAllButtonRef = useRef();
   const downloadSelectedButtonRef = useRef();

--- a/frontend/src/hooks/useCookiePage.js
+++ b/frontend/src/hooks/useCookiePage.js
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useState } from 'react';
+import Cookies from 'js-cookie'; // theres a package for it, look i know you can do it by hand but I don't wanna
+
+const COOKIE_OPTIONS = {
+  sameSite: 'Lax',
+};
+
+/**
+ * useCookieSorting takes in an object containing a sort configuration
+ * ex: {
+    sortBy: 'updatedAt',
+    direction: 'desc',
+  }
+ * and a component name
+ * and returns a useState like array of a getter and a setter
+ *
+ * @param {Object[]} defaultSortConfig
+ * @param {String} component
+ * @returns {[ Object[], Function ]}
+ */
+export default function useCookiePage(defaultPage, component) {
+  // get sorting from cookie, otherwise fall back to default sorting
+  // also memoize it so that we aren't constantly reading the cookie
+  const url = useMemo(() => new URL(window.location), []);
+
+  const cookieSchema = useMemo(() => `${url.hostname}-${url.pathname}-${url.search}-${component}-page`, [component, url]);
+  const existingPage = useMemo(() => {
+    const currentCookie = Cookies.get(cookieSchema);
+    if (currentCookie) {
+      const parsedCookie = parseInt(currentCookie, 10);
+      if (!Number.isNaN(parsedCookie)) {
+        return parsedCookie;
+      }
+    }
+
+    return false;
+  }, [cookieSchema]); // none of this stuff should be changing
+
+  // put it in state
+  const [currentPage, setCurrentPage] = useState(existingPage || defaultPage);
+
+  useEffect(() => {
+    // when sort config changes, update the cookie value
+    Cookies.set(cookieSchema, currentPage, COOKIE_OPTIONS);
+  // note that with url stored in a no dependency useMemo, it will not trigger re-renders
+  // even if the url changes, like with a filter being applied
+  }, [cookieSchema, currentPage]);
+
+  return [currentPage, setCurrentPage];
+}

--- a/frontend/src/hooks/useCookieSorting.js
+++ b/frontend/src/hooks/useCookieSorting.js
@@ -1,0 +1,55 @@
+import { useEffect, useMemo, useState } from 'react';
+import Cookies from 'js-cookie'; // theres a package for it, look i know you can do it by hand but I don't wanna
+
+const COOKIE_OPTIONS = {
+  sameSite: 'Lax',
+};
+
+/**
+ * useCookieSorting takes in an object containing a sort configuration
+ * ex: {
+    sortBy: 'updatedAt',
+    direction: 'desc',
+  }
+ * and a component name
+ * and returns a useState like array of a getter and a setter
+ *
+ * @param {Object[]} defaultSortConfig
+ * @param {String} component
+ * @returns {[ Object[], Function ]}
+ */
+export default function useCookieSorting(defaultSortConfig, component) {
+  // get sorting from cookie, otherwise fall back to default sorting
+  // also memoize it so that we aren't constantly reading the cookie
+  const url = useMemo(() => new URL(window.location), []);
+  // example: localhost:3000-/activity-reports-activityReportsTable-sorting
+  const cookieSchema = useMemo(() => `${url.hostname}-${url.pathname}-${component}-sorting`, [component, url.hostname, url.pathname]);
+  const existingSort = useMemo(() => {
+    const currentCookie = Cookies.get(cookieSchema);
+    if (currentCookie) {
+      const parsedCookie = JSON.parse(currentCookie);
+      // this is really just to make sure nothing weird gets in there
+      const {
+        sortBy, direction,
+      } = parsedCookie;
+      return {
+        sortBy,
+        direction,
+      };
+    }
+
+    return false;
+  }, [cookieSchema]); // none of this stuff should be changing
+
+  // put it in state
+  const [sortConfig, setSortConfig] = useState(existingSort || defaultSortConfig);
+
+  useEffect(() => {
+    // when sort config changes, update the cookie value
+    Cookies.set(cookieSchema, JSON.stringify(sortConfig), COOKIE_OPTIONS);
+  // note that with url stored in a no dependency useMemo, it will not trigger re-renders
+  // even if the url changes, like with a filter being applied
+  }, [cookieSchema, sortConfig]);
+
+  return [sortConfig, setSortConfig];
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7121,6 +7121,11 @@ jest@^27.4.3:
     import-local "^3.0.2"
     jest-cli "^27.4.7"
 
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## Description of change
Add some cookies to preserve pagination and sorting on the activity report component.

## How to test
Observe when changing pages and refreshing that your sort and page is preserved. You can see what's happening by looking closely at your browser cookies.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-252

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
