### PR TITLE
Nightly download sets auditlog metadata

### DIFF
--- a/src/lib/fileUtils.js
+++ b/src/lib/fileUtils.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+import fs from 'fs';
+import crypto from 'crypto';
+
+export function fileHash(filepath) {
+  const fileBuffer = fs.readFileSync(filepath);
+  const hashSum = crypto.createHash('sha256');
+  hashSum.update(fileBuffer);
+  return hashSum.digest('hex');
+}

--- a/src/lib/updateGrantsRecipients.js
+++ b/src/lib/updateGrantsRecipients.js
@@ -44,10 +44,10 @@ export async function processFiles(hashSumHex) {
     await sequelize.transaction(async (transaction) => {
       await sequelize.query(
         `SELECT
-          set_config('audit.loggedUser', '0', TRUE) as "loggedUser",
-          set_config('audit.transactionId', '${uuidv4()}', TRUE) as "transactionId",
-          set_config('audit.sessionSig', '${new Date().toISOString()}T${hashSumHex}', TRUE) as "sessionSig",
-          set_config('audit.auditDescriptor', 'Grant data import from HSES', TRUE) as "auditDescriptor";`,
+          set_config('audit.loggedUser', '0', true) as "loggedUser",
+          set_config('audit.transactionId', '${uuidv4()}', true) as "transactionId",
+          set_config('audit.sessionSig', '${new Date().toISOString()}T${hashSumHex}', true) as "sessionSig",
+          set_config('audit.auditDescriptor', 'Grant data import from HSES', true) as "auditDescriptor";`,
         { transaction },
       );
 

--- a/src/lib/updateGrantsRecipients.js
+++ b/src/lib/updateGrantsRecipients.js
@@ -3,9 +3,11 @@ import { toJson } from 'xml2json';
 import { } from 'dotenv/config';
 import axios from 'axios';
 import { keyBy, mapValues } from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 
+import { fileHash } from './fileUtils';
 import {
-  Recipient, Grant, Program,
+  Recipient, Grant, Program, sequelize,
 } from '../models';
 import { logger, auditLogger } from '../logger';
 
@@ -37,149 +39,165 @@ function combineNames(firstName, lastName) {
  * The recipient data is them filtered to exclude delegates
  *
  */
-export async function processFiles() {
+export async function processFiles(hashSumHex) {
   try {
-    const grantAgencyData = await fs.readFile('./temp/grant_agency.xml');
-    const json = toJson(grantAgencyData);
-    const grantAgency = JSON.parse(json);
-    // we are only interested in non-delegates
-    const grantRecipients = grantAgency.grant_agencies.grant_agency.filter(
-      (g) => g.grant_agency_number === '0',
-    );
-
-    // process recipients aka agencies that are non-delegates
-    const agencyData = await fs.readFile('./temp/agency.xml');
-    const agency = JSON.parse(toJson(agencyData));
-
-    // filter out delegates by matching to the non-delegates;
-    // filter out recipient 5 (TTAHUB-705)
-    // eslint-disable-next-line max-len
-    const recipientsNonDelegates = agency.agencies.agency.filter((a) => grantRecipients.some((gg) => gg.agency_id === a.agency_id && a.agency_id !== '5'));
-    const recipientsForDb = recipientsNonDelegates.map((g) => ({
-      id: parseInt(g.agency_id, 10),
-      name: g.agency_name,
-      recipientType: valueFromXML(g.agency_type),
-    }));
-
-    logger.debug(`updateGrantsRecipients: calling bulkCreate for ${recipientsForDb.length} recipients`);
-    await Recipient.bulkCreate(
-      recipientsForDb,
-      {
-        updateOnDuplicate: ['name', 'recipientType', 'updatedAt'],
-      },
-    );
-
-    // process grants
-    const grantData = await fs.readFile('./temp/grant_award.xml');
-    const grant = JSON.parse(toJson(grantData));
-
-    const programData = await fs.readFile('./temp/grant_program.xml');
-    const programs = JSON.parse(toJson(programData));
-
-    const grantsForDb = grant.grant_awards.grant_award.map((g) => {
-      let { grant_start_date: startDate, grant_end_date: endDate } = g;
-      if (typeof startDate === 'object') { startDate = null; }
-      if (typeof endDate === 'object') { endDate = null; }
-
-      const programSpecialistName = combineNames(
-        g.program_specialist_first_name,
-        g.program_specialist_last_name,
-      );
-      const grantSpecialistName = combineNames(
-        g.grants_specialist_first_name,
-        g.grants_specialist_last_name,
+    await sequelize.transaction(async (transaction) => {
+      await sequelize.query(
+        `SELECT
+          set_config('audit.loggedUser', '0', TRUE) as "loggedUser",
+          set_config('audit.transactionId', '${uuidv4()}', TRUE) as "transactionId",
+          set_config('audit.sessionSig', '${new Date().toISOString()}T${hashSumHex}', TRUE) as "sessionSig",
+          set_config('audit.auditDescriptor', 'Grant data import from HSES', TRUE) as "auditDescriptor";`,
+        { transaction },
       );
 
-      const regionId = parseInt(g.region_id, 10);
-      const cdi = regionId === 13;
-      // grant belonging to recipient's id 5 is merged under recipient's id 7782  (TTAHUB-705)
-      return {
-        id: parseInt(g.grant_award_id, 10),
-        number: g.grant_number,
-        recipientId: g.agency_id === '5' ? 7782 : parseInt(g.agency_id, 10),
-        status: g.grant_status,
-        stateCode: valueFromXML(g.grantee_state),
-        startDate,
-        endDate,
-        regionId,
-        cdi,
-        programSpecialistName,
-        programSpecialistEmail: valueFromXML(g.program_specialist_email),
-        grantSpecialistName,
-        grantSpecialistEmail: valueFromXML(g.grants_specialist_email),
-        annualFundingMonth: valueFromXML(g.annual_funding_month),
-      };
-    });
+      const grantAgencyData = await fs.readFile('./temp/grant_agency.xml');
+      const json = toJson(grantAgencyData);
+      const grantAgency = JSON.parse(json);
+      // we are only interested in non-delegates
+      const grantRecipients = grantAgency.grant_agencies.grant_agency.filter(
+        (g) => g.grant_agency_number === '0',
+      );
 
-    const grantIds = grantsForDb.map((g) => g.id);
-    const grantPrograms = grantRecipients.filter(
-      (ga) => grantIds.includes(parseInt(ga.grant_award_id, 10)),
-    );
+      // process recipients aka agencies that are non-delegates
+      const agencyData = await fs.readFile('./temp/agency.xml');
+      const agency = JSON.parse(toJson(agencyData));
 
-    const grantAgencyMap = mapValues(keyBy(grantPrograms, 'grant_agency_id'), 'grant_award_id');
-    const programsWithGrants = programs.grant_programs.grant_program.filter(
-      (p) => parseInt(p.grant_agency_id, 10) in grantAgencyMap,
-    );
+      // filter out delegates by matching to the non-delegates;
+      // filter out recipient 5 (TTAHUB-705)
+      // eslint-disable-next-line max-len
+      const recipientsNonDelegates = agency.agencies.agency.filter((a) => grantRecipients.some((gg) => gg.agency_id === a.agency_id && a.agency_id !== '5'));
+      const recipientsForDb = recipientsNonDelegates.map((g) => ({
+        id: parseInt(g.agency_id, 10),
+        name: g.agency_name,
+        recipientType: valueFromXML(g.agency_type),
+      }));
 
-    const programsForDb = programsWithGrants.map((program) => ({
-      id: parseInt(program.grant_program_id, 10),
-      grantId: parseInt(grantAgencyMap[program.grant_agency_id], 10),
-      programType: valueFromXML(program.program_type),
-      startYear: valueFromXML(program.program_start_year),
-      startDate: valueFromXML(program.grant_program_start_date),
-      endDate: valueFromXML(program.grant_program_end_date),
-      status: valueFromXML(program.program_status),
-      name: valueFromXML(program.program_name),
-    }));
-
-    const cdiGrants = grantsForDb.filter((g) => g.regionId === 13);
-    const nonCdiGrants = grantsForDb.filter((g) => g.regionId !== 13);
-
-    logger.debug(`updateGrantsRecipients: calling bulkCreate for ${grantsForDb.length} grants`);
-    await Grant.bulkCreate(
-      nonCdiGrants,
-      {
-        updateOnDuplicate: ['number', 'regionId', 'recipientId', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode', 'annualFundingMonth'],
-      },
-    );
-
-    await Grant.bulkCreate(
-      cdiGrants,
-      {
-        updateOnDuplicate: ['number', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode', 'annualFundingMonth'],
-      },
-    );
-
-    // Load and Process grant replacement data.
-    const grantReplacementsData = await fs.readFile('./temp/grant_award_replacement.xml');
-    const grantReplacementsJson = JSON.parse(toJson(grantReplacementsData));
-    const grantReplacements = grantReplacementsJson
-      .grant_award_replacements.grant_award_replacement;
-
-    const grantsToUpdate = grantReplacements.filter(
-      (g) => grantIds.includes(parseInt(g.replaced_grant_award_id, 10))
-        && grantIds.includes(parseInt(g.replacement_grant_award_id, 10)),
-    );
-
-    const grantUpdatePromises = grantsToUpdate.map((g) => (
-      Grant.update(
-        { oldGrantId: parseInt(g.replaced_grant_award_id, 10) },
+      logger.debug(`updateGrantsRecipients: calling bulkCreate for ${recipientsForDb.length} recipients`);
+      await Recipient.bulkCreate(
+        recipientsForDb,
         {
-          where: { id: parseInt(g.replacement_grant_award_id, 10) },
-          fields: ['oldGrantId'],
-          sideEffects: false,
+          updateOnDuplicate: ['name', 'recipientType', 'updatedAt'],
+          transaction,
         },
-      )
-    ));
+      );
 
-    await Promise.all(grantUpdatePromises);
+      // process grants
+      const grantData = await fs.readFile('./temp/grant_award.xml');
+      const grant = JSON.parse(toJson(grantData));
 
-    await Program.bulkCreate(
-      programsForDb,
-      {
-        updateOnDuplicate: ['programType', 'startYear', 'startDate', 'endDate', 'status', 'name'],
-      },
-    );
+      const programData = await fs.readFile('./temp/grant_program.xml');
+      const programs = JSON.parse(toJson(programData));
+
+      const grantsForDb = grant.grant_awards.grant_award.map((g) => {
+        let { grant_start_date: startDate, grant_end_date: endDate } = g;
+        if (typeof startDate === 'object') { startDate = null; }
+        if (typeof endDate === 'object') { endDate = null; }
+
+        const programSpecialistName = combineNames(
+          g.program_specialist_first_name,
+          g.program_specialist_last_name,
+        );
+        const grantSpecialistName = combineNames(
+          g.grants_specialist_first_name,
+          g.grants_specialist_last_name,
+        );
+
+        const regionId = parseInt(g.region_id, 10);
+        const cdi = regionId === 13;
+        // grant belonging to recipient's id 5 is merged under recipient's id 7782  (TTAHUB-705)
+        return {
+          id: parseInt(g.grant_award_id, 10),
+          number: g.grant_number,
+          recipientId: g.agency_id === '5' ? 7782 : parseInt(g.agency_id, 10),
+          status: g.grant_status,
+          stateCode: valueFromXML(g.grantee_state),
+          startDate,
+          endDate,
+          regionId,
+          cdi,
+          programSpecialistName,
+          programSpecialistEmail: valueFromXML(g.program_specialist_email),
+          grantSpecialistName,
+          grantSpecialistEmail: valueFromXML(g.grants_specialist_email),
+          annualFundingMonth: valueFromXML(g.annual_funding_month),
+        };
+      });
+
+      const grantIds = grantsForDb.map((g) => g.id);
+      const grantPrograms = grantRecipients.filter(
+        (ga) => grantIds.includes(parseInt(ga.grant_award_id, 10)),
+      );
+
+      const grantAgencyMap = mapValues(keyBy(grantPrograms, 'grant_agency_id'), 'grant_award_id');
+      const programsWithGrants = programs.grant_programs.grant_program.filter(
+        (p) => parseInt(p.grant_agency_id, 10) in grantAgencyMap,
+      );
+
+      const programsForDb = programsWithGrants.map((program) => ({
+        id: parseInt(program.grant_program_id, 10),
+        grantId: parseInt(grantAgencyMap[program.grant_agency_id], 10),
+        programType: valueFromXML(program.program_type),
+        startYear: valueFromXML(program.program_start_year),
+        startDate: valueFromXML(program.grant_program_start_date),
+        endDate: valueFromXML(program.grant_program_end_date),
+        status: valueFromXML(program.program_status),
+        name: valueFromXML(program.program_name),
+      }));
+
+      const cdiGrants = grantsForDb.filter((g) => g.regionId === 13);
+      const nonCdiGrants = grantsForDb.filter((g) => g.regionId !== 13);
+
+      logger.debug(`updateGrantsRecipients: calling bulkCreate for ${grantsForDb.length} grants`);
+      await Grant.bulkCreate(
+        nonCdiGrants,
+        {
+          updateOnDuplicate: ['number', 'regionId', 'recipientId', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode', 'annualFundingMonth'],
+          transaction,
+        },
+      );
+
+      await Grant.bulkCreate(
+        cdiGrants,
+        {
+          updateOnDuplicate: ['number', 'status', 'startDate', 'endDate', 'updatedAt', 'programSpecialistName', 'programSpecialistEmail', 'grantSpecialistName', 'grantSpecialistEmail', 'stateCode', 'annualFundingMonth'],
+          transaction,
+        },
+      );
+
+      // Load and Process grant replacement data.
+      const grantReplacementsData = await fs.readFile('./temp/grant_award_replacement.xml');
+      const grantReplacementsJson = JSON.parse(toJson(grantReplacementsData));
+      const grantReplacements = grantReplacementsJson
+        .grant_award_replacements.grant_award_replacement;
+
+      const grantsToUpdate = grantReplacements.filter(
+        (g) => grantIds.includes(parseInt(g.replaced_grant_award_id, 10))
+          && grantIds.includes(parseInt(g.replacement_grant_award_id, 10)),
+      );
+
+      const grantUpdatePromises = grantsToUpdate.map((g) => (
+        Grant.update(
+          { oldGrantId: parseInt(g.replaced_grant_award_id, 10) },
+          {
+            where: { id: parseInt(g.replacement_grant_award_id, 10) },
+            fields: ['oldGrantId'],
+            sideEffects: false,
+            transaction,
+          },
+        )
+      ));
+
+      await Promise.all(grantUpdatePromises);
+
+      await Program.bulkCreate(
+        programsForDb,
+        {
+          updateOnDuplicate: ['programType', 'startYear', 'startDate', 'endDate', 'status', 'name'],
+          transaction,
+        },
+      );
+    });
   } catch (error) {
     auditLogger.error(`Error reading or updating database on HSES data import: ${error.message}`);
     throw error;
@@ -226,11 +244,13 @@ export default async function updateGrantsRecipients(_processFiles = processFile
   logger.debug('updateGrantsRecipients: wrote file from HSES');
 
   const zip = new AdmZip('./hses.zip');
+  const hex = fileHash('./hses.zip');
+
   logger.debug('updateGrantsRecipients: extracting zip file');
   // extract to target path. Pass true to overwrite
   zip.extractAllTo('./temp', true);
   logger.debug('updateGrantsRecipients: unzipped files');
 
-  await _processFiles();
+  await _processFiles(hex);
   logger.info('updateGrantsRecipients: processFiles completed');
 }

--- a/src/lib/updateGrantsRecipients.test.js
+++ b/src/lib/updateGrantsRecipients.test.js
@@ -240,6 +240,7 @@ describe('Update grants and recipients', () => {
     expect(dml_txid).not.toMatch(/^00000000/);
     expect(session_sig).not.toBeNull();
 
+    // eslint-disable-next-line camelcase
     const res = await sequelize.query(`SELECT descriptor FROM "ZADescriptor" WHERE id = ${descriptor_id}`, { type: QueryTypes.SELECT });
     expect(res[0].descriptor).toEqual('Grant data import from HSES');
   });

--- a/src/models/auditModelGenerator.js
+++ b/src/models/auditModelGenerator.js
@@ -23,19 +23,32 @@ const tryJsonParse = (data) => {
   return newData;
 };
 
+const pgSetConfigIfNull = (settingName, value) => `
+  set_config(
+    '${settingName}',
+    COALESCE(current_setting('${settingName}', true), '${value}'),
+    true
+  )`;
+
 const addAuditTransactionSettings = async (sequelize, instance, options, type) => {
   const loggedUser = httpContext.get('loggedUser') ? httpContext.get('loggedUser') : '';
   const transactionId = httpContext.get('transactionId') ? httpContext.get('transactionId') : '';
   const sessionSig = httpContext.get('sessionSig') ? httpContext.get('sessionSig') : '';
   const auditDescriptor = httpContext.get('auditDescriptor') ? httpContext.get('auditDescriptor') : '';
+
+  const statements = [
+    pgSetConfigIfNull('audit.loggedUser', loggedUser),
+    pgSetConfigIfNull('audit.transactionId', transactionId),
+    pgSetConfigIfNull('audit.sessionSig', sessionSig),
+    pgSetConfigIfNull('audit.auditDescriptor', auditDescriptor),
+  ];
+
   if (loggedUser !== '' || transactionId !== '' || auditDescriptor !== '') {
     const result = await sequelize.queryInterface.sequelize.query(
       `SELECT
         -- Type: ${type}
-        set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
-        set_config('audit.transactionId', '${transactionId}', TRUE) as "transactionId",
-        set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
-        set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+        ${statements.join(',')}
+      `,
       { transaction: options.transaction },
     );
     auditLogger.info(JSON.stringify(result));

--- a/src/models/auditModelGenerator.js
+++ b/src/models/auditModelGenerator.js
@@ -23,12 +23,12 @@ const tryJsonParse = (data) => {
   return newData;
 };
 
-const pgSetConfigIfNull = (settingName, value) => `
+const pgSetConfigIfNull = (settingName, value, alias) => `
   set_config(
     '${settingName}',
     COALESCE(current_setting('${settingName}', true), '${value}'),
     true
-  )`;
+  ) as "${alias}"`;
 
 const addAuditTransactionSettings = async (sequelize, instance, options, type) => {
   const loggedUser = httpContext.get('loggedUser') ? httpContext.get('loggedUser') : '';
@@ -37,10 +37,10 @@ const addAuditTransactionSettings = async (sequelize, instance, options, type) =
   const auditDescriptor = httpContext.get('auditDescriptor') ? httpContext.get('auditDescriptor') : '';
 
   const statements = [
-    pgSetConfigIfNull('audit.loggedUser', loggedUser),
-    pgSetConfigIfNull('audit.transactionId', transactionId),
-    pgSetConfigIfNull('audit.sessionSig', sessionSig),
-    pgSetConfigIfNull('audit.auditDescriptor', auditDescriptor),
+    pgSetConfigIfNull('audit.loggedUser', loggedUser, 'loggedUser'),
+    pgSetConfigIfNull('audit.transactionId', transactionId, 'transactionId'),
+    pgSetConfigIfNull('audit.sessionSig', sessionSig, 'sessionSig'),
+    pgSetConfigIfNull('audit.auditDescriptor', auditDescriptor, 'auditDescriptor'),
   ];
 
   if (loggedUser !== '' || transactionId !== '' || auditDescriptor !== '') {


### PR DESCRIPTION
## Description of change

Audit log metadata for the nightly download is now set. Since the nightly job has no access to the `httpContext` the audit* variables are only set if they are null. This allows those variables to be set for the transaction before hitting sequelize hooks and without using an `httpContext`.

I also tried moving all DB calls down to the bottom of `processFiles` so we wouldn't have to wrap the whole method in a transaction. Even though I kept the same order of the calls I was seeing foreign key errors. I wasn't able to track down what exactly was happening.

* The user id is set to 0 to distinguish between the "null" case and system user
* Transaction ID is a UUID
* Session signature is the timestamp of the run followed by the sha256 of the zip file processed
* The audit descriptor lets us know the change was from the nightly download

## How to test

Verify tests pass. Also verify you can still make edits and see the correct info in the audit log (such as the user you made the changes with)

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-672

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- ~[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
