### PR TITLE
[TTAHUB-618] Add Agency ID to CSV export

### DIFF
--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -252,6 +252,7 @@ const arTransformers = [
   transformDate('createdAt'),
   transformDate('approvedAt'),
   transformGrantModel('programSpecialistName'),
+  transformGrantModel('recipientInfo'),
 ];
 
 /**

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -138,28 +138,28 @@ describe('activityReportToCsvRecord', () => {
       id: 4,
       grantId: 4,
       grant: {
-        name: 'test4', programSpecialistName: 'Program Specialist 4', recipientId: 4, recipient: { name: 'test4' },
+        name: 'test4', programSpecialistName: 'Program Specialist 4', recipientId: 4, number: 'grant number 4', recipient: { id: 4, name: 'test4' },
       },
     },
     {
       id: 1,
       grantId: 1,
       grant: {
-        name: 'test1', programSpecialistName: 'Program Specialist 1', recipientId: 1, recipient: { name: 'test1' },
+        name: 'test1', programSpecialistName: 'Program Specialist 1', recipientId: 1, number: 'grant number 1', recipient: { id: 1, name: 'test1' },
       },
     },
     {
       id: 2,
       grantId: 2,
       grant: {
-        name: 'test2', programSpecialistName: 'Program Specialist 2', recipientId: 2, recipient: { name: 'test2' },
+        name: 'test2', programSpecialistName: 'Program Specialist 2', recipientId: 2, number: 'grant number 2', recipient: { id: 2, name: 'test2' },
       },
     },
     {
       id: 3,
       grantId: 3,
       grant: {
-        name: 'test3', programSpecialistName: 'Program Specialist 1', recipientId: 3, recipient: { name: 'test3' },
+        name: 'test3', programSpecialistName: 'Program Specialist 1', recipientId: 3, number: 'grant number 3', recipient: { id: 3, name: 'test3' },
       },
     },
   ];
@@ -315,13 +315,14 @@ describe('activityReportToCsvRecord', () => {
     });
     const output = await activityReportToCsvRecord(report);
     const {
-      author, lastUpdatedBy, collaborators, programSpecialistName, approvers,
+      author, lastUpdatedBy, collaborators, programSpecialistName, approvers, recipientInfo,
     } = output;
     expect(author).toEqual('Arthur, GS');
     expect(lastUpdatedBy).toEqual('Arthur');
     expect(collaborators).toEqual('Collaborator 1, GS, HS\nCollaborator 2');
     expect(programSpecialistName).toEqual('Program Specialist 1\nProgram Specialist 2\nProgram Specialist 4');
     expect(approvers).toEqual('Test Approver 1\nTest Approver 2\nTest Approver 3');
+    expect(recipientInfo).toEqual('test1 - grant number 1 - 1\ntest2 - grant number 2 - 2\ntest3 - grant number 3 - 3\ntest4 - grant number 4 - 4');
   });
 
   it('transforms goals and objectives into many values', async () => {

--- a/src/models/grant.js
+++ b/src/models/grant.js
@@ -67,6 +67,12 @@ module.exports = (sequelize, DataTypes) => {
         return `${this.recipient.name} - ${this.number}${programTypes}`;
       },
     },
+    recipientInfo: {
+      type: DataTypes.VIRTUAL,
+      get() {
+        return `${this.recipient.name} - ${this.number} - ${this.recipient.id}`;
+      },
+    },
   }, {
     sequelize,
     modelName: 'Grant',

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -184,6 +184,10 @@ async function sendActivityReportCSV(reports, res) {
           key: 'lastSaved',
           header: 'Last saved',
         },
+        {
+          key: 'recipientInfo',
+          header: 'Recipient name - Grant number - Recipient ID',
+        },
       ],
     };
 

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -716,14 +716,14 @@ async function getDownloadableActivityReports(where) {
           include: [
             {
               model: Grant,
-              attributes: ['id', 'number', 'programSpecialistName'],
+              attributes: ['id', 'number', 'programSpecialistName', 'recipientInfo'],
               as: 'grant',
               required: false,
               include: [
                 {
                   model: Recipient,
                   as: 'recipient',
-                  attributes: ['name'],
+                  attributes: ['id', 'name'],
                 },
                 {
                   model: Program,


### PR DESCRIPTION
## Description of change

Add agency id "Recipient name - Grant number - Recipient ID" to csv export.

## How to test

Export the AR CSV on the far right of the export we should now have a column for agency id. This column should be a combination of the recipient name - grant number - recipient id.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-618


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated`
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
