### PR TITLE
[TTAHUB-718] Handle null "numberOfParticipants" on approved activity reports

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
@@ -35,7 +35,7 @@ describe('Activity report print and share view', () => {
     specialistNextSteps: [],
     recipientNextSteps: [],
     participants: ['Commander of Pants', 'Princess of Castles'],
-    numberOfParticipants: 3,
+    numberOfParticipants: null,
     reason: ['Needed it'],
     startDate: '08/01/1968',
     endDate: '08/02/1969',

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -204,7 +204,7 @@ export default function ApprovedActivityReport({ match, user }) {
         ${a.note ? a.note : '<p>No manager notes</p>'}`).join('');
 
         const attendees = formatSimpleArray(data.participants);
-        const participantCount = data.numberOfParticipants ? data.numberOfParticipants.toString() : '0';
+        const participantCount = data.numberOfParticipants ? data.numberOfParticipants.toString() : '';
         const reasons = formatSimpleArray(data.reason);
         const startDate = moment(data.startDate, DATE_DISPLAY_FORMAT).format('MMMM D, YYYY');
         const endDate = moment(data.endDate, DATE_DISPLAY_FORMAT).format('MMMM D, YYYY');

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -204,7 +204,7 @@ export default function ApprovedActivityReport({ match, user }) {
         ${a.note ? a.note : '<p>No manager notes</p>'}`).join('');
 
         const attendees = formatSimpleArray(data.participants);
-        const participantCount = data.numberOfParticipants.toString();
+        const participantCount = data.numberOfParticipants ? data.numberOfParticipants.toString() : '0';
         const reasons = formatSimpleArray(data.reason);
         const startDate = moment(data.startDate, DATE_DISPLAY_FORMAT).format('MMMM D, YYYY');
         const endDate = moment(data.endDate, DATE_DISPLAY_FORMAT).format('MMMM D, YYYY');


### PR DESCRIPTION
## Description of change
Approved activity reports with a null numberOfParticipants were causing a caught error to render nothing on the approved report view. This fixes it

## How to test
View an approved report with a null numberOfParticipants. The site doesn't crash.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-718


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
