### PR TITLE
update bash script for frontend

### DIFF
--- a/frontend/run-yarn-audit.sh
+++ b/frontend/run-yarn-audit.sh
@@ -17,17 +17,20 @@ fi
 
 if [ -f yarn-audit-known-issues ] && echo "$output" | grep auditAdvisory | diff -q yarn-audit-known-issues - > /dev/null 2>&1; then
 	echo
-	echo Ignorning known vulnerabilities
+	echo Ignoring known vulnerabilities
 	exit 0
 fi
 
+
+# we compare the json output to see if they are the same list of package names and version numbers
+# if so, exit without error
 
 curr=$(cat yarn-audit-known-issues | jq -s 'map({name: .data.advisory.module_name, version: .data.advisory.findings[0].version})| unique | sort_by(.data.advisory.module_name) | tostring')
 new=$(yarn audit --level low --json --groups dependencies | jq -s 'map(select(.type == "auditAdvisory")) | map({name: .data.advisory.module_name, version: .data.advisory.findings[0].version})| unique | sort_by(.data.advisory.module_name) | tostring')
 
 if [ "$curr" = "$new" ]; then
     echo
-	echo Ignorning known vulnerabilities
+	echo Ignoring previously known and accepted vulnerabilitie
 	exit 0
 fi
 

--- a/frontend/run-yarn-audit.sh
+++ b/frontend/run-yarn-audit.sh
@@ -21,6 +21,16 @@ if [ -f yarn-audit-known-issues ] && echo "$output" | grep auditAdvisory | diff 
 	exit 0
 fi
 
+
+curr=$(cat yarn-audit-known-issues | jq -s 'map({name: .data.advisory.module_name, version: .data.advisory.findings[0].version})| unique | sort_by(.data.advisory.module_name) | tostring')
+new=$(yarn audit --level low --json --groups dependencies | jq -s 'map(select(.type == "auditAdvisory")) | map({name: .data.advisory.module_name, version: .data.advisory.findings[0].version})| unique | sort_by(.data.advisory.module_name) | tostring')
+
+if [ "$curr" = "$new" ]; then
+    echo
+	echo Ignorning known vulnerabilities
+	exit 0
+fi
+
 echo
 echo Security vulnerabilities were found that were not ignored:
 echo "$output" | jq -s 'map(select(.type == "auditAdvisory")) | map({name: .data.advisory.module_name, version: .data.advisory.findings[0].version})| unique'

--- a/run-yarn-audit.sh
+++ b/run-yarn-audit.sh
@@ -22,15 +22,17 @@ if [ -f yarn-audit-known-issues ] && echo "$output" | grep auditAdvisory | diff 
 fi
 
 
+# we compare the json output to see if they are the same list of package names and version numbers
+# if so, exit without error
+
 curr=$(cat yarn-audit-known-issues | jq -s 'map({name: .data.advisory.module_name, version: .data.advisory.findings[0].version})| unique | sort_by(.data.advisory.module_name) | tostring')
 new=$(yarn audit --level low --json --groups dependencies | jq -s 'map(select(.type == "auditAdvisory")) | map({name: .data.advisory.module_name, version: .data.advisory.findings[0].version})| unique | sort_by(.data.advisory.module_name) | tostring')
 
 if [ "$curr" = "$new" ]; then
     echo
-	echo Ignorning known vulnerabilities
+	echo Ignoring previously known and accepted vulnerabilitie
 	exit 0
 fi
-
 
 echo
 echo Security vulnerabilities were found that were not ignored:


### PR DESCRIPTION
## Description of change

Added a little snippet to the bash script for the frontend to match the backend, so that if the ignored dependencies are functionally identical the script is exited without error, stopping the situation where stuff is moved around in the dependency tree and retriggers yarn audit failures

Already added the same snippet to the backend in #825, didn't realize we were running two identical versions of the same script (an issue for another time, perhaps)

## How to test
CI passes

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
