### PR TITLE
Audit log tables are truncated in "processData"

### DIFF
--- a/src/tools/processData.js
+++ b/src/tools/processData.js
@@ -2,11 +2,11 @@
 /* eslint-disable quotes */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-loop-func */
-import sequelize, { Op } from 'sequelize';
+import { Op } from 'sequelize';
 import cheerio from 'cheerio';
 import faker from '@faker-js/faker';
 import {
-  ActivityReport, User, Recipient, Grant, File, Permission, RequestErrors,
+  ActivityReport, User, Recipient, Grant, File, Permission, RequestErrors, sequelize,
 } from '../models';
 
 const SITE_ACCESS = 1;
@@ -338,6 +338,21 @@ export const bootstrapUsers = async () => {
   }
 };
 
+export const truncateAuditTables = async () => {
+  const tablesToTruncate = await sequelize.query(`
+    SELECT table_name FROM information_schema.tables
+    WHERE
+      table_name like 'ZAL%' AND
+      table_name not in ('ZALDDL', 'ZALZADescriptor', 'ZALZAFilter')
+  `, { raw: true });
+
+  for await (const table of tablesToTruncate) {
+    await sequelize.query(`ALTER TABLE "${table}" DISABLE TRIGGER all`);
+    await sequelize.query(`TRUNCATE TABLE "${table}"`);
+    await sequelize.query(`ALTER TABLE "${table}" ENABLE TRIGGER all`);
+  }
+};
+
 const processData = async (mockReport) => {
   const activityReportId = mockReport ? mockReport.id : null;
   const where = activityReportId ? { id: activityReportId } : {};
@@ -359,6 +374,8 @@ const processData = async (mockReport) => {
   await hideUsers(userIds);
   // Hide recipients and grants
   await hideRecipientsGrants(recipientsGrants);
+
+  await truncateAuditTables();
 
   // loop through the found reports
   for await (const report of reports) {

--- a/src/tools/processData.test.js
+++ b/src/tools/processData.test.js
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import {
   sequelize,
   ActivityReport,
@@ -9,8 +10,9 @@ import {
   NextStep,
   Permission,
   RequestErrors,
+  ZALGoal,
 } from '../models';
-import processData, { hideUsers, hideRecipientsGrants, bootstrapUsers } from './processData';
+import processData, { truncateAuditTables, hideUsers, hideRecipientsGrants, bootstrapUsers } from './processData';
 import { REPORT_STATUSES } from '../constants';
 
 jest.mock('../logger');
@@ -223,6 +225,20 @@ describe('processData', () => {
 
     const requestErrors = await RequestErrors.findAll();
     expect(requestErrors.length).toBe(0);
+  });
+
+  it('truncates audit tables', async () => {
+    await ZALGoal.create({
+      data_id: 1,
+      dml_type: 'INSERT',
+      new_row_data: { test: 'test' },
+      dml_timestamp: new Date().toISOString(),
+      dml_by: 1,
+      dml_txid: uuidv4(),
+    });
+
+    await truncateAuditTables();
+    expect(await ZALGoal.count()).toBe(0);
   });
 
   describe('hideUsers', () => {


### PR DESCRIPTION
## Description of change

`ProcessData` now truncates audit tables. Have to turn off audit table truncation protection, do the truncation, and then turn the protection back on.

## How to test

Run tests. Run the import script and make sure all audit tables have no data.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-681

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- ~[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
