### PR TITLE
[Audit Vuln] Update Moment

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "html-to-draftjs": "^1.5.0",
     "http-proxy-middleware": "^2.0.1",
     "lodash": "^4.17.20",
-    "moment": "^2.29.1",
+    "moment": "^2.29.2",
     "moment-timezone": "^0.5.33",
     "plotly.js": "^2.5.1",
     "plotly.js-basic-dist": "^2.2.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7746,10 +7746,15 @@ moment-timezone@^0.5.33:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.29.1:
+"moment@>= 2.9.0":
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moment@^2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 mouse-change@^1.4.0:
   version "1.4.0"

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "html-to-text": "^8.1.0",
     "http-codes": "^1.0.0",
     "lodash": "^4.17.20",
-    "moment": "^2.29.1",
+    "moment": "^2.29.2",
     "multiparty": "^4.2.2",
     "mz": "^2.7.0",
     "newrelic": "^8.7.0",


### PR DESCRIPTION
## Description of change

Update moment from "29.1" to "29.2" on FE and BE to fix audit vuln.

## How to test

Make sure all unit tests pass. Anything that uses dates in the app should work the same (filters/start date/end date).

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-N/A


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
