### PR TITLE
[TTAHUB-767] WYSIWYG field auto expands to accommodate long pasted text

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "js-644-fix-copy-paste-into-wysiwyg-component"
+    default: "WYSIWYG-auto-expands"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "kw-fix-double-recipient"

--- a/frontend/src/components/RichEditor.js
+++ b/frontend/src/components/RichEditor.js
@@ -33,14 +33,7 @@ const RichEditor = ({
 }) => {
   const [height, setHeight] = useState(BASE_EDITOR_HEIGHT);
 
-  // I wish I could link to a reason/some documentation why I had to do this
-  // but honestly I just reverse engineered the errors I was getting in the console
-  // until it worked (not setting a value to ref said something to the effect of
-  // 'editorRef is not a function' and we went from there)
-  const editorRef = useRef((ref) => {
-    editorRef.current = ref;
-    return ref;
-  });
+  const editorRef = useRef();
 
   let defaultEditorState;
   if (value) {
@@ -58,7 +51,14 @@ const RichEditor = ({
 
   return (
     <Editor
-      editorRef={editorRef}
+      // I wish I could link to a reason/some documentation why I had to do this
+      // but honestly I just reverse engineered the errors I was getting in the console
+      // until it worked (not setting a value to ref said something to the effect of
+      // 'editorRef is not a function' and we went from there)
+      editorRef={(ref) => {
+        editorRef.current = ref;
+        return ref;
+      }}
       spellCheck
       defaultEditorState={defaultEditorState}
       onChange={onInternalChange}

--- a/frontend/src/components/RichEditor.js
+++ b/frontend/src/components/RichEditor.js
@@ -10,13 +10,15 @@
  * threshold as well.
 */
 
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Editor } from 'react-draft-wysiwyg';
 import draftToHtml from 'draftjs-to-html';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 
 import { getEditorState } from '../utils';
+
+const BASE_EDITOR_HEIGHT = '10rem';
 
 /**
  * Component that provides basic Rich Text Editor.
@@ -29,24 +31,35 @@ import { getEditorState } from '../utils';
 const RichEditor = ({
   ariaLabel, value, onChange,
 }) => {
+  const [height, setHeight] = useState(BASE_EDITOR_HEIGHT);
+
+  const editorRef = useRef((ref) => {
+    editorRef.current = ref;
+    return ref;
+  });
+
   let defaultEditorState;
   if (value) {
     defaultEditorState = getEditorState(value);
   }
 
   const onInternalChange = (currentContentState) => {
+    setHeight(editorRef.current && editorRef.current.scrollHeight ? `${editorRef.current.scrollHeight}px` : BASE_EDITOR_HEIGHT);
+
     const html = draftToHtml(currentContentState);
     onChange(html);
   };
+
   return (
     <Editor
+      editorRef={editorRef}
       spellCheck
       defaultEditorState={defaultEditorState}
       onChange={onInternalChange}
       ariaLabel={ariaLabel}
       handlePastedText={() => false}
       tabIndex="0"
-      editorStyle={{ border: '1px solid #565c65', height: '10rem' }}
+      editorStyle={{ border: '1px solid #565c65', height: `${height}` }}
       toolbar={{
         options: ['inline', 'blockType', 'list'],
         inline: {

--- a/frontend/src/components/RichEditor.js
+++ b/frontend/src/components/RichEditor.js
@@ -33,6 +33,10 @@ const RichEditor = ({
 }) => {
   const [height, setHeight] = useState(BASE_EDITOR_HEIGHT);
 
+  // I wish I could link to a reason/some documentation why I had to do this
+  // but honestly I just reverse engineered the errors I was getting in the console
+  // until it worked (not setting a value to ref said something to the effect of
+  // 'editorRef is not a function' and we went from there)
   const editorRef = useRef((ref) => {
     editorRef.current = ref;
     return ref;
@@ -44,6 +48,8 @@ const RichEditor = ({
   }
 
   const onInternalChange = (currentContentState) => {
+    // an improvement would be converting to rems to match the initial height but
+    // it might not matter since we're deriving the scroll height directly from the client here
     setHeight(editorRef.current && editorRef.current.scrollHeight ? `${editorRef.current.scrollHeight}px` : BASE_EDITOR_HEIGHT);
 
     const html = draftToHtml(currentContentState);
@@ -59,7 +65,7 @@ const RichEditor = ({
       ariaLabel={ariaLabel}
       handlePastedText={() => false}
       tabIndex="0"
-      editorStyle={{ border: '1px solid #565c65', height: `${height}` }}
+      editorStyle={{ border: '1px solid #565c65', height }}
       toolbar={{
         options: ['inline', 'blockType', 'list'],
         inline: {


### PR DESCRIPTION
## Description of change

There is confusion around resizing the textarea & rich text fields. We should force the height of the text box to expand to accommodate long pasted content, or just a particularly verbose report writer.

## How to test

Checkout this branch (the feature is also on dev). You should be able to paste large amounts of text into any of the Rich Text components in the activity report and watch it grow.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-767


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
