### PR TITLE
[TTAHUB-617] Fix legacy imported target population

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
     "updateDeliveryData": "node ./build/server/tools/updateDeliveryDataCLI.js",
     "updateDeliveryData:local": "./node_modules/.bin/babel-node ./src/tools/updateDeliveryDataCLI.js",
     "updateChildInvolvementTargetPopulation": "node ./build/server/tools/updateChildInvolvementTargetPopulationCLI.js",
-    "updateChildInvolvementTargetPopulation:local": "./node_modules/.bin/babel-node ./src/tools/updateChildInvolvementTargetPopulationCLI.js"
+    "updateChildInvolvementTargetPopulation:local": "./node_modules/.bin/babel-node ./src/tools/updateChildInvolvementTargetPopulationCLI.js",
+    "updateChildInvolvementLegacyTargetPopulationCLI": "node ./build/server/tools/updateChildInvolvementLegacyTargetPopulationCLI.js",
+    "updateChildInvolvementLegacyTargetPopulationCLI:local": "./node_modules/.bin/babel-node ./src/tools/updateChildInvolvementLegacyTargetPopulationCLI.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "updateDeliveryData:local": "./node_modules/.bin/babel-node ./src/tools/updateDeliveryDataCLI.js",
     "updateChildInvolvementTargetPopulation": "node ./build/server/tools/updateChildInvolvementTargetPopulationCLI.js",
     "updateChildInvolvementTargetPopulation:local": "./node_modules/.bin/babel-node ./src/tools/updateChildInvolvementTargetPopulationCLI.js",
-    "updateChildInvolvementLegacyTargetPopulationCLI": "node ./build/server/tools/updateChildInvolvementLegacyTargetPopulationCLI.js",
-    "updateChildInvolvementLegacyTargetPopulationCLI:local": "./node_modules/.bin/babel-node ./src/tools/updateChildInvolvementLegacyTargetPopulationCLI.js"
+    "updateChildInvolvementLegacyTargetPopulation": "node ./build/server/tools/updateChildInvolvementLegacyTargetPopulationCLI.js",
+    "updateChildInvolvementLegacyTargetPopulation:local": "./node_modules/.bin/babel-node ./src/tools/updateChildInvolvementLegacyTargetPopulationCLI.js"
   },
   "repository": {
     "type": "git",

--- a/src/tools/updateChildInvolvementLegacyTargetPopulation.js
+++ b/src/tools/updateChildInvolvementLegacyTargetPopulation.js
@@ -1,0 +1,38 @@
+import { Op } from 'sequelize';
+import {
+  ActivityReport,
+} from '../models';
+import { auditLogger } from '../logger';
+
+export default async function updateChildInvolvementLegacyTargetPopulation() {
+  const legacyReports = await ActivityReport.findAll({
+    attributes: [
+      'id',
+      'imported',
+    ],
+    where: {
+      [Op.and]: [
+        {
+          imported: { [Op.not]: null },
+        },
+        {
+          imported: {
+            targetPopulations: {
+              [Op.like]: '%Affected by Child Welfare involvement%',
+            },
+          },
+        },
+      ],
+    },
+  });
+
+  auditLogger.info(`${legacyReports.length ? legacyReports.length : 0} reports with affected data found...`);
+  return Promise.all(legacyReports.map(async (report) => {
+    const newTgtPop = report.imported.targetPopulations.replace('Affected by Child Welfare involvement', 'Affected by Child Welfare Involvement');
+    auditLogger.info(`Changing imported target population value from: ${report.imported.targetPopulations} to: ${newTgtPop}`);
+    const updatedImported = { ...report.imported, targetPopulations: newTgtPop };
+    return report.update({
+      imported: updatedImported,
+    });
+  }));
+}

--- a/src/tools/updateChildInvolvementLegacyTargetPopulation.js
+++ b/src/tools/updateChildInvolvementLegacyTargetPopulation.js
@@ -11,18 +11,11 @@ export default async function updateChildInvolvementLegacyTargetPopulation() {
       'imported',
     ],
     where: {
-      [Op.and]: [
-        {
-          imported: { [Op.not]: null },
+      imported: {
+        targetPopulations: {
+          [Op.like]: '%Affected by Child Welfare involvement%',
         },
-        {
-          imported: {
-            targetPopulations: {
-              [Op.like]: '%Affected by Child Welfare involvement%',
-            },
-          },
-        },
-      ],
+      },
     },
   });
 

