### PR TITLE
[TTAHUB-706] Add Creator Role Selection for NEEDS_ACTION

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
@@ -20,8 +20,7 @@ const NeedsAction = ({
   const hasIncompletePages = incompletePages.length > 0;
   const { user } = useContext(UserContext);
   const userHasOneRole = user && user.role && user.role.length === 1;
-  const [submitCR, setSubmitCR] = useState(!creatorRole && userHasOneRole
-    ? user.role[0] : '');
+  const [submitCR, setSubmitCR] = useState(!creatorRole && userHasOneRole ? user.role[0] : creatorRole || '');
   const [showCreatorRoleError, setShowCreatorRoleError] = useState(false);
 
   const submit = async () => {

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Fieldset, FormItem, Dropdown,
+  FormGroup, Button, Fieldset, Dropdown, ErrorMessage,
 } from '@trussworks/react-uswds';
 import { Editor } from 'react-draft-wysiwyg';
 import { getEditorState } from '../../../../../utils';
@@ -21,15 +21,24 @@ const NeedsAction = ({
   const { user } = useContext(UserContext);
   const userHasOneRole = user && user.role && user.role.length === 1;
   const [submitCR, setSubmitCR] = useState(!creatorRole && userHasOneRole
-    ? user.role[0] : creatorRole);;
+    ? user.role[0] : '');
+  const [showCreatorRoleError, setShowCreatorRoleError] = useState(false);
+
   const submit = async () => {
-    if (!hasIncompletePages) {
+    if (!submitCR) {
+      setShowCreatorRoleError(true);
+    } else if (!hasIncompletePages) {
       await onSubmit({
         approvers: approverStatusList,
         additionalNotes,
         creatorRole: submitCR,
       });
     }
+  };
+
+  const creatorRoleChange = (e) => {
+    setSubmitCR(e.target.value);
+    setShowCreatorRoleError(false);
   };
 
   const additionalNotesState = getEditorState(additionalNotes || 'No creator notes');
@@ -42,16 +51,24 @@ const NeedsAction = ({
             ? (
               <>
                 <span className="text-bold">Creator role</span>
-                <Dropdown
-                  id="creatorRole"
-                  name="creatorRole"
-                  onChange={(e) => setSubmitCR(e.target.value)}
-                >
-                  <option name="default" value="" disabled hidden>- Select -</option>
-                  {user.role.map((role) => (
-                    <option key={role} value={role}>{role}</option>
-                  ))}
-                </Dropdown>
+                <span className="smart-hub--form-required"> (Required)</span>
+                <FormGroup error={showCreatorRoleError}>
+                  <Fieldset>
+                    {showCreatorRoleError
+                      ? <ErrorMessage>Please select a creator role.</ErrorMessage> : null}
+                    <Dropdown
+                      id="creatorRole"
+                      name="creatorRole"
+                      value={submitCR}
+                      onChange={creatorRoleChange}
+                    >
+                      <option name="default" value="" disabled hidden>- Select -</option>
+                      {user.role.map((role) => (
+                        <option key={role} value={role}>{role}</option>
+                      ))}
+                    </Dropdown>
+                  </Fieldset>
+                </FormGroup>
               </>
             )
             : null

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Submitted.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Submitted.js
@@ -50,7 +50,7 @@ const Submitted = ({
       </div>
       <NotEditableAlert />
       <div className="margin-top-3">
-        <Button type="button" onClick={resetToDraft}>Reset to Draft</Button>
+        <Button className="margin-bottom-3" type="button" onClick={resetToDraft}>Reset to Draft</Button>
       </div>
     </>
   );

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/__tests__/index.js
@@ -222,6 +222,16 @@ describe('Submitter review page', () => {
       await waitFor(() => expect(mockSubmit).toHaveBeenCalled());
     });
 
+    it('creator role auto populates on needs_action', async () => {
+      const mockSubmit = jest.fn();
+      renderReview(REPORT_STATUSES.NEEDS_ACTION, mockSubmit, true, () => { }, () => { }, [], { ...defaultUser, role: ['COR'] });
+
+      // Resubmit.
+      const reSubmit = await screen.findByRole('button', { name: /re-submit for approval/i });
+      userEvent.click(reSubmit);
+      await waitFor(() => expect(mockSubmit).toHaveBeenCalled());
+    });
+
     it('requires creator role on needs_action multiple roles', async () => {
       const mockSubmit = jest.fn();
       renderReview(REPORT_STATUSES.NEEDS_ACTION, mockSubmit, true, () => { }, () => { }, [], { ...defaultUser, role: ['COR', 'Health Specialist', 'TTAC'] });
@@ -272,7 +282,7 @@ describe('Submitter review page', () => {
     });
   });
 
-  describe('creator role', () => {
+  describe('creator role when report is draft', () => {
     it('hides with single role', async () => {
       renderReview(REPORT_STATUSES.DRAFT, () => { }, true, () => { }, () => { }, [], { ...defaultUser, role: ['Health Specialist'] });
       expect(screen.queryByRole('combobox', { name: /creator role \(required\)/i })).toBeNull();

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/index.js
@@ -136,6 +136,7 @@ const Submitter = ({
               onSubmit={onFormSubmit}
               incompletePages={incompletePages}
               approverStatusList={approverStatusList}
+              creatorRole={creatorRole}
             />
           )}
         {approved

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -274,6 +274,21 @@ describe('ActivityReport', () => {
       userEvent.click(button);
       await waitFor(() => expect(fetchMock.called('/api/activity-reports/1')).toBeTruthy());
     });
+
+    it('automatically sets creator role on existing report', async () => {
+      const data = formData();
+      fetchMock.get('/api/activity-reports/1', { ...data, creatorRole: null });
+      fetchMock.put('/api/activity-reports/1', {});
+      renderActivityReport(1);
+
+      const button = await screen.findByRole('button', { name: 'Save draft' });
+      userEvent.click(button);
+
+      const lastOptions = fetchMock.lastOptions();
+      const bodyObj = JSON.parse(lastOptions.body);
+      await waitFor(() => expect(fetchMock.called('/api/activity-reports/1')).toBeTruthy());
+      expect(bodyObj.creatorRole).toEqual('Reporter');
+    });
   });
 
   describe('recipient select', () => {

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -181,11 +181,15 @@ function ActivityReport({
         } else {
           report = {
             ...defaultValues,
-            creatorRole: user && user.role && user.role.length === 1 ? user.role[0] : null,
             pageState: defaultPageState,
             userId: user.id,
             regionId: region || getRegionWithReadWrite(user),
           };
+        }
+
+        // If creator role is null and user has single role set it.
+        if (!report.creatorRole) {
+          report.creatorRole = user && user.role && user.role.length === 1 ? user.role[0] : null;
         }
 
         const apiCalls = [
@@ -337,6 +341,7 @@ function ActivityReport({
 
   const onFormSubmit = async (data) => {
     const approverIds = data.approvers.map((a) => a.User.id);
+    console.log('On Submit Parent value: ', data.creatorRole);
     const reportToSubmit = {
       additionalNotes: data.additionalNotes,
       approverUserIds: approverIds,

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -341,7 +341,6 @@ function ActivityReport({
 
   const onFormSubmit = async (data) => {
     const approverIds = data.approvers.map((a) => a.User.id);
-    console.log('On Submit Parent value: ', data.creatorRole);
     const reportToSubmit = {
       additionalNotes: data.additionalNotes,
       approverUserIds: approverIds,

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -323,16 +323,10 @@ function ActivityReport({
       reportId.current = savedReport.id;
       window.history.replaceState(null, null, `/activity-reports/${savedReport.id}/${currentPage}`);
     } else {
-      // If user has one role set creator role.
-      if (!data.creatorRole && userHasOneRole) {
-        const [onlyUserRole] = user.role;
-        // eslint-disable-next-line no-param-reassign
-        data.creatorRole = onlyUserRole;
-      }
-
       // if it isn't a new report, we compare it to the last response from the backend (formData)
       // and pass only the updated to save report
-      const updatedFields = findWhatsChanged(data, formData);
+      const creatorRole = !data.creatorRole && userHasOneRole ? user.role[0] : data.creatorRole;
+      const updatedFields = findWhatsChanged({ ...data, creatorRole }, formData);
       const updatedReport = await saveReport(
         reportId.current, { ...updatedFields, approverUserIds: approverIds },
         {},

--- a/src/models/activityReport.js
+++ b/src/models/activityReport.js
@@ -191,6 +191,7 @@ module.exports = (sequelize, DataTypes) => {
             this.participants,
             this.topics,
             this.ttaType,
+            this.creatorRole,
           ];
           const draftStatuses = [REPORT_STATUSES.DRAFT, REPORT_STATUSES.DELETED];
           if (!draftStatuses.includes(this.submissionStatus)) {

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -10,12 +10,12 @@ import findOrCreateUser from './findOrCreateUser';
  * req.session.userId if that is set, or res.locals.userId otherwise
  */
 export function currentUserId(req, res) {
-  if (req.session && req.session.userId) {
+ /* if (req.session && req.session.userId) {
     return req.session.userId;
   }
   if (res.locals && res.locals.userId) {
     return res.locals.userId;
-  }
+  }*/
   // bypass authorization, used for cucumber UAT and axe accessibility testing
   if (process.env.NODE_ENV !== 'production' && process.env.BYPASS_AUTH === 'true') {
     const userId = process.env.CURRENT_USER_ID;

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -10,12 +10,12 @@ import findOrCreateUser from './findOrCreateUser';
  * req.session.userId if that is set, or res.locals.userId otherwise
  */
 export function currentUserId(req, res) {
- /* if (req.session && req.session.userId) {
+  if (req.session && req.session.userId) {
     return req.session.userId;
   }
   if (res.locals && res.locals.userId) {
     return res.locals.userId;
-  }*/
+  }
   // bypass authorization, used for cucumber UAT and axe accessibility testing
   if (process.env.NODE_ENV !== 'production' && process.env.BYPASS_AUTH === 'true') {
     const userId = process.env.CURRENT_USER_ID;


### PR DESCRIPTION
## Description of change

We encountered an issue when deploying the new creator role field to production. If a report was in NEEDS_ACTION state the user has no way of setting the required creator role. This prevented them from resubmitting the report. We also found out that the same issue existed if the user had one role and a report was in the DRAFT state.

## How to test

All steps needs to be tested with a user that has a single **AND** multiple roles:

**Draft:**
1. Create a report in DRAFT state. 
2. Manually set the creator role to NULL in the DB for that report. 
3. Revisit the DRAFT report. 
4. Saving the report should automatically populate the creator role OR if you have multiple roles fore the user to select the creator role.

**Needs Action:**
1. Create a report and put it in the NEEDS_ACTION state. 
2. Manually set the creator role to NULL in the DB for that report. 
3. Revisit the NEEDS_ACTION report.
4. If the user only has one role they should be able to resubmit without error. If they user has more than one role they should be able to set the creator role on the review and submit page.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-706


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
