### PR TITLE
[TTAHUB-795] Save AR Collaborator Role

### DIFF
--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -42,7 +42,7 @@ function ReportRow({
 
   const collaboratorNames = activityReportCollaborators
     ? activityReportCollaborators.map((collaborator) => (
-      collaborator.user.fullName)) : [];
+      collaborator.fullNameSubstituteRoles)) : [];
 
   const viewOrEditLink = calculatedStatus === 'approved' ? `/activity-reports/view/${id}` : `/activity-reports/${id}`;
   const linkTarget = legacyId ? `/activity-reports/legacy/${legacyId}` : viewOrEditLink;

--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -24,13 +24,13 @@ function ReportRow({
     activityRecipients,
     startDate,
     topics,
-    collaborators,
     lastSaved,
     calculatedStatus,
     approvedAt,
     createdAt,
     legacyId,
     creatorName,
+    activityReportCollaborators,
   } = report;
 
   const [trClassname, setTrClassname] = useState('tta-smarthub--report-row');
@@ -40,8 +40,9 @@ function ReportRow({
     ar.grant ? ar.grant.recipient.name : ar.name
   ));
 
-  const collaboratorNames = collaborators && collaborators.map((collaborator) => (
-    collaborator.fullName));
+  const collaboratorNames = activityReportCollaborators
+    ? activityReportCollaborators.map((collaborator) => (
+      collaborator.user.fullName)) : [];
 
   const viewOrEditLink = calculatedStatus === 'approved' ? `/activity-reports/view/${id}` : `/activity-reports/${id}`;
   const linkTarget = legacyId ? `/activity-reports/legacy/${legacyId}` : viewOrEditLink;
@@ -161,9 +162,11 @@ export const reportPropTypes = PropTypes.shape({
   createdAt: PropTypes.string,
   startDate: PropTypes.string.isRequired,
   topics: PropTypes.arrayOf(PropTypes.string).isRequired,
-  collaborators: PropTypes.arrayOf(
+  activityReportCollaborators: PropTypes.arrayOf(
     PropTypes.shape({
-      fullName: PropTypes.string,
+      user: PropTypes.shape({
+        fullName: PropTypes.string,
+      }),
     }),
   ),
   lastSaved: PropTypes.string,

--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -42,7 +42,7 @@ function ReportRow({
 
   const collaboratorNames = activityReportCollaborators
     ? activityReportCollaborators.map((collaborator) => (
-      collaborator.fullNameSubstituteRoles)) : [];
+      collaborator.fullName)) : [];
 
   const viewOrEditLink = calculatedStatus === 'approved' ? `/activity-reports/view/${id}` : `/activity-reports/${id}`;
   const linkTarget = legacyId ? `/activity-reports/legacy/${legacyId}` : viewOrEditLink;

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -53,7 +53,6 @@ function ActivityReportsTable({
           perPage,
           filterQuery,
         );
-
         setReports(rows);
         setReportsCount(count || 0);
         setError('');

--- a/frontend/src/components/ActivityReportsTable/mocks.js
+++ b/frontend/src/components/ActivityReportsTable/mocks.js
@@ -59,7 +59,6 @@ const activityReports = [
     activityReportCollaborators: [
       {
         fullName: 'Orange, GS',
-        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -68,7 +67,6 @@ const activityReports = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -110,7 +108,6 @@ const activityReports = [
     activityReportCollaborators: [
       {
         fullName: 'Cucumber User, GS',
-        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -119,7 +116,6 @@ const activityReports = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -163,7 +159,6 @@ export const activityReportsSorted = [
     activityReportCollaborators: [
       {
         fullName: 'Cucumber User, GS',
-        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -172,7 +167,6 @@ export const activityReportsSorted = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -240,7 +234,6 @@ export const activityReportsSorted = [
     activityReportCollaborators: [
       {
         fullName: 'Orange, GS',
-        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -249,7 +242,6 @@ export const activityReportsSorted = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -322,7 +314,6 @@ export const generateXFakeReports = (count, status = []) => {
         activityReportCollaborators: [
           {
             fullName: 'Orange, GS',
-            fullNameSubstituteRoles: 'Orange, GS',
             user: {
               fullName: 'Orange, GS',
               name: 'Orange',
@@ -331,7 +322,6 @@ export const generateXFakeReports = (count, status = []) => {
           },
           {
             fullName: 'Hermione Granger, SS',
-            fullNameSubstituteRoles: 'Hermione Granger, SS',
             user: {
               fullName: 'Hermione Granger, SS',
               name: 'Hermione Granger',

--- a/frontend/src/components/ActivityReportsTable/mocks.js
+++ b/frontend/src/components/ActivityReportsTable/mocks.js
@@ -56,16 +56,20 @@ const activityReports = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Orange, GS',
-        name: 'Orange',
-        role: 'Grants Specialist',
+        user: {
+          fullName: 'Orange, GS',
+          name: 'Orange',
+          role: 'Grants Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -99,16 +103,20 @@ const activityReports = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Cucumber User, GS',
-        name: 'Cucumber User',
-        role: 'Recipient Specialist',
+        user: {
+          fullName: 'Cucumber User, GS',
+          name: 'Cucumber User',
+          role: 'Recipient Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -144,16 +152,20 @@ export const activityReportsSorted = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Cucumber User, GS',
-        name: 'Cucumber User',
-        role: 'Recipient Specialist',
+        user: {
+          fullName: 'Cucumber User, GS',
+          name: 'Cucumber User',
+          role: 'Recipient Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -213,16 +225,20 @@ export const activityReportsSorted = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Orange, GS',
-        name: 'Orange',
-        role: 'Grants Specialist',
+        user: {
+          fullName: 'Orange, GS',
+          name: 'Orange',
+          role: 'Grants Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -287,16 +303,20 @@ export const generateXFakeReports = (count, status = []) => {
           role: 'Grants Specialist',
           homeRegionId: 14,
         },
-        collaborators: [
+        activityReportCollaborators: [
           {
-            fullName: 'Orange, GS',
-            name: 'Orange',
-            role: 'Grants Specialist',
+            user: {
+              fullName: 'Orange, GS',
+              name: 'Orange',
+              role: 'Grants Specialist',
+            },
           },
           {
-            fullName: 'Hermione Granger, SS',
-            name: 'Hermione Granger',
-            role: 'System Specialist',
+            user: {
+              fullName: 'Hermione Granger, SS',
+              name: 'Hermione Granger',
+              role: 'System Specialist',
+            },
           },
         ],
       },

--- a/frontend/src/components/ActivityReportsTable/mocks.js
+++ b/frontend/src/components/ActivityReportsTable/mocks.js
@@ -58,6 +58,8 @@ const activityReports = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Orange, GS',
+        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -65,6 +67,8 @@ const activityReports = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -105,6 +109,8 @@ const activityReports = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Cucumber User, GS',
+        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -112,6 +118,8 @@ const activityReports = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -154,6 +162,8 @@ export const activityReportsSorted = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Cucumber User, GS',
+        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -161,6 +171,8 @@ export const activityReportsSorted = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -227,6 +239,8 @@ export const activityReportsSorted = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Orange, GS',
+        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -234,6 +248,8 @@ export const activityReportsSorted = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -305,6 +321,8 @@ export const generateXFakeReports = (count, status = []) => {
         },
         activityReportCollaborators: [
           {
+            fullName: 'Orange, GS',
+            fullNameSubstituteRoles: 'Orange, GS',
             user: {
               fullName: 'Orange, GS',
               name: 'Orange',
@@ -312,6 +330,8 @@ export const generateXFakeReports = (count, status = []) => {
             },
           },
           {
+            fullName: 'Hermione Granger, SS',
+            fullNameSubstituteRoles: 'Hermione Granger, SS',
             user: {
               fullName: 'Hermione Granger, SS',
               name: 'Hermione Granger',

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -512,7 +512,6 @@ export default {
   review: false,
   render: (additionalData) => {
     const { recipients, collaborators } = additionalData;
-    console.log('Additional Data: ', additionalData);
     return (
       <ActivitySummary
         recipients={recipients}

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -167,15 +167,15 @@ const ActivitySummary = ({
           {!connectionActive && !collaborators.length ? <ConnectionError /> : null }
           <FormItem
             label="Collaborating Specialists"
-            name="collaborators"
+            name="activityReportCollaborators"
             required={false}
           >
             <MultiSelect
-              name="collaborators"
+              name="activityReportCollaborators"
               control={control}
               required={false}
-              valueProperty="id"
-              labelProperty="name"
+              valueProperty="user.id"
+              labelProperty="user.fullName"
               simple={false}
               options={collaborators.map((user) => ({ value: user.id, label: user.name }))}
             />
@@ -460,7 +460,7 @@ const sections = [
       { label: 'Recipient or other entity', name: 'activityRecipientType', sort: true },
       { label: 'Activity Participants', name: 'activityRecipients', path: 'name' },
       {
-        label: 'Collaborating specialist(s)', name: 'collaborators', path: 'name', sort: true,
+        label: 'Collaborating specialist(s)', name: 'activityReportCollaborators', path: 'user.fullName', sort: true,
       },
       { label: 'Target Populations addressed', name: 'targetPopulations', sort: true },
     ],
@@ -512,6 +512,7 @@ export default {
   review: false,
   render: (additionalData) => {
     const { recipients, collaborators } = additionalData;
+    console.log('Additional Data: ', additionalData);
     return (
       <ActivitySummary
         recipients={recipients}

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -53,7 +53,7 @@ const defaultValues = {
   activityType: [],
   additionalNotes: null,
   attachments: [],
-  collaborators: [],
+  activityReportCollaborators: [],
   context: '',
   deliveryMethod: null,
   duration: '',
@@ -243,10 +243,8 @@ function ActivityReport({
   const convertReportToFormData = (fetchedReport) => {
     const ECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.ECLKCResourcesUsed);
     const nonECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.nonECLKCResourcesUsed);
-    const collaborators = fetchedReport.activityReportCollaborators
-      ? fetchedReport.activityReportCollaborators.map((c) => c.user) : [];
     return {
-      ...fetchedReport, ECLKCResourcesUsed, nonECLKCResourcesUsed, collaborators,
+      ...fetchedReport, ECLKCResourcesUsed, nonECLKCResourcesUsed,
     };
   };
 

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -243,7 +243,11 @@ function ActivityReport({
   const convertReportToFormData = (fetchedReport) => {
     const ECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.ECLKCResourcesUsed);
     const nonECLKCResourcesUsed = unflattenResourcesUsed(fetchedReport.nonECLKCResourcesUsed);
-    return { ...fetchedReport, ECLKCResourcesUsed, nonECLKCResourcesUsed };
+    const collaborators = fetchedReport.activityReportCollaborators
+      ? fetchedReport.activityReportCollaborators.map((c) => c.user) : [];
+    return {
+      ...fetchedReport, ECLKCResourcesUsed, nonECLKCResourcesUsed, collaborators,
+    };
   };
 
   // cleanup local storage if the report has been submitted or approved

--- a/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
@@ -24,12 +24,10 @@ describe('Activity report print and share view', () => {
     activityReportCollaborators: [
       {
         fullName: 'Test',
-        fullNameSubstituteRoles: 'Test',
         user: { fullName: 'Test' },
       },
       {
         fullName: 'Test 2',
-        fullNameSubstituteRoles: 'Test 2',
         user: { fullName: 'Test 2' },
       }],
     approvers: [

--- a/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
@@ -21,7 +21,7 @@ describe('Activity report print and share view', () => {
     author: {
       fullName: 'Captain Tim Tina Boat',
     },
-    collaborators: ['Test', 'Test 2'],
+    activityReportCollaborators: [{ user: { fullName: 'Test' } }, { user: { fullName: 'Test 2' } }],
     approvers: [
       {
         id: 1, status: '', note: '', User: { id: 1, fullName: 'John Q Fullname' },
@@ -177,7 +177,7 @@ describe('Activity report print and share view', () => {
     await waitFor(() => {
       expect(screen.getByText(/technical assistance, virtual \(phone\)/i)).toBeInTheDocument();
       expect(screen.getByText('Goal')).toBeInTheDocument();
-      expect(screen.getByText(/test/i)).toBeInTheDocument();
+      expect(screen.getByText(/test 2/i)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
@@ -21,7 +21,17 @@ describe('Activity report print and share view', () => {
     author: {
       fullName: 'Captain Tim Tina Boat',
     },
-    activityReportCollaborators: [{ user: { fullName: 'Test' } }, { user: { fullName: 'Test 2' } }],
+    activityReportCollaborators: [
+      {
+        fullName: 'Test',
+        fullNameSubstituteRoles: 'Test',
+        user: { fullName: 'Test' },
+      },
+      {
+        fullName: 'Test 2',
+        fullNameSubstituteRoles: 'Test 2',
+        user: { fullName: 'Test 2' },
+      }],
     approvers: [
       {
         id: 1, status: '', note: '', User: { id: 1, fullName: 'John Q Fullname' },

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -215,6 +215,7 @@ export default function ApprovedActivityReport({ match, user }) {
         const arRecipients = data.activityRecipients.map((arRecipient) => arRecipient.name).sort().join(', ');
         const targetPopulations = data.targetPopulations.map((population) => population).join(', '); // Approvers.
         const approvingManagers = data.approvers.map((a) => a.User.fullName).join(', ');
+        const collaborators = data.activityReportCollaborators.map((a) => a.user);
 
         // Approver Notes.
         const managerNotes = data.approvers.map((a) => `
@@ -238,7 +239,7 @@ export default function ApprovedActivityReport({ match, user }) {
 
         // third table
         const {
-          context, id, displayId, additionalNotes, collaborators,
+          context, id, displayId, additionalNotes,
         } = data;
         const [goalsAndObjectiveHeadings, goalsAndObjectives] = calculateGoalsAndObjectives(data);
 
@@ -335,7 +336,6 @@ export default function ApprovedActivityReport({ match, user }) {
       </>
     );
   }
-
   const {
     reportId,
     displayId,

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -215,7 +215,9 @@ export default function ApprovedActivityReport({ match, user }) {
         const arRecipients = data.activityRecipients.map((arRecipient) => arRecipient.name).sort().join(', ');
         const targetPopulations = data.targetPopulations.map((population) => population).join(', '); // Approvers.
         const approvingManagers = data.approvers.map((a) => a.User.fullName).join(', ');
-        const collaborators = data.activityReportCollaborators.map((a) => a.user);
+        const collaborators = data.activityReportCollaborators.map(
+          (a) => a.fullNameSubstituteRoles, // Match what we show on the landing.
+        );
 
         // Approver Notes.
         const managerNotes = data.approvers.map((a) => `
@@ -471,7 +473,7 @@ export default function ApprovedActivityReport({ match, user }) {
           <p>
             <strong>Collaborators:</strong>
             {' '}
-            {collaborators.map((collaborator) => collaborator.fullName).join(', ')}
+            {collaborators.map((collaborator) => collaborator).join(', ')}
           </p>
           <p>
             <strong>Managers:</strong>

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -216,7 +216,7 @@ export default function ApprovedActivityReport({ match, user }) {
         const targetPopulations = data.targetPopulations.map((population) => population).join(', '); // Approvers.
         const approvingManagers = data.approvers.map((a) => a.User.fullName).join(', ');
         const collaborators = data.activityReportCollaborators.map(
-          (a) => a.fullNameSubstituteRoles, // Match what we show on the landing.
+          (a) => a.fullName,
         );
 
         // Approver Notes.

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -37,24 +37,24 @@ export function ReportsRow({ reports, removeAlert, message }) {
       displayId,
       activityRecipients,
       startDate,
-      collaborators,
       calculatedStatus,
       pendingApprovals,
       approvers,
       createdAt,
       creatorName,
+      activityReportCollaborators,
     } = report;
 
     const justSubmitted = message && message.reportId === id;
-
     const recipients = activityRecipients.map((ar) => (
       ar.grant ? ar.grant.recipient.name : ar.name
     ));
 
     const approversToolTipText = approvers ? approvers.map((a) => a.User.fullName) : [];
 
-    const collaboratorNames = collaborators && collaborators.map((collaborator) => (
-      collaborator.fullName));
+    const collaboratorNames = activityReportCollaborators
+      ? activityReportCollaborators.map((collaborator) => (
+        collaborator.user.fullName)) : [];
 
     const idKey = `my_alerts_${id}`;
     const idLink = `/activity-reports/${id}`;

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -51,10 +51,9 @@ export function ReportsRow({ reports, removeAlert, message }) {
     ));
 
     const approversToolTipText = approvers ? approvers.map((a) => a.User.fullName) : [];
-
     const collaboratorNames = activityReportCollaborators
       ? activityReportCollaborators.map((collaborator) => (
-        collaborator.user.fullName)) : [];
+        collaborator.fullName)) : [];
 
     const idKey = `my_alerts_${id}`;
     const idLink = `/activity-reports/${id}`;

--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -465,7 +465,6 @@ describe('My alerts sorting', () => {
     fetchMock.get(`${base}`, { count: 0, rows: [] });
 
     fireEvent.click(columnHeaders[0]);
-
     const firstCell = /Cucumber User, GS Hermione Granger, SS click to visually reveal the collaborators for R14-AR-2$/i;
     const secondCell = /Orange, GS Hermione Granger, SS click to visually reveal the collaborators for R14-AR-1$/i;
     await waitFor(() => expect(screen.getAllByRole('cell')[5]).toHaveTextContent(firstCell));

--- a/frontend/src/pages/Landing/mocks.js
+++ b/frontend/src/pages/Landing/mocks.js
@@ -56,16 +56,20 @@ const activityReports = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Orange, GS',
-        name: 'Orange',
-        role: 'Grants Specialist',
+        user: {
+          fullName: 'Orange, GS',
+          name: 'Orange',
+          role: 'Grants Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -99,16 +103,20 @@ const activityReports = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Cucumber User, GS',
-        name: 'Cucumber User',
-        role: 'Grantee Specialist',
+        user: {
+          fullName: 'Cucumber User, GS',
+          name: 'Cucumber User',
+          role: 'Grantee Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -144,16 +152,20 @@ export const activityReportsSorted = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Cucumber User, GS',
-        name: 'Cucumber User',
-        role: 'Grantee Specialist',
+        user: {
+          fullName: 'Cucumber User, GS',
+          name: 'Cucumber User',
+          role: 'Grantee Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -213,16 +225,20 @@ export const activityReportsSorted = [
       role: 'Grants Specialist',
       homeRegionId: 14,
     },
-    collaborators: [
+    activityReportCollaborators: [
       {
-        fullName: 'Orange, GS',
-        name: 'Orange',
-        role: 'Grants Specialist',
+        user: {
+          fullName: 'Orange, GS',
+          name: 'Orange',
+          role: 'Grants Specialist',
+        },
       },
       {
-        fullName: 'Hermione Granger, SS',
-        name: 'Hermione Granger',
-        role: 'System Specialist',
+        user: {
+          fullName: 'Hermione Granger, SS',
+          name: 'Hermione Granger',
+          role: 'System Specialist',
+        },
       },
     ],
   },
@@ -287,16 +303,21 @@ export const generateXFakeReports = (count) => {
           role: 'Grants Specialist',
           homeRegionId: 14,
         },
-        collaborators: [
+        activityReportCollaborators: [
           {
-            fullName: 'Orange, GS',
-            name: 'Orange',
-            role: 'Grants Specialist',
+            user: {
+              fullName: 'Orange, GS',
+              name: 'Orange',
+              role: 'Grants Specialist',
+            },
           },
           {
-            fullName: 'Hermione Granger, SS',
-            name: 'Hermione Granger',
-            role: 'System Specialist',
+
+            user: {
+              fullName: 'Hermione Granger, SS',
+              name: 'Hermione Granger',
+              role: 'System Specialist',
+            },
           },
         ],
       },

--- a/frontend/src/pages/Landing/mocks.js
+++ b/frontend/src/pages/Landing/mocks.js
@@ -59,7 +59,6 @@ const activityReports = [
     activityReportCollaborators: [
       {
         fullName: 'Orange, GS',
-        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -68,7 +67,6 @@ const activityReports = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -110,7 +108,6 @@ const activityReports = [
     activityReportCollaborators: [
       {
         fullName: 'Cucumber User, GS',
-        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -119,7 +116,6 @@ const activityReports = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -163,7 +159,6 @@ export const activityReportsSorted = [
     activityReportCollaborators: [
       {
         fullName: 'Cucumber User, GS',
-        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -172,7 +167,6 @@ export const activityReportsSorted = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -240,7 +234,6 @@ export const activityReportsSorted = [
     activityReportCollaborators: [
       {
         fullName: 'Orange, GS',
-        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -249,7 +242,6 @@ export const activityReportsSorted = [
       },
       {
         fullName: 'Hermione Granger, SS',
-        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -322,7 +314,6 @@ export const generateXFakeReports = (count) => {
         activityReportCollaborators: [
           {
             fullName: 'Orange, GS',
-            fullNameSubstituteRoles: 'Orange, GS',
             user: {
               fullName: 'Orange, GS',
               name: 'Orange',
@@ -331,7 +322,6 @@ export const generateXFakeReports = (count) => {
           },
           {
             fullName: 'Hermione Granger, SS',
-            fullNameSubstituteRoles: 'Hermione Granger, SS',
             user: {
               fullName: 'Hermione Granger, SS',
               name: 'Hermione Granger',

--- a/frontend/src/pages/Landing/mocks.js
+++ b/frontend/src/pages/Landing/mocks.js
@@ -58,6 +58,8 @@ const activityReports = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Orange, GS',
+        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -65,6 +67,8 @@ const activityReports = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -105,6 +109,8 @@ const activityReports = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Cucumber User, GS',
+        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -112,6 +118,8 @@ const activityReports = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -154,6 +162,8 @@ export const activityReportsSorted = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Cucumber User, GS',
+        fullNameSubstituteRoles: 'Cucumber User, GS',
         user: {
           fullName: 'Cucumber User, GS',
           name: 'Cucumber User',
@@ -161,6 +171,8 @@ export const activityReportsSorted = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -227,6 +239,8 @@ export const activityReportsSorted = [
     },
     activityReportCollaborators: [
       {
+        fullName: 'Orange, GS',
+        fullNameSubstituteRoles: 'Orange, GS',
         user: {
           fullName: 'Orange, GS',
           name: 'Orange',
@@ -234,6 +248,8 @@ export const activityReportsSorted = [
         },
       },
       {
+        fullName: 'Hermione Granger, SS',
+        fullNameSubstituteRoles: 'Hermione Granger, SS',
         user: {
           fullName: 'Hermione Granger, SS',
           name: 'Hermione Granger',
@@ -305,6 +321,8 @@ export const generateXFakeReports = (count) => {
         },
         activityReportCollaborators: [
           {
+            fullName: 'Orange, GS',
+            fullNameSubstituteRoles: 'Orange, GS',
             user: {
               fullName: 'Orange, GS',
               name: 'Orange',
@@ -312,7 +330,8 @@ export const generateXFakeReports = (count) => {
             },
           },
           {
-
+            fullName: 'Hermione Granger, SS',
+            fullNameSubstituteRoles: 'Hermione Granger, SS',
             user: {
               fullName: 'Hermione Granger, SS',
               name: 'Hermione Granger',

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -204,7 +204,7 @@ export const collaboratorAssignedNotification = (report, newCollaborators) => {
     try {
       const data = {
         report,
-        newCollaborator: collaborator,
+        newCollaborator: collaborator.user,
       };
       notificationQueue.add('collaboratorAssigned', data);
     } catch (err) {

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -245,7 +245,6 @@ const arTransformers = [
   'creatorName',
   transformRelatedModel('lastUpdatedBy', 'name'),
   'requester',
-  transformCollaborators('activityReportCollaborators', 'fullNameSubstituteRoles', 'collaborators'),
   transformCollaborators('activityReportCollaborators', 'fullName', 'alertCollaborators'),
   transformApproversModel('name'),
   'targetPopulations',

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -63,7 +63,7 @@ function transformRelatedModel(field, prop) {
   return transformer;
 }
 
-function transformCollaborators(joinTable, table, field, fieldName) {
+function transformCollaborators(joinTable, field, fieldName) {
   function transformer(instance) {
     const obj = {};
     let records = instance[joinTable];
@@ -71,7 +71,7 @@ function transformCollaborators(joinTable, table, field, fieldName) {
       if (!Array.isArray(records)) {
         records = [records];
       }
-      const value = records.map((r) => r[table][field]).sort().join('\n');
+      const value = records.map((r) => r[field]).sort().join('\n');
       Object.defineProperty(obj, fieldName, {
         value,
         enumerable: true,
@@ -245,7 +245,8 @@ const arTransformers = [
   'creatorName',
   transformRelatedModel('lastUpdatedBy', 'name'),
   'requester',
-  transformCollaborators('activityReportCollaborators', 'user', 'fullName', 'collaborators'),
+  transformCollaborators('activityReportCollaborators', 'fullNameSubstituteRoles', 'collaborators'),
+  transformCollaborators('activityReportCollaborators', 'fullName', 'alertCollaborators'),
   transformApproversModel('name'),
   'targetPopulations',
   'virtualDeliveryType',

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -245,7 +245,7 @@ const arTransformers = [
   'creatorName',
   transformRelatedModel('lastUpdatedBy', 'name'),
   'requester',
-  transformCollaborators('activityReportCollaborators', 'fullName', 'alertCollaborators'),
+  transformCollaborators('activityReportCollaborators', 'fullName', 'collaborators'),
   transformApproversModel('name'),
   'targetPopulations',
   'virtualDeliveryType',

--- a/src/migrations/20220520133458-add-collaborator-roles.js
+++ b/src/migrations/20220520133458-add-collaborator-roles.js
@@ -9,6 +9,7 @@ module.exports = {
     activityReportCollaboratorId: {
       type: Sequelize.INTEGER,
       allowNull: false,
+      onDelete: 'CASCADE',
       references: {
         model: {
           tableName: 'ActivityReportCollaborators',

--- a/src/migrations/20220520133458-add-collaborator-roles.js
+++ b/src/migrations/20220520133458-add-collaborator-roles.js
@@ -1,0 +1,33 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('CollaboratorRoles', {
+    id: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    activityReportCollaboratorId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: {
+          tableName: 'ActivityReportCollaborators',
+        },
+        key: 'id',
+      },
+    },
+    role: {
+      allowNull: false,
+      type: Sequelize.STRING,
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+  down: (queryInterface) => queryInterface.dropTable('CollaboratorRoles'),
+};

--- a/src/models/CollaboratorRole.js
+++ b/src/models/CollaboratorRole.js
@@ -1,0 +1,31 @@
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class CollaboratorRole extends Model {
+    static associate(models) {
+      CollaboratorRole.belongsTo(models.ActivityReportCollaborator, { foreignKey: 'activityReportCollaboratorId', as: 'activityReportCollaborator' });
+    }
+  }
+  CollaboratorRole.init({
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: null,
+      comment: null,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    activityReportCollaboratorId: {
+      allowNull: false,
+      type: DataTypes.INTEGER,
+    },
+    role: {
+      allowNull: false,
+      type: DataTypes.STRING,
+    },
+  }, {
+    sequelize,
+    modelName: 'CollaboratorRole',
+  });
+  return CollaboratorRole;
+};

--- a/src/models/activityReport.js
+++ b/src/models/activityReport.js
@@ -38,15 +38,6 @@ module.exports = (sequelize, DataTypes) => {
       ActivityReport.belongsTo(models.User, { foreignKey: 'lastUpdatedById', as: 'lastUpdatedBy' });
       ActivityReport.hasMany(models.ActivityRecipient, { foreignKey: 'activityReportId', as: 'activityRecipients' });
       ActivityReport.hasMany(models.ActivityReportCollaborator, { foreignKey: 'activityReportId', as: 'activityReportCollaborators' });
-      ActivityReport.belongsToMany(models.User, {
-        through: models.ActivityReportCollaborator,
-        // The key in the join table that points to the model defined in this file
-        foreignKey: 'activityReportId',
-        // The key in the join table that points to the "target" of the belongs to many (Users in
-        // this case)
-        otherKey: 'userId',
-        as: 'collaborators',
-      });
       ActivityReport.belongsTo(models.Region, { foreignKey: 'regionId', as: 'region' });
       ActivityReport.hasMany(models.File, { foreignKey: 'activityReportId', as: 'attachments' });
       ActivityReport.hasMany(models.NextStep, { foreignKey: 'activityReportId', as: 'specialistNextSteps' });

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -1,5 +1,21 @@
 const { Model } = require('sequelize');
 
+const generateFullName = (user, collaboratorRoles, substituteUserRoles = false) => {
+  const roles = collaboratorRoles.map((r) => r.role).sort();
+
+  if (!roles.length && substituteUserRoles) {
+    return user.fullName;
+  }
+
+  const combinedRoles = roles.reduce((result, val) => {
+    if (val) {
+      return val === 'TTAC' || val === 'COR' ? `${result}, ${val}` : `${result}, ${val.split(' ').map((word) => word[0]).join('')}`;
+    }
+    return '';
+  }, []);
+  return combinedRoles.length > 0 ? `${user.name}${combinedRoles}` : user.name;
+};
+
 module.exports = (sequelize, DataTypes) => {
   class ActivityReportCollaborator extends Model {
     static associate(models) {
@@ -16,6 +32,23 @@ module.exports = (sequelize, DataTypes) => {
     userId: {
       allowNull: false,
       type: DataTypes.INTEGER,
+    },
+    fullName: {
+      type: DataTypes.VIRTUAL,
+      get() {
+        return this.collaboratorRoles
+          ? generateFullName(this.user, this.collaboratorRoles)
+          : this.user.name;
+      },
+    },
+    fullNameSubstituteRoles: {
+      type: DataTypes.VIRTUAL,
+      get() {
+        // If the report was created before we saved collaborator roles.
+        // We can use this field to ensure roles showed as they did before.
+        // Otherwise it will pull from the 'CollaboratorRoles' table.
+        return generateFullName(this.user, this.collaboratorRoles, true);
+      },
     },
   }, {
     sequelize,

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -5,6 +5,7 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       ActivityReportCollaborator.belongsTo(models.ActivityReport, { foreignKey: 'activityReportId', as: 'activityReport' });
       ActivityReportCollaborator.belongsTo(models.User, { foreignKey: 'userId', as: 'user' });
+      ActivityReportCollaborator.hasMany(models.CollaboratorRole, { foreignKey: 'activityReportCollaboratorId', as: 'collaboratorRoles' });
     }
   }
   ActivityReportCollaborator.init({

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -1,10 +1,10 @@
 const { Model } = require('sequelize');
 
 const generateFullName = (user, collaboratorRoles) => {
-  if (!collaboratorRoles.length) {
-    return user.fullName; // Contains name and roles from user.
+  const roles = collaboratorRoles ? collaboratorRoles.map((r) => r.role).sort() : [];
+  if (!roles.length) {
+    return user.fullName;
   }
-  const roles = collaboratorRoles.map((r) => r.role).sort();
   const combinedRoles = roles.reduce((result, val) => {
     if (val) {
       return val === 'TTAC' || val === 'COR' ? `${result}, ${val}` : `${result}, ${val.split(' ').map((word) => word[0]).join('')}`;

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -1,7 +1,7 @@
 const { Model } = require('sequelize');
 
 const generateFullName = (user, collaboratorRoles, substituteUserRoles = false) => {
-  const roles = collaboratorRoles.map((r) => r.role).sort();
+  const roles = collaboratorRoles ? collaboratorRoles.map((r) => r.role).sort() : [];
 
   if (!roles.length && substituteUserRoles) {
     return user.fullName;

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -5,7 +5,7 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       ActivityReportCollaborator.belongsTo(models.ActivityReport, { foreignKey: 'activityReportId', as: 'activityReport' });
       ActivityReportCollaborator.belongsTo(models.User, { foreignKey: 'userId', as: 'user' });
-      ActivityReportCollaborator.hasMany(models.CollaboratorRole, { foreignKey: 'activityReportCollaboratorId', as: 'collaboratorRoles' });
+      ActivityReportCollaborator.hasMany(models.CollaboratorRole, { foreignKey: 'activityReportCollaboratorId', onDelete: 'cascade', as: 'collaboratorRoles' });
     }
   }
   ActivityReportCollaborator.init({

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -1,12 +1,10 @@
 const { Model } = require('sequelize');
 
-const generateFullName = (user, collaboratorRoles, substituteUserRoles = false) => {
-  const roles = collaboratorRoles ? collaboratorRoles.map((r) => r.role).sort() : [];
-
-  if (!roles.length && substituteUserRoles) {
-    return user.fullName;
+const generateFullName = (user, collaboratorRoles) => {
+  if (!collaboratorRoles.length) {
+    return user.fullName; // Contains name and roles from user.
   }
-
+  const roles = collaboratorRoles.map((r) => r.role).sort();
   const combinedRoles = roles.reduce((result, val) => {
     if (val) {
       return val === 'TTAC' || val === 'COR' ? `${result}, ${val}` : `${result}, ${val.split(' ').map((word) => word[0]).join('')}`;
@@ -36,18 +34,7 @@ module.exports = (sequelize, DataTypes) => {
     fullName: {
       type: DataTypes.VIRTUAL,
       get() {
-        return this.collaboratorRoles
-          ? generateFullName(this.user, this.collaboratorRoles)
-          : this.user.name;
-      },
-    },
-    fullNameSubstituteRoles: {
-      type: DataTypes.VIRTUAL,
-      get() {
-        // If the report was created before we saved collaborator roles.
-        // We can use this field to ensure roles showed as they did before.
-        // Otherwise it will pull from the 'CollaboratorRoles' table.
-        return generateFullName(this.user, this.collaboratorRoles, true);
+        return generateFullName(this.user, this.collaboratorRoles);
       },
     },
   }, {

--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -130,7 +130,13 @@ export default class ActivityReport {
   }
 
   isCollaborator() {
-    return this.activityReport.collaborators.some((user) => user.id === this.user.id);
+    if (!this.activityReport.activityReportCollaborators
+      || this.activityReport.activityReportCollaborators.length === 0) {
+      return false;
+    }
+
+    return this.activityReport
+      .activityReportCollaborators.some((collab) => collab.user.id === this.user.id);
   }
 
   isApprovingManager() {

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -4,7 +4,7 @@ import { REPORT_STATUSES } from '../constants';
 
 function activityReport(
   author,
-  collaborator,
+  activityReportCollaborator,
   approvers,
   submissionStatus = REPORT_STATUSES.DRAFT,
   calculatedStatus = null,
@@ -12,14 +12,14 @@ function activityReport(
   const report = {
     userId: author,
     regionId: 1,
-    collaborators: [],
+    activityReportCollaborators: [],
     approvers: [],
     submissionStatus,
     calculatedStatus,
   };
 
-  if (collaborator) {
-    report.collaborators.push(collaborator);
+  if (activityReportCollaborator) {
+    report.activityReportCollaborators.push(activityReportCollaborator);
   }
 
   if (approvers) {
@@ -66,7 +66,7 @@ function user(write, read, admin, approve, id = 1) {
 }
 
 const author = user(true, false, false, false, 1);
-const collaborator = user(true, false, false, false, 2);
+const activityReportCollaborator = { user: user(true, false, false, false, 2) };
 const manager = user(true, false, false, false, 3);
 const otherUser = user(false, true, false, false, 4);
 const canNotReadRegion = user(false, false, false, false, 5);
@@ -131,8 +131,8 @@ describe('Activity Report policies', () => {
       });
 
       it('is true if the user is a collaborator', () => {
-        const report = activityReport(author.id, collaborator);
-        const policy = new ActivityReport(collaborator, report);
+        const report = activityReport(author.id, activityReportCollaborator);
+        const policy = new ActivityReport(activityReportCollaborator.user, report);
         expect(policy.canUpdate()).toBeTruthy();
       });
 
@@ -256,19 +256,19 @@ describe('Activity Report policies', () => {
     it('is true for collaborators', () => {
       const report = activityReport(
         author.id,
-        collaborator,
+        activityReportCollaborator,
         null,
         REPORT_STATUSES.SUBMITTED,
         REPORT_STATUSES.SUBMITTED,
       );
-      const policy = new ActivityReport(collaborator, report);
+      const policy = new ActivityReport(activityReportCollaborator.user, report);
       expect(policy.canReset()).toBeTruthy();
     });
 
     it('is false for other users', () => {
       const report = activityReport(
         author.id,
-        collaborator,
+        activityReportCollaborator,
         null,
         REPORT_STATUSES.SUBMITTED,
         REPORT_STATUSES.SUBMITTED,
@@ -307,8 +307,8 @@ describe('Activity Report policies', () => {
       });
 
       it('is true for the collaborator', () => {
-        const report = activityReport(author.id, collaborator);
-        const policy = new ActivityReport(collaborator, report);
+        const report = activityReport(author.id, activityReportCollaborator);
+        const policy = new ActivityReport(activityReportCollaborator.user, report);
         expect(policy.canGet()).toBeTruthy();
       });
 
@@ -390,8 +390,8 @@ describe('Activity Report policies', () => {
     });
 
     it('is false for any non-admin/non-author user of draft report', () => {
-      const report = activityReport(author.id, collaborator);
-      const policy = new ActivityReport(collaborator, report);
+      const report = activityReport(author.id, activityReportCollaborator);
+      const policy = new ActivityReport(activityReportCollaborator.user, report);
       expect(policy.canDelete()).toBeFalsy();
     });
 

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -2,7 +2,9 @@ import stringify from 'csv-stringify/lib/sync';
 import handleErrors from '../../lib/apiErrorHandler';
 import SCOPES from '../../middleware/scopeConstants';
 import {
-  ActivityReport as ActivityReportModel, ActivityReportApprover, User as UserModel,
+  ActivityReport as ActivityReportModel,
+  ActivityReportApprover,
+  User as UserModel,
 } from '../../models';
 import ActivityReport from '../../policies/activityReport';
 import User from '../../policies/user';
@@ -570,11 +572,11 @@ export async function saveReport(req, res) {
     // join the updated report with the model object retrieved from the API
     // since we may not get all fields in the request body
     const savedReport = await createOrUpdate({ ...report, ...newReport }, report);
-    if (savedReport.collaborators) {
+    if (savedReport.activityReportCollaborators) {
       // only include collaborators that aren't already in the report
-      const newCollaborators = savedReport.collaborators.filter((c) => {
-        const oldCollaborators = report.collaborators.map((x) => x.email);
-        return !oldCollaborators.includes(c.email);
+      const newCollaborators = savedReport.activityReportCollaborators.filter((c) => {
+        const oldCollaborators = report.activityReportCollaborators.map((x) => x.user.email);
+        return !oldCollaborators.includes(c.user.email);
       });
       collaboratorAssignedNotification(savedReport, newCollaborators);
     }
@@ -608,10 +610,10 @@ export async function createReport(req, res) {
       res.sendStatus(403);
       return;
     }
-
+    // updateCollaboratorRoles(newReport);
     const report = await createOrUpdate(newReport);
-    if (report.collaborators) {
-      collaboratorAssignedNotification(report, report.collaborators);
+    if (report.activityReportCollaborators) {
+      collaboratorAssignedNotification(report, report.activityReportCollaborators);
     }
     res.json(report);
   } catch (error) {

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -45,7 +45,7 @@ const logContext = {
 
 export const LEGACY_WARNING = 'Reports done before March 17, 2021 may have blank fields. These were done in a SmartSheet, not the TTA Hub.';
 
-async function sendActivityReportCSV(reports, res) {
+async function sendActivityReportCSV(reports, res, isAlerts = false) {
   const csvRows = await Promise.all(reports.map((r) => activityReportToCsvRecord(r)));
 
   // base options
@@ -73,7 +73,8 @@ async function sendActivityReportCSV(reports, res) {
           header: 'Creator',
         },
         {
-          key: 'collaborators',
+          // Alerts export should match what we show.
+          key: isAlerts ? 'alertCollaborators' : 'collaborators',
           header: 'Collaborators',
         },
         {
@@ -671,7 +672,7 @@ export async function downloadAllAlerts(req, res) {
     const query = await setReadRegions(req.query, userId);
     const rows = await getAllDownloadableActivityReportAlerts(userId, query);
 
-    await sendActivityReportCSV(rows, res);
+    await sendActivityReportCSV(rows, res, true);
   } catch (error) {
     await handleErrors(req, res, error, logContext);
   }

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -73,8 +73,7 @@ async function sendActivityReportCSV(reports, res, isAlerts = false) {
           header: 'Creator',
         },
         {
-          // Alerts export should match what we show.
-          key: isAlerts ? 'alertCollaborators' : 'collaborators',
+          key: 'collaborators',
           header: 'Collaborators',
         },
         {

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -45,7 +45,7 @@ const logContext = {
 
 export const LEGACY_WARNING = 'Reports done before March 17, 2021 may have blank fields. These were done in a SmartSheet, not the TTA Hub.';
 
-async function sendActivityReportCSV(reports, res, isAlerts = false) {
+async function sendActivityReportCSV(reports, res) {
   const csvRows = await Promise.all(reports.map((r) => activityReportToCsvRecord(r)));
 
   // base options
@@ -671,7 +671,7 @@ export async function downloadAllAlerts(req, res) {
     const query = await setReadRegions(req.query, userId);
     const rows = await getAllDownloadableActivityReportAlerts(userId, query);
 
-    await sendActivityReportCSV(rows, res, true);
+    await sendActivityReportCSV(rows, res);
   } catch (error) {
     await handleErrors(req, res, error, logContext);
   }

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -688,6 +688,8 @@ describe('Activity Report handlers', () => {
         },
         activityReportCollaborators: [
           {
+            fullName: 'Jarty, , SS, GS',
+            fullNameSubstituteRoles: 'Jarty, SS, GS',
             user: {
               name: 'Jarty',
               role: ['System Specialist', 'Grantee Specialist'],

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -688,7 +688,7 @@ describe('Activity Report handlers', () => {
         },
         activityReportCollaborators: [
           {
-            fullName: 'Jarty, , SS, GS',
+            fullName: 'Jarty, SS, GS',
             user: {
               name: 'Jarty',
               role: ['System Specialist', 'Grantee Specialist'],

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -689,7 +689,6 @@ describe('Activity Report handlers', () => {
         activityReportCollaborators: [
           {
             fullName: 'Jarty, , SS, GS',
-            fullNameSubstituteRoles: 'Jarty, SS, GS',
             user: {
               name: 'Jarty',
               role: ['System Specialist', 'Grantee Specialist'],

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -121,18 +121,22 @@ async function saveReportCollaborators(activityReportId, collaborators) {
   );
 
   // If we have collaborators missing roles.
-  let updatedRoles = [];
-  rolesToAdd.forEach((collaborator) => {
+  if (rolesToAdd && rolesToAdd.length > 0) {
+    let updatedRoles = [];
+    rolesToAdd.forEach((collaborator) => {
     // Set collaborator roles.
-    const { role } = collaborator.user;
-    // Concat list of collaborator role updates promises.
-    updatedRoles = updatedRoles.concat(role.map((r) => CollaboratorRole.findOrCreate(
-      { where: { activityReportCollaboratorId: collaborator.id, role: r } },
-    )));
-  });
+      const { role } = collaborator.user;
+      // Concat list of collaborator role updates promises.
+      updatedRoles = updatedRoles.concat(role.map((r) => CollaboratorRole.findOrCreate(
+        { where: { activityReportCollaboratorId: collaborator.id, role: r } },
+      )));
+    });
 
-  // Resolve all role update promises.
-  await Promise.all(updatedRoles);
+    // Resolve all role update promises.
+    if (updatedRoles && updatedRoles.length > 0) {
+      await Promise.all(updatedRoles);
+    }
+  }
 }
 
 async function saveReportRecipients(

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -72,38 +72,6 @@ async function saveReportCollaborators(activityReportId, collaborators) {
     userId: collaborator,
   }));
 
-  // Get the currently saved activity report collaborators.
-  const savedCollaborators = await ActivityReportCollaborator.findAll({
-    where: { activityReportId },
-    include: [
-      {
-        model: User,
-        as: 'user',
-      },
-      {
-        model: CollaboratorRole,
-        as: 'collaboratorRoles',
-      },
-    ],
-  });
-
-  // Get list of collaborator roles to delete.
-  const reportCollaboratorsUserIds = collaborators.map((u) => u.id);
-  const collaboratorsToRemove = savedCollaborators.filter(
-    (u) => !reportCollaboratorsUserIds.includes(parseInt(u.user.id, 10)),
-  ).map((c) => c.id);
-
-  // Remove deleted collaborator roles.
-  await CollaboratorRole.destroy(
-    {
-      where: {
-        activityReportCollaboratorId: {
-          [Op.in]: collaboratorsToRemove,
-        },
-      },
-    },
-  );
-
   // Create and delete activity report collaborators.
   if (newCollaborators.length > 0) {
     await ActivityReportCollaborator.bulkCreate(

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -692,7 +692,7 @@ export async function createOrUpdate(newActivityReport, report) {
     const newCollaborators = activityReportCollaborators.map(
       (c) => c.user.id,
     );
-    await saveReportCollaborators(id, newCollaborators, activityReportCollaborators);
+    await saveReportCollaborators(id, newCollaborators);
   }
   if (activityRecipients) {
     const { activityRecipientType, id } = savedReport;

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -876,6 +876,10 @@ async function getDownloadableActivityReports(where, separate = true) {
           model: User,
           as: 'user',
           attributes: ['id', 'name', 'role', 'fullName'],
+        },
+        {
+          model: CollaboratorRole,
+          as: 'collaboratorRoles',
         }],
       },
       {

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -618,7 +618,7 @@ export async function createOrUpdate(newActivityReport, report) {
     goals,
     objectivesWithGoals,
     objectivesWithoutGoals,
-    collaborators,
+    activityReportCollaborators,
     activityRecipients,
     attachments,
     author,
@@ -646,17 +646,10 @@ export async function createOrUpdate(newActivityReport, report) {
   } else {
     savedReport = await create(updatedFields);
   }
-  /* if (activityReportCollaborators) {
+  if (activityReportCollaborators) {
     const { id } = savedReport;
     const newCollaborators = activityReportCollaborators.map(
       (c) => c.user.id,
-    );
-    await saveReportCollaborators(id, newCollaborators);
-  } */
-  if (collaborators) {
-    const { id } = savedReport;
-    const newCollaborators = collaborators.map(
-      (g) => g.id,
     );
     await saveReportCollaborators(id, newCollaborators);
   }

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -489,6 +489,10 @@ export function activityReports(
               as: 'user',
               attributes: ['id', 'name', 'role', 'fullName'],
             },
+            {
+              model: CollaboratorRole,
+              as: 'collaboratorRoles',
+            },
           ],
         },
         {
@@ -625,6 +629,10 @@ export async function activityReportAlerts(userId, {
               as: 'user',
               attributes: ['id', 'name', 'role', 'fullName'],
               duplicating: true,
+            },
+            {
+              model: CollaboratorRole,
+              as: 'collaboratorRoles',
             },
           ],
         },

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -376,8 +376,8 @@ describe('Activity report service', () => {
           ...reportObject,
           collaborators: [{ id: mockUser.id }],
         });
-        expect(report.collaborators.length).toBe(1);
-        expect(report.collaborators[0].name).toBe(mockUser.name);
+        expect(report.activityReportCollaborators.length).toBe(1);
+        expect(report.activityReportCollaborators[0].user.name).toBe(mockUser.name);
       });
 
       it('handles notes being created', async () => {
@@ -673,7 +673,7 @@ describe('Activity report service', () => {
           sortBy: 'collaborators', sortDir: 'asc', offset: 0, limit: 12, 'region.in': ['1'], 'reportId.nctn': idsToExclude,
         });
         expect(rows.length).toBe(5);
-        expect(rows[0].collaborators[0].name).toBe(mockUser.name);
+        expect(rows[0].activityReportCollaborators[0].user.name).toBe(mockUser.name);
       });
 
       it('retrieves reports sorted by id', async () => {

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -374,7 +374,7 @@ describe('Activity report service', () => {
       it('handles reports with collaborators', async () => {
         const report = await createOrUpdate({
           ...reportObject,
-          collaborators: [{ id: mockUser.id }],
+          activityReportCollaborators: [{ user: { id: mockUser.id } }],
         });
         expect(report.activityReportCollaborators.length).toBe(1);
         expect(report.activityReportCollaborators[0].user.name).toBe(mockUser.name);

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -319,7 +319,7 @@ describe('Activity report service', () => {
           additionalNotes: null,
           approvingManagerId: null,
           attachments: [],
-          collaborators: [],
+          activityReportCollaborators: [],
           context: '',
           deliveryMethod: null,
           duration: null,
@@ -618,7 +618,7 @@ describe('Activity report service', () => {
         await createOrUpdate({
           ...submittedReport,
           calculatedStatus: REPORT_STATUSES.APPROVED,
-          collaborators: [{ id: mockUser.id }],
+          activityReportCollaborators: [{ user: { id: mockUser.id } }],
         });
         await ActivityReport.create({
           ...submittedReport,

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -404,6 +404,9 @@ describe('Activity report service', () => {
         expect(activityReportCollaborator).not.toBe(null);
         expect(activityReportCollaborator.length).toBe(1);
         expect(activityReportCollaborator[0].collaboratorRoles.length).toBe(2);
+        activityReportCollaborator[0].collaboratorRoles.sort(
+          (a, b) => ((a.role > b.role) ? 1 : -1),
+        );
         expect(activityReportCollaborator[0].collaboratorRoles[0].role).toBe('Grants Specialist');
         expect(activityReportCollaborator[0].collaboratorRoles[1].role).toBe('Health Specialist');
 
@@ -462,6 +465,9 @@ describe('Activity report service', () => {
         expect(activityReportCollaborator).not.toBe(null);
         expect(activityReportCollaborator.length).toBe(1);
         expect(activityReportCollaborator[0].collaboratorRoles.length).toBe(2);
+        activityReportCollaborator[0].collaboratorRoles.sort(
+          (a, b) => ((a.role > b.role) ? 1 : -1),
+        );
         expect(activityReportCollaborator[0].collaboratorRoles[0].role).toBe('Grants Specialist');
         expect(activityReportCollaborator[0].collaboratorRoles[1].role).toBe('Health Specialist');
 

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -30,6 +30,7 @@ const mockUser = {
   name: 'user1115665161',
   hsesUsername: 'user1115665161',
   hsesUserId: 'user1115665161',
+  role: ['Grants Specialist'],
 };
 
 const mockUserTwo = {
@@ -47,6 +48,7 @@ const mockUserThree = {
   name: 'user39861962',
   hsesUserId: 'user39861962',
   hsesUsername: 'user39861962',
+  role: [],
 };
 
 const mockUserFour = {
@@ -55,6 +57,7 @@ const mockUserFour = {
   name: 'user49861962',
   hsesUserId: 'user49861962',
   hsesUsername: 'user49861962',
+  role: [],
 };
 
 const mockUserFive = {
@@ -63,6 +66,7 @@ const mockUserFive = {
   name: 'user55861962',
   hsesUserId: 'user55861962',
   hsesUsername: 'user55861962',
+  role: [],
 };
 
 const alertsMockUserOne = {
@@ -71,6 +75,7 @@ const alertsMockUserOne = {
   name: 'a',
   hsesUserId: 'a',
   hsesUsername: 'a',
+  role: [],
 };
 
 const alertsMockUserTwo = {
@@ -79,6 +84,7 @@ const alertsMockUserTwo = {
   name: 'b',
   hsesUserId: 'b',
   hsesUsername: 'b',
+  role: [],
 };
 
 const reportObject = {

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -408,7 +408,6 @@ describe('Activity report service', () => {
           (a, b) => ((a.role > b.role) ? 1 : -1),
         );
         expect(activityReportCollaborator[0].fullName).toBe('user1115665161, GS, HS');
-        expect(activityReportCollaborator[0].fullNameSubstituteRoles).toBe('user1115665161, GS, HS');
         expect(activityReportCollaborator[0].collaboratorRoles[0].role).toBe('Grants Specialist');
         expect(activityReportCollaborator[0].collaboratorRoles[1].role).toBe('Health Specialist');
 
@@ -419,7 +418,6 @@ describe('Activity report service', () => {
         expect(activityReportCollaborator).not.toBe(null);
         expect(activityReportCollaborator.length).toBe(1);
         expect(activityReportCollaborator[0].fullName).toBe('user265157914, COR');
-        expect(activityReportCollaborator[0].fullNameSubstituteRoles).toBe('user265157914, COR');
         expect(activityReportCollaborator[0].collaboratorRoles.length).toBe(1);
         expect(activityReportCollaborator[0].collaboratorRoles[0].role).toBe('COR');
 
@@ -430,7 +428,6 @@ describe('Activity report service', () => {
         expect(activityReportCollaborator).not.toBe(null);
         expect(activityReportCollaborator.length).toBe(1);
         expect(activityReportCollaborator[0].fullName).toBe('user39861962');
-        expect(activityReportCollaborator[0].fullNameSubstituteRoles).toBe('user39861962');
         expect(activityReportCollaborator[0].collaboratorRoles.length).toBe(0);
       });
 

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -407,6 +407,8 @@ describe('Activity report service', () => {
         activityReportCollaborator[0].collaboratorRoles.sort(
           (a, b) => ((a.role > b.role) ? 1 : -1),
         );
+        expect(activityReportCollaborator[0].fullName).toBe('user1115665161, GS, HS');
+        expect(activityReportCollaborator[0].fullNameSubstituteRoles).toBe('user1115665161, GS, HS');
         expect(activityReportCollaborator[0].collaboratorRoles[0].role).toBe('Grants Specialist');
         expect(activityReportCollaborator[0].collaboratorRoles[1].role).toBe('Health Specialist');
 
@@ -416,6 +418,8 @@ describe('Activity report service', () => {
         );
         expect(activityReportCollaborator).not.toBe(null);
         expect(activityReportCollaborator.length).toBe(1);
+        expect(activityReportCollaborator[0].fullName).toBe('user265157914, COR');
+        expect(activityReportCollaborator[0].fullNameSubstituteRoles).toBe('user265157914, COR');
         expect(activityReportCollaborator[0].collaboratorRoles.length).toBe(1);
         expect(activityReportCollaborator[0].collaboratorRoles[0].role).toBe('COR');
 
@@ -425,6 +429,8 @@ describe('Activity report service', () => {
         );
         expect(activityReportCollaborator).not.toBe(null);
         expect(activityReportCollaborator.length).toBe(1);
+        expect(activityReportCollaborator[0].fullName).toBe('user39861962');
+        expect(activityReportCollaborator[0].fullNameSubstituteRoles).toBe('user39861962');
         expect(activityReportCollaborator[0].collaboratorRoles.length).toBe(0);
       });
 


### PR DESCRIPTION
## Description of change

When a collaborator is added to an AR we want to save their roles "at that time" with the report.

## How to test

- Verify landing page correctly shows Alerts and Approved report Collaborators. 
- Create / Update / Reset / Submit / Approve Report
- Should test a case where a collaborator is added without roles. Then the same report is saved when the user has roles added.
- On the AR landing page the Alerts table should show collaborators saved on reports (and export).
- On the AR landing page the Approved AR table should show what's saved on the report else user roles (and export).

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-795


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
