### PR TITLE
[TTAHUB-942] Add custom "isPageComplete" validation to two AR pages

### DIFF
--- a/frontend/src/components/ControlledDatePicker.js
+++ b/frontend/src/components/ControlledDatePicker.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { useController } from 'react-hook-form/dist/index.ie11';
@@ -65,13 +65,18 @@ export default function ControlledDatePicker({
   }
 
   const {
-    field: { onChange },
+    field: { onChange, onBlur: onFieldBlur },
   } = useController({
     name,
     control,
     rules: { validate },
     defaultValue: formattedValue,
   });
+
+  const handleOnBlur = useCallback((e) => {
+    onFieldBlur(e);
+    onBlur(e);
+  }, [onBlur, onFieldBlur]);
 
   const datePickerOnChange = (d) => {
     if (isStartDate) {
@@ -99,7 +104,7 @@ export default function ControlledDatePicker({
       onChange={datePickerOnChange}
       minDate={min.datePicker}
       maxDate={max.datePicker}
-      onBlur={onBlur}
+      onBlur={(e) => handleOnBlur(e)}
     />
   );
 }

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -95,7 +95,7 @@ function Navigator({
     }
 
     const currentPageState = pageState[page.position];
-    const isComplete = page.isPageComplete ? page.isPageComplete(getValues()) : isValid;
+    const isComplete = page.isPageComplete ? page.isPageComplete(getValues(), formState) : isValid;
     const newPageState = { ...pageState };
 
     if (isComplete) {

--- a/frontend/src/pages/ActivityReport/Pages/__tests__/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/activitySummary.js
@@ -1,0 +1,49 @@
+import { isPageComplete } from '../activitySummary';
+
+const FORM_DATA = {
+  activityRecipientType: 'specialist',
+  requester: 'specialist',
+  deliveryMethod: 'test',
+  virtualDeliveryType: '',
+  activityRecipients: [{}],
+  targetPopulations: ['people'],
+  reason: ['reason'],
+  ttaType: ['tta'],
+  participants: ['participant'],
+  duration: 1,
+  numberOfParticipants: 3,
+  startDate: '09/01/2020',
+  endDate: '09/01/2020',
+};
+
+describe('activitySummary isPageComplete', () => {
+  it('returns true if validated by hook form', async () => {
+    const result = isPageComplete({}, { isValid: true });
+    expect(result).toBe(true);
+  });
+
+  it('validates strings', async () => {
+    const result = isPageComplete({ ...FORM_DATA, requester: null }, { isValid: false });
+    expect(result).toBe(false);
+  });
+
+  it('validates arrays', async () => {
+    const result = isPageComplete({ ...FORM_DATA, activityRecipients: [] }, { isValid: false });
+    expect(result).toBe(false);
+  });
+
+  it('validates numbers', async () => {
+    const result = isPageComplete({ ...FORM_DATA, duration: null }, { isValid: false });
+    expect(result).toBe(false);
+  });
+
+  it('validates dates', async () => {
+    const result = isPageComplete({ ...FORM_DATA, startDate: null }, { isValid: false });
+    expect(result).toBe(false);
+  });
+
+  it('validates delivery method', async () => {
+    const result = isPageComplete({ ...FORM_DATA, deliveryMethod: 'virtual' }, { isValid: false });
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
@@ -7,7 +7,7 @@ import {
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
 
-import nextSteps from '../nextSteps';
+import nextSteps, { isPageComplete } from '../nextSteps';
 
 const SPECIALIST_INPUT = 'specialistNextSteps-input';
 const SPECIALIST_BUTTON = 'specialistNextSteps-button';
@@ -200,5 +200,56 @@ describe('next steps', () => {
 
     // Assert date change.
     await waitFor(() => expect(dateInput).toHaveValue('06/04/2022'));
+  });
+});
+
+describe('isPageComplete for Next steps', () => {
+  it('returns true if validated by hook form', async () => {
+    const result = isPageComplete({}, { isValid: true });
+    expect(result).toBe(true);
+  });
+
+  it('returns false if either data point is missing', async () => {
+    const result = isPageComplete({ specialistNextSteps: [] }, { isValid: false });
+    expect(result).toBe(false);
+  });
+
+  it('returns false if no next steps are provided', async () => {
+    const result = isPageComplete({
+      specialistNextSteps: [], participantNextSteps: [],
+    }, { isValid: false });
+    expect(result).toBe(false);
+  });
+
+  it('returns false if no note was provided on one step', async () => {
+    const result = isPageComplete({
+      specialistNextSteps: [{
+        note: '',
+        completeDate: '09/17/2017',
+      }],
+      participantNextSteps: [
+        {
+          note: 'A step sir',
+          completeDate: '09/17/2017',
+        },
+      ],
+    }, { isValid: false });
+    expect(result).toBe(false);
+  });
+
+  it('returns false if an invalid date was provided on one step', async () => {
+    const result = isPageComplete({
+      specialistNextSteps: [{
+        note: 'a step',
+        completeDate: '09/17/2017',
+      }],
+      participantNextSteps: [
+        {
+          note: 'A step sir',
+          completeDate: 'a step a step a step',
+        },
+      ],
+    }, { isValid: false });
+    expect(result).toBe(false);
   });
 });

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -8,6 +8,7 @@ import { isEmpty, isUndefined } from 'lodash';
 import {
   Fieldset, Radio, Grid, TextInput, Checkbox, Label,
 } from '@trussworks/react-uswds';
+import moment from 'moment';
 import ReviewPage from './Review/ReviewPage';
 import MultiSelect from '../../../components/MultiSelect';
 import {
@@ -570,5 +571,72 @@ export default {
         collaborators={collaborators}
       />
     );
+  },
+  isPageComplete: (formData, formState) => {
+    const { isValid } = formState;
+    if (isValid) {
+      return true;
+    }
+
+    const {
+      // strings
+      activityRecipientType,
+      requester,
+      deliveryMethod,
+      virtualDeliveryType,
+
+      // arrays
+      activityRecipients,
+      targetPopulations: targetPopulationsArray,
+      reason,
+      ttaType,
+      participants,
+
+      // numbers
+      duration,
+      numberOfParticipants,
+
+      // dates
+      startDate,
+      endDate,
+    } = formData;
+
+    const stringsToValidate = [
+      activityRecipientType,
+      requester,
+      deliveryMethod,
+      virtualDeliveryType,
+    ];
+
+    if (!stringsToValidate.every((str) => str)) {
+      return false;
+    }
+
+    const arraysToValidate = [
+      activityRecipients,
+      targetPopulationsArray,
+      reason,
+      ttaType,
+      participants,
+    ];
+
+    if (!arraysToValidate.every((arr) => arr.length)) {
+      return false;
+    }
+
+    const numbersToValidate = [
+      duration,
+      numberOfParticipants,
+    ];
+
+    if (!numbersToValidate.every((num) => num && Number.isNaN(num) === false)) {
+      return false;
+    }
+
+    if (![startDate, endDate].every((date) => moment(date, 'MM/DD/YYYY').isValid())) {
+      return false;
+    }
+
+    return true;
   },
 };

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -557,6 +557,77 @@ const ReviewSection = () => {
   );
 };
 
+export const isPageComplete = (formData, formState) => {
+  const { isValid } = formState;
+  if (isValid) {
+    return true;
+  }
+
+  const {
+    // strings
+    activityRecipientType,
+    requester,
+    deliveryMethod,
+    virtualDeliveryType,
+
+    // arrays
+    activityRecipients,
+    targetPopulations: targetPopulationsArray,
+    reason,
+    ttaType,
+    participants,
+
+    // numbers
+    duration,
+    numberOfParticipants,
+
+    // dates
+    startDate,
+    endDate,
+  } = formData;
+
+  const stringsToValidate = [
+    activityRecipientType,
+    requester,
+    deliveryMethod,
+  ];
+
+  if (!stringsToValidate.every((str) => str)) {
+    return false;
+  }
+
+  const arraysToValidate = [
+    activityRecipients,
+    targetPopulationsArray,
+    reason,
+    ttaType,
+    participants,
+  ];
+
+  if (!arraysToValidate.every((arr) => arr.length)) {
+    return false;
+  }
+
+  const numbersToValidate = [
+    duration,
+    numberOfParticipants,
+  ];
+
+  if (!numbersToValidate.every((num) => num && Number.isNaN(num) === false)) {
+    return false;
+  }
+
+  if (![startDate, endDate].every((date) => moment(date, 'MM/DD/YYYY').isValid())) {
+    return false;
+  }
+
+  if (deliveryMethod === 'virtual' && !virtualDeliveryType) {
+    return false;
+  }
+
+  return true;
+};
+
 export default {
   position: 1,
   label: 'Activity summary',
@@ -572,71 +643,5 @@ export default {
       />
     );
   },
-  isPageComplete: (formData, formState) => {
-    const { isValid } = formState;
-    if (isValid) {
-      return true;
-    }
-
-    const {
-      // strings
-      activityRecipientType,
-      requester,
-      deliveryMethod,
-      virtualDeliveryType,
-
-      // arrays
-      activityRecipients,
-      targetPopulations: targetPopulationsArray,
-      reason,
-      ttaType,
-      participants,
-
-      // numbers
-      duration,
-      numberOfParticipants,
-
-      // dates
-      startDate,
-      endDate,
-    } = formData;
-
-    const stringsToValidate = [
-      activityRecipientType,
-      requester,
-      deliveryMethod,
-      virtualDeliveryType,
-    ];
-
-    if (!stringsToValidate.every((str) => str)) {
-      return false;
-    }
-
-    const arraysToValidate = [
-      activityRecipients,
-      targetPopulationsArray,
-      reason,
-      ttaType,
-      participants,
-    ];
-
-    if (!arraysToValidate.every((arr) => arr.length)) {
-      return false;
-    }
-
-    const numbersToValidate = [
-      duration,
-      numberOfParticipants,
-    ];
-
-    if (!numbersToValidate.every((num) => num && Number.isNaN(num) === false)) {
-      return false;
-    }
-
-    if (![startDate, endDate].every((date) => moment(date, 'MM/DD/YYYY').isValid())) {
-      return false;
-    }
-
-    return true;
-  },
+  isPageComplete,
 };

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -6,6 +6,28 @@ import { Fieldset } from '@trussworks/react-uswds';
 import NextStepsRepeater from './components/NextStepsRepeater';
 import ReviewPage from './Review/ReviewPage';
 
+export const isPageComplete = (formData, formState) => {
+  const { isValid } = formState;
+  if (isValid) {
+    return true;
+  }
+
+  const { specialistNextSteps, participantNextSteps } = formData;
+  if (!specialistNextSteps || !participantNextSteps) {
+    return false;
+  }
+
+  if (!specialistNextSteps.length || !participantNextSteps.length) {
+    return false;
+  }
+
+  if (![...specialistNextSteps, ...participantNextSteps].every((step) => step.note && moment(step.completeDate, 'MM/DD/YYYY').isValid())) {
+    return false;
+  }
+
+  return true;
+};
+
 const NextSteps = ({ activityRecipientType }) => {
   // Create labels.
   const labelDisplayName = activityRecipientType === 'other-entity' ? 'Other entities' : "Recipient's";
@@ -72,21 +94,5 @@ export default {
     const { activityRecipientType } = formData;
     return (<NextSteps activityRecipientType={activityRecipientType} />);
   },
-  isPageComplete: (formData, formState) => {
-    const { isValid } = formState;
-    if (isValid) {
-      return true;
-    }
-
-    const { specialistNextSteps, participantNextSteps } = formData;
-    if (!specialistNextSteps || !participantNextSteps) {
-      return false;
-    }
-
-    if (![...specialistNextSteps, ...participantNextSteps].every((step) => step.note && moment(step.completeDate, 'MM/DD/YYYY').isValid())) {
-      return false;
-    }
-
-    return true;
-  },
+  isPageComplete,
 };

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { Fieldset } from '@trussworks/react-uswds';
@@ -70,5 +71,22 @@ export default {
   render: (_additionalData, formData) => {
     const { activityRecipientType } = formData;
     return (<NextSteps activityRecipientType={activityRecipientType} />);
+  },
+  isPageComplete: (formData, formState) => {
+    const { isValid } = formState;
+    if (isValid) {
+      return true;
+    }
+
+    const { specialistNextSteps, participantNextSteps } = formData;
+    if (!specialistNextSteps || !participantNextSteps) {
+      return false;
+    }
+
+    if (![...specialistNextSteps, ...participantNextSteps].every((step) => step.note && moment(step.completeDate, 'MM/DD/YYYY').isValid())) {
+      return false;
+    }
+
+    return true;
   },
 };


### PR DESCRIPTION
## Description of change

I was having trouble getting the new goal form, the hook form registration, and the ControlledDatePicker to all agree. This change fixes it.

## How to test
On a new activity report, complete the activity summary, the goal and objectives, and the next steps sections. All should show as complete in the left hand sub navigation if they are complete and incomplete if they are not. Submitting a form should still work the same way.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-942


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
