### PR TITLE
[TTAHUB-683] Fix overview widget failing when adding program type filter

### DIFF
--- a/src/scopes/grants/index.test.js
+++ b/src/scopes/grants/index.test.js
@@ -227,17 +227,29 @@ describe('grant filtersToScopes', () => {
     it('filters by', async () => {
       const filters = { 'programType.in': ['EHS'] };
       const scope = filtersToScopes(filters);
-      const found = await Grant.findAll({
-        where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+      const found = await Recipient.findAll({
+        include: [
+          {
+            model: Grant,
+            as: 'grants',
+            where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+          },
+        ],
       });
       expect(found.length).toBe(1);
-      expect(found.map((f) => f.id)).toContain(recipients[0].id);
+      expect(found[0].id).toBe(recipients[0].id);
     });
     it('filters out', async () => {
       const filters = { 'programType.nin': ['EHS'] };
       const scope = filtersToScopes(filters);
-      const found = await Grant.findAll({
-        where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+      const found = await Recipient.findAll({
+        include: [
+          {
+            model: Grant,
+            as: 'grants',
+            where: { [Op.and]: [scope.grant, { id: possibleIds }] },
+          },
+        ],
       });
       expect(found.length).toBe(2);
       expect(found.map((f) => f.id)).toContain(recipients[2].id);

--- a/src/scopes/grants/programType.js
+++ b/src/scopes/grants/programType.js
@@ -5,7 +5,7 @@ import { filterAssociation } from '../utils';
 const programTypeFilter = 'SELECT "grantId" FROM "Programs" WHERE "programType"';
 
 function subQuery(baseQuery, searchTerms, operator, comparator) {
-  return searchTerms.map((term) => sequelize.literal(`"Grant"."id" ${operator} (${baseQuery} ${comparator} ${sequelize.escape(`${term}`)})`));
+  return searchTerms.map((term) => sequelize.literal(`"grants"."id" ${operator} (${baseQuery} ${comparator} ${sequelize.escape(`${term}`)})`));
 }
 
 export function withProgramTypes(types) {


### PR DESCRIPTION
## Description of change

Fix overview widget failing when adding program type filter.

## How to test

Create a filter on the AR landing that contains program types. The Overview widget at the top should no longer show an error message.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-683


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
