### PR TITLE
switch form validation back to onChange

### DIFF
--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -59,7 +59,7 @@ function Navigator({
   const page = pages.find((p) => p.path === currentPage);
 
   const hookForm = useForm({
-    mode: 'onBlur',
+    mode: 'onChange', // 'onBlur' fails existing date picker validations.
     defaultValues: formData,
     shouldUnregister: false,
   });


### PR DESCRIPTION
## Description of change

If we switch form validation to 'onBlur' the date picker components on the Summary and Next Steps fails validation.

For now we will roll this back to 'onChange'.

## How to test

Create a new AR when all data is filled out on the Summary and Next Steps pages. The page naviagator should show these pages as 'Complete' and NOT 'In Progress'.

## Issue(s)

~* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0~


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
