### PR TITLE
[TTAHUB-821] Remove the default date filter from the goals & objectives page

### DIFF
--- a/frontend/src/pages/RecipientRecord/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/__tests__/index.js
@@ -103,8 +103,8 @@ describe('recipient record page', () => {
     fetchMock.get(`/api/widgets/frequencyGraph?startDate.win=${yearToDate}`, 200);
     fetchMock.get('/api/widgets/targetPopulationTable?region.in[]=45&recipientId.ctn[]=1', 200);
     fetchMock.get(`/api/widgets/targetPopulationTable?startDate.win=${yearToDate}&region.in[]=45&recipientId.ctn[]=1`, 200);
-    fetchMock.get(`/api/widgets/goalStatusGraph?createDate.win=${yearToDate}&region.in[]=45&recipientId.ctn[]=1`, 200);
-    fetchMock.get(`/api/recipient/1/region/45/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5&createDate.win=${yearToDate}`, {});
+    fetchMock.get('/api/widgets/goalStatusGraph?region.in[]=45&recipientId.ctn[]=1', 200);
+    fetchMock.get('/api/recipient/1/region/45/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5', {});
   });
   afterEach(() => {
     fetchMock.restore();

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -1,12 +1,11 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { v4 as uuidv4 } from 'uuid';
 import { Grid } from '@trussworks/react-uswds';
 import { Helmet } from 'react-helmet';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import useSessionFiltersAndReflectInUrl from '../../../hooks/useSessionFiltersAndReflectInUrl';
 import FilterPanel from '../../../components/filter/FilterPanel';
-import { expandFilters, formatDateRange } from '../../../utils';
+import { expandFilters } from '../../../utils';
 import { getGoalsAndObjectivesFilterConfig } from './constants';
 import GoalStatusGraph from '../../../widgets/GoalStatusGraph';
 import GoalsTable from '../../../components/GoalsTable/GoalsTable';
@@ -19,18 +18,12 @@ export default function GoalsObjectives({
   const { user } = useContext(UserContext);
   const regions = useMemo(() => getUserRegions(user), [user]);
   const showNewGoals = location.state && location.state.ids && location.state.ids.length > 0;
-  const yearToDate = formatDateRange({ yearToDate: true, forDateTime: true });
 
   const FILTER_KEY = 'goals-objectives-filters';
 
   const [filters, setFilters] = useSessionFiltersAndReflectInUrl(
     FILTER_KEY,
-    [{
-      id: uuidv4(),
-      topic: 'createDate',
-      condition: 'is within',
-      query: yearToDate,
-    }],
+    [],
   );
 
   const possibleGrants = recipient.grants;


### PR DESCRIPTION
## Description of change
Remove the default date filter from the goals & objectives tab on the RTR

## How to test
Visit the RTR -> goals & objectives tab
Observe there is no default date

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-821

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
