### PR TITLE
[TTAHUB-740] Show new goals after they are created.

### DIFF
--- a/frontend/src/components/GoalsTable/GoalsTable.js
+++ b/frontend/src/components/GoalsTable/GoalsTable.js
@@ -17,6 +17,7 @@ function GoalsTable({
   regionId,
   filters,
   hasActiveGrants,
+  showNewGoals,
 }) {
   // Goal Data.
   const [goals, setGoals] = useState([]);
@@ -30,10 +31,15 @@ function GoalsTable({
   const [goalsCount, setGoalsCount] = useState(0);
   const [offset, setOffset] = useState(0);
   const [perPage] = useState(GOALS_PER_PAGE);
-  const [sortConfig, setSortConfig] = useState({
-    sortBy: 'goalStatus',
-    direction: 'asc',
-  });
+  const [sortConfig, setSortConfig] = useState(showNewGoals
+    ? {
+      sortBy: 'createdOn',
+      direction: 'desc',
+    }
+    : {
+      sortBy: 'goalStatus',
+      direction: 'asc',
+    });
 
   useEffect(() => {
     async function fetchGoals() {
@@ -60,7 +66,7 @@ function GoalsTable({
       setLoading(false);
     }
     fetchGoals();
-  }, [sortConfig, offset, perPage, filters, recipientId, regionId]);
+  }, [sortConfig, offset, perPage, filters, recipientId, regionId, showNewGoals]);
 
   const handlePageChange = (pageNumber) => {
     if (!loading) {
@@ -200,6 +206,7 @@ GoalsTable.propTypes = {
     }),
   ).isRequired,
   hasActiveGrants: PropTypes.bool.isRequired,
+  showNewGoals: PropTypes.bool.isRequired,
 };
 
 export default GoalsTable;

--- a/frontend/src/pages/RecipientRecord/index.js
+++ b/frontend/src/pages/RecipientRecord/index.js
@@ -161,7 +161,7 @@ export default function RecipientRecord({ match }) {
         />
         <Route
           path="/recipient-tta-records/:recipientId/region/:regionId/goals-objectives"
-          render={() => (
+          render={({ location }) => (
             <PageWithHeading
               regionId={regionId}
               recipientId={recipientId}
@@ -170,6 +170,7 @@ export default function RecipientRecord({ match }) {
             >
               <FeatureFlag flag="recipient_goals_objectives" renderNotFound>
                 <GoalsObjectives
+                  location={location}
                   recipientId={recipientId}
                   regionId={regionId}
                   recipient={recipientData}

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import { Grid } from '@trussworks/react-uswds';
 import { Helmet } from 'react-helmet';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import useSessionFiltersAndReflectInUrl from '../../../hooks/useSessionFiltersAndReflectInUrl';
 import FilterPanel from '../../../components/filter/FilterPanel';
 import { expandFilters, formatDateRange } from '../../../utils';
@@ -10,7 +11,10 @@ import { getGoalsAndObjectivesFilterConfig } from './constants';
 import GoalStatusGraph from '../../../widgets/GoalStatusGraph';
 import GoalsTable from '../../../components/GoalsTable/GoalsTable';
 
-export default function GoalsObjectives({ recipientId, regionId, recipient }) {
+export default function GoalsObjectives({
+  recipientId, regionId, recipient, location,
+}) {
+  const showNewGoals = !!((location.state && location.state.ids && location.state.ids.length > 0));
   const yearToDate = formatDateRange({ yearToDate: true, forDateTime: true });
 
   const FILTER_KEY = 'goals-objectives-filters';
@@ -82,6 +86,7 @@ export default function GoalsObjectives({ recipientId, regionId, recipient }) {
           regionId={regionId}
           filters={expandFilters(filters)}
           hasActiveGrants={hasActiveGrants}
+          showNewGoals={showNewGoals}
         />
       </div>
     </>
@@ -97,4 +102,5 @@ GoalsObjectives.propTypes = {
       numberWithProgramTypes: PropTypes.string.isRequired,
     })).isRequired,
   }).isRequired,
+  location: ReactRouterPropTypes.location.isRequired,
 };

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -14,7 +14,7 @@ import GoalsTable from '../../../components/GoalsTable/GoalsTable';
 export default function GoalsObjectives({
   recipientId, regionId, recipient, location,
 }) {
-  const showNewGoals = !!((location.state && location.state.ids && location.state.ids.length > 0));
+  const showNewGoals = location.state && location.state.ids && location.state.ids.length > 0;
   const yearToDate = formatDateRange({ yearToDate: true, forDateTime: true });
 
   const FILTER_KEY = 'goals-objectives-filters';

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -133,10 +133,6 @@ describe('Goals and Objectives', () => {
 
     const goalStatusGraphUnfiltered = '/api/widgets/goalStatusGraph?region.in[]=1&recipientId.ctn[]=401';
     fetchMock.get(goalStatusGraphUnfiltered, statusRes);
-
-    // Created New Goal.
-    const newGoalsUrl = '/api/recipient/401/region/1/goals?sortBy=createdOn&sortDir=desc&offset=0&limit=5';
-    fetchMock.get(newGoalsUrl, { count: 1, goalRows: goals });
   });
 
   afterEach(() => {
@@ -203,7 +199,18 @@ describe('Goals and Objectives', () => {
   });
 
   it('sorts by created on desc when new goals are created', async () => {
+    // Created New Goal.
+    const newGoalsUrl = '/api/recipient/401/region/1/goals?sortBy=createdOn&sortDir=desc&offset=0&limit=5';
+    fetchMock.get(newGoalsUrl, {
+      count: 3,
+      goalRows: [
+        { id: 1, ...goals[0] },
+        { id: 2, ...goals[0] },
+        { id: 3, ...goals[0] },
+      ],
+    });
     act(() => renderGoalsAndObjectives([1]));
-    expect(await screen.findByText(/1-1 of 1/i)).toBeVisible();
+    // If api request contains 3 we know it included the desired sort.
+    expect(await screen.findByText(/1-3 of 3/i)).toBeVisible();
   });
 });

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -89,7 +89,7 @@ describe('Goals and Objectives', () => {
     ],
   };
 
-  const renderGoalsAndObjectives = () => {
+  const renderGoalsAndObjectives = (ids = []) => {
     render(
       <Router history={memoryHistory}>
         <UserContext.Provider value={{ user }}>
@@ -97,6 +97,9 @@ describe('Goals and Objectives', () => {
             recipientId="401"
             regionId="1"
             recipient={recipient}
+            location={{
+              state: { ids }, hash: '', pathname: '', search: '',
+            }}
           />
         </UserContext.Provider>
       </Router>,
@@ -130,6 +133,10 @@ describe('Goals and Objectives', () => {
 
     const goalStatusGraphUnfiltered = '/api/widgets/goalStatusGraph?region.in[]=1&recipientId.ctn[]=401';
     fetchMock.get(goalStatusGraphUnfiltered, statusRes);
+
+    // Created New Goal.
+    const newGoalsUrl = '/api/recipient/401/region/1/goals?sortBy=createdOn&sortDir=desc&offset=0&limit=5';
+    fetchMock.get(newGoalsUrl, { count: 1, goalRows: goals });
   });
 
   afterEach(() => {
@@ -193,5 +200,10 @@ describe('Goals and Objectives', () => {
     expect(screen.getAllByRole('cell')[9]).toHaveTextContent(/this is goal text 2/i);
     expect(screen.getAllByRole('cell')[10]).toHaveTextContent(/program planning and services/i);
     expect(screen.getAllByRole('cell')[11]).toHaveTextContent('1 Objective(s)');
+  });
+
+  it('sorts by created on desc when new goals are created', async () => {
+    act(() => renderGoalsAndObjectives([1]));
+    expect(await screen.findByText(/1-1 of 1/i)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description of change

After a user creates new goals we redirect back to the Goals page. We want to sort by created on desc to ensure the new goals show at the top.


## How to test

Create a new goal. When redirected back to the goals page the table should be sorted by Created On in Desc order. If no goals are created the table should have the same sort as it did before.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-740


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
