### PR TITLE
[TTAHUB-825] Move AR Summary Context

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -327,6 +327,12 @@ const ActivitySummary = ({
           </Grid>
         </div>
       </Fieldset>
+      <Fieldset className="smart-hub--report-legend margin-top-4" legend="Context">
+        <Label htmlFor="context">Provide background or context for this activity</Label>
+        <div className="smart-hub--text-area__resize-vertical margin-top-1">
+          <HookFormRichEditor ariaLabel="Context" name="context" id="context" />
+        </div>
+      </Fieldset>
       <Fieldset className="smart-hub--report-legend margin-top-4" legend="Training or Technical Assistance">
         <div id="tta" />
         <div className="margin-top-2">
@@ -436,12 +442,7 @@ const ActivitySummary = ({
               </Grid>
             </Grid>
           </FormItem>
-          <Fieldset className="smart-hub--report-legend margin-top-4" legend="Context">
-            <Label htmlFor="context">Provide background or context for this activity</Label>
-            <div className="smart-hub--text-area__resize-vertical margin-top-1">
-              <HookFormRichEditor ariaLabel="Context" name="context" id="context" />
-            </div>
-          </Fieldset>
+
         </div>
       </Fieldset>
     </>


### PR DESCRIPTION
## Description of change

For the AR redesign move the context box above TTA provided.

## How to test

Create a new AR and make sure the context box now appears above the TTA provided. Given the current state of the AR redesign PR you may not be able to save the report.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-825


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
