### PR TITLE
update minimist via resolutions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,13 +62,14 @@
     "lint:ci": "eslint -f eslint-formatter-multiple src"
   },
   "resolutions": {
-    "glob-parent": "^5.1.2",
-    "nth-check": "^2.0.1",
-    "browserslist": "^4.16.5",
     "ansi-regex": "^5.0.1",
+    "browserslist": "^4.16.5",
+    "follow-redirects": "^1.14.8",
+    "glob-parent": "^5.1.2", 
+    "minimist": "^1.2.6",
     "nanoid": "^3.2.0",
     "node-fetch": "^2.6.7",
-    "follow-redirects": "^1.14.8",
+    "nth-check": "^2.0.1",    
     "tar": "^4.4.18"
   },
   "eslintConfig": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7707,10 +7707,10 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass@^2.6.0, minipass@^2.9.0:
   version "2.9.0"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "follow-redirects": "^1.14.8",
     "json-pointer": "0.6.2",
     "marked": "^4.0.10",
+    "minimist": "^1.2.6",
     "nanoid": "^3.2.0",
     "node-fetch": "^2.6.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6922,10 +6922,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixin-deep@^1.2.0:
   version "1.3.2"


### PR DESCRIPTION
## Description of change
We added minimist v 1.25 to ignored audit vulnerabilities last week given that there was no newer version at the time. There is now a newer version, so let's bump that up a pip.

## How to test
CI passes

## Issue(s)

no ticket

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
