### PR TITLE
[TTAHUB-632] Fix URL sharing

### DIFF
--- a/frontend/src/__tests__/utils.js
+++ b/frontend/src/__tests__/utils.js
@@ -8,7 +8,7 @@ describe('queryStringToFilters', () => {
     expect(filters.length).toBe(2);
     expect(filters.map((filter) => filter.topic)).toStrictEqual(['region', 'startDate']);
     expect(filters.map((filter) => filter.condition)).toStrictEqual(['Is', 'Is within']);
-    expect(filters.map((filter) => filter.query)).toStrictEqual(['14', '2021/11/13-2021/12/13']);
+    expect(filters.map((filter) => filter.query)).toStrictEqual([['14'], '2021/11/13-2021/12/13']);
   });
 });
 

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -139,7 +139,8 @@ export function queryStringToFilters(queryString) {
         id: uuidv4(),
         topic,
         condition,
-        query: decodedQueryParam,
+        // we use is and is not for query parameters
+        query: condition === 'Is not' || condition === 'Is' ? [decodedQueryParam] : decodedQueryParam,
       };
     }
 


### PR DESCRIPTION
## Description of change
Certain filter components expect an array from the query, but it wasn't being decoded as such, and the JS app was crashing

## How to test
[this link should fire with your local machine active](http://localhost:3000/regional-dashboard?startDate.win=2022%2F01%2F05-2022%2F02%2F04&role.in[]=Early%20Childhood%20Specialist&topic.in[]=CLASS%3A%20Emotional%20Support%2CCLASS%3A%20Instructional%20Support&grantNumber.ctn[]=1&programSpecialist.ctn[]=12&programType.in[]=HS&reason.in[]=Change%20in%20Scope&region.in[]=2&recipient.ctn[]=2&reportId.ctn[]=2&stateCode.ctn[]=AK&targetPopulations.in[]=Affected%20by%20Child%20Welfare%20Involvement). It contains all the possible filters and should load a page (not just a blank white screen)

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-632

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
