### PR TITLE
[TTAHUB-858] Added Secondary Sort to Goal List

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
@@ -40,6 +40,7 @@ describe('Activity report print and share view', () => {
       },
     ],
     targetPopulations: ['Mid size sedans'],
+    activityRecipientType: 'recipient',
     specialistNextSteps: [],
     recipientNextSteps: [],
     participants: ['Commander of Pants', 'Princess of Castles'],

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -211,9 +211,10 @@ export default function ApprovedActivityReport({ match, user }) {
         }
 
         // first table
-        let recipientType = data.activityRecipients[0].grantId ? 'Recipient' : 'Other entity';
+        const isRecipient = data.activityRecipientType === 'recipient';
+        let recipientType = isRecipient ? 'Recipient' : 'Other entity';
         if (data.activityRecipients.length > 1) {
-          recipientType = data.activityRecipients[0].grantId ? 'Recipients' : 'Other entities';
+          recipientType = isRecipient ? 'Recipients' : 'Other entities';
         }
 
         const arRecipients = data.activityRecipients.map((arRecipient) => arRecipient.name).sort().join(', ');

--- a/src/lib/orderGoalsBy.js
+++ b/src/lib/orderGoalsBy.js
@@ -6,10 +6,16 @@ const orderGoalsBy = (sortBy, sortDir) => {
   let result = '';
   switch (sortBy) {
     case 'goalStatus':
-      result = [[sequelize.literal(`status_sort ${sortDir}`)]];
+      result = [
+        [sequelize.literal(`status_sort ${sortDir}`)],
+        ['createdAt', 'DESC'],
+      ];
       break;
     case 'createdOn':
-      result = [['createdAt', sortDir]];
+      result = [
+        ['createdAt', sortDir],
+        [sequelize.literal('status_sort ASC')],
+      ];
       break;
     default:
       break;

--- a/src/lib/orderGoalsBy.test.js
+++ b/src/lib/orderGoalsBy.test.js
@@ -8,12 +8,21 @@ describe('orderGoalsBy', () => {
       [
         sequelize.literal('status_sort asc'),
       ],
+      [
+        'createdAt',
+        'DESC',
+      ],
     ]);
 
     const two = orderGoalsBy('createdOn', 'desc');
-    expect(two).toStrictEqual([[
-      'createdAt', 'desc',
-    ]]);
+    expect(two).toStrictEqual([
+      [
+        'createdAt', 'desc',
+      ],
+      [
+        sequelize.literal('status_sort ASC'),
+      ],
+    ]);
 
     const three = orderGoalsBy('fuzzbucket', 'desc');
     expect(three).toStrictEqual('');


### PR DESCRIPTION
## Description of change

Added secondary sort to goals list. 
- If sorting by status the secondary sort is create date DESC.
- If sorting by create date secondary sort is status ASC.

Also fixed display issue on approved reports where the Recipient vs Other Entity label was displaying incorrectly.

## How to test

Sort goals list secondary sort should also be applied.

Create a Recipient and Other Entity approved report both should correctly show their labels.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-858


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated`
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
