### PR TITLE
[TTAHUB-669] On Goals Replace Nested Objectives Table

### DIFF
--- a/frontend/src/components/GoalsTable/GoalRow.css
+++ b/frontend/src/components/GoalsTable/GoalRow.css
@@ -1,6 +1,6 @@
 .goals-table .usa-table .tta-smarthub--goal-row td:first-child {
   border-left: 1px solid #c5c5c5;
-  /* min-width: 160px; */
+  min-width: 170px;
 }
 
 .goals-table .usa-table .tta-smarthub--goal-row td:last-child {
@@ -12,8 +12,8 @@
 }
 
 .goals-table .usa-table .tta-smarthub--goal-row td:nth-child(3) {
-  max-width: 500px;
-  min-width: 500px;
+  max-width: 490px;
+  min-width: 490px;
 }
 
 .goals-table .usa-table .tta-smarthub--goal-row td:nth-child(4) {
@@ -80,4 +80,20 @@ vertical-align: top;
 .tta-smarthub--goal-row td:nth-child(4) .smart-hub-tooltip button {
   line-height: 1.7;
   vertical-align: baseline;
+}
+
+
+.tta-smarthub--goal-row-obj-table-header {
+  background-color: white;
+  border-top: solid 1.5px;
+  border-color: #eceef1;
+  border-bottom: none;
+  padding-right: 0px;
+  padding-top: 0px;
+  padding-left: 0px;
+  padding-bottom: 8px;
+  background-color: white;
+  border-style: none;
+  color: black;
+  font-weight: 700;
 }

--- a/frontend/src/components/GoalsTable/GoalRow.css
+++ b/frontend/src/components/GoalsTable/GoalRow.css
@@ -12,8 +12,8 @@
 }
 
 .goals-table .usa-table .tta-smarthub--goal-row td:nth-child(3) {
-  max-width: 490px;
-  min-width: 490px;
+  max-width: 480px;
+  min-width: 480px;
 }
 
 .goals-table .usa-table .tta-smarthub--goal-row td:nth-child(4) {

--- a/frontend/src/components/GoalsTable/GoalRow.js
+++ b/frontend/src/components/GoalsTable/GoalRow.js
@@ -276,7 +276,6 @@ function GoalRow({
               <ObjectiveRow
                 key={`objective_${obj.id}`}
                 objective={obj}
-                onCollapseObjectives={closeOrOpenObjectives}
               />
             ))}
           </div>

