### PR TITLE
[TTAHUB-921] Add front end validation for file size

### DIFF
--- a/frontend/src/components/FileUploader.js
+++ b/frontend/src/components/FileUploader.js
@@ -19,6 +19,7 @@ import './FileUploader.scss';
 
 export const upload = async (file, reportId, setErrorMessage) => {
   let res;
+
   try {
     const data = new FormData();
     data.append('reportId', reportId);
@@ -95,11 +96,12 @@ function Dropzone(props) {
   const [errorMessage, setErrorMessage] = useState();
   const onDrop = (e) => handleDrop(e, reportId, id, onChange, setErrorMessage);
   const maxSize = 30000000;
+  const minSize = 1; // at least 1 byte
 
   const {
     fileRejections, getRootProps, getInputProps,
   } = useDropzone({
-    onDrop, minSize: 0, maxSize, accept: 'image/*, .pdf, .docx, .xlsx, .pptx, .doc, .xls, .ppt, .zip, .txt, .csv',
+    onDrop, minSize, maxSize, accept: 'image/*, .pdf, .docx, .xlsx, .pptx, .doc, .xls, .ppt, .zip, .txt, .csv',
   });
 
   const rootProps = getRootProps();


### PR DESCRIPTION
## Description of change
Right now, a file with a size of 0 bytes causes the backend to reject the upload, which causes the react app to crash. This change disallows empty file uploads.

## How to test
Try to upload a file with a file size of 0 bytes. Note that the site errors instead of crashes.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-921


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
