### PR TITLE
Process data tweaks

### DIFF
--- a/src/tools/processData.js
+++ b/src/tools/processData.js
@@ -353,7 +353,7 @@ export const truncateAuditTables = async () => {
   }
 };
 
-const processData = async (mockReport) => {
+const processData = async (mockReport) => sequelize.transaction(async () => {
   const activityReportId = mockReport ? mockReport.id : null;
   const where = activityReportId ? { id: activityReportId } : {};
   const filesWhere = activityReportId ? { activityReportId } : {};
@@ -374,8 +374,6 @@ const processData = async (mockReport) => {
   await hideUsers(userIds);
   // Hide recipients and grants
   await hideRecipientsGrants(recipientsGrants);
-
-  await truncateAuditTables();
 
   // loop through the found reports
   for await (const report of reports) {
@@ -462,8 +460,8 @@ const processData = async (mockReport) => {
     where: {},
     truncate: true,
   });
-
-  return Promise.all(promises);
-};
+  await Promise.all(promises);
+  return truncateAuditTables();
+});
 
 export default processData;


### PR DESCRIPTION
## Description of change

Process data needs to be wrapped in a transaction. Also does no good to truncate audit log tables and then make audit log creating edits. Audit logs are now truncated after all other data has been updated
