### PR TITLE
[TTAHUB-617] Fix Incorrect Target Population Value

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "updateLegacyCreatorsAndCollaborators": "node ./build/server/tools/updateLegacyCreatorsAndCollaboratorsCLI.js",
     "updateLegacyCreatorsAndCollaborators:local": "./node_modules/.bin/babel-node ./src/tools/updateLegacyCreatorsAndCollaboratorsCLI.js",
     "updateDeliveryData": "node ./build/server/tools/updateDeliveryDataCLI.js",
-    "updateDeliveryData:local": "./node_modules/.bin/babel-node ./src/tools/updateDeliveryDataCLI.js"
+    "updateDeliveryData:local": "./node_modules/.bin/babel-node ./src/tools/updateDeliveryDataCLI.js",
+    "updateChildInvolvementTargetPopulation": "node ./build/server/tools/updateChildInvolvementTargetPopulationCLI.js",
+    "updateChildInvolvementTargetPopulation:local": "./node_modules/.bin/babel-node ./src/tools/updateChildInvolvementTargetPopulationCLI.js"
   },
   "repository": {
     "type": "git",

--- a/src/tools/updateChildInvolvementTargetPopulation.js
+++ b/src/tools/updateChildInvolvementTargetPopulation.js
@@ -1,0 +1,29 @@
+import { Op } from 'sequelize';
+import { ActivityReport } from '../models';
+import { auditLogger } from '../logger';
+
+export default async function updateChildInvolvementTargetPopulation() {
+  auditLogger.info('Updating target populations...');
+
+  const badTargetPopulation = 'Affected by Child Welfare involvement';
+  const goodTargetPopulation = 'Affected by Child Welfare Involvement';
+
+  const reports = await ActivityReport.findAll({
+    attributes: ['id', 'targetPopulations'],
+    where: {
+      targetPopulations: { [Op.contains]: [badTargetPopulation] },
+    },
+  });
+
+  auditLogger.info(`${reports.length ? reports.length : 0} reports with affected data found...`);
+
+  return Promise.all(reports.map(async (report) => {
+    const indexOf = report.targetPopulations.indexOf(badTargetPopulation);
+    const newTgtPop = [...report.targetPopulations];
+    newTgtPop[indexOf] = goodTargetPopulation;
+    auditLogger.info(`changing target population value from: ${report.targetPopulations} to: ${newTgtPop}`);
+    return report.update({
+      targetPopulations: newTgtPop,
+    });
+  }));
+}

--- a/src/tools/updateChildInvolvementTargetPopulation.test.js
+++ b/src/tools/updateChildInvolvementTargetPopulation.test.js
@@ -1,0 +1,166 @@
+/* eslint-disable jest/no-conditional-expect */
+import {
+  ActivityReport,
+  User,
+  sequelize,
+} from '../models';
+import updateChildInvolvementTargetPopulation from './updateChildInvolvementTargetPopulation';
+import { REPORT_STATUSES } from '../constants';
+
+const sampleReport = {
+  submissionStatus: REPORT_STATUSES.SUBMITTED,
+  calculatedStatus: REPORT_STATUSES.APPROVED,
+  oldApprovingManagerId: 1,
+  numberOfParticipants: 1,
+  deliveryMethod: 'method',
+  duration: 0,
+  endDate: '2020-01-01T12:00:00Z',
+  startDate: '2020-01-01T12:00:00Z',
+  requester: 'requester',
+  programTypes: ['type'],
+  reason: ['reason'],
+  topics: ['topics'],
+  ttaType: ['type'],
+  regionId: 1,
+  targetPopulations: [],
+};
+
+const mockUser = {
+  name: 'Joe Green',
+  role: null,
+  phoneNumber: '555-555-554',
+  hsesUserId: '49',
+  hsesUsername: 'test49@test.com',
+  hsesAuthorities: ['ROLE_FEDERAL'],
+  email: 'test49@test.com',
+  homeRegionId: 1,
+  lastLogin: new Date('2021-02-09T15:13:00.000Z'),
+  permissions: [
+    {
+      userId: 49,
+      regionId: 1,
+      scopeId: 1,
+    },
+    {
+      userId: 49,
+      regionId: 2,
+      scopeId: 1,
+    },
+  ],
+  flags: [],
+};
+
+describe('updateChildInvolvementTargetPopulations', () => {
+  let reportOne;
+  let reportTwo;
+  let reportThree;
+  let reportFour;
+  let reportFive;
+
+  let reportIds;
+  let user;
+
+  beforeAll(async () => {
+    user = await User.create({
+      ...mockUser,
+    });
+
+    // Contains incorrect value.
+    reportOne = await ActivityReport.create({
+      ...sampleReport,
+      userId: user.id,
+      targetPopulations: [
+        'Dual-Language Learners',
+        'Infants and Toddlers (ages birth to 3)',
+        'Affected by Child Welfare involvement',
+        'Preschool (ages 3-5)',
+      ],
+    });
+
+    // Contains corrected value.
+    reportTwo = await ActivityReport.create({
+      ...sampleReport,
+      userId: user.id,
+      targetPopulations: [
+        'Dual-Language Learners',
+        'Affected by Child Welfare Involvement',
+      ],
+    });
+
+    // Contains no values.
+    reportThree = await ActivityReport.create({
+      ...sampleReport,
+      userId: user.id,
+      targetPopulations: [],
+    });
+
+    // Contains other values.
+    reportFour = await ActivityReport.create({
+      ...sampleReport,
+      userId: user.id,
+      targetPopulations: [
+        'Children Experiencing Homelessness',
+        'Children with Special Health Care Needs',
+        'Preschool (ages 3-5)',
+      ],
+    });
+
+    // Contains only bad value.
+    reportFive = await ActivityReport.create({
+      ...sampleReport,
+      userId: user.id,
+      targetPopulations: [
+        'Affected by Child Welfare involvement',
+      ],
+    });
+
+    reportIds = [reportOne.id, reportTwo.id, reportThree.id, reportFour.id, reportFive.id];
+  });
+
+  afterAll(async () => {
+    await ActivityReport.destroy({ where: { id: reportIds } });
+    await User.destroy({ where: { id: user.id } });
+    await sequelize.close();
+  });
+
+  it('update bad child involvement target populations', async () => {
+    await updateChildInvolvementTargetPopulation();
+
+    const r1 = await ActivityReport.findOne({ where: { id: reportOne.id } });
+    expect(r1.targetPopulations).toEqual(
+      [
+        'Dual-Language Learners',
+        'Infants and Toddlers (ages birth to 3)',
+        'Affected by Child Welfare Involvement',
+        'Preschool (ages 3-5)',
+      ],
+    );
+
+    const r2 = await ActivityReport.findOne({ where: { id: reportTwo.id } });
+    expect(r2.targetPopulations).toEqual(
+      [
+        'Dual-Language Learners',
+        'Affected by Child Welfare Involvement',
+      ],
+    );
+
+    const r3 = await ActivityReport.findOne({ where: { id: reportThree.id } });
+    expect(r3.targetPopulations).toEqual([]);
+
+    const r4 = await ActivityReport.findOne({ where: { id: reportFour.id } });
+    expect(r4.targetPopulations).toEqual(
+      [
+        'Children Experiencing Homelessness',
+        'Children with Special Health Care Needs',
+        'Preschool (ages 3-5)',
+      ],
+    );
+
+    const r5 = await ActivityReport.findOne({ where: { id: reportFive.id } });
+    expect(r5.targetPopulations).toEqual(
+      [
+        'Affected by Child Welfare Involvement',
+      ],
+    );
+  });
+});

--- a/src/tools/updateChildInvolvementTargetPopulationCLI.js
+++ b/src/tools/updateChildInvolvementTargetPopulationCLI.js
@@ -1,0 +1,7 @@
+import updateChildInvolvementTargetPopulation from './updateChildInvolvementTargetPopulation';
+import { auditLogger } from '../logger';
+
+updateChildInvolvementTargetPopulation().catch((e) => {
+  auditLogger.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description of change

There are 32 ARs that list "Affected by Child Welfare involvement" (with a lowercase i), where as the actual text should have a capital I - "Affected by Child Welfare Involvement".

## How to test

Run this query on your local db to get a list of affected reports:

`SELECT "targetPopulations" FROM "ActivityReports" WHERE 'Affected by Child Welfare involvement'=ANY("targetPopulations");`

Run the new package.json script updateChildInvolvementTargetPopulationCLI or updateChildInvolvementTargetPopulation:local.

Rerun the above query it should return no results.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-617


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