--- a/frontend/src/components/GoalsTable/GoalRow.js
+++ b/frontend/src/components/GoalsTable/GoalRow.js
@@ -259,31 +259,22 @@ function GoalRow({
       </tr>
       <tr className="tta-smarthub--objective-rows">
         <td style={{ borderLeft: objectivesExpanded ? `4px solid ${getStatusColor()}` : '' }} colSpan="6">
-          <table>
-            <caption className="usa-sr-only">
-              Objectives for goal
-              {' '}
-              {goalNumber}
-            </caption>
-            <thead>
-              <tr>
-                <th scope="col">Objective</th>
-                <th scope="col">Activity report</th>
-                <th scope="col">End date</th>
-                <th scope="col">Reasons</th>
-                <th scope="col">Objectives status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {objectives.map((obj) => (
-                <ObjectiveRow
-                  key={`objective_${obj.id}`}
-                  objective={obj}
-                  onCollapseObjectives={closeOrOpenObjectives}
-                />
-              ))}
-            </tbody>
-          </table>
+          <div className="tta-smarthub--goal-row-obj-table">
+            <ul className="usa-list usa-list--unstyled display-inline-flex tta-smarthub--goal-row-obj-table-header">
+              <li>Objective</li>
+              <li>Activity report</li>
+              <li>End date</li>
+              <li>Reasons</li>
+              <li>Objectives status</li>
+            </ul>
+            {objectives.map((obj) => (
+              <ObjectiveRow
+                key={`objective_${obj.id}`}
+                objective={obj}
+                onCollapseObjectives={closeOrOpenObjectives}
+              />
+            ))}
+          </div>
         </td>
       </tr>
       <tr className="height-1" aria-hidden="true" />

--- a/frontend/src/components/GoalsTable/GoalRow.js
+++ b/frontend/src/components/GoalsTable/GoalRow.js
@@ -260,7 +260,12 @@ function GoalRow({
       <tr className="tta-smarthub--objective-rows">
         <td style={{ borderLeft: objectivesExpanded ? `4px solid ${getStatusColor()}` : '' }} colSpan="6">
           <div className="tta-smarthub--goal-row-obj-table">
-            <ul className="usa-list usa-list--unstyled display-inline-flex tta-smarthub--goal-row-obj-table-header">
+            <caption className="usa-sr-only">
+              Objectives for goal
+              {' '}
+              {goalNumber}
+            </caption>
+            <ul aria-hidden className="usa-list usa-list--unstyled display-inline-flex tta-smarthub--goal-row-obj-table-header">
               <li>Objective</li>
               <li>Activity report</li>
               <li>End date</li>

--- a/frontend/src/components/GoalsTable/ObjectiveRow.css
+++ b/frontend/src/components/GoalsTable/ObjectiveRow.css
@@ -17,13 +17,21 @@
   border-bottom: 1px solid #c5c5c5;
 }
 
-.goals-table .usa-table .tta-smarthub--objective-rows table tbody {
+.tta-smarthub--goal-row-obj-table-rows,
+.tta-smarthub--objective-rows .usa-list:last-child{
   background-color: #f8f8f8;
-
+  margin-bottom: 16px;
 }
 
 .goals-table .usa-table .tta-smarthub--objective-reasons-list {
   list-style-type: none;
+}
+
+.tta-smarthub--objective-rows .tta-smarthub--objective-reasons-list li,
+.tta-smarthub--goal-row-obj-table  .tta-smarthub--objective-reasons-list li:first-child {
+  padding: 0px;
+  max-width: 270px;
+  min-width: 270px;
 }
 
 .goals-table .tta-smarthub--objective-rows .tta-smarthub--objective-row td {
@@ -31,34 +39,33 @@
   }
 
   /* Objective Cells */
-  .goals-table .usa-table-container .tta-smarthub--objective-rows .tta-smarthub--objective-row td {
+  .tta-smarthub--goal-row-obj-table li {
     padding: 24px;
   }
 
-  .goals-table .usa-table-container .tta-smarthub--objective-rows .tta-smarthub--objective-row td:first-child,
-  .goals-table .usa-table-container .tta-smarthub--objective-rows .tta-smarthub--objective-row tr:first-child {
+  .tta-smarthub--goal-row-obj-table li:first-child {
     max-width: 490px;
     min-width: 490px;
   }
 
-  .goals-table .usa-table-container .tta-smarthub--objective-rows .tta-smarthub--objective-row td:nth-child(2) {
+  .tta-smarthub--goal-row-obj-table li:nth-child(2) {
     max-width: 200px;
     min-width: 200px;
   }
 
-  .goals-table .usa-table-container .tta-smarthub--objective-rows .tta-smarthub--objective-row td:nth-child(3) {
+  .tta-smarthub--goal-row-obj-table li:nth-child(3) {
     max-width: 140px;
     min-width: 140px;
   }
 
-  .goals-table .usa-table-container .tta-smarthub--objective-rows .tta-smarthub--objective-row td:nth-child(4) {
-    max-width: 300px;
-    min-width: 300px;
+  .tta-smarthub--goal-row-obj-table li:nth-child(4) {
+    max-width: 280px;
+    min-width: 280px;
   }
 
-  .goals-table .usa-table-container .tta-smarthub--objective-rows .tta-smarthub--objective-row td:nth-child(5) {
-    max-width: 160px;
-    min-width: 160px;
+  .tta-smarthub--goal-row-obj-table li:nth-child(5) {
+    max-width: 180px;
+    min-width: 180px;
   }
 
   /* Collapse Objectives Button */

--- a/frontend/src/components/GoalsTable/ObjectiveRow.css
+++ b/frontend/src/components/GoalsTable/ObjectiveRow.css
@@ -85,3 +85,8 @@
     opacity: 0;
     pointer-events: none;
   }
+
+  .tta-smarthub--goal-row-obj-table-header li {
+    padding-top: 8px;
+    padding-bottom: 16px;
+  }

--- a/frontend/src/components/GoalsTable/ObjectiveRow.js
+++ b/frontend/src/components/GoalsTable/ObjectiveRow.js
@@ -9,7 +9,7 @@ import { reasonsToMonitor } from '../../pages/ActivityReport/constants';
 import './ObjectiveRow.css';
 
 function ObjectiveRow({
-  objective, onCollapseObjectives,
+  objective,
 }) {
   const {
     title,
@@ -97,14 +97,6 @@ function ObjectiveRow({
     <>
       <ul className="usa-list usa-list--unstyled display-inline-flex tta-smarthub--goal-row-obj-table-rows margin-bottom-2">
         <li>
-          <button
-            type="button"
-            className="usa-button usa-button--outline tta-smarthub--objective-rows-collapse-button"
-            onClick={() => onCollapseObjectives(true)}
-            aria-label="Return to goals"
-          >
-            Collapse objective(s)
-          </button>
           <span className="sr-only">Objective:</span>
           {title}
         </li>
@@ -156,6 +148,5 @@ objectivePropTypes.defaultProps = {
 };
 ObjectiveRow.propTypes = {
   objective: objectivePropTypes.isRequired,
-  onCollapseObjectives: PropTypes.func.isRequired,
 };
 export default ObjectiveRow;

--- a/frontend/src/components/GoalsTable/ObjectiveRow.js
+++ b/frontend/src/components/GoalsTable/ObjectiveRow.js
@@ -95,8 +95,8 @@ function ObjectiveRow({
 
   return (
     <>
-      <tr className="tta-smarthub--objective-row">
-        <td>
+      <ul className="usa-list usa-list--unstyled display-inline-flex tta-smarthub--goal-row-obj-table-rows margin-bottom-2">
+        <li>
           <button
             type="button"
             className="usa-button usa-button--outline tta-smarthub--objective-rows-collapse-button"
@@ -106,24 +106,24 @@ function ObjectiveRow({
             Collapse objective(s)
           </button>
           {title}
-        </td>
-        <td>
+        </li>
+        <li>
           {' '}
           <Link
             to={linkToAr}
           >
             {arNumber}
           </Link>
-        </td>
-        <td>{endDate}</td>
-        <td>
+        </li>
+        <li>{endDate}</li>
+        <li>
           {reasons && displayReasonsList(reasons.sort())}
-        </td>
-        <td>
+        </li>
+        <li>
           {getObjectiveStatusIcon()}
           {displayObjStatus}
-        </td>
-      </tr>
+        </li>
+      </ul>
     </>
   );
 }

--- a/frontend/src/components/GoalsTable/ObjectiveRow.js
+++ b/frontend/src/components/GoalsTable/ObjectiveRow.js
@@ -105,9 +105,11 @@ function ObjectiveRow({
           >
             Collapse objective(s)
           </button>
+          <span className="sr-only">Objective:</span>
           {title}
         </li>
         <li>
+          <span className="sr-only">Activity report:</span>
           {' '}
           <Link
             to={linkToAr}
@@ -115,11 +117,16 @@ function ObjectiveRow({
             {arNumber}
           </Link>
         </li>
-        <li>{endDate}</li>
         <li>
+          <span className="sr-only">End date:</span>
+          {endDate}
+        </li>
+        <li>
+          <span className="sr-only">Reasons:</span>
           {reasons && displayReasonsList(reasons.sort())}
         </li>
         <li>
+          <span className="sr-only">Objective status:</span>
           {getObjectiveStatusIcon()}
           {displayObjStatus}
         </li>

--- a/frontend/src/components/GoalsTable/__tests__/GoalsTable.js
+++ b/frontend/src/components/GoalsTable/__tests__/GoalsTable.js
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import {
-  render, screen, waitFor, fireEvent, act,
+  render, screen, waitFor, fireEvent,
 } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import fetchMock from 'fetch-mock';
@@ -296,30 +297,26 @@ describe('Goals Table', () => {
     });
 
     it('Shows the correct objective data', async () => {
-      renderTable(defaultUser);
+      act(() => renderTable(defaultUser));
       await screen.findByText('TTA goals and objectives');
-      const inProgress = await screen.findAllByRole('cell', { name: 'In progress' });
-      expect(inProgress.length).toBe(2);
 
       // Objective 1.
-      await screen.findByRole('cell', { name: /objective 1 title/i });
-      await screen.findByRole('cell', { name: /ar-number-1/i });
-      await screen.findByRole('cell', { name: '06/14/2021' });
-      await screen.findByRole('cell', { name: /monitoring | deficiency/i });
+      await screen.findByText(/objective 1 title/i);
+      await screen.findByRole('link', { name: /ar-number-1/i });
+      await screen.findByText('06/14/2021');
+      await screen.findByText(/monitoring | deficiency/i);
 
       // Objective 2.
-      await screen.findByRole('cell', { name: /objective 2 title/i });
-      await screen.findByRole('cell', { name: /ar-number-2/i });
-      await screen.findByRole('cell', { name: '05/14/2021' });
-      await screen.findByRole('cell', { name: 'Below Competitive Threshold (CLASS)' });
-      await screen.findByRole('cell', { name: /not started/i });
+      await screen.findByText(/objective 2 title/i);
+      await screen.findByRole('link', { name: /ar-number-2/i });
+      await screen.findByText('05/14/2021');
+      await screen.findByText('Below Competitive Threshold (CLASS)');
 
       // Objective 3.
-      await screen.findByRole('cell', { name: /objective 3 title/i });
-      await screen.findByRole('cell', { name: /ar-number-3/i });
-      await screen.findByRole('cell', { name: '04/14/2021' });
-      await screen.findByRole('cell', { name: 'COVID-19 response' });
-      await screen.findByRole('cell', { name: /closed/i });
+      await screen.findByText(/objective 3 title/i);
+      await screen.findByRole('link', { name: /ar-number-3/i });
+      await screen.findByText('04/14/2021');
+      await screen.findByText(/covid-19 response/i);
 
       expect(await screen.findByText(/1-1 of 1/i)).toBeVisible();
       expect(screen.getAllByRole('cell')[0]).toHaveTextContent(/in progress/i);

--- a/frontend/src/components/GoalsTable/__tests__/GoalsTable.js
+++ b/frontend/src/components/GoalsTable/__tests__/GoalsTable.js
@@ -333,13 +333,10 @@ describe('Goals Table', () => {
       fireEvent.click(expandObjectives);
       expect(document.querySelector('.tta-smarthub--goal-row-collapsed')).not.toBeInTheDocument();
 
-      const collapseButton = await screen.findAllByRole('button', { name: /return to goals/i });
-      fireEvent.click(collapseButton[0]);
+      // Collapse Objectives via click.
+      const collapseButton = await screen.findByRole('button', { name: "Collapse objective's for goal R14-G-4598" });
+      fireEvent.click(collapseButton);
       expect(document.querySelector('.tta-smarthub--goal-row-collapsed')).toBeInTheDocument();
-
-      // We should set focus back to the expand button.
-      const expandWithFocus = await screen.findByRole('button', { name: /expand objective's for goal r14-g-4598/i });
-      expect(expandWithFocus).toHaveFocus();
     });
 
     it('hides the add new goal button if recipient has no active grants', async () => {


### PR DESCRIPTION
## Description of change

We want to avoid nested tables at all costs as they can be a nightmare to navigate with a screen reader. This change replaces the nested Objectives table in Goals with lists.

## How to test

View the Goals & Objectives tab of the RTR. Upon inspecting the element structure all Objectives info should be shown in unordered lists (un-styled). All behavior of the Goals table should behave as it did before.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-669


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
