### PR TITLE
[TTAHUB-684/751] Fix Issues Found with Region Permission Modal

### DIFF
--- a/frontend/src/components/Modal.js
+++ b/frontend/src/components/Modal.js
@@ -20,8 +20,7 @@ const Modal = ({
   okButtonCss,
   cancelButtonCss,
   showTitleRequired,
-  secondaryActionButtonText,
-  onSecondaryAction,
+  SecondaryActionButton,
   hideCancelButton,
   forceAction,
 
@@ -62,12 +61,8 @@ const Modal = ({
               : null
           }
           {
-            secondaryActionButtonText
-              ? (
-                <Button className={okButtonCss || 'usa-button usa-button--secondary usa-button'} type="button" aria-label={okButtonAriaLabel} onClick={onSecondaryAction}>
-                  {secondaryActionButtonText}
-                </Button>
-              )
+            SecondaryActionButton
+              ? <SecondaryActionButton />
               : null
           }
         </ButtonGroup>
@@ -94,11 +89,14 @@ Modal.propTypes = {
   okButtonCss: PropTypes.string,
   cancelButtonCss: PropTypes.string,
   showTitleRequired: PropTypes.bool,
-  secondaryActionButtonText: PropTypes.string,
-  onSecondaryAction: PropTypes.string,
+  SecondaryActionButton: PropTypes.func,
   hideCancelButton: PropTypes.bool,
   forceAction: PropTypes.bool,
 };
+
+function DefaultSecondaryActionButton() {
+  return <span />;
+}
 
 Modal.defaultProps = {
   onOk: () => { },
@@ -111,8 +109,7 @@ Modal.defaultProps = {
   okButtonCss: null,
   cancelButtonCss: null,
   showTitleRequired: false,
-  secondaryActionButtonText: null,
-  onSecondaryAction: () => { },
+  SecondaryActionButton: DefaultSecondaryActionButton,
   hideCancelButton: false,
   forceAction: false,
 };

--- a/frontend/src/components/RegionPermissionModal.css
+++ b/frontend/src/components/RegionPermissionModal.css
@@ -5,11 +5,13 @@
 
 
 .smart-hub--region-permission-modal .usa-modal--lg .usa-modal__heading {
-    font-size: 1.85rem;
+    font-size: 1.70rem;
 }
 
-.smart-hub--region-permission-modal .popup-modal button {
+.smart-hub--region-permission-modal .popup-modal button,
+.smart-hub--region-permission-modal .popup-modal a {
     padding: 8px 16px;
+    font-size: medium;
 }
 
 .smart-hub--region-permission-modal .usa-modal--lg .usa-button-group li:first-child {

--- a/frontend/src/components/RegionPermissionModal.js
+++ b/frontend/src/components/RegionPermissionModal.js
@@ -19,7 +19,7 @@ function RegionPermissionModal({
       .includes(parseInt(f.query, DECIMAL_BASE)))
     .map((m) => m.query), [filters, userRegions]);
 
-  const showMultipleRegions = missingRegions && missingRegions.length > 1 ? "'s" : '';
+  const showMultipleRegions = missingRegions && missingRegions.length > 1 ? 's' : '';
   const missingRegionsList = missingRegions && missingRegions.length > 0 ? missingRegions.sort().join(', ') : '';
 
   useEffect(() => {

--- a/frontend/src/components/RegionPermissionModal.js
+++ b/frontend/src/components/RegionPermissionModal.js
@@ -1,4 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React, {
+  useEffect, useRef, useMemo,
+} from 'react';
 import PropTypes from 'prop-types';
 import Modal from './Modal';
 import { DECIMAL_BASE } from '../Constants';
@@ -11,41 +13,36 @@ function RegionPermissionModal({
   const modalRef = useRef();
   const userRegions = getUserRegions(user);
 
-  useEffect(() => {
-    // Check if user has permission to region.
-    const regionFilters = filters.filter((f) => f.topic === 'region' && f.condition !== 'is not');
-    if (regionFilters.length > 0) {
-      let showRegionPermissionsModal = false;
-      const deniedRegionsList = [];
-      regionFilters.forEach((f) => {
-        const filterRegion = f.query;
-        const filterRegionNum = parseInt(filterRegion, DECIMAL_BASE);
-        if (!userRegions.includes(filterRegionNum)) {
-          showRegionPermissionsModal = true;
-          deniedRegionsList.push(filterRegionNum);
-        }
-      });
+  const missingRegions = useMemo(() => filters.filter((f) => f.topic === 'region'
+    && f.condition !== 'is not'
+    && !userRegions
+      .includes(parseInt(f.query, DECIMAL_BASE)))
+    .map((m) => m.query), [filters, userRegions]);
 
-      if (showRegionPermissionsModal && !modalRef.current.modalIsOpen) {
-        // Show region permission modal.
-        modalRef.current.toggleModal(true);
-      }
+  const showMultipleRegions = missingRegions && missingRegions.length > 1 ? "'s" : '';
+  const missingRegionsList = missingRegions && missingRegions.length > 0 ? missingRegions.sort().join(', ') : '';
+
+  useEffect(() => {
+    if (missingRegions
+        && missingRegions.length > 0
+        && !modalRef.current.modalIsOpen) {
+      // Show region permission modal.
+      modalRef.current.toggleModal(true);
     }
-  }, [userRegions, filters]);
+  }, [missingRegions]);
 
   const showFilterWithMyRegionAccess = () => {
     showFilterWithMyRegions();
     modalRef.current.toggleModal(false);
   };
 
-  const smartSheetAccessLink = 'https://app.smartsheetgov.com/b/form/f0b4725683f04f349a939bd2e3f5425a';
   const requestSmartSheetAccess = () => {
-    // Open link in new tab and close modal.
-    window.open(smartSheetAccessLink, '_blank');
     showFilterWithMyRegions();
     modalRef.current.toggleModal(false);
   };
 
+  const smartSheetAccessLink = 'https://app.smartsheetgov.com/b/form/f0b4725683f04f349a939bd2e3f5425a';
+  const openSmartSheetRequest = () => <a href={smartSheetAccessLink} className="usa-button usa-button--primary" target="_blank" rel="noreferrer" onClick={requestSmartSheetAccess}>Request access via Smartsheet</a>;
   return (
     <div className="smart-hub--region-permission-modal">
       <Modal
@@ -53,10 +50,9 @@ function RegionPermissionModal({
         onOk={showFilterWithMyRegionAccess}
         okButtonCss="usa-button--primary"
         modalId="RegionPermissionModal"
-        title="You need permission to access this region"
+        title={`You need permission to access region${showMultipleRegions} ${missingRegionsList}`}
         okButtonText="Show filter with my regions"
-        secondaryActionButtonText="Request access via Smartsheet"
-        onSecondaryAction={requestSmartSheetAccess}
+        SecondaryActionButton={openSmartSheetRequest}
         hideCancelButton
         isLarge
         forceAction

--- a/frontend/src/components/__tests__/Modal.js
+++ b/frontend/src/components/__tests__/Modal.js
@@ -5,7 +5,7 @@ import {
   render, screen,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ModalToggleButton } from '@trussworks/react-uswds';
+import { ModalToggleButton, Button } from '@trussworks/react-uswds';
 import Modal from '../Modal';
 
 const ModalComponent = (
@@ -19,13 +19,12 @@ const ModalComponent = (
     cancelButtonText = 'Cancel',
     showCloseX = false,
     isLarge = false,
-    secondaryActionButtonText = null,
+    SecondaryActionButton = null,
     onSecondaryAction = () => {},
     hideCancelButton = false,
   },
 ) => {
   const modalRef = useRef();
-
   return (
     <div>
       <ModalToggleButton modalRef={modalRef} opener>Open</ModalToggleButton>
@@ -41,7 +40,7 @@ const ModalComponent = (
         cancelButtonText={cancelButtonText}
         showCloseX={showCloseX}
         isLarge={isLarge}
-        secondaryActionButtonText={secondaryActionButtonText}
+        SecondaryActionButton={SecondaryActionButton}
         onSecondaryAction={onSecondaryAction}
         hideCancelButton={hideCancelButton}
       >
@@ -115,7 +114,8 @@ describe('Modal', () => {
 
   it('shows secondary ok button', async () => {
     const secondaryOk = jest.fn();
-    render(<ModalComponent secondaryActionButtonText="My Secondary Button" onSecondaryAction={secondaryOk} />);
+    const secondaryButton = () => <Button type="button" onClick={secondaryOk}>my secondary button</Button>;
+    render(<ModalComponent SecondaryActionButton={secondaryButton} />);
     expect(await screen.findByText(/my secondary button/i)).toBeVisible();
 
     // Click secondary OK.

--- a/frontend/src/components/__tests__/RegionPermissionModal.js
+++ b/frontend/src/components/__tests__/RegionPermissionModal.js
@@ -170,7 +170,7 @@ describe('Region Permission Modal', () => {
     render(<PermissionModal filters={filtersToPass} showFilterWithMyRegions={showFiltersFn} />);
 
     // Click show filters with my regions.
-    const showFiltersBtn = await screen.findByRole('button', { name: /request access via smartsheet/i, hidden: true });
+    const showFiltersBtn = await screen.findByRole('link', { name: /request access via smartsheet/i, hidden: true });
     userEvent.click(showFiltersBtn);
     expect(showFiltersFn).toHaveBeenCalled();
 
@@ -196,5 +196,55 @@ describe('Region Permission Modal', () => {
     // Modal is hidden.
     const modalElement = document.querySelector('.popup-modal');
     expect(modalElement.firstChild).toHaveClass('is-hidden');
+  });
+
+  it('correctly shows the header with a single denied regions', async () => {
+    const filtersToPass = [
+      ...defaultFilters,
+      {
+        id: uuidv4(),
+        topic: 'region',
+        condition: 'is',
+        query: 1,
+      },
+      {
+        id: uuidv4(),
+        topic: 'region',
+        condition: 'is',
+        query: 3,
+      },
+    ];
+
+    render(<PermissionModal filters={filtersToPass} />);
+
+    expect(await screen.findByRole('heading', { name: /you need permission to access region 3/i, hidden: true })).toBeVisible();
+  });
+
+  it('correctly shows the header with multiple denied regions', async () => {
+    const filtersToPass = [
+      ...defaultFilters,
+      {
+        id: uuidv4(),
+        topic: 'region',
+        condition: 'is',
+        query: 1,
+      },
+      {
+        id: uuidv4(),
+        topic: 'region',
+        condition: 'is',
+        query: 3,
+      },
+      {
+        id: uuidv4(),
+        topic: 'region',
+        condition: 'is',
+        query: 4,
+      },
+    ];
+
+    render(<PermissionModal filters={filtersToPass} />);
+
+    expect(await screen.findByRole('heading', { name: /you need permission to access region's 3, 4/i, hidden: true })).toBeVisible();
   });
 });

--- a/frontend/src/components/__tests__/RegionPermissionModal.js
+++ b/frontend/src/components/__tests__/RegionPermissionModal.js
@@ -245,6 +245,6 @@ describe('Region Permission Modal', () => {
 
     render(<PermissionModal filters={filtersToPass} />);
 
-    expect(await screen.findByRole('heading', { name: /you need permission to access region's 3, 4/i, hidden: true })).toBeVisible();
+    expect(await screen.findByRole('heading', { name: /you need permission to access regions 3, 4/i, hidden: true })).toBeVisible();
   });
 });

--- a/frontend/src/components/filter/FilterPanel.js
+++ b/frontend/src/components/filter/FilterPanel.js
@@ -1,21 +1,40 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import FilterMenu from './FilterMenu';
 import FilterPills from './FilterPills';
 import { filterConfigProp, filterProp } from './props';
 
-export default function FilterPanel(props) {
-  const { onRemoveFilter, filters, filterConfig } = props;
+export default function FilterPanel({
+  filters,
+  onApplyFilters,
+  onRemoveFilter,
+  applyButtonAria,
+  filterConfig,
+}) {
+  const [filtersToUse, setFiltersToUse] = useState(filters);
+  useEffect(() => {
+    // If filter config doesn't contain regions dont display region filters.
+    const regionFilters = filters.find((f) => f.topic === 'region');
+    const regionConfig = filterConfig.find((c) => c.id === 'region');
+    if (regionFilters && !regionConfig) {
+      const filtersWithoutRegion = filters.filter((f) => f.topic !== 'region');
+      setFiltersToUse(filtersWithoutRegion);
+    } else {
+      setFiltersToUse(filters);
+    }
+  }, [filters, filterConfig]);
 
   return (
     <>
       <FilterMenu
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
+        filters={filtersToUse}
+        onApplyFilters={onApplyFilters}
+        applyButtonAria={applyButtonAria}
+        filterConfig={filterConfig}
       />
       <FilterPills
         filterConfig={filterConfig}
-        filters={filters}
+        filters={filtersToUse}
         onRemoveFilter={onRemoveFilter}
       />
     </>

--- a/frontend/src/components/filter/FilterPills.js
+++ b/frontend/src/components/filter/FilterPills.js
@@ -17,7 +17,15 @@ export function Pill({
     query,
   } = filter;
 
-  const filterName = filterConfig.find((f) => f.id === topic).display;
+  const determineFilterName = () => {
+    const filterConfigToUse = filterConfig.find((f) => f.id === topic);
+    if (filterConfigToUse) {
+      return filterConfigToUse.display;
+    }
+    return null;
+  };
+
+  const filterName = determineFilterName();
 
   let showToolTip = false;
 

--- a/frontend/src/components/filter/__tests__/FilterPanel.js
+++ b/frontend/src/components/filter/__tests__/FilterPanel.js
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+import FilterPanel from '../FilterPanel';
+import UserContext from '../../../UserContext';
+import { formatDateRange } from '../../../utils';
+import { LANDING_FILTER_CONFIG_WITH_REGIONS, LANDING_BASE_FILTER_CONFIG } from '../../../pages/Landing/constants';
+import { SCOPE_IDS } from '../../../Constants';
+
+const { READ_ACTIVITY_REPORTS } = SCOPE_IDS;
+
+const defaultDate = formatDateRange({
+  lastThirtyDays: true,
+  forDateTime: true,
+});
+
+describe('Filter Panel', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  const renderFilterPanel = (
+    filters = [],
+    filterConfig = LANDING_FILTER_CONFIG_WITH_REGIONS,
+    onApplyFilters = jest.fn(),
+    onRemoveFilter = jest.fn(),
+  ) => {
+    const user = {
+      permissions: [
+        {
+          regionId: 1,
+          scopeId: READ_ACTIVITY_REPORTS,
+        },
+      ],
+    };
+
+    render(
+      <UserContext.Provider value={{ user }}>
+        <h1>Filter Panel</h1>
+        <div>
+          <FilterPanel
+            applyButtonAria="apply filters for activity reports"
+            filters={filters}
+            onApplyFilters={onApplyFilters}
+            onRemoveFilter={onRemoveFilter}
+            filterConfig={filterConfig}
+          />
+        </div>
+      </UserContext.Provider>,
+    );
+  };
+  it('Passing region filters with no region config hides region items', async () => {
+    const filters = [{
+      id: 1,
+      topic: 'region',
+      condition: 'is',
+      query: 1,
+    },
+    {
+      id: 2,
+      topic: 'region',
+      condition: 'is',
+      query: 2,
+    },
+    {
+      id: 3,
+      topic: 'startDate',
+      condition: 'is within',
+      query: defaultDate,
+    }];
+    renderFilterPanel(filters, LANDING_BASE_FILTER_CONFIG);
+    expect(await screen.findByText(/filters \(1\)/i)).toBeVisible();
+    expect(screen.getAllByText(/date started/i).length).toBe(2);
+    expect(screen.queryByText(/region/i)).toBeNull();
+  });
+
+  it('Passing region filters with region config shows region items', async () => {
+    const filters = [{
+      id: 1,
+      topic: 'region',
+      condition: 'is',
+      query: 1,
+    },
+    {
+      id: 2,
+      topic: 'region',
+      condition: 'is',
+      query: 2,
+    },
+    {
+      id: 3,
+      topic: 'startDate',
+      condition: 'is within',
+      query: defaultDate,
+    }];
+    renderFilterPanel(filters);
+    expect(await screen.findByText(/filters \(3\)/i)).toBeVisible();
+    expect(screen.getAllByText(/date started/i).length).toBe(2);
+    expect(await screen.findByRole('button', { name: /this button removes the filter: region is 1/i })).toBeVisible();
+    expect(await screen.findByRole('button', { name: /this button removes the filter: region is 2/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description of change

This is a continuation of **TTAHUB-684** to address some issues found by Patrice with the modal language during the demo.

It also contains a fix for **TTTAHUB-751** users who only have access to one region pasting a region URL filter.

## How to test

Region permission modal language should show when URL filter contains regions that the user cannot access. 

Users with only one region can paste a URL filter with one or many regions without error.

The two modal options should work as they did before. Note that we now display the regions that the user cannot access.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-684


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
