### PR TITLE
[TTAHUB-942] add created via column to goals

### DIFF
--- a/src/migrations/20220804175018-add-created-via-to-goals.js
+++ b/src/migrations/20220804175018-add-created-via-to-goals.js
@@ -3,6 +3,18 @@ module.exports = {
   up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction(async (transaction) => {
     const createdViaSources = ['imported', 'activityReport', 'rtr'];
 
+    const loggedUser = '0';
+    const sessionSig = __filename;
+    const auditDescriptor = 'RUN MIGRATIONS';
+    await queryInterface.sequelize.query(
+      `SELECT
+          set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+          set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+          set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+          set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+      { transaction },
+    );
+
     await queryInterface.addColumn(
       'Goals',
       'createdVia',

--- a/src/migrations/20220804175018-add-created-via-to-goals.js
+++ b/src/migrations/20220804175018-add-created-via-to-goals.js
@@ -16,9 +16,13 @@ module.exports = {
       UPDATE "Goals" SET "createdVia" = 'activityReport' WHERE "isFromSmartsheetTtaPlan" IS NULL OR "isFromSmartsheetTtaPlan" = false;
     `, { transaction });
   }),
-  down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => queryInterface.removeColumn(
-    'Goals',
-    'createdVia',
-    { transaction },
-  )),
+   down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
+    const query = 'DROP TYPE public."enum_Goals_createdVia";';
+    await queryInterface.removeColumn(
+      'Goals',
+      'createdVia',
+      { transaction },
+    );
+    await queryInterface.sequelize.query(query, { transaction });
+  }),
 };

--- a/src/migrations/20220804175018-add-created-via-to-goals.js
+++ b/src/migrations/20220804175018-add-created-via-to-goals.js
@@ -16,7 +16,7 @@ module.exports = {
       UPDATE "Goals" SET "createdVia" = 'activityReport' WHERE "isFromSmartsheetTtaPlan" IS NULL OR "isFromSmartsheetTtaPlan" = false;
     `, { transaction });
   }),
-   down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
+  down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
     const query = 'DROP TYPE public."enum_Goals_createdVia";';
     await queryInterface.removeColumn(
       'Goals',

--- a/src/migrations/20220804175018-add-created-via-to-goals.js
+++ b/src/migrations/20220804175018-add-created-via-to-goals.js
@@ -1,0 +1,24 @@
+/* eslint-disable max-len */
+module.exports = {
+  up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction(async (transaction) => {
+    const createdViaSources = ['imported', 'activityReport', 'rtr'];
+
+    await queryInterface.addColumn(
+      'Goals',
+      'createdVia',
+      { type: Sequelize.DataTypes.ENUM(createdViaSources), allowNull: true },
+      { transaction },
+    );
+
+    // we can do this as the RTR is brand new
+    await queryInterface.sequelize.query(`
+      UPDATE "Goals" SET "createdVia" = 'imported' WHERE "isFromSmartsheetTtaPlan" IS true;
+      UPDATE "Goals" SET "createdVia" = 'activityReport' WHERE "isFromSmartsheetTtaPlan" IS NULL OR "isFromSmartsheetTtaPlan" = false;
+    `, { transaction });
+  }),
+  down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => queryInterface.removeColumn(
+    'Goals',
+    'createdVia',
+    { transaction },
+  )),
+};

--- a/src/models/goal.js
+++ b/src/models/goal.js
@@ -115,6 +115,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.DATE,
       allowNull: true,
     },
+    createdVia: {
+      type: DataTypes.ENUM(['imported', 'activityReport', 'rtr']),
+      allowNull: true,
+    },
   }, {
     sequelize,
     modelName: 'Goal',

--- a/src/services/createOrUpdateGoals.test.js
+++ b/src/services/createOrUpdateGoals.test.js
@@ -120,6 +120,7 @@ describe('createOrUpdateGoals', () => {
       {
         ...basicGoal,
         id: goal.id,
+        createdVia: 'activityReport',
         status: 'Not Started',
         objectives: [
           {
@@ -171,6 +172,7 @@ describe('createOrUpdateGoals', () => {
     expect(updatedGoal.status).toBe('Not Started');
     expect(updatedGoal.goalName).toBe('This is some serious goal text');
     expect(updatedGoal.grantIds.length).toBe(1);
+    expect(updatedGoal.createdVia).toBe('activityReport');
     expect(updatedGoal.grantIds).toContain(grants[0].id);
 
     const grantRegions = updatedGoal.grants.map((g) => g.regionId);
@@ -223,5 +225,6 @@ describe('createOrUpdateGoals', () => {
     expect(newGoal.grant.id).toBe(grants[1].id);
     expect(newGoal.grant.regionId).toBe(1);
     expect(newGoal.grant.recipientId).toBe(recipient.id);
+    expect(newGoal.createdVia).toBe('rtr');
   });
 });

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -27,6 +27,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
     [sequelize.col('grant.regionId'), 'regionId'],
     [sequelize.col('grant.recipient.id'), 'recipientId'],
     'goalNumber',
+    'createdVia',
     [
       sequelize.literal(`
         (
@@ -473,7 +474,7 @@ export async function goalsByIdAndRecipient(ids, recipientId) {
 
 export async function goalByIdWithActivityReportsAndRegions(goalId) {
   return Goal.findOne({
-    attributes: ['name', 'id', 'status'],
+    attributes: ['name', 'id', 'status', 'createdVia'],
     where: {
       id: goalId,
     },

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -568,6 +568,7 @@ export async function createOrUpdateGoals(goals) {
       regionId,
       objectives,
       status,
+      createdVia,
       ...fields
     } = goalData;
 
@@ -591,7 +592,7 @@ export async function createOrUpdateGoals(goals) {
     });
 
     await newGoal.update(
-      { ...options, status },
+      { ...options, status, createdVia: createdVia || 'rtr' },
       { individualHooks: true },
     );
 
@@ -1107,7 +1108,13 @@ export async function saveGoalsForReport(goals, report) {
     // we have a param to determine if goals are new
     if (goal.isNew) {
       const {
-        isNew, objectives, id, grantIds, status: discardedStatus, onApprovedAR, ...fields
+        isNew,
+        objectives,
+        id, grantIds,
+        status: discardedStatus,
+        onApprovedAR,
+        createdVia,
+        ...fields
       } = goal;
 
       newGoals = await Promise.all(goal.grantIds.map(async (grantId) => {
@@ -1142,6 +1149,7 @@ export async function saveGoalsForReport(goals, report) {
         goalIds,
         id, // this is unique and we can't trying to set this
         onApprovedAR, // we don't want to set this manually
+        createdVia,
         ...fields
       } = goal;
 
@@ -1183,7 +1191,7 @@ export async function saveGoalsForReport(goals, report) {
           defaults: { ...fields, status },
         });
 
-        await newGoal.update({ ...fields, status }, { individualHooks: true });
+        await newGoal.update({ ...fields, status, createdVia: createdVia || 'activityReport' }, { individualHooks: true });
 
         await ActivityReportGoal.findOrCreate({
           where: {


### PR DESCRIPTION
## Description of change

To make sequelize a little easier and more semantic (as well as for future thinking), we are adding a "createdVia" col to the goals table.

## How to test
Run the migration. Check that all your goals have a createdVia col in the DB.
Create goals each way (other than importing) - ensure that the db value is accurate.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
