### PR TITLE
[TTAHUB-928] Show all recipients on CSV

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -928,28 +928,6 @@ async function getDownloadableActivityReports(where, separate = true) {
         as: 'activityRecipients',
         required: false,
         separate,
-        include: [
-          {
-            model: Grant,
-            attributes: ['id', 'number', 'programSpecialistName', 'recipientInfo', 'programTypes'],
-            as: 'grant',
-            include: [
-              {
-                model: Recipient,
-                as: 'recipient',
-              },
-              {
-                model: Program,
-                as: 'programs',
-                attributes: ['programType'],
-              },
-            ],
-          },
-          {
-            model: OtherEntity,
-            as: 'otherEntity',
-          },
-        ],
       },
       {
         model: File,


### PR DESCRIPTION
## Description of change
Database schema change did a little damage to the way the CSV works. Specifically, a report with multiple recipients was only showing the first one - this change fixes that issue.

## How to test
Export a CSV with multiple recipients. They should all show up in the CSV.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-928


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
