### PR TITLE
Use draft.js paste handler instead of react-draft-wysiwyg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "TTAHUB-359/add-filters-to-dashboard"
+    default: "js-644-fix-copy-paste-into-wysiwyg-component"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "TTAHUB-249/update-node-to-v16"

--- a/frontend/src/components/RichEditor.js
+++ b/frontend/src/components/RichEditor.js
@@ -44,6 +44,7 @@ const RichEditor = ({
       defaultEditorState={defaultEditorState}
       onChange={onInternalChange}
       ariaLabel={ariaLabel}
+      handlePastedText={() => false}
       tabIndex="0"
       editorStyle={{ border: '1px solid #565c65', height: '10rem' }}
       toolbar={{


### PR DESCRIPTION
## Description of change

See https://github.com/jpuri/react-draft-wysiwyg/issues/967. This change should make pasting formatted text behave better, most note-ably stopping random line breaks in bulleted lists.

before
![Screenshot from 2022-02-10 15-29-23](https://user-images.githubusercontent.com/6631790/153500495-425bca79-dec1-4bf1-a672-8359c1700aa7.png)

after
![Screenshot from 2022-02-10 15-29-36](https://user-images.githubusercontent.com/6631790/153500512-d7a112eb-0c0a-4489-ac20-e1d4cb80d2fb.png)

We will lose some formatting from the source, background highlights and font family. May be other things we lose. We should gather a list of all the formatting we want to carry over from word docs to verify what we want to work actually does work.

## How to test

From main, copy bulleted lists from a google doc into the context field. Note the extra newlines. Checkout this branch and copy the same text into the context field.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-644

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
