### PR TITLE
Await "setStatus" call

### DIFF
--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -374,7 +374,7 @@ export async function softDeleteReport(req, res) {
       return;
     }
 
-    setStatus(report, REPORT_STATUSES.DELETED);
+    await setStatus(report, REPORT_STATUSES.DELETED);
     res.sendStatus(204);
   } catch (error) {
     await handleErrors(req, res, error, logContext);


### PR DESCRIPTION
## Description of change

The call to `setStatus` in the report delete handler returns a promise. This promise is not `await'ed` or chained (`.next()`). This means execution immediately flows out of the handler and exits the `transactionWrapper` function causing the transaction started in the wrapper to `commit`. The promise then starts to execute and uses a transaction that has already been committed, causing the app to error out and crash. Express can't catch the exception because it has already finished executing, which causes node to crash on the unhandled exception. I would _assume_ there is a bit of a race here where some SQL calls can execute before the transaction is closed but the audit log and `setStatus` call hit the DB enough to slow the promise down to the point it will probably always fail.

Now we `await` the `setStatus` call causing us to wait in the handler for all DB calls to finish before closing the transaction.

## How to test

Deleting a report does not crash the server

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
