### PR TITLE
Darken graph font colors

### DIFF
--- a/frontend/src/widgets/BarGraph.js
+++ b/frontend/src/widgets/BarGraph.js
@@ -74,6 +74,9 @@ function BarGraph({ data, yAxisLabel, xAxisLabel }) {
           size: 16,
         },
       },
+      font: {
+        color: '#1b1b1b',
+      },
       width,
       margin: {
         l: 80,

--- a/frontend/src/widgets/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/TopicFrequencyGraph.js
@@ -115,6 +115,9 @@ export function TopicFrequencyGraphWidget({
           size: 16,
         },
       },
+      font: {
+        color: '#1b1b1b',
+      },
       width,
       margin: {
         l: 80,
@@ -124,12 +127,20 @@ export function TopicFrequencyGraphWidget({
       xaxis: {
         automargin: true,
         tickangle: 0,
+        title: {
+          font: {
+            color: '#1b1b1b',
+          },
+        },
       },
       yaxis: {
         tickformat: ',.0d',
         title: {
           standoff: 60,
           text: 'Number of Activity Reports',
+          font: {
+            color: '#1b1b1b',
+          },
         },
       },
       hovermode: 'none',

--- a/frontend/src/widgets/TotalHrsAndRecipientGraph.js
+++ b/frontend/src/widgets/TotalHrsAndRecipientGraph.js
@@ -110,6 +110,9 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
           color: '#fff',
         },
       },
+      font: {
+        color: '#1b1b1b',
+      },
       margin: {
         l: 50,
         t: 0,
@@ -131,7 +134,7 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
           font: {
             family: 'Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif',
             size: 18,
-            color: '#7f7f7f',
+            color: '##1b1b1b',
           },
         },
       },
@@ -150,7 +153,7 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
           font: {
             family: 'Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif',
             size: 18,
-            color: '#7f7f7f',
+            color: '##1b1b1b',
           },
         },
       },

--- a/frontend/src/widgets/TotalHrsAndRecipientGraph.js
+++ b/frontend/src/widgets/TotalHrsAndRecipientGraph.js
@@ -134,7 +134,7 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
           font: {
             family: 'Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif',
             size: 18,
-            color: '##1b1b1b',
+            color: '#1b1b1b',
           },
         },
       },
@@ -153,7 +153,7 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
           font: {
             family: 'Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif',
             size: 18,
-            color: '##1b1b1b',
+            color: '#1b1b1b',
           },
         },
       },


### PR DESCRIPTION
## Description of change

Font colors on our graphs weren't passing accessibility scanning. This change darkens the color on the labels on our graph's x & y axis's.

## How to test
The graphs still render. They all have the same font color (#1b1b1b).

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-711

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