--- a/src/tools/updateChildInvolvementLegacyTargetPopulation.test.js
+++ b/src/tools/updateChildInvolvementLegacyTargetPopulation.test.js
@@ -1,0 +1,175 @@
+/* eslint-disable jest/no-conditional-expect */
+import {
+  ActivityReport,
+  User,
+  ActivityReportCollaborator,
+  sequelize,
+} from '../models';
+import updateChildInvolvementLegacyTargetPopulation from './updateChildInvolvementLegacyTargetPopulation';
+import { REPORT_STATUSES } from '../constants';
+import { destroyReport } from '../testUtils';
+
+const baseReport = {
+  submissionStatus: REPORT_STATUSES.SUBMITTED,
+  calculatedStatus: REPORT_STATUSES.APPROVED,
+  oldApprovingManagerId: 1,
+  numberOfParticipants: 1,
+  deliveryMethod: 'method',
+  duration: 0,
+  endDate: '2020-01-01T12:00:00Z',
+  startDate: '2020-01-01T12:00:00Z',
+  requester: 'requester',
+  programTypes: ['type'],
+  reason: ['reason'],
+  topics: ['topics'],
+  ttaType: ['type'],
+  regionId: 1,
+  targetPopulations: ['Dual-Language Learners'],
+};
+
+const mockUser = {
+  name: 'Joe Green',
+  role: null,
+  phoneNumber: '555-555-554',
+  hsesUserId: '49',
+  hsesUsername: 'test49@test.com',
+  hsesAuthorities: ['ROLE_FEDERAL'],
+  email: 'test49@test.com',
+  homeRegionId: 1,
+  lastLogin: new Date('2021-02-09T15:13:00.000Z'),
+  permissions: [
+    {
+      userId: 49,
+      regionId: 1,
+      scopeId: 1,
+    },
+    {
+      userId: 49,
+      regionId: 2,
+      scopeId: 1,
+    },
+  ],
+  flags: [],
+};
+
+describe('updateChildInvolvementLegacyTargetPopulation', () => {
+  let reportOne;
+  let reportTwo;
+  let reportThree;
+  let reportFour;
+
+  let user;
+
+  beforeAll(async () => {
+    user = await User.create(mockUser);
+
+    reportOne = await ActivityReport.create({
+      ...baseReport,
+      userId: user.id,
+      imported: {
+        tta: 'Technical Assistance 1',
+        goal1: 'Goal 1',
+        duration: '1',
+        targetPopulations: 'Affected by Child Welfare involvement\nChildren Experiencing Homelessness\nPreschool (ages 3-5)',
+      },
+    });
+    reportTwo = await ActivityReport.create({
+      ...baseReport,
+      userId: user.id,
+      imported: {
+        tta: 'Technical Assistance 2',
+        goal1: 'Goal 2',
+        duration: '2',
+        targetPopulations: 'Children Experiencing Homelessness\nPreschool (ages 3-5)',
+      },
+    });
+    reportThree = await ActivityReport.create({
+      ...baseReport,
+      userId: user.id,
+      imported: {
+        tta: 'Technical Assistance 3',
+        goal1: 'Goal 3',
+        duration: '3',
+        targetPopulations: 'Children Experiencing Homelessness\nAffected by Child Welfare Involvement',
+      },
+    });
+    reportFour = await ActivityReport.create({
+      ...baseReport,
+      userId: user.id,
+      imported: {
+        tta: 'Technical Assistance 4',
+        goal1: 'Goal 4',
+        duration: '4',
+        targetPopulations: null,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    const reports = [
+      reportOne, reportTwo, reportThree, reportFour,
+    ];
+
+    const reportIds = reports.map((r) => r.id);
+
+    await ActivityReportCollaborator.destroy({
+      where: {
+        activityReportId: reportIds,
+      },
+    });
+
+    await Promise.all(reports.map((r) => destroyReport(r)));
+
+    await User.destroy({
+      where: {
+        id: user.id,
+      },
+    });
+
+    await sequelize.close();
+  });
+
+  it('updates legacy imported target populations', async () => {
+    await updateChildInvolvementLegacyTargetPopulation();
+
+    const r1 = await ActivityReport.findOne({ where: { id: reportOne.id } });
+    expect(r1.imported).toEqual(
+      {
+        tta: 'Technical Assistance 1',
+        goal1: 'Goal 1',
+        duration: '1',
+        targetPopulations: 'Affected by Child Welfare Involvement\nChildren Experiencing Homelessness\nPreschool (ages 3-5)',
+      },
+    );
+
+    const r2 = await ActivityReport.findOne({ where: { id: reportTwo.id } });
+    expect(r2.imported).toEqual(
+      {
+        tta: 'Technical Assistance 2',
+        goal1: 'Goal 2',
+        duration: '2',
+        targetPopulations: 'Children Experiencing Homelessness\nPreschool (ages 3-5)',
+      },
+    );
+
+    const r3 = await ActivityReport.findOne({ where: { id: reportThree.id } });
+    expect(r3.imported).toEqual(
+      {
+        tta: 'Technical Assistance 3',
+        goal1: 'Goal 3',
+        duration: '3',
+        targetPopulations: 'Children Experiencing Homelessness\nAffected by Child Welfare Involvement',
+      },
+    );
+
+    const r4 = await ActivityReport.findOne({ where: { id: reportFour.id } });
+    expect(r4.imported).toEqual(
+      {
+        tta: 'Technical Assistance 4',
+        goal1: 'Goal 4',
+        duration: '4',
+        targetPopulations: null,
+      },
+    );
+  });
+});

--- a/src/tools/updateChildInvolvementLegacyTargetPopulationCLI.js
+++ b/src/tools/updateChildInvolvementLegacyTargetPopulationCLI.js
@@ -1,0 +1,7 @@
+import updateChildInvolvementLegacyTargetPopulation from './updateChildInvolvementLegacyTargetPopulation';
+import { auditLogger } from '../logger';
+
+updateChildInvolvementLegacyTargetPopulation().catch((e) => {
+  auditLogger.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description of change

This fixes the "Affected by Child Welfare involvement" issue on the imported json (what we display).

## How to test

Run the script all legacy reports that had "Affected by Child Welfare involvement" should now have ""Affected by Child Welfare Involvement".

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-617


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
