### PR TITLE
Sessions now have a unique id

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,8 @@ import join from 'url-join';
 import { omit } from 'lodash';
 import { INTERNAL_SERVER_ERROR } from 'http-codes';
 import { CronJob } from 'cron';
+import { v4 as uuidv4 } from 'uuid';
+
 import { hsesAuth } from './middleware/authMiddleware';
 import { retrieveUserDetails } from './services/currentUser';
 import cookieSession from './middleware/sessionMiddleware';
@@ -48,6 +50,7 @@ app.get(oauth2CallbackPath, cookieSession, async (req, res) => {
 
     const dbUser = await retrieveUserDetails(user);
     req.session.userId = dbUser.id;
+    req.session.uuid = uuidv4();
     auditLogger.info(`User ${dbUser.id} logged in`);
 
     logger.debug(`referrer path: ${req.session.referrerPath}`);

--- a/src/routes/apiDirectory.js
+++ b/src/routes/apiDirectory.js
@@ -28,29 +28,13 @@ router.use(cookieSession);
 router.use(authMiddleware.unless({ path: [join('/api', loginPath)] }));
 
 router.use((req, res, next) => {
-  const getSessionSig = (cookie) => {
-    try {
-      if (cookie !== undefined && (typeof cookie === 'string' || cookie instanceof String)) {
-        const sessionSigs = cookie.split('; ').filter((s) => s.includes('session.sig='));
-        return sessionSigs.length > 0
-          ? sessionSigs[0].replace('session.sig=', '')
-          : '';
-      }
-    } catch (err) {
-      auditLogger.error(err);
-    }
-    return '';
-  };
-
   try {
-    const { userId } = req.session;
+    const { userId, uuid } = req.session;
     const transactionId = uuidv4();
-    const { cookie } = req.headers;
-    const sessionSig = getSessionSig(cookie);
 
     httpContext.set('loggedUser', userId);
     httpContext.set('transactionId', transactionId);
-    httpContext.set('sessionSig', sessionSig);
+    httpContext.set('sessionSig', uuid);
   } catch (err) {
     auditLogger.error(err);
   }

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import isEmail from 'validator/lib/isEmail';
+import { v4 as uuidv4 } from 'uuid';
+
 import { logger, auditLogger } from '../logger';
 import findOrCreateUser from './findOrCreateUser';
 
@@ -22,6 +24,7 @@ export function currentUserId(req, res) {
     auditLogger.warn(`Bypassing authentication in authMiddleware - using User ${userId}`);
     if (req.session) {
       req.session.userId = userId;
+      req.session.uuid = uuidv4();
     }
     return userId;
   }


### PR DESCRIPTION
## Description of change

Sessions now have a unique id. This session id is used by the audit system to uniquely identify sessions. Before this change the `session.sig` value was always the same for the same user, even after logout/login. The session signature is based on the session, which before this change was always `{userId: $userId$}`. Now the session looks like `{userId: $userId$, uuid: $uuid$}`. With the UUID we generate the value of `session.sig` should change every time you log out and back in. 

See https://github.com/expressjs/cookie-session for an explanation how our cookies work.

## How to test

Log in and out on main and note the `session.sig` value never changes. Checkout this branch and do the same, `session.sig` should now change.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-622

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- ~[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
