### PR TITLE
[TTAHUB-898] Fix Goals Being Marked as In Progress

### DIFF
--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -296,6 +296,9 @@ const automaticStatusChangeOnAprovalForGoals = async (sequelize, instance, optio
           {
             model: sequelize.models.Objective,
             as: 'objectives',
+            where: {
+              status: ['In Progress', 'Completed'],
+            },
           },
           {
             model: sequelize.models.ActivityReport,
@@ -308,11 +311,8 @@ const automaticStatusChangeOnAprovalForGoals = async (sequelize, instance, optio
       },
     );
 
-    // Goals updated to 'In Progress' must have at least one objective 'Completed' or 'In Progress'.
-    const goalsToUpdate = goals.filter((g) => g.objectives.some((o) => o.status === 'In Progress' || o.status === 'Completed'));
-
     // Update Goal status to 'In Progress'.
-    await Promise.all(goalsToUpdate.map(async (goal) => {
+    await Promise.all(goals.map(async (goal) => {
       goal.set('status', 'In Progress');
       return goal.save();
     }));


### PR DESCRIPTION
## Description of change

Goals with 'Not Started' Objectives were being set as 'In Progress'.

## How to test

Create a Goal with a single objective of 'Not Started' status. Viewing this Goal in the RTR should show a status of 'Not Started'.

Create a Goal with at least one Objective of status 'In Progress' or 'Completed'. The RTR should show the goal as 'In Progress'.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-898


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
