### PR TITLE
switch to new, maintained version of faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.1",
+    "@faker-js/faker": "^6.0.0",
     "adm-zip": "^0.5.1",
     "aws-sdk": "^2.826.0",
     "axios": "^0.24.0",
@@ -196,7 +197,6 @@
     "express-http-context": "^1.2.4",
     "express-unless": "^1.0.0",
     "express-winston": "^4.0.5",
-    "faker": "^5.5.3",
     "file-type": "^16.1.0",
     "form-data": "^4.0.0",
     "helmet": "^5.0.1",

--- a/src/models/tests/auditModelGenerator.test.js
+++ b/src/models/tests/auditModelGenerator.test.js
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { Model } from 'sequelize';
 import db, { User, ZALUser } from '..';
 import { auditLogger } from '../../logger';

--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { Op } from 'sequelize';
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import filtersToScopes from '../index';
 import { auditLogger } from '../../logger';
 

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import faker from '@faker-js/faker';
 
 import { REPORT_STATUSES } from './constants';
 import {

--- a/src/tools/processData.js
+++ b/src/tools/processData.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-loop-func */
 import sequelize, { Op } from 'sequelize';
 import cheerio from 'cheerio';
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import {
   ActivityReport, User, Recipient, Grant, File, Permission, RequestErrors,
 } from '../models';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,11 @@
   resolved "https://registry.yarnpkg.com/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz#7985f681564cff4ffaebb5896eb4be20af3aae7a"
   integrity sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ==
 
+"@faker-js/faker@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.0.0.tgz#b613ebf5f5ebb2ab987afb567d8b7fe860199c13"
+  integrity sha512-10zLCKhp3YEmBuko71ivcMoIZcCLXgQVck6aNswX+AWwaek/L8S3yz9i8m3tHigRkcF6F2vI+qtdtyySHK+bGA==
+
 "@grpc/grpc-js@^1.2.11":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.5.0.tgz#fa0ca3170d7544aa89db6f64f7b4778603d0a786"
@@ -4501,11 +4506,6 @@ extsprintf@^1.2.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
-
-faker@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
## Description of change
There is a new **maintained** version of faker js. We were locked onto the last stable version of the [previous maintainer](https://stackoverflow.com/questions/70597019/what-happened-with-faker-js)'s work.

This change updates us to use the new community maintained version of faker.
- [From the faker team](https://fakerjs.dev/update.html)

## How to test
CI passes, faker still works in tests

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-730


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
