### PR TITLE
api docs use port 5003 now

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ those services are already running on your machine.
 6. Change the `AUTH_CLIENT_ID` and `AUTH_CLIENT_SECRET` variables to to values found in the "Values for local development" section of the "Development Credentials" document. If you don't have access to this document, please ask in the hs-vendors-ohs-tta channel of the gsa-tts slack channel.
 7. Optionally, set `CURRENT_USER` to your current user's uid:gid. This will cause files created by docker compose to be owned by your user instead of root.
 3. Run `yarn docker:reset`. This builds the frontend and backend, installs dependencies, then runs database migrations and seeders. If this returns errors that the version of nodejs is incorrect, you may have older versions of the containers built. Delete those images and it should rebuild them.
-10. Run `yarn docker:start` to start the application. The frontend will be available on `localhost:3000` and the backend will run on `localhost:8080`, API documentation will run on `localhost:5000`, and minio will run on `localhost:9000`.
+10. Run `yarn docker:start` to start the application. The frontend will be available on `localhost:3000` and the backend will run on `localhost:8080`, API documentation will run on `localhost:5003`, and minio will run on `localhost:9000`.
 11. Run `yarn docker:stop` to stop the servers and remove the docker containers.
 
 The frontend [proxies requests](https://create-react-app.dev/docs/proxying-api-requests-in-development/) to paths it doesn't recognize to the backend.
@@ -116,7 +116,7 @@ You may run into some issues running the docker commands on Windows:
 | | Run the linter only for the backend | `yarn lint` | |
 | | Run the linter for the the backend with results output to xml files | `yarn lint:ci`| |
 | | Run `yarn lint:ci` for both the frontend and backend | `yarn lint:all`| |
-| | Host the open api 3 spec using [redoc](https://github.com/Redocly/redoc) at `localhost:5000` | `yarn docs:serve` | |
+| | Host the open api 3 spec using [redoc](https://github.com/Redocly/redoc) at `localhost:5003` | `yarn docs:serve` | |
 | | Run cucumber tests | `yarn cucumber` | |
 
 ## Infrastructure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   api-docs:
     image: redocly/redoc
     ports:
-      - "5000:80"
+      - "5003:80"
     volumes:
       - "./docs/openapi/:/usr/share/nginx/html/swagger/"
     environment:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:fix:single": "eslint --fix",
     "lint:fix:all": "yarn lint:fix && yarn --cwd frontend lint:fix",
     "clean": "rm -rf coverage reports frontend/coverage frontend/reports frontend/build",
-    "docs:serve": "npx redoc-cli serve -p 5000 docs/openapi/index.yaml",
+    "docs:serve": "npx redoc-cli serve -p 5003 docs/openapi/index.yaml",
     "cucumber": "./node_modules/.bin/cucumber-js --publish ./cucumber/features/*.feature -f json:./reports/cucumber_report.json && node ./cucumber/index.js",
     "cucumber:ci": "cross-env TTA_SMART_HUB_URI=http://localhost:3000 yarn cucumber",
     "migrate:create": "npx sequelize-cli migration:generate --name",


### PR DESCRIPTION
## Description of change

Having some port confusion with IT management software and our API doc server
https://adhoc.slack.com/archives/C017Z3PC6MS/p1649772705706809

## How to test
Docker & API server spin up with no problems

## Issue(s)


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
