### PR TITLE
[TTAHUB-785] update circle ci ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ parameters:
     default: "TTAHUB-467/apply-color-palette"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "kw-add-mail"
+    default: "TTAHUB-785/update-job-image"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
           POSTGRES_DB: ttasmarthub
   machine-executor:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:current
 commands:
   create_combined_yarnlock:
     description: "Concatenate all yarn.json files into single file.


### PR DESCRIPTION
## Description of change
CircleCI informed us about a potential issue with deprecation and EOL. 

> We are deprecating Ubuntu 14.04-based machine images on CircleCI in preparation for an EOL on Tuesday, May 31, 2022 to ensure your builds remain secure. For more details on why we are deprecating these images and a complete schedule of the timeline, [please see our blog post](https://go.circleci.com/NDg1LVpNSC02MjYAAAGDLWNmOEuTBr6LADLrY7-advdrG8vwtiISQD9hpyayvqcNFIWQsVA2hPdPnlQGIyq5DRbt19g=).

We did specify "circleci/classic", an image that was being deprecated, in our config. I updated that to the image they recommended in their blog post, Ubuntu 20.04, and deployed it to sandbox.

## How to test
CI specifies the image we use in the the "build and lint" step. Confirm that is not a deprecated 16.x image. 
The new config is deployed to sandbox. Confirm that everything works

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-785

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
