### PR TITLE
fix errors in legacy update scripts

### DIFF
--- a/src/tools/updateLegacyParticipants.js
+++ b/src/tools/updateLegacyParticipants.js
@@ -11,11 +11,7 @@ export default async function updateLegacyParticipants() {
     attributes: ['id', 'participants'],
     where: {
       participants: {
-        [Op.or]: [
-          {
-            [Op.contains]: ['Family Chlid Care'],
-          },
-        ],
+        [Op.contains]: ['Family Chlid Care'],
       },
     },
   });

--- a/src/tools/updateTopicNames.js
+++ b/src/tools/updateTopicNames.js
@@ -52,8 +52,12 @@ const TOPIC_DICTIONARY = [
     new: 'Child Assessment, Development, Screening',
   },
   {
+    old: 'Coaching / Teaching / Instructional Support | ECS, FES',
+    new: ['Coaching', 'CLASS: Instructional Support'],
+  },
+  {
     old: 'Children with Disabilities | ECS',
-    new: 'School Readiness',
+    reason: 'School Readiness Goals',
     population: 'Children with Disabilities',
   },
   {
@@ -130,7 +134,7 @@ const TOPIC_DICTIONARY = [
   },
   {
     old: 'Quality Improvement / QIP | GS',
-    new: 'Quality Improvement / QIP',
+    new: 'Quality Improvement Plan / QIP',
   },
   {
     old: 'Safety Practices | HS',
@@ -169,7 +173,7 @@ const TOPIC_DICTIONARY = [
 export default async function updateTopicNames() {
   // we find any activity reports that have ANY of the old topics in their topics field
   const reports = await ActivityReport.findAll({
-    attributes: ['id', 'topics', 'targetPopulations'],
+    attributes: ['id', 'topics', 'targetPopulations', 'reason'],
     where: {
       topics: {
         [Op.overlap]: TOPIC_DICTIONARY.map((dict) => dict.old),
@@ -185,6 +189,7 @@ export default async function updateTopicNames() {
     // copy existing state
       let topics = [...report.topics];
       let targetPopulations = [...report.targetPopulations];
+      let reason = [...report.reason];
 
       // within each report, check our array of topics to rename
       TOPIC_DICTIONARY.forEach((topic) => {
@@ -215,10 +220,18 @@ export default async function updateTopicNames() {
             targetPopulations = [...targetPopulations, ...[topic.population]].flat();
           }
         }
+
+        if (index !== -1 && topic.reason) {
+          const popIndex = reason.indexOf(topic.reason);
+          if (popIndex === -1) {
+            logger.info(`Renaming ${topic.old} to reason ${topic.reason} in ${report.id}`);
+            reason = [...reason, ...[topic.reason]].flat();
+          }
+        }
       });
 
       // push our update operation to our promises array
-      return report.update({ topics, targetPopulations }, { transaction });
+      return report.update({ topics, targetPopulations, reason }, { transaction });
     }));
   });
 }

--- a/src/tools/updateTopicNames.test.js
+++ b/src/tools/updateTopicNames.test.js
@@ -100,6 +100,8 @@ describe('update topic names job', () => {
     updatedReports.forEach((report) => {
       let topics = [];
       let pop = ['pop'];
+      let reason = ['reason'];
+
       if (report.requester === 'Bruce') {
         topics = [
           'Behavioral / Mental Health / Trauma',
@@ -131,10 +133,11 @@ describe('update topic names job', () => {
       }
 
       if (report.requester === 'Bubert 2') {
-        topics = ['School Readiness'];
+        reason = ['reason', 'School Readiness Goals'];
         pop = ['pop', 'Children with Disabilities'];
       }
 
+      expect(report.reason).toStrictEqual(reason);
       expect(report.topics).toStrictEqual(topics);
       expect(report.targetPopulations).toStrictEqual(pop);
     });


### PR DESCRIPTION
## Description of change

Previous already merged PR's contained errors that came up when preparing to demo them. ```updateLegacyParticipants``` was querying a lot of unnecessary data and ```updateTopicNames``` was missing some data mappings/had one in error.

## How to test

The following query gives you the number of misspelled participants and a list of all topics that aren't currently selectable.

```sql
-- misspelled participants
SELECT COUNT("id") from "ActivityReports" 
WHERE "participants" && ARRAY['Family Chlid Care']::VARCHAR(255)[];

-- reports w/ wrong or strange topics
select unnest(topics) from
	"ActivityReports" where "calculatedStatus" not in ('deleted', 'draft')
	AND "calculatedStatus" is not null and id not in (
		select id from "ActivityReports" where topics && ARRAY[
			'Behavioral / Mental Health / Trauma',
			'Child Assessment, Development, Screening',
			'CLASS: Classroom Organization',
			'CLASS: Emotional Support',
			'CLASS: Instructional Support',
			'Coaching',
			'Communication',
			'Community and Self-Assessment',
			'Culture & Language',
			'Curriculum (Instructional or Parenting)',
			'Data and Evaluation',
			'ERSEA',
			'Environmental Health and Safety / EPRR',
			'Equity',
			'Facilities',
			'Family Support Services',
			'Fiscal / Budget',
			'Five-Year Grant',
			'Home Visiting',
			'Human Resources',
			'Leadership / Governance',
			'Learning Environments',
			'Nutrition',
			'Oral Health',
			'Parent and Family Engagement',
			'Partnerships and Community Engagement',
			'Physical Health and Screenings',
			'Pregnancy Services / Expectant Families',
			'Program Planning and Services',
			'Quality Improvement Plan / QIP',
			'Recordkeeping and Reporting',
			'Safety Practices',
			'Staff Wellness',
			'Teaching Practices / Teacher-Child Interactions',
			'Technology and Information Systems',
			'Transition Practices',
			'Transportation'
		]::VARCHAR(256)[])
	group by unnest(topics)
```

If you run ```yarn updateTopicNames:local;yarn updateLegacyParticipants:local``` and then re-run the query above, you should see the count of partipants go to 0 and the second query return only "Other", a set of reports which will be addressed in a future PR.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-581
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-582


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
