### PR TITLE
[TTAHUB-834] clear local storage when create new is pressed

### DIFF
--- a/frontend/src/components/Navigator/components/SideNav.scss
+++ b/frontend/src/components/Navigator/components/SideNav.scss
@@ -44,7 +44,7 @@
 }
 
 .smart-hub--tag-submitted {
-  background-color: $ttahub-medium-blue;
+  background-color: $base-lighter;
 }
 
 .smart-hub--tag-needs-action {

--- a/frontend/src/hooks/useARLocalStorage.js
+++ b/frontend/src/hooks/useARLocalStorage.js
@@ -20,9 +20,7 @@ export default function useARLocalStorage(key, defaultValue) {
 
     if (storedValue
       && storedValue.calculatedStatus
-      && (storedValue.calculatedStatus === REPORT_STATUSES.APPROVED
-        || storedValue.calculatedStatus === REPORT_STATUSES.SUBMITTED
-      )
+      && storedValue.calculatedStatus !== REPORT_STATUSES.DRAFT
     ) {
       toSave = false;
     }

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -313,16 +313,16 @@ function ActivityReport({
 
         let shouldUpdateFromNetwork = true;
 
-        // this if statemenrt compares the "saved to storage time" and the
+        // this if statement compares the "saved to storage time" and the
         // time retrieved from the network (report.updatedAt)
-        // and whichever is newe "wins"
+        // and whichever is newer "wins"
 
         if (formData && savedToStorageTime) {
           const updatedAtFromNetwork = moment(report.updatedAt);
           const updatedAtFromLocalStorage = moment(savedToStorageTime);
           if (updatedAtFromNetwork.isValid() && updatedAtFromLocalStorage.isValid()) {
             const storageIsNewer = updatedAtFromLocalStorage.isAfter(updatedAtFromNetwork);
-            if (storageIsNewer) {
+            if (storageIsNewer && formData.calculatedStatus === REPORT_STATUSES.DRAFT) {
               shouldUpdateFromNetwork = false;
             }
           }

--- a/frontend/src/pages/Landing/NewReport.js
+++ b/frontend/src/pages/Landing/NewReport.js
@@ -1,20 +1,37 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-
+import { Button } from '@trussworks/react-uswds';
+import { useHistory } from 'react-router-dom';
+import {
+  LOCAL_STORAGE_DATA_KEY,
+  LOCAL_STORAGE_ADDITIONAL_DATA_KEY,
+  LOCAL_STORAGE_EDITABLE_KEY,
+} from '../../Constants';
 import './index.scss';
 
 function NewReport() {
-  return (
-    <Link
-      to="/activity-reports/new/activity-summary"
-      referrerPolicy="same-origin"
+  const history = useHistory();
+  const key = 'new';
+  const onClick = () => {
+    try {
+      // clear out any saved report data from local storage
+      window.localStorage.removeItem(LOCAL_STORAGE_DATA_KEY(key));
+      window.localStorage.removeItem(LOCAL_STORAGE_ADDITIONAL_DATA_KEY(key));
+      window.localStorage.removeItem(LOCAL_STORAGE_EDITABLE_KEY(key));
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log(e);
+    } finally {
+      history.push('/activity-reports/new/activity-summary');
+    }
+  }; return (
+    <Button
+      onClick={onClick}
       className="usa-button smart-hub--new-report-btn"
       variant="unstyled"
     >
       <span className="smart-hub--plus">+</span>
       <span className="smart-hub--new-report">New Activity Report</span>
-    </Link>
+    </Button>
   );
 }
-
 export default NewReport;

--- a/frontend/src/pages/Landing/__tests__/NewReport.js
+++ b/frontend/src/pages/Landing/__tests__/NewReport.js
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render, screen,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
+
+import NewReport from '../NewReport';
+import { mockWindowProperty } from '../../../testHelpers';
+
+describe('NewReport', () => {
+  const history = createMemoryHistory();
+  const removeItem = jest.fn();
+
+  const historyPush = jest.fn();
+  history.push = historyPush;
+
+  mockWindowProperty('localStorage', {
+    removeItem,
+  });
+
+  const renderNewReport = () => {
+    render(<Router history={history}><NewReport /></Router>);
+  };
+
+  it('attempts to clear local storage and navigates the page', async () => {
+    renderNewReport();
+    expect(removeItem).not.toHaveBeenCalled();
+    const button = await screen.findByRole('button');
+    userEvent.click(button);
+    expect(removeItem).toHaveBeenCalled();
+    expect(historyPush).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description of change

Clear local storage of any previous "new" report data when "Create New Report" is pressed.
Local storage should also be ignored/cleaned up if the report is not in "Draft" status.
Also fixed an inaccessible/wrong color on the submitted tag/badges/whatever.

## How to test

Start creating a new report, fill out a few fields. Do not save or navigate within the report. Return to the /activity-reports landing page. View local storage. Confirm that you have data in there. Click on "create new report" and confirm that the data is reset to the default state.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-834


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
