### PR TITLE
Clean up warnings on the landing and report pages

### DIFF
--- a/frontend/src/components/Accordion.js
+++ b/frontend/src/components/Accordion.js
@@ -39,19 +39,23 @@ export const AccordionItem = ({
   );
 };
 
-AccordionItem.propTypes = {
+const accordionItemPropTypes = {
   title: PropTypes.string.isRequired,
-  content: PropTypes.string.isRequired,
-  expanded: PropTypes.bool.isRequired,
+  content: PropTypes.node.isRequired,
+  expanded: PropTypes.bool,
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
   handleToggle: PropTypes.func,
-  headingSize: PropTypes.number.isRequired,
+  headingSize: PropTypes.number,
 };
+
+AccordionItem.propTypes = accordionItemPropTypes;
 
 AccordionItem.defaultProps = {
   className: '',
   handleToggle: () => { },
+  expanded: false,
+  headingSize: 2,
 };
 
 export const Accordion = ({
@@ -109,7 +113,7 @@ export const Accordion = ({
 Accordion.propTypes = {
   bordered: PropTypes.bool,
   multiselectable: PropTypes.bool,
-  items: PropTypes.arrayOf(PropTypes.shape(AccordionItem)).isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape(accordionItemPropTypes)).isRequired,
   headingSize: PropTypes.number,
 };
 

--- a/frontend/src/components/ControlledDatePicker.js
+++ b/frontend/src/components/ControlledDatePicker.js
@@ -109,7 +109,7 @@ ControlledDatePicker.propTypes = {
   minDate: PropTypes.string,
   maxDate: PropTypes.string,
   name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   control: PropTypes.shape({
     name: PropTypes.string,
     value: PropTypes.string,
@@ -124,4 +124,5 @@ ControlledDatePicker.defaultProps = {
   maxDate: moment().format(DATE_DISPLAY_FORMAT),
   isStartDate: false,
   setEndDate: () => {},
+  value: '',
 };

--- a/frontend/src/components/FormItem.js
+++ b/frontend/src/components/FormItem.js
@@ -16,7 +16,7 @@ const labelPropTypes = {
 
 function FieldSetWrapper({ label, children, className }) {
   return (
-    <Fieldset unstyled className={className}>
+    <Fieldset unstyled="true" className={className}>
       <legend>{label}</legend>
       {children}
     </Fieldset>

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -261,7 +261,7 @@ Navigator.propTypes = {
       position: PropTypes.number.isRequired,
       path: PropTypes.string.isRequired,
       render: PropTypes.func.isRequired,
-      label: PropTypes.isRequired,
+      label: PropTypes.string.isRequired,
     }),
   ).isRequired,
   currentPage: PropTypes.string.isRequired,

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
@@ -178,8 +178,12 @@ Draft.propTypes = {
     approver: PropTypes.string,
     status: PropTypes.string,
   })).isRequired,
-  lastSaveTime: PropTypes.instanceOf(moment).isRequired,
+  lastSaveTime: PropTypes.instanceOf(moment),
   creatorRole: PropTypes.string.isRequired,
+};
+
+Draft.defaultProps = {
+  lastSaveTime: undefined,
 };
 
 export default Draft;

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/index.js
@@ -178,12 +178,13 @@ Submitter.propTypes = {
       }),
     ),
   }).isRequired,
-  lastSaveTime: PropTypes.instanceOf(moment).isRequired,
+  lastSaveTime: PropTypes.instanceOf(moment),
 
 };
 
 Submitter.defaultProps = {
   error: '',
+  lastSaveTime: undefined,
 };
 
 export default Submitter;

--- a/frontend/src/pages/ActivityReport/Pages/Review/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/index.js
@@ -148,7 +148,11 @@ ReviewSubmit.propTypes = {
     state: PropTypes.string,
     label: PropTypes.string,
   })).isRequired,
-  lastSaveTime: PropTypes.instanceOf(moment).isRequired,
+  lastSaveTime: PropTypes.instanceOf(moment),
+};
+
+ReviewSubmit.defaultProps = {
+  lastSaveTime: undefined,
 };
 
 export default ReviewSubmit;

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalInput.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalInput.js
@@ -31,6 +31,14 @@ const Input = ({
   isDisabled,
   theme,
   selectProps,
+  clearValue,
+  getValue,
+  hasValue,
+  isMulti,
+  isRtl,
+  options,
+  selectOption,
+  setValue,
   ...props
 }) => {
   const selectedGoals = selectProps.value.length;

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -323,7 +323,7 @@ MyAlerts.propTypes = {
   loading: PropTypes.bool.isRequired,
   message: PropTypes.shape({
     time: PropTypes.string,
-    reportId: PropTypes.string,
+    reportId: PropTypes.number,
     displayId: PropTypes.string,
     status: PropTypes.string,
   }),
@@ -349,7 +349,7 @@ MyAlerts.defaultProps = {
   alertsActivePage: 1,
   message: {
     time: '',
-    reportId: '',
+    reportId: null,
     displayId: '',
     status: '',
   },

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -109,7 +109,7 @@ function Landing() {
   const [alertsActivePage, setAlertsActivePage] = useState(1);
   const [alertReportsCount, setAlertReportsCount] = useState(0);
   const [isDownloadingAlerts, setIsDownloadingAlerts] = useState(false);
-  const [downloadAlertsError, setDownloadAlertsError] = useState('');
+  const [downloadAlertsError, setDownloadAlertsError] = useState(false);
   const downloadAllAlertsButtonRef = useRef();
 
   function getAppliedRegion() {


### PR DESCRIPTION
## Description of change

* Landing page still has an error dealing with a `div` inside a `table`. This is the modal that pops up when deleting a report. Will need a closer look to resolve
* Creating an AR should no longer have prop type or other warnings in the console

## How to test

* Enter an activity report. You should see no errors
* Open the landing page. You should only see the warning mentioned above

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-464

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
