### PR TITLE
Fix error on recipient name filter selection

### DIFF
--- a/src/scopes/grants/index.test.js
+++ b/src/scopes/grants/index.test.js
@@ -175,8 +175,14 @@ describe('grant filtersToScopes', () => {
     it('filters by', async () => {
       const filters = { 'recipient.ctn': '13269' };
       const scope = filtersToScopes(filters);
-      const found = await Grant.findAll({
-        where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+      const found = await Recipient.findAll({
+        include: [
+          {
+            model: Grant,
+            as: 'grants',
+            where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+          },
+        ],
       });
       expect(found.length).toBe(1);
       expect(found.map((f) => f.id)).toContain(recipients[1].id);
@@ -184,8 +190,14 @@ describe('grant filtersToScopes', () => {
     it('filters out', async () => {
       const filters = { 'recipient.nctn': '13269' };
       const scope = filtersToScopes(filters);
-      const found = await Grant.findAll({
-        where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+      const found = await Recipient.findAll({
+        include: [
+          {
+            model: Grant,
+            as: 'grants',
+            where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+          },
+        ],
       });
       expect(found.map((f) => f.id)).toStrictEqual([13259, 13279]);
     });

--- a/src/scopes/grants/utils.js
+++ b/src/scopes/grants/utils.js
@@ -3,7 +3,7 @@ import { sequelize } from '../../models';
 import { filterAssociation as filter } from '../utils';
 
 function grantInSubQuery(baseQuery, searchTerms, operator, comparator) {
-  return searchTerms.map((term) => sequelize.literal(`"Grant"."id" ${operator} (${baseQuery} ${comparator} ${sequelize.escape(`%${term}%`)})`));
+  return searchTerms.map((term) => sequelize.literal(`"grants"."id" ${operator} (${baseQuery} ${comparator} ${sequelize.escape(`%${term}%`)})`));
 }
 
 export function expandArrayContains(key, array, exclude) {


### PR DESCRIPTION
## Description of change
Fixes an error on selecting a filter with "Recipient name". 


## How to test
- On the landing page, create a new filter using "Recipient name contains"
- Verify that the Overview widget loads correctly (On Dev there is an error)
- Verify that the "Does not contain" clause also works

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-673


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
