### PR TITLE
[TTAHUB-918] Fix newly introduced bug when adding resources to new report

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/ResourceSelector.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ResourceSelector.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { useFormContext, useFieldArray } from 'react-hook-form/dist/index.ie11';
@@ -27,6 +27,12 @@ const ResourceSelector = ({ name, ariaName }) => {
       append({ value: '' });
     }
   };
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      append({ value: '' });
+    }
+  }, [append, fields]);
 
   return (
     <>

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -533,6 +533,8 @@ function ActivityReport({
         const savedReport = await createReport(
           {
             ...fields,
+            ECLKCResourcesUsed: data.ECLKCResourcesUsed.map((r) => (r.value)),
+            nonECLKCResourcesUsed: data.nonECLKCResourcesUsed.map((r) => (r.value)),
             startDate: startDateToSave,
             endDate: endDateToSave,
             regionId: formData.regionId,


### PR DESCRIPTION
## Description of change

The fix I added yesterday added a bug on new reports where the default value of the ECLKC resources would be a nested JSON string ```{ value: '\{value\:""\}'}``` or thereabouts. Some additional tweaking was made to ensure that 1) a default blank box is always presented, as now, and that there wasn't any weirdness beyond that.

## How to test
Ensure that adding resources works as you'd expect.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-918


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
