### PR TITLE
Fix the vertical spacing on the regional dashboard title

### DIFF
--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -86,7 +86,7 @@ export default function RegionalDashboard() {
       <Helmet titleTemplate="%s - Dashboard - TTA Hub" defaultTitle="TTA Hub - Dashboard" />
       <>
         <Helmet titleTemplate="%s - Dashboard - TTA Hub" defaultTitle="TTA Hub - Dashboard" />
-        <h1 className="ttahub--dashboard-title">
+        <h1 className="landing">
           {userHasOnlyOneRegion ? `Region ${defaultRegion}` : 'Regional'}
           {' '}
           TTA Activity Dashboard


### PR DESCRIPTION
## Description of change
It has been bothering me since it was pointed out. A quick fix - the regional dashboard now uses the same CSS as the other page headings (less the recipient record page, which is kind of a unique ball of wax)

## How to test

View the regional dashboard, then the activity reports page. The headings are now in roughly the same spot relative to the top of the page

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-636


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
