### PR TITLE
Rollback Max Report Export to 2k

### DIFF
--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -8,7 +8,7 @@ import './ReportMenu.css';
 import Loader from '../../components/Loader';
 import colors from '../../colors';
 
-export const MAXIMUM_EXPORTED_REPORTS = 20000;
+export const MAXIMUM_EXPORTED_REPORTS = 2000;
 
 function ReportMenu({
   onExportAll,


### PR DESCRIPTION
## Description of change

Rollback Max Report Export to 2k

## How to test

User should only be able to max export 2,000 reports.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
~- [ ] API Documentation updated~
~- [ ] Boundary diagram updated~
~- [ ] Logical Data Model updated~
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
