### PR TITLE
Fix wrong version number in Staging and Dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "WYSIWYG-auto-expands"
+    default: "kw-fix-staging-notifications"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "kw-add-mail"

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,6 +23,8 @@ applications:
       SMTP_HOST: ((SMTP_HOST))
       SMTP_PORT: ((SMTP_PORT))
       SEND_NOTIFICATIONS: ((SEND_NOTIFICATIONS))
+      SMTP_SECURE: ((SMTP_SECURE))
+      FROM_EMAIL_ADDRESS: ((FROM_EMAIL_ADDRESS))
     services:
       - ttahub-((env))
       - ttahub-redis-((env))


### PR DESCRIPTION
## Description of change
Email notifications were working in Sandbox, but we were still getting `ssl3_get_record:wrong version number` error in Staging and Dev. This PR fixes this.


## How to test
In Dev, create an activity report and assign yourself as a collaborator. Verify that an email is received.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
