### PR TITLE
[TTAHUB-858] Increase Goals Filter Performance

### DIFF
--- a/src/scopes/goals/index.js
+++ b/src/scopes/goals/index.js
@@ -21,8 +21,8 @@ export const topicToQuery = {
     nin: (query) => withoutStatus(query),
   },
   topic: {
-    in: (query) => withTopics(query),
-    nin: (query) => withoutTopics(query),
+    in: (query, options) => withTopics(query, options),
+    nin: (query, options) => withoutTopics(query, options),
   },
   reason: {
     in: (query) => withReasons(query),
@@ -45,6 +45,6 @@ export const topicToQuery = {
   },
 };
 
-export function goalsFiltersToScopes(filters) {
-  return createFiltersToScopes(filters, topicToQuery);
+export function goalsFiltersToScopes(filters, options) {
+  return createFiltersToScopes(filters, topicToQuery, options);
 }

--- a/src/scopes/goals/topics.js
+++ b/src/scopes/goals/topics.js
@@ -16,26 +16,30 @@ ON "Objectives"."goalId" = "Goal"."id"
 WHERE "Topics"."name"`;
 */
 
-const topicFilter = `
-SELECT DISTINCT g.id
-FROM "ActivityReports" ar
-INNER JOIN "ActivityReportObjectives" aro ON ar."id" = aro."activityReportId"
-INNER JOIN "Objectives" o ON aro."objectiveId" = o.id
-INNER JOIN "Goals" g ON o."goalId" = g.id
-WHERE ARRAY_TO_STRING(ar."topics", ',')`;
+const topicFilter = (options) => {
+  const useRecipient = options && options.recipientId;
+  return `
+          SELECT DISTINCT g.id
+          FROM "ActivityReports" ar
+          INNER JOIN "ActivityReportGoals" arg ON ar.id = arg."activityReportId"
+          INNER JOIN "Goals" g ON arg."goalId" = g.id
+          INNER JOIN "Grants" gr ON g."grantId" = gr."id"
+          WHERE ${useRecipient ? `gr."recipientId' = ${options.recipientId} AND ` : ''}
+          ARRAY_TO_STRING(ar."topics", ',')`;
+};
 
-export function withTopics(topics) {
+export function withTopics(topics, options) {
   return {
     [Op.or]: [
-      filterAssociation(topicFilter, topics, false),
+      filterAssociation(topicFilter(options), topics, false),
     ],
   };
 }
 
-export function withoutTopics(topics) {
+export function withoutTopics(topics, options) {
   return {
     [Op.and]: [
-      filterAssociation(topicFilter, topics, true),
+      filterAssociation(topicFilter(options), topics, true),
     ],
   };
 }

--- a/src/scopes/grants/index.js
+++ b/src/scopes/grants/index.js
@@ -40,11 +40,12 @@ export const topicToQuery = {
   },
 };
 
-export function grantsFiltersToScopes(filters, subset) {
+export function grantsFiltersToScopes(filters, options) {
+  const isSubset = options && options.subset;
   const validFilters = pickBy(filters, (query, topicAndCondition) => {
     const [topic, condition] = topicAndCondition.split('.');
 
-    if ((topic === 'startDate' || topic === 'endDate') && subset) {
+    if ((topic === 'startDate' || topic === 'endDate') && isSubset) {
       return condition in topicToQuery.activeWithin;
     }
 
@@ -58,7 +59,7 @@ export function grantsFiltersToScopes(filters, subset) {
   return map(validFilters, (query, topicAndCondition) => {
     const [topic, condition] = topicAndCondition.split('.');
 
-    if ((topic === 'startDate' || topic === 'endDate') && subset) {
+    if ((topic === 'startDate' || topic === 'endDate') && isSubset) {
       return topicToQuery.activeWithin[condition]([query].flat());
     }
 

--- a/src/scopes/index.js
+++ b/src/scopes/index.js
@@ -31,7 +31,7 @@ const models = {
  * that the scopes returned should be to produce a total subset based on which model is
  * specified. that feels like a bit of word salad, so hopefully that makes sense.
  *
- * In the current use case for this option, we are somtimes query for activity reports
+ * In the current use case for this option, we are sometimes query for activity reports
  * as the main model but in the overview widgets we also need a matching subset of grants
  * so this specifies that the grant query should be returned as a subset based on the activity
  * report filters. I'm not sure about the naming here.
@@ -44,7 +44,7 @@ export default function filtersToScopes(filters, options) {
   return Object.keys(models).reduce((scopes, model) => {
     // we make em an object like so
     Object.assign(scopes, {
-      [model]: models[model](filters, options && options[model] && options[model].subset),
+      [model]: models[model](filters, options && options[model]),
     });
     return scopes;
   }, {});

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -202,7 +202,9 @@ export async function getGoalsByActivityRecipient(
   },
 ) {
   // Scopes.
-  const { goal: scopes } = filtersToScopes(filters, 'goal');
+  // const { goal: scopes } = filtersToScopes(filters, 'goal');
+  const { goal: scopes } = filtersToScopes(filters, { goal: { recipientId } });
+  // , { grant: { subset: true } }
 
   // Paging.
   const limitNum = parseInt(limit, 10);


### PR DESCRIPTION
## Description of change

A performance issue was found when filtering goals on the sandbox site by Reasons and Topics. This change passes the recipient id to the scopes query to narrow down what we filter.

## How to test

Filtering Goals on reasons and topics should be fairly quick and no longer hang for 3 seconds. All existing filtering should work as it did before.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-858


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
