### PR TITLE
Remove feature flag from goals & objectives tab

### DIFF
--- a/frontend/src/pages/RecipientRecord/components/RecipientTabs.js
+++ b/frontend/src/pages/RecipientRecord/components/RecipientTabs.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
-import FeatureFlag from '../../../components/FeatureFlag';
 import './RecipientTabs.scss';
 import colors from '../../../colors';
 
@@ -21,11 +20,9 @@ export default function RecipientTabs({ region, recipientId, backLink }) {
           <li className={liClass}>
             <NavLink activeClassName={`${linkClass}--active`} className={`${linkClass}`} to={`/recipient-tta-records/${recipientId}/region/${region}/tta-history`}>TTA History</NavLink>
           </li>
-          <FeatureFlag flag="recipient_goals_objectives">
-            <li className={liClass}>
-              <NavLink activeClassName={`${linkClass}--active`} className={`${linkClass}`} to={`/recipient-tta-records/${recipientId}/region/${region}/goals-objectives`}>Goals & Objectives</NavLink>
-            </li>
-          </FeatureFlag>
+          <li className={liClass}>
+            <NavLink activeClassName={`${linkClass}--active`} className={`${linkClass}`} to={`/recipient-tta-records/${recipientId}/region/${region}/goals-objectives`}>Goals & Objectives</NavLink>
+          </li>
         </ul>
       </nav>
       <FontAwesomeIcon className="margin-left-2 margin-right-1" color={colors.ttahubMediumBlue} icon={faArrowLeft} />

--- a/frontend/src/pages/RecipientRecord/index.js
+++ b/frontend/src/pages/RecipientRecord/index.js
@@ -186,13 +186,12 @@ export default function RecipientRecord({ match }) {
                 </Link>
               )}
             >
-              <FeatureFlag flag="recipient_goals_objectives" renderNotFound>
-                <PrintGoals
-                  recipientId={recipientId}
-                  regionId={regionId}
-                  location={location}
-                />
-              </FeatureFlag>
+              <PrintGoals
+                recipientId={recipientId}
+                regionId={regionId}
+                location={location}
+              />
+
             </PageWithHeading>
           )}
         />
@@ -205,14 +204,12 @@ export default function RecipientRecord({ match }) {
               error={error}
               recipientNameWithRegion={recipientNameWithRegion}
             >
-              <FeatureFlag flag="recipient_goals_objectives" renderNotFound>
-                <GoalsObjectives
-                  location={location}
-                  recipientId={recipientId}
-                  regionId={regionId}
-                  recipient={recipientData}
-                />
-              </FeatureFlag>
+              <GoalsObjectives
+                location={location}
+                recipientId={recipientId}
+                regionId={regionId}
+                recipient={recipientData}
+              />
             </PageWithHeading>
           )}
         />


### PR DESCRIPTION
## Description of change

This change removes the feature flag hiding the Goals & Objectives tab. We'll want to merge this into the migration branch or main when we want the feature to go "live."

## How to test

View the site as a user without the feature flag. Confirm that you can see everything you are supposed to and that you won't see anything you aren't.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-NO


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
