### PR TITLE
Overview widget now includes legacy reports

### DIFF
--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -134,7 +134,7 @@ export default async function overview(scopes) {
         model: ActivityRecipient,
         as: 'activityRecipients',
         attributes: [],
-        required: true,
+        required: false,
         include: [
           {
             model: Grant,


### PR DESCRIPTION
## Description of change

Legacy reports do not have activity report recipients. By making that association optional we now include legacy reports in the overview widget "activity reports" count.

## How to test

Open the landing page with no date filter, note overview widget count does not match activity reports table count. Checkout this branch, the overview widget count should now match the table count.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-784

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- ~[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
