### PR TITLE
[TTAHUB-736] wrong number of recipients depending on date scopes

### DIFF
--- a/src/scopes/grants/activeWithin.js
+++ b/src/scopes/grants/activeWithin.js
@@ -4,7 +4,7 @@ export function activeBefore(dates) {
   const scopes = dates.reduce((acc, date) => [
     ...acc,
     {
-      endDate: {
+      startDate: {
         [Op.lte]: new Date(date),
       },
     },

--- a/src/scopes/grants/index.test.js
+++ b/src/scopes/grants/index.test.js
@@ -17,6 +17,10 @@ const recipients = [
     id: 13279,
     name: 'recipient 13279',
   },
+  {
+    id: 13289,
+    name: 'recipient 13279',
+  },
 ];
 
 const possibleIds = recipients.map((recipient) => recipient.id);
@@ -25,6 +29,17 @@ describe('grant filtersToScopes', () => {
   beforeAll(async () => {
     await Promise.all(recipients.map((g) => Recipient.create(g)));
     await Promise.all([
+      Grant.create({
+        id: recipients[3].id,
+        number: '119559',
+        regionId: 4,
+        recipientId: recipients[3].id,
+        status: 'Active',
+        startDate: new Date('08/03/1997'),
+        endDate: new Date('08/03/1997'),
+        programSpecialistName: 'No',
+        stateCode: 'RI',
+      }),
       Grant.create({
         id: recipients[0].id,
         number: '1195543',
@@ -140,9 +155,9 @@ describe('grant filtersToScopes', () => {
       const found = await Grant.findAll({
         where: { [Op.and]: [scope.grant, { id: possibleIds }] },
       });
-      expect(found.length).toBe(2);
+      expect(found.length).toBe(3);
       expect(found.map((f) => f.id))
-        .toEqual(expect.arrayContaining([recipients[1].id, recipients[2].id]));
+        .toEqual(expect.arrayContaining([recipients[1].id, recipients[2].id, recipients[3].id]));
     });
 
     it('within', async () => {
@@ -199,7 +214,11 @@ describe('grant filtersToScopes', () => {
           },
         ],
       });
-      expect(found.map((f) => f.id)).toStrictEqual([13259, 13279]);
+      expect(found.length).toBe(3);
+      const recips = found.map((f) => f.id);
+      expect(recips).toContain(recipients[0].id);
+      expect(recips).toContain(recipients[2].id);
+      expect(recips).toContain(recipients[3].id);
     });
   });
 
@@ -219,8 +238,11 @@ describe('grant filtersToScopes', () => {
       const found = await Grant.findAll({
         where: { [Op.and]: [scope.grant, { id: possibleIds }] },
       });
-      expect(found.length).toBe(2);
-      expect(found.map((f) => f.id)).toStrictEqual([13259, 13269]);
+      expect(found.length).toBe(3);
+      const recips = found.map((f) => f.id);
+      expect(recips).toContain(recipients[0].id);
+      expect(recips).toContain(recipients[1].id);
+      expect(recips).toContain(recipients[3].id);
     });
   });
   describe('programType', () => {
@@ -251,9 +273,11 @@ describe('grant filtersToScopes', () => {
           },
         ],
       });
-      expect(found.length).toBe(2);
-      expect(found.map((f) => f.id)).toContain(recipients[2].id);
-      expect(found.map((f) => f.id)).toContain(recipients[1].id);
+      expect(found.length).toBe(3);
+      const recips = found.map((f) => f.id);
+      expect(recips).toContain(recipients[3].id);
+      expect(recips).toContain(recipients[2].id);
+      expect(recips).toContain(recipients[1].id);
     });
   });
   describe('grantNumber', () => {
@@ -272,9 +296,11 @@ describe('grant filtersToScopes', () => {
       const found = await Grant.findAll({
         where: { [Op.and]: [scope.grant, { id: possibleIds }] },
       });
-      expect(found.length).toBe(2);
-      expect(found.map((f) => f.id)).toContain(recipients[2].id);
-      expect(found.map((f) => f.id)).toContain(recipients[1].id);
+      expect(found.length).toBe(3);
+      const recips = found.map((f) => f.id);
+      expect(recips).toContain(recipients[3].id);
+      expect(recips).toContain(recipients[2].id);
+      expect(recips).toContain(recipients[1].id);
     });
   });
   describe('stateCode', () => {


### PR DESCRIPTION
## Description of change
Date scopes are transformed for application to the grant/recipient, to determine whether or that recipient had an active grant during the time range filtered in the overview widget. There was a bug in this transformation that I believe has been addressed.

start or end date filters **before** a given date are transformed into the scope **grant start date is less than or equal** to the same given date

start or end date filters **after** a given date are transformed into the scope **grant end date is greater than or equal** to the same given date

This matches the "within" date range implementation, and I think it covers all cases

## How to test
The date range filters return accurate info on the overview widget, specifically for "total recipients"

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-736


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
