### PR TITLE
[TTAHUB-456] Add goal status visualization to frontend

### DIFF
--- a/frontend/src/components/filter/FilterStatus.js
+++ b/frontend/src/components/filter/FilterStatus.js
@@ -7,28 +7,28 @@ import FilterSelect from './FilterSelect';
 
 const options = [
   {
-    label: 'Needs Status',
-    value: 'Needs Status',
+    label: 'Needs status',
+    value: 'Needs status',
   },
   {
     label: 'Draft',
     value: 'Draft',
   },
   {
-    label: 'Not Started',
-    value: 'Not Started',
+    label: 'Not started',
+    value: 'Not started',
   },
   {
-    label: 'In Progress',
-    value: 'In Progress',
+    label: 'In progress',
+    value: 'In progress',
   },
   {
-    label: 'Completed',
-    value: 'Completed',
+    label: 'Closed',
+    value: 'Closed',
   },
   {
-    label: 'Ceased/Suspended',
-    value: 'Ceased/Suspended',
+    label: 'Ceased/suspended',
+    value: 'Ceased/suspended',
   },
 ];
 

--- a/frontend/src/pages/RecipientRecord/index.js
+++ b/frontend/src/pages/RecipientRecord/index.js
@@ -116,7 +116,10 @@ export default function RecipientRecord({ match }) {
                 <Route
                   path="/recipient-tta-records/:recipientId/region/:regionId/goals-objectives"
                   render={() => (
-                    <GoalsObjectives />
+                    <GoalsObjectives
+                      recipientId={recipientId}
+                      regionId={regionId}
+                    />
                   )}
                 />
               </FeatureFlag>

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import { Grid } from '@trussworks/react-uswds';
 import useUrlFilters from '../../../hooks/useUrlFilters';
 import FilterPanel from '../../../components/filter/FilterPanel';
-import { formatDateRange } from '../../../utils';
+import { expandFilters, formatDateRange } from '../../../utils';
 import { GOALS_AND_OBJECTIVES_FILTER_CONFIG } from './constants';
 import GoalStatusGraph from '../../../widgets/GoalStatusGraph';
 
 const yearToDate = formatDateRange({ yearToDate: true, forDateTime: true });
 
-export default function GoalsObjectives() {
+export default function GoalsObjectives({ regionId, recipientId }) {
   const [filters, setFilters] = useUrlFilters([{
     id: uuidv4(),
     topic: 'createDate',
@@ -26,6 +27,20 @@ export default function GoalsObjectives() {
     }
   };
 
+  const filtersToApply = [
+    ...expandFilters(filters),
+    {
+      topic: 'region',
+      condition: 'Is',
+      query: regionId,
+    },
+    {
+      topic: 'recipientId',
+      condition: 'Contains',
+      query: recipientId,
+    },
+  ];
+
   return (
     <div className="margin-x-2 maxw-widescreen" id="goalsObjectives">
       <div className="display-flex flex-wrap margin-bottom-2" data-testid="filter-panel">
@@ -39,9 +54,14 @@ export default function GoalsObjectives() {
       </div>
       <Grid row>
         <Grid desktop={{ col: 6 }} mobileLg={{ col: 12 }}>
-          <GoalStatusGraph filters={filters} />
+          <GoalStatusGraph filters={filtersToApply} />
         </Grid>
       </Grid>
     </div>
   );
 }
+
+GoalsObjectives.propTypes = {
+  recipientId: PropTypes.string.isRequired,
+  regionId: PropTypes.string.isRequired,
+};

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -68,7 +68,7 @@ export default function GoalsObjectives({ recipientId, regionId }) {
         <GoalsTable
           recipientId={recipientId}
           regionId={regionId}
-          filters={filtersToApply}
+          filters={filters}
         />
       </div>
     </>

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import { Grid } from '@trussworks/react-uswds';
 import useUrlFilters from '../../../hooks/useUrlFilters';
 import FilterPanel from '../../../components/filter/FilterPanel';
 import { formatDateRange } from '../../../utils';
 import { GOALS_AND_OBJECTIVES_FILTER_CONFIG } from './constants';
+import GoalStatusGraph from '../../../widgets/GoalStatusGraph';
 
 const yearToDate = formatDateRange({ yearToDate: true, forDateTime: true });
 
@@ -35,6 +37,11 @@ export default function GoalsObjectives() {
           filters={filters}
         />
       </div>
+      <Grid row>
+        <Grid desktop={{ col: 6 }} mobileLg={{ col: 12 }}>
+          <GoalStatusGraph filters={filters} />
+        </Grid>
+      </Grid>
     </div>
   );
 }

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -75,6 +75,7 @@ describe('Goals and Objectives', () => {
 
   beforeEach(async () => {
     fetchMock.reset();
+
     // Default.
     const goalsUrl = `/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5&createDate.win=${yearToDate}`;
     fetchMock.get(goalsUrl, { count: 1, goalRows: goals });
@@ -86,6 +87,19 @@ describe('Goals and Objectives', () => {
     // No Filters.
     const noFilterUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5';
     fetchMock.get(noFilterUrl, { count: 2, goalRows: noFilterGoals });
+
+    const statusRes = {
+      total: 0, 'Not started': 0, 'In progress': 0, Closed: 0, Suspended: 0,
+    };
+
+    const goalStatusGraph = `/api/widgets/goalStatusGraph?createDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`;
+    fetchMock.get(goalStatusGraph, statusRes);
+
+    const goalStatusGraphWStatus = '/api/widgets/goalStatusGraph?status.in[]=Not%20Started&region.in[]=1&recipientId.ctn[]=401';
+    fetchMock.get(goalStatusGraphWStatus, statusRes);
+
+    const goalStatusGraphUnfiltered = '/api/widgets/goalStatusGraph?region.in[]=1&recipientId.ctn[]=401';
+    fetchMock.get(goalStatusGraphUnfiltered, statusRes);
   });
 
   afterEach(() => {

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -81,7 +81,7 @@ describe('Goals and Objectives', () => {
     fetchMock.get(goalsUrl, { count: 1, goalRows: goals });
 
     // Filters Status.
-    const filterStatusUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5&status.in[]=Not%20Started';
+    const filterStatusUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5&status.in[]=Not%20started';
     fetchMock.get(filterStatusUrl, { count: 1, goalRows: filterStatusGoals });
 
     // No Filters.
@@ -95,7 +95,7 @@ describe('Goals and Objectives', () => {
     const goalStatusGraph = `/api/widgets/goalStatusGraph?createDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`;
     fetchMock.get(goalStatusGraph, statusRes);
 
-    const goalStatusGraphWStatus = '/api/widgets/goalStatusGraph?status.in[]=Not%20Started&region.in[]=1&recipientId.ctn[]=401';
+    const goalStatusGraphWStatus = '/api/widgets/goalStatusGraph?status.in[]=Not%20started&region.in[]=1&recipientId.ctn[]=401';
     fetchMock.get(goalStatusGraphWStatus, statusRes);
 
     const goalStatusGraphUnfiltered = '/api/widgets/goalStatusGraph?region.in[]=1&recipientId.ctn[]=401';
@@ -135,7 +135,7 @@ describe('Goals and Objectives', () => {
     userEvent.selectOptions(await screen.findByRole('combobox', { name: 'condition' }), 'Is');
 
     const statusSelect = await screen.findByLabelText(/select status to filter by/i);
-    await selectEvent.select(statusSelect, ['Not Started']);
+    await selectEvent.select(statusSelect, ['Not started']);
 
     const apply = await screen.findByRole('button', { name: /apply filters to goals/i });
     userEvent.click(apply);

--- a/frontend/src/widgets/AccessibleWidgetData.js
+++ b/frontend/src/widgets/AccessibleWidgetData.js
@@ -14,7 +14,7 @@ export default function AccessibleWidgetData({ caption, columnHeadings, rows }) 
   }
 
   return (
-    <div className="overflow-hidden overflow-x-scroll">
+    <div className="overflow-hidden overflow-x-auto">
       <table className="ttahub--accessible-widget-data usa-table usa-table--borderless usa-table--striped">
         <caption className="sr-only">
           {caption}

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -6,10 +6,10 @@ import Container from '../components/Container';
 import AccessibleWidgetData from './AccessibleWidgetData';
 
 const GOAL_STATUSES = [
-  'Not Started',
-  'In Progress',
+  'Not started',
+  'In progress',
   'Closed',
-  'Ceased/Suspended',
+  'Suspended',
 ];
 
 const STATUS_COLORS = [
@@ -84,7 +84,7 @@ export function GoalStatusChart({ data, loading }) {
     const newBars = GOAL_STATUSES.map((status, index) => ({
       ratio: `${data[status]}/${data.total}`,
       percentage: data[status] / data.total,
-      label: status === 'Ceased/Suspended' ? 'Suspended' : status,
+      label: status,
       color: STATUS_COLORS[index],
       count: data[status],
       total: data.total,
@@ -167,10 +167,10 @@ GoalStatusChart.propTypes = {
 GoalStatusChart.defaultProps = {
   data: {
     total: 0,
-    'Not Started': 0,
-    'In Progress': 0,
+    'Not started': 0,
+    'In progress': 0,
     Closed: 0,
-    'Ceased/Suspended': 0,
+    Suspended: 0,
   },
 };
 

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -1,0 +1,170 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from '@trussworks/react-uswds';
+import withWidgetData from './withWidgetData';
+import Container from '../components/Container';
+import AccessibleWidgetData from './AccessibleWidgetData';
+
+const GOAL_STATUSES = [
+  'Not Started',
+  'In Progress',
+  'Closed',
+  'Ceased/Suspended',
+];
+
+const STATUS_COLORS = [
+  '#e2a04d',
+  '#0166ab',
+  '#148439',
+  '#b50908',
+];
+
+function Bar({
+  count, percentage, label, color, ratio, total,
+}) {
+  const style = {
+    // 0/0 is NaN
+    width: Number.isNaN(percentage) ? '0%' : `${percentage * 100}%`,
+    backgroundColor: color,
+  };
+
+  const readablePercentage = `${(
+    percentage * 100).toLocaleString('en-us', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
+  } percent of goals are ${label}`;
+
+  const readableRatio = `That's ${count} of ${total} goals`;
+
+  return (
+    <div className="ttahub-goal-bar-container display-flex flex-justify margin-y-2">
+      <span className="flex-2 margin-right-1 flex-align-self-center" aria-label={readablePercentage}>
+        {label}
+      </span>
+      <div className="ttahub-goal-bar height-3 bg-base-lightest flex-6 margin-right-1 width-full" aria-hidden="true">
+        <div className="ttahub-goal-bar-color height-full width-full" style={style} />
+      </div>
+      <span aria-label={readableRatio} className="flex-1 flex-align-self-center text-right padding-left-1">{ratio}</span>
+    </div>
+  );
+}
+
+Bar.propTypes = {
+  count: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  percentage: PropTypes.number.isRequired,
+  ratio: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired,
+  color: PropTypes.string.isRequired,
+};
+
+export function GoalStatusChart({ data, loading }) {
+  // whether to show the data as accessible widget data or not
+  const [showAccessibleData, updateShowAccessibleData] = useState(false);
+
+  // the lil bar objects that we'll render to the DOM
+  const [bars, setBars] = useState([]);
+
+  // we only need to recompute this when the data changes, not when the
+  // bars or display type are changed
+  const accessibleRows = useMemo(
+    () => GOAL_STATUSES.map((status) => ({ data: [status, data[status]] })), [data],
+  );
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    const newBars = GOAL_STATUSES.map((status, index) => ({
+      ratio: `${data[status]}/${data.total}`,
+      percentage: data[status] / data.total,
+      label: status,
+      color: STATUS_COLORS[index],
+      count: data[status],
+      total: data.total,
+    }));
+
+    setBars(newBars);
+  }, [data]);
+
+  // toggle the data table
+  function toggleAccessibleData() {
+    updateShowAccessibleData((current) => !current);
+  }
+
+  return (
+    <Container className="ttahub--goal-status-graph" padding={3} loading={loading} loadingLabel="goal statuses by number loading">
+      <Grid row className="position-relative margin-bottom-2">
+        <Grid className="flex-align-self-center desktop:display-flex flex-align-center" desktop={{ col: 'auto' }} mobileLg={{ col: 10 }}>
+          <h2 className="margin-0">
+            Total goals by status
+          </h2>
+        </Grid>
+        <Grid desktop={{ col: 'auto' }} className="ttahub--show-accessible-data-button flex-align-self-center">
+          <button
+            type="button"
+            className="usa-button--unstyled"
+            aria-label={showAccessibleData ? 'display goal statuses by number as a graph' : 'display goal statuses by number as a table'}
+            onClick={toggleAccessibleData}
+          >
+            {showAccessibleData ? 'Display graph' : 'Display table'}
+          </button>
+        </Grid>
+      </Grid>
+      { showAccessibleData
+        ? (
+          <AccessibleWidgetData
+            caption="Goal Statuses By Number"
+            columnHeadings={['Status', 'Count']}
+            rows={accessibleRows}
+          />
+        )
+        : (
+          <>
+            <div className="border-top border-gray-5">
+              <h3>
+                {data.total}
+                {' '}
+                goals
+              </h3>
+              {bars.map(({
+                count, percentage, label, color, ratio, total,
+              }) => (
+                <Bar
+                  key={color}
+                  count={count}
+                  percentage={percentage}
+                  label={label}
+                  color={color}
+                  ratio={ratio}
+                  total={total}
+                />
+              ))}
+            </div>
+          </>
+        )}
+    </Container>
+  );
+}
+
+GoalStatusChart.propTypes = {
+  data: PropTypes.shape({
+    total: PropTypes.number,
+    'Not Started': PropTypes.number,
+    'In Progress': PropTypes.number,
+    Closed: PropTypes.number,
+    'Ceased/Suspended': PropTypes.number,
+  }),
+  loading: PropTypes.bool.isRequired,
+};
+
+GoalStatusChart.defaultProps = {
+  data: {
+    total: 0,
+    'Not Started': 0,
+    'In Progress': 0,
+    Closed: 0,
+    'Ceased/Suspended': 0,
+  },
+};
+
+export default withWidgetData(GoalStatusChart, 'goalStatusGraph');

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -36,7 +36,7 @@ function Bar({
 
   return (
     <div className="ttahub-goal-bar-container display-flex flex-justify margin-y-2">
-      <span className="flex-2 margin-right-1 flex-align-self-center" aria-label={readablePercentage}>
+      <span className="width-10 margin-right-4 flex-align-self-center" aria-label={readablePercentage}>
         {label}
       </span>
       <div className="ttahub-goal-bar height-3 bg-base-lightest flex-6 margin-right-1 width-full" aria-hidden="true">

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -42,16 +42,16 @@ function Bar({
       <div className="ttahub-goal-bar height-3 bg-base-lightest flex-6 margin-right-1 width-full" aria-hidden="true">
         <div className="ttahub-goal-bar-color height-full width-full" style={style} />
       </div>
-      <span aria-label={readableRatio} className="flex-1 flex-align-self-center text-right padding-left-1">{ratio}</span>
+      <span aria-label={readableRatio} className="width-10 flex-align-self-center text-right padding-left-1">{ratio}</span>
     </div>
   );
 }
 
 Bar.propTypes = {
-  count: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
   percentage: PropTypes.number.isRequired,
-  ratio: PropTypes.number.isRequired,
+  ratio: PropTypes.string.isRequired,
   total: PropTypes.number.isRequired,
   color: PropTypes.string.isRequired,
 };
@@ -77,7 +77,7 @@ export function GoalStatusChart({ data, loading }) {
     const newBars = GOAL_STATUSES.map((status, index) => ({
       ratio: `${data[status]}/${data.total}`,
       percentage: data[status] / data.total,
-      label: status,
+      label: status === 'Ceased/Suspended' ? 'Suspended' : status,
       color: STATUS_COLORS[index],
       count: data[status],
       total: data.total,
@@ -96,7 +96,7 @@ export function GoalStatusChart({ data, loading }) {
       <Grid row className="position-relative margin-bottom-2">
         <Grid className="flex-align-self-center desktop:display-flex flex-align-center" desktop={{ col: 'auto' }} mobileLg={{ col: 10 }}>
           <h2 className="margin-0">
-            Total goals by status
+            Number of goals by status
           </h2>
         </Grid>
         <Grid desktop={{ col: 'auto' }} className="ttahub--show-accessible-data-button flex-align-self-center">

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -20,16 +20,23 @@ const STATUS_COLORS = [
 ];
 
 function Bar({
-  count, percentage, label, color, ratio, total,
+  count,
+  percentage,
+  label,
+  color,
+  ratio,
+  total,
 }) {
+  // 0/0 is NaN
+  const percent = Number.isNaN(percentage) ? 0 : percentage * 100;
+
   const style = {
-    // 0/0 is NaN
-    width: Number.isNaN(percentage) ? '0%' : `${percentage * 100}%`,
+    width: `${percent}%`,
     backgroundColor: color,
   };
 
-  const readablePercentage = `${(
-    percentage * 100).toLocaleString('en-us', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
+  const readablePercentage = `${
+    (percent).toLocaleString('en-us', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
   } percent of goals are ${label}`;
 
   const readableRatio = `That's ${count} of ${total} goals`;

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -42,7 +42,7 @@ function Bar({
       <div className="ttahub-goal-bar height-3 bg-base-lightest flex-6 margin-right-1 width-full" aria-hidden="true">
         <div className="ttahub-goal-bar-color height-full width-full" style={style} />
       </div>
-      <span aria-label={readableRatio} className="width-10 flex-align-self-center text-right padding-left-1">{ratio}</span>
+      <span aria-label={readableRatio} className="width-8 flex-align-self-center text-right padding-left-1">{ratio}</span>
     </div>
   );
 }

--- a/frontend/src/widgets/__tests__/FrequencyGraph.js
+++ b/frontend/src/widgets/__tests__/FrequencyGraph.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import '@testing-library/jest-dom';
 import React from 'react';
 import {

--- a/frontend/src/widgets/__tests__/GoalStatusGraph.js
+++ b/frontend/src/widgets/__tests__/GoalStatusGraph.js
@@ -24,7 +24,7 @@ describe('GoalStatusChart', () => {
 
     await screen.findByText('Not Started');
     await screen.findByText('In Progress');
-    await screen.findByText('Ceased/Suspended');
+    await screen.findByText('Suspended');
     await screen.findByText('Closed');
 
     const twentyFives = await screen.findAllByText(/25\/300/i);

--- a/frontend/src/widgets/__tests__/GoalStatusGraph.js
+++ b/frontend/src/widgets/__tests__/GoalStatusGraph.js
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GoalStatusChart } from '../GoalStatusGraph';
+
+describe('GoalStatusChart', () => {
+  const testData = {
+    total: 300,
+    'Not Started': 150,
+    'In Progress': 25,
+    Closed: 100,
+    'Ceased/Suspended': 25,
+  };
+
+  const renderGoalStatusChart = (data) => render(<GoalStatusChart data={data} />);
+
+  it('renders the bar graph', async () => {
+    renderGoalStatusChart(testData);
+    expect(await screen.findByText('300 goals')).toBeVisible();
+
+    await screen.findByText('Not Started');
+    await screen.findByText('In Progress');
+    await screen.findByText('Ceased/Suspended');
+    await screen.findByText('Closed');
+
+    const twentyFives = await screen.findAllByText(/25\/300/i);
+    expect(twentyFives.length).toBe(2);
+    await screen.findByText(/100\/300/i);
+    await screen.findByText(/150\/300/i);
+
+    const bars = document.querySelectorAll('.ttahub-goal-bar');
+    expect(bars.length).toBe(4);
+  });
+
+  it('switches to accessible data', async () => {
+    renderGoalStatusChart(testData);
+    const button = await screen.findByRole('button', { name: /display goal statuses by number as a table/i });
+    userEvent.click(button);
+    expect(await screen.findByRole('columnheader', { name: /status/i })).toBeVisible();
+  });
+});

--- a/frontend/src/widgets/__tests__/GoalStatusGraph.js
+++ b/frontend/src/widgets/__tests__/GoalStatusGraph.js
@@ -10,10 +10,10 @@ import { GoalStatusChart } from '../GoalStatusGraph';
 describe('GoalStatusChart', () => {
   const testData = {
     total: 300,
-    'Not Started': 150,
-    'In Progress': 25,
+    'Not started': 150,
+    'In progress': 25,
     Closed: 100,
-    'Ceased/Suspended': 25,
+    Suspended: 25,
   };
 
   const renderGoalStatusChart = (data) => render(<GoalStatusChart data={data} />);
@@ -22,8 +22,8 @@ describe('GoalStatusChart', () => {
     renderGoalStatusChart(testData);
     expect(await screen.findByText('300 goals')).toBeVisible();
 
-    await screen.findByText('Not Started');
-    await screen.findByText('In Progress');
+    await screen.findByText('Not started');
+    await screen.findByText('In progress');
     await screen.findByText('Suspended');
     await screen.findByText('Closed');
 

--- a/src/scopes/goals/index.test.js
+++ b/src/scopes/goals/index.test.js
@@ -270,7 +270,7 @@ describe('goal filtersToScopes', () => {
       expect(found.map((g) => g.name)).toContain('Goal 4');
     });
     it('filters out by status', async () => {
-      const filters = { 'status.nin': 'Ceased/Suspended' };
+      const filters = { 'status.nin': ['Suspended'] };
       const { goal: scope } = filtersToScopes(filters);
       const found = await Goal.findAll({
         where: {

--- a/src/scopes/goals/index.test.js
+++ b/src/scopes/goals/index.test.js
@@ -251,7 +251,7 @@ describe('goal filtersToScopes', () => {
 
   describe('status', () => {
     it('filters in by status', async () => {
-      const filters = { 'status.in': ['Active', 'Needs Status'] };
+      const filters = { 'status.in': ['Active', 'Needs status'] };
       const { goal: scope } = filtersToScopes(filters, 'goal');
       const found = await Goal.findAll({
         where: {

--- a/src/scopes/goals/status.js
+++ b/src/scopes/goals/status.js
@@ -7,7 +7,9 @@ export function withStatus(status) {
       [Op.or]: [
         {
           status: {
-            [Op.in]: status,
+            [Op.or]: status.map((s) => ({
+              [Op.iLike]: `%${s}%`, // sequelize escapes this
+            })),
           },
         },
         {
@@ -22,7 +24,11 @@ export function withStatus(status) {
   return sequelize.where(
     sequelize.col('"Goal".status'),
     {
-      [Op.in]: status,
+      status: {
+        [Op.or]: status.map((s) => ({
+          [Op.iLike]: `%${s}%`, // sequelize escapes this
+        })),
+      },
     },
   );
 }
@@ -32,7 +38,9 @@ export function withoutStatus(status) {
     [Op.or]: [
       {
         status: {
-          [Op.not]: status,
+          [Op.or]: status.map((s) => ({
+            [Op.notILike]: `%${s}%`, // sequelize escapes this
+          })),
         },
       },
       {

--- a/src/scopes/goals/status.js
+++ b/src/scopes/goals/status.js
@@ -1,7 +1,7 @@
 import { Op } from 'sequelize';
 
 export function withStatus(statuses) {
-  if (statuses.includes('Needs Status')) {
+  if (statuses.includes('Needs status')) {
     return {
       [Op.or]: [
         ...statuses.map((s) => ({
@@ -28,7 +28,7 @@ export function withStatus(statuses) {
 }
 
 export function withoutStatus(statuses) {
-  if (statuses.includes('Needs Status')) {
+  if (statuses.includes('Needs status')) {
     return {
       [Op.or]: [
         {

--- a/src/scopes/goals/status.js
+++ b/src/scopes/goals/status.js
@@ -1,17 +1,14 @@
 import { Op } from 'sequelize';
-import { sequelize } from '../../models';
 
-export function withStatus(status) {
-  if (status.includes('Needs Status')) {
+export function withStatus(statuses) {
+  if (statuses.includes('Needs Status')) {
     return {
       [Op.or]: [
-        {
+        ...statuses.map((s) => ({
           status: {
-            [Op.or]: status.map((s) => ({
-              [Op.iLike]: `%${s}%`, // sequelize escapes this
-            })),
+            [Op.iLike]: `%${s}%`, // sequelize escapes this
           },
-        },
+        })),
         {
           status: {
             [Op.eq]: null,
@@ -21,32 +18,48 @@ export function withStatus(status) {
     };
   }
 
-  return sequelize.where(
-    sequelize.col('"Goal".status'),
-    {
+  return {
+    [Op.or]: statuses.map((s) => ({
       status: {
-        [Op.or]: status.map((s) => ({
-          [Op.iLike]: `%${s}%`, // sequelize escapes this
-        })),
+        [Op.iLike]: `%${s}%`, // sequelize escapes this
       },
-    },
-  );
+    })),
+  };
 }
 
-export function withoutStatus(status) {
+export function withoutStatus(statuses) {
+  if (statuses.includes('Needs Status')) {
+    return {
+      [Op.or]: [
+        {
+          [Op.and]: statuses.map((s) => ({
+            status: {
+              [Op.notILike]: `%${s}%`, // sequelize escapes this
+            },
+          })),
+        },
+        {
+          status: {
+            [Op.not]: null,
+          },
+        },
+      ],
+    };
+  }
+
   return {
     [Op.or]: [
       {
         status: {
-          [Op.or]: status.map((s) => ({
-            [Op.notILike]: `%${s}%`, // sequelize escapes this
-          })),
+          [Op.eq]: null,
         },
       },
       {
-        status: {
-          [Op.is]: null,
-        },
+        [Op.and]: statuses.map((s) => ({
+          status: {
+            [Op.notILike]: `%${s}%`, // sequelize escapes this
+          },
+        })),
       },
     ],
   };

--- a/src/widgets/goalStatusGraph.js
+++ b/src/widgets/goalStatusGraph.js
@@ -47,15 +47,17 @@ export default async function goalStatusGraph(scopes) {
     }],
   });
 
-  const goals = STATUSES_TO_INCLUDE.map((status) => {
+  let total = 0;
+
+  const goals = STATUSES_TO_INCLUDE.reduce((accumulator, status) => {
     const goal = goalsFromDb.find((g) => g.status === status);
     const count = goal ? goal.count : 0;
-    return { status, count };
-  });
+    total += count;
+    return { ...accumulator, [status]: count };
+  }, {});
 
-  const total = goals.reduce((sum, g) => sum + g.count, 0);
   return {
     total,
-    goals,
+    ...goals,
   };
 }

--- a/src/widgets/goalStatusGraph.js
+++ b/src/widgets/goalStatusGraph.js
@@ -58,6 +58,9 @@ export default async function goalStatusGraph(scopes) {
 
   return {
     total,
-    ...goals,
+    'Not started': goals[GOAL_STATUS.NOT_STARTED],
+    'In progress': goals[GOAL_STATUS.IN_PROGRESS],
+    Closed: goals[GOAL_STATUS.CLOSED],
+    Suspended: goals[GOAL_STATUS.CEASED],
   };
 }

--- a/src/widgets/goalStatusGraph.test.js
+++ b/src/widgets/goalStatusGraph.test.js
@@ -8,8 +8,7 @@ describe('goalStatusGraph', () => {
   const goals = [];
   let recipient;
   let grant;
-  let total;
-  let allGoals;
+  let response;
 
   beforeAll(async () => {
     recipient = await createRecipient();
@@ -72,9 +71,7 @@ describe('goalStatusGraph', () => {
       grantId,
       recipientId,
     }));
-    const res = await goalStatusGraph({ goal: { id: goals.map((g) => g.id) } });
-    total = res.total;
-    allGoals = res.goals;
+    response = await goalStatusGraph({ goal: { id: goals.map((g) => g.id) } });
   });
 
   afterAll(async () => {
@@ -94,44 +91,44 @@ describe('goalStatusGraph', () => {
   });
 
   it('counts the total number of goals', () => {
-    expect(total).toBe(7);
+    expect(response.total).toBe(7);
   });
 
   describe('it counts status of', () => {
     it('not started', () => {
-      const notStarted = allGoals.find((r) => r.status === GOAL_STATUS.NOT_STARTED);
+      const notStarted = response[GOAL_STATUS.NOT_STARTED];
       expect(notStarted.count).toBe(2);
     });
 
     it('in progress', () => {
-      const inProgress = allGoals.find((r) => r.status === GOAL_STATUS.IN_PROGRESS);
+      const inProgress = response[GOAL_STATUS.IN_PROGRESS];
       expect(inProgress.count).toBe(3);
     });
 
     it('closed', () => {
-      const closed = allGoals.find((r) => r.status === GOAL_STATUS.CLOSED);
+      const closed = response[GOAL_STATUS.CLOSED];
       expect(closed.count).toBe(2);
     });
 
     it('ceased', () => {
-      const ceased = allGoals.find((r) => r.status === GOAL_STATUS.CEASED);
+      const ceased = response[GOAL_STATUS.CEASED];
       expect(ceased.count).toBe(0);
     });
   });
 
   describe('it ignores status of', () => {
     it('null', () => {
-      const notDefined = allGoals.find((r) => r.status === null);
+      const notDefined = response.null;
       expect(notDefined).toBeUndefined();
     });
 
     it('draft', () => {
-      const draft = allGoals.find((r) => r.status === GOAL_STATUS.DRAFT);
+      const draft = response[GOAL_STATUS.DRAFT];
       expect(draft).toBeUndefined();
     });
 
     it('empty string', () => {
-      const empty = allGoals.find((r) => r.status === '');
+      const empty = response[''];
       expect(empty).toBeUndefined();
     });
   });

--- a/src/widgets/goalStatusGraph.test.js
+++ b/src/widgets/goalStatusGraph.test.js
@@ -96,22 +96,22 @@ describe('goalStatusGraph', () => {
 
   describe('it counts status of', () => {
     it('not started', () => {
-      const notStarted = response[GOAL_STATUS.NOT_STARTED];
+      const notStarted = response['Not started'];
       expect(notStarted).toBe(2);
     });
 
     it('in progress', () => {
-      const inProgress = response[GOAL_STATUS.IN_PROGRESS];
+      const inProgress = response['In progress'];
       expect(inProgress).toBe(3);
     });
 
     it('closed', () => {
-      const closed = response[GOAL_STATUS.CLOSED];
+      const closed = response.Closed;
       expect(closed).toBe(2);
     });
 
     it('ceased', () => {
-      const ceased = response[GOAL_STATUS.CEASED];
+      const ceased = response.Suspended;
       expect(ceased).toBe(0);
     });
   });

--- a/src/widgets/goalStatusGraph.test.js
+++ b/src/widgets/goalStatusGraph.test.js
@@ -97,22 +97,22 @@ describe('goalStatusGraph', () => {
   describe('it counts status of', () => {
     it('not started', () => {
       const notStarted = response[GOAL_STATUS.NOT_STARTED];
-      expect(notStarted.count).toBe(2);
+      expect(notStarted).toBe(2);
     });
 
     it('in progress', () => {
       const inProgress = response[GOAL_STATUS.IN_PROGRESS];
-      expect(inProgress.count).toBe(3);
+      expect(inProgress).toBe(3);
     });
 
     it('closed', () => {
       const closed = response[GOAL_STATUS.CLOSED];
-      expect(closed.count).toBe(2);
+      expect(closed).toBe(2);
     });
 
     it('ceased', () => {
       const ceased = response[GOAL_STATUS.CEASED];
-      expect(ceased.count).toBe(0);
+      expect(ceased).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Description of change
Added goal status visualization to frontend (bar graph showing status/counts for a given recipients goals). It can be found on the goals & objectives tab of the recipient record page.

## How to test
View the goal status visualization. Confirm that it shows the counts returned from the backend and that filters apply to it. Confirm that the data can be viewing as a simple HTML table rather than a horizontal bar graph.

## Issue(s)
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-456


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
