### PR TITLE
[TTAHUB-702] Recipient record search settings saved in session storage

### DIFF
--- a/frontend/src/hooks/__tests__/useSession.js
+++ b/frontend/src/hooks/__tests__/useSession.js
@@ -4,11 +4,11 @@ import {
   render, screen,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import useSessionFilters from '../useSessionFilters';
+import useSession from '../useSession';
 import { mockWindowProperty } from '../../testHelpers';
 
 const SessionFilters = () => {
-  const [storage, setStorage] = useSessionFilters('test', 'this');
+  const [storage, setStorage] = useSession('test', 'this');
 
   return (
     <>
@@ -20,7 +20,7 @@ const SessionFilters = () => {
 
 const renderSessionFilters = () => render(<SessionFilters />);
 
-describe('useSessionFilters', () => {
+describe('useSession', () => {
   const setItem = jest.fn();
 
   mockWindowProperty('sessionStorage', {

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -4,19 +4,19 @@ import useSessionStorage from './useSessionStorage';
 const { sessionStorage } = window;
 
 /**
- * useSessionFilters takes in an key and an array of default filters
+ * useSession takes in an key and an array of default filters
  * and returns a useState like array of a getter and a setter
  * while updating the filters in the session
  *
  * @param {Object[]} defaultFilters
  * @returns {[ Object[], Function ]}
  */
-export default function useSessionFilters(key, initialValue) {
+export default function useSession(key, initialValue) {
   const initial = useMemo(() => {
     try {
-      const filtersFromStorage = sessionStorage.getItem(key);
-      if (filtersFromStorage) {
-        return JSON.parse(filtersFromStorage);
+      const fromStorage = sessionStorage.getItem(key);
+      if (fromStorage) {
+        return JSON.parse(fromStorage);
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/frontend/src/hooks/useSessionFiltersAndReflectInUrl.js
+++ b/frontend/src/hooks/useSessionFiltersAndReflectInUrl.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import useSessionFilters from './useSessionFilters';
+import useSession from './useSession';
 import useUrlFilters from './useUrlFilters';
 
 /**
@@ -12,7 +12,7 @@ import useUrlFilters from './useUrlFilters';
  */
 export default function useSessionFiltersAndReflectInUrl(key, defaultFilters) {
   const [initialValue, updateUrl] = useUrlFilters(defaultFilters);
-  const [filters, setFilters] = useSessionFilters(key, initialValue);
+  const [filters, setFilters] = useSession(key, initialValue);
 
   useEffect(() => {
     updateUrl(filters);

--- a/frontend/src/pages/RecipientSearch/__tests__/index.js
+++ b/frontend/src/pages/RecipientSearch/__tests__/index.js
@@ -14,6 +14,7 @@ import join from 'url-join';
 import { act } from 'react-dom/test-utils';
 import RecipientSearch from '../index';
 import { SCOPE_IDS } from '../../../Constants';
+import { mockWindowProperty } from '../../../testHelpers';
 
 const query = 'ground control';
 
@@ -123,10 +124,17 @@ const renderRecipientSearch = (user) => {
 };
 
 describe('the recipient search page', () => {
+  mockWindowProperty('sessionStorage', {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  });
+
   beforeEach(() => {
-    fetchMock.reset();
+    fetchMock.restore();
     const url = join(recipientUrl, 'search', '?s=&region.in[]=1&sortBy=name&direction=asc&offset=0');
     fetchMock.get(url, res);
+    fetchMock.get('/api/recipient/search?s=&region.in[]=1&region.in[]=2&sortBy=regionId&direction=asc&offset=0', res);
   });
 
   afterEach(() => {
@@ -230,6 +238,10 @@ describe('the recipient search page', () => {
   });
 
   it('the regional select works with all regions', async () => {
+    fetchMock.restore();
+    const beforeUrl = join(recipientUrl, 'search', '?s=&region.in[]=1&sortBy=name&direction=asc&offset=0');
+    fetchMock.get(beforeUrl, res);
+
     const user = { ...userBluePrint, homeRegionId: 14 };
 
     fetchMock.get('/api/recipient/search?s=&region.in[]=1&region.in[]=2&sortBy=regionId&direction=asc&offset=0', res);

--- a/frontend/src/pages/RecipientSearch/index.js
+++ b/frontend/src/pages/RecipientSearch/index.js
@@ -29,11 +29,11 @@ const DEFAULT_CENTRAL_OFFICE_SORT = {
 function RecipientSearch({ user }) {
   const hasCentralOffice = user && user.homeRegionId && user.homeRegionId === 14;
   const regions = getUserRegions(user);
-  const [appliedRegion, setAppliedRegion] = useState(hasCentralOffice ? 14 : regions[0]);
   const [queryAndSort, setQueryAndSort] = useSession('rtr-search', {
     query: '',
     activePage: 1,
     sortConfig: hasCentralOffice ? DEFAULT_CENTRAL_OFFICE_SORT : DEFAULT_SORT,
+    appliedRegion: hasCentralOffice ? 14 : regions[0],
   });
 
   const [results, setResults] = useState({ count: 0, rows: [] });
@@ -54,6 +54,10 @@ function RecipientSearch({ user }) {
     updateQueryAndSort('activePage', ap);
   };
 
+  const setAppliedRegion = (ar) => {
+    updateQueryAndSort('appliedRegion', ar);
+  };
+
   const inputRef = useRef();
   const offset = (activePage - 1) * RECIPIENTS_PER_PAGE;
 
@@ -61,7 +65,7 @@ function RecipientSearch({ user }) {
     async function fetchRecipients() {
       const filters = [];
 
-      if (appliedRegion === 14) {
+      if (queryAndSort.appliedRegion === 14) {
         getUserRegions(user).forEach((region) => {
           filters.push({
             id: uuidv4(),
@@ -75,7 +79,7 @@ function RecipientSearch({ user }) {
           id: uuidv4(),
           topic: 'region',
           condition: 'is',
-          query: appliedRegion,
+          query: queryAndSort.appliedRegion,
         });
       }
 
@@ -107,7 +111,7 @@ function RecipientSearch({ user }) {
     }
 
     fetchRecipients();
-  }, [appliedRegion, offset, sortConfig, user, queryAndSort, query, setQueryAndSort]);
+  }, [offset, sortConfig, user, queryAndSort, query, setQueryAndSort]);
 
   function onApplyRegion(region) {
     setAppliedRegion(region.value);
@@ -153,7 +157,7 @@ function RecipientSearch({ user }) {
                     regions={regions}
                     onApply={onApplyRegion}
                     hasCentralOffice={hasCentralOffice}
-                    appliedRegion={appliedRegion}
+                    appliedRegion={queryAndSort.appliedRegion}
                     disabled={loading}
                   />
                 </div>


### PR DESCRIPTION
## Description of change

Search query, sort config, and active page are all saved in session storage on the recipient record search page. This persists through back button, on site navigation, and back to search link, for the life of a browser tab.

## How to test

On the RTR search page, sort the data, change the page, and enter a query. Test that it persists through back button, on site navigation, and clicking the back to search link from a record page.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-702


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
