### PR TITLE
fix collaborators are unable to edit bug

### DIFF
--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -288,8 +288,9 @@ function ActivityReport({
 
         const [recipients, collaborators, availableApprovers] = await Promise.all(apiCalls);
 
-        const isCollaborator = report.collaborators
-          && report.collaborators.find((u) => u.id === user.id);
+        const isCollaborator = report.activityReportCollaborators
+          && report.activityReportCollaborators.find((u) => u.userId === user.id);
+
         const isAuthor = report.userId === user.id;
 
         // The report can be edited if its in draft OR needs_action state.


### PR DESCRIPTION
## Description of change

At some point, the collaborators object returned from the API changed shape, and this left collaborators unable to edit reports. I updated the code that identifies a collaborator, and hopefully have resolved the issue.

## How to test

Collaborators can edit reports.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
