### PR TITLE
[TTAHUB-858] Show and Filter on Objective Topics on Goals and Objective Page

### DIFF
--- a/src/scopes/goals/index.test.js
+++ b/src/scopes/goals/index.test.js
@@ -42,6 +42,7 @@ describe('goal filtersToScopes', () => {
     reportWithReasons = await createReport({
       calculatedStatus: 'approved',
       reason: ['Full Enrollment'],
+      topics: ['CLASS: Emotional Support'],
       activityRecipients: [],
       region: 15,
     });
@@ -49,6 +50,7 @@ describe('goal filtersToScopes', () => {
       calculatedStatus: 'approved',
       reason: ['Complaint'],
       activityRecipients: [],
+      topics: ['Behavioral / Mental Health / Trauma'],
       region: 15,
     });
 

--- a/src/scopes/goals/topics.js
+++ b/src/scopes/goals/topics.js
@@ -1,6 +1,7 @@
 import { Op } from 'sequelize';
 import { filterAssociation } from './utils';
 
+/* TODO: Switch for New Goal Creation. */
 /*
 const topicFilter = `
 SELECT

--- a/src/scopes/goals/topics.js
+++ b/src/scopes/goals/topics.js
@@ -1,6 +1,7 @@
 import { Op } from 'sequelize';
 import { filterAssociation } from './utils';
 
+/*
 const topicFilter = `
 SELECT
   DISTINCT "Goal"."id"
@@ -12,6 +13,15 @@ ON "ObjectiveTopics"."topicId" = "Topics"."id"
 INNER JOIN "Goals" "Goal"
 ON "Objectives"."goalId" = "Goal"."id"
 WHERE "Topics"."name"`;
+*/
+
+const topicFilter = `
+SELECT DISTINCT g.id
+FROM "ActivityReports" ar
+INNER JOIN "ActivityReportObjectives" aro ON ar."id" = aro."activityReportId"
+INNER JOIN "Objectives" o ON aro."objectiveId" = o.id
+INNER JOIN "Goals" g ON o."goalId" = g.id
+WHERE ARRAY_TO_STRING(ar."topics", ',')`;
 
 export function withTopics(topics) {
   return {

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -12,6 +12,7 @@ import {
   ActivityReportObjective,
   // ObjectiveTemplate,
   Objective,
+  /* TODO: Switch for New Goal Creation. */
   // ObjectiveTopic,
   // Topic,
 } from '../../models';
@@ -143,6 +144,8 @@ describe('Goals by Recipient Test', () => {
 
   let objectiveIds = [];
   let goalIds = [];
+
+  /* TODO: Switch for New Goal Creation. */
   // let topicIds = [];
   // let objectiveTopicIds = [];
 
@@ -359,6 +362,8 @@ describe('Goals by Recipient Test', () => {
 
     // Get Objective Ids for Delete.
     objectiveIds = objectives.map((o) => o.id);
+
+    /* TODO: Switch for New Goal Creation. */
     /*
     // Create Objective Topics.
     const topics = await Promise.all([
@@ -463,6 +468,8 @@ describe('Goals by Recipient Test', () => {
         id: objectiveIds,
       },
     });
+
+    /* TODO: Switch for New Goal Creation. */
     /*
     // Delete Objective Topics.
     await ObjectiveTopic.destroy({

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -12,6 +12,8 @@ import {
   ActivityReportObjective,
   // ObjectiveTemplate,
   Objective,
+  ObjectiveTopic,
+  Topic,
 } from '../../models';
 
 import { getGoalsByActivityRecipient } from '../recipient';
@@ -141,6 +143,8 @@ describe('Goals by Recipient Test', () => {
 
   let objectiveIds = [];
   let goalIds = [];
+  let topicIds = [];
+  let objectiveTopicIds = [];
 
   beforeAll(async () => {
     // Create User.
@@ -356,6 +360,41 @@ describe('Goals by Recipient Test', () => {
     // Get Objective Ids for Delete.
     objectiveIds = objectives.map((o) => o.id);
 
+    // Create Objective Topics.
+    const topics = await Promise.all([
+      Topic.create({
+        name: 'objective topic 1',
+      }),
+      Topic.create({
+        name: 'objective topic 2',
+      }),
+      Topic.create({
+        name: 'objective topic 3',
+      }),
+    ]);
+
+    topicIds = topics.map((o) => o.id);
+
+    // Assign Objective Topics.
+    const objectiveTopics = await Promise.all(
+      [
+        await ObjectiveTopic.create({
+          topicId: topicIds[0],
+          objectiveId: objectiveIds[0],
+        }),
+        await ObjectiveTopic.create({
+          topicId: topicIds[1],
+          objectiveId: objectiveIds[2],
+        }),
+        await ObjectiveTopic.create({
+          topicId: topicIds[2],
+          objectiveId: objectiveIds[3],
+        }),
+      ],
+    );
+
+    objectiveTopicIds = objectiveTopics.map((o) => o.id);
+
     // AR Objectives.
     await Promise.all(
       [
@@ -424,6 +463,20 @@ describe('Goals by Recipient Test', () => {
       },
     });
 
+    // Delete Objective Topics.
+    await ObjectiveTopic.destroy({
+      where: {
+        id: objectiveTopicIds,
+      },
+    });
+
+    // Delete Topics.
+    await Topic.destroy({
+      where: {
+        id: topicIds,
+      },
+    });
+
     // Delete Goals.
     await Goal.destroy({
       where: {
@@ -483,7 +536,6 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[0].goalNumber).toBe(`R1-G-${goalRowsx[0].id}`);
       expect(goalRowsx[0].objectiveCount).toBe(1);
       expect(goalRowsx[0].reasons).toEqual(['Monitoring | Area of Concern', 'New Director or Management', 'New Program Option']);
-      expect(goalRowsx[0].goalTopics).toEqual(['Child Assessment, Development, Screening', 'Communication']);
       expect(goalRowsx[0].objectives.length).toBe(1);
 
       // Goal 3.
@@ -492,7 +544,7 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[1].goalNumber).toBe(`R1-G-${goalRowsx[1].id}`);
       expect(goalRowsx[1].objectiveCount).toBe(2);
       expect(goalRowsx[1].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[1].goalTopics).toEqual(['Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
+      expect(goalRowsx[1].goalTopics).toEqual(['objective topic 2', 'objective topic 3']);
 
       // Goal 3 Objectives.
       expect(goalRowsx[1].objectives.length).toBe(2);
@@ -514,7 +566,6 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[2].goalNumber).toBe(`R1-G-${goalRowsx[2].id}`);
       expect(goalRowsx[2].objectiveCount).toBe(1);
       expect(goalRowsx[2].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[2].goalTopics).toEqual(['Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
       expect(goalRowsx[2].objectives.length).toBe(1);
 
       // Goal 1.
@@ -523,7 +574,7 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[3].goalNumber).toBe(`R1-G-${goalRowsx[3].id}`);
       expect(goalRowsx[3].objectiveCount).toBe(1);
       expect(goalRowsx[3].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[3].goalTopics).toEqual(['Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
+      expect(goalRowsx[3].goalTopics).toEqual(['objective topic 1']);
       expect(goalRowsx[3].objectives.length).toBe(1);
     });
   });

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -12,8 +12,8 @@ import {
   ActivityReportObjective,
   // ObjectiveTemplate,
   Objective,
-  ObjectiveTopic,
-  Topic,
+  // ObjectiveTopic,
+  // Topic,
 } from '../../models';
 
 import { getGoalsByActivityRecipient } from '../recipient';
@@ -143,8 +143,8 @@ describe('Goals by Recipient Test', () => {
 
   let objectiveIds = [];
   let goalIds = [];
-  let topicIds = [];
-  let objectiveTopicIds = [];
+  // let topicIds = [];
+  // let objectiveTopicIds = [];
 
   beforeAll(async () => {
     // Create User.
@@ -359,7 +359,7 @@ describe('Goals by Recipient Test', () => {
 
     // Get Objective Ids for Delete.
     objectiveIds = objectives.map((o) => o.id);
-
+    /*
     // Create Objective Topics.
     const topics = await Promise.all([
       Topic.create({
@@ -394,6 +394,7 @@ describe('Goals by Recipient Test', () => {
     );
 
     objectiveTopicIds = objectiveTopics.map((o) => o.id);
+      */
 
     // AR Objectives.
     await Promise.all(
@@ -462,7 +463,7 @@ describe('Goals by Recipient Test', () => {
         id: objectiveIds,
       },
     });
-
+    /*
     // Delete Objective Topics.
     await ObjectiveTopic.destroy({
       where: {
@@ -476,7 +477,7 @@ describe('Goals by Recipient Test', () => {
         id: topicIds,
       },
     });
-
+    */
     // Delete Goals.
     await Goal.destroy({
       where: {
@@ -536,6 +537,7 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[0].goalNumber).toBe(`R1-G-${goalRowsx[0].id}`);
       expect(goalRowsx[0].objectiveCount).toBe(1);
       expect(goalRowsx[0].reasons).toEqual(['Monitoring | Area of Concern', 'New Director or Management', 'New Program Option']);
+      expect(goalRowsx[0].goalTopics).toEqual(['Child Assessment, Development, Screening', 'Communication']);
       expect(goalRowsx[0].objectives.length).toBe(1);
 
       // Goal 3.
@@ -544,7 +546,8 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[1].goalNumber).toBe(`R1-G-${goalRowsx[1].id}`);
       expect(goalRowsx[1].objectiveCount).toBe(2);
       expect(goalRowsx[1].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[1].goalTopics).toEqual(['objective topic 2', 'objective topic 3']);
+      expect(goalRowsx[1].goalTopics).toEqual(['Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
+      // expect(goalRowsx[1].goalTopics).toEqual(['objective topic 2', 'objective topic 3']);
 
       // Goal 3 Objectives.
       expect(goalRowsx[1].objectives.length).toBe(2);
@@ -566,6 +569,7 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[2].goalNumber).toBe(`R1-G-${goalRowsx[2].id}`);
       expect(goalRowsx[2].objectiveCount).toBe(1);
       expect(goalRowsx[2].reasons).toEqual(['COVID-19 response', 'Complaint']);
+      expect(goalRowsx[2].goalTopics).toEqual(['Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
       expect(goalRowsx[2].objectives.length).toBe(1);
 
       // Goal 1.
@@ -574,7 +578,8 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[3].goalNumber).toBe(`R1-G-${goalRowsx[3].id}`);
       expect(goalRowsx[3].objectiveCount).toBe(1);
       expect(goalRowsx[3].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[3].goalTopics).toEqual(['objective topic 1']);
+      expect(goalRowsx[3].goalTopics).toEqual(['Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
+      // expect(goalRowsx[3].goalTopics).toEqual(['objective topic 1']);
       expect(goalRowsx[3].objectives.length).toBe(1);
     });
   });

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -9,6 +9,7 @@ import {
   ActivityReport,
   ActivityReportObjective,
   Objective,
+  Topic,
 } from '../models';
 import orderRecipientsBy from '../lib/orderRecipientsBy';
 import { RECIPIENTS_PER_PAGE, GOALS_PER_PAGE } from '../constants';
@@ -240,6 +241,11 @@ export async function getGoalsByActivityRecipient(
         required: false,
         include: [
           {
+            model: Topic,
+            as: 'topics',
+            required: false,
+          },
+          {
             attributes: ['ttaProvided'],
             model: ActivityReportObjective,
             as: 'activityReportObjectives',
@@ -300,13 +306,17 @@ export async function getGoalsByActivityRecipient(
       if (o.activityReports && o.activityReports.length > 0) {
         // eslint-disable-next-line prefer-destructuring
         activityReport = o.activityReports[0];
-        goalToAdd.goalTopics = Array.from(
-          new Set([...goalToAdd.goalTopics, ...activityReport.topics]),
-        );
         goalToAdd.reasons = Array.from(
           new Set([...goalToAdd.reasons, ...activityReport.reason]),
         );
       }
+
+      // Add Objective Topics.
+      o.topics.forEach((t) => {
+        goalToAdd.goalTopics = Array.from(
+          new Set([...goalToAdd.goalTopics, t.name]),
+        );
+      });
 
       // Add Objective.
       goalToAdd.objectives.push({

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -240,6 +240,7 @@ export async function getGoalsByActivityRecipient(
         as: 'objectives',
         required: false,
         include: [
+          /* TODO: Switch for New Goal Creation. */
           /* {
             model: Topic,
             as: 'topics',
@@ -306,14 +307,17 @@ export async function getGoalsByActivityRecipient(
       if (o.activityReports && o.activityReports.length > 0) {
         // eslint-disable-next-line prefer-destructuring
         activityReport = o.activityReports[0];
+        /* TODO: Switch for New Goal Creation (Remove). */
         goalToAdd.goalTopics = Array.from(
           new Set([...goalToAdd.goalTopics, ...activityReport.topics]),
         );
+
         goalToAdd.reasons = Array.from(
           new Set([...goalToAdd.reasons, ...activityReport.reason]),
         );
       }
 
+      /* TODO: Switch for New Goal Creation. */
       // Add Objective Topics.
       /*
       o.topics.forEach((t) => {

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -9,7 +9,7 @@ import {
   ActivityReport,
   ActivityReportObjective,
   Objective,
-  Topic,
+  // Topic,
 } from '../models';
 import orderRecipientsBy from '../lib/orderRecipientsBy';
 import { RECIPIENTS_PER_PAGE, GOALS_PER_PAGE } from '../constants';
@@ -240,11 +240,11 @@ export async function getGoalsByActivityRecipient(
         as: 'objectives',
         required: false,
         include: [
-          {
+          /* {
             model: Topic,
             as: 'topics',
             required: false,
-          },
+          }, */
           {
             attributes: ['ttaProvided'],
             model: ActivityReportObjective,
@@ -306,17 +306,22 @@ export async function getGoalsByActivityRecipient(
       if (o.activityReports && o.activityReports.length > 0) {
         // eslint-disable-next-line prefer-destructuring
         activityReport = o.activityReports[0];
+        goalToAdd.goalTopics = Array.from(
+          new Set([...goalToAdd.goalTopics, ...activityReport.topics]),
+        );
         goalToAdd.reasons = Array.from(
           new Set([...goalToAdd.reasons, ...activityReport.reason]),
         );
       }
 
       // Add Objective Topics.
+      /*
       o.topics.forEach((t) => {
         goalToAdd.goalTopics = Array.from(
           new Set([...goalToAdd.goalTopics, t.name]),
         );
       });
+      */
 
       // Add Objective.
       goalToAdd.objectives.push({


### PR DESCRIPTION
## Description of change

~~We need to make sure that we display and filter goals based on the objective topics.~~

For now we will ONLY show AR topics and filter AR topics.

**Note:** Garrett is updating the migration script to move AR topics to the objectives.

## How to test

~~Create a goal with objective topics. These objective topics should show on the Goals and Objectives page. Filtering on these topics should reflect the goals we display.~~

User should be able to see and filter the Goals and Objective tab using AR topics only.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-858


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
