### PR TITLE
[TTAHUB-942] Fix the editing of multiple goals on the RTR

### DIFF
--- a/frontend/src/components/GoalForm/GoalDate.js
+++ b/frontend/src/components/GoalForm/GoalDate.js
@@ -17,7 +17,7 @@ export default function GoalDate({
   return (
     <FormGroup error={error.props.children}>
       <Label htmlFor={inputName}>
-        Estimated close date (mm/dd/yyyy)
+        Anticipated close date (mm/dd/yyyy)
         {' '}
         <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
         <QuestionTooltip text="When do you expect to end TTA work and mark this goal as closed?" />

--- a/frontend/src/components/GoalForm/ReadOnly.js
+++ b/frontend/src/components/GoalForm/ReadOnly.js
@@ -73,7 +73,7 @@ export default function ReadOnly({
               <p className="margin-top-0">{goal.goalName}</p>
               {goal.endDate ? (
                 <>
-                  <h4 className="margin-bottom-1">Estimated close date</h4>
+                  <h4 className="margin-bottom-1">Anticipated close date</h4>
                   <p className="margin-top-0">{goal.endDate}</p>
                 </>
               ) : null }

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -48,7 +48,7 @@ describe('create goal', () => {
 
   const postResponse = [{
     id: 64175,
-    goalName: 'This is goal text',
+    name: 'This is goal text',
     status: 'Draft',
     endDate: '08/15/2023',
     isFromSmartsheetTtaPlan: false,
@@ -117,7 +117,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     const save = await screen.findByRole('button', { name: /save and continue/i });
@@ -200,7 +200,7 @@ describe('create goal', () => {
     userEvent.click(save);
     await screen.findByText('Enter a valid date');
 
-    const ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, 'apple season');
 
     userEvent.click(save);
@@ -243,7 +243,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     const save = await screen.findByRole('button', { name: /save and continue/i });
@@ -306,7 +306,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     const newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -366,7 +366,7 @@ describe('create goal', () => {
     let goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    let ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    let ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     let newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -403,7 +403,7 @@ describe('create goal', () => {
     goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is more goal text');
 
-    ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -456,7 +456,7 @@ describe('create goal', () => {
     let goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     const newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -511,7 +511,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     const cancel = await screen.findByRole('link', { name: 'Cancel' });
@@ -565,7 +565,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /Estimated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
     userEvent.type(ed, '08/15/2023');
 
     let newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -621,7 +621,7 @@ describe('create goal', () => {
 
   it('fetches and prepopulates goal data given an appropriate ID', async () => {
     fetchMock.get('/api/goals/12389/recipient/1', {
-      goalName: 'This is a goal name',
+      name: 'This is a goal name',
       status: 'Not Started',
       endDate: '10/08/2021',
       grant: {
@@ -651,13 +651,13 @@ describe('create goal', () => {
     expect(goalName).toBeVisible();
     expect(objectiveTitle).toBeVisible();
 
-    const endDate = await screen.findByRole('textbox', { name: /Estimated close date/i });
+    const endDate = await screen.findByRole('textbox', { name: /anticipated close date/i });
     expect(endDate.value).toBe('10/08/2021');
   });
 
   it('draft goals don\'t show status dropdowns', async () => {
     fetchMock.get('/api/goals/12389/recipient/1', {
-      goalName: 'This is a goal name',
+      name: 'This is a goal name',
       status: 'Draft',
       endDate: '10/08/2021',
       grant: {
@@ -687,13 +687,13 @@ describe('create goal', () => {
     expect(goalName).toBeVisible();
     expect(objectiveTitle).toBeVisible();
 
-    const endDate = await screen.findByRole('textbox', { name: /Estimated close date/i });
+    const endDate = await screen.findByRole('textbox', { name: /anticipated close date/i });
     expect(endDate.value).toBe('10/08/2021');
   });
 
   it('not started goals on AR', async () => {
     fetchMock.get('/api/goals/12389/recipient/1', {
-      goalName: 'This is a goal name',
+      name: 'This is a goal name',
       status: 'Not Started',
       endDate: '10/08/2021',
       grant: {
@@ -733,13 +733,13 @@ describe('create goal', () => {
     await screen.findByText(/Some fields can't be edited/i);
 
     // only close date should be editable
-    const endDate = await screen.findByRole('textbox', { name: /Estimated close date/i });
+    const endDate = await screen.findByRole('textbox', { name: /anticipated close date/i });
     expect(endDate.value).toBe('10/08/2021');
   });
 
   it('the correct fields are read only when the goal is in progress', async () => {
     fetchMock.get('/api/goals/12389/recipient/1', {
-      goalName: 'This is a goal name',
+      name: 'This is a goal name',
       status: 'In Progress',
       endDate: '10/08/2021',
       grant: {
@@ -770,7 +770,7 @@ describe('create goal', () => {
     expect(goalName).toBeVisible();
     expect(objectiveTitle).toBeVisible();
 
-    const endDate = await screen.findByRole('textbox', { name: /Estimated close date/i });
+    const endDate = await screen.findByRole('textbox', { name: /anticipated close date/i });
     expect(endDate.value).toBe('10/08/2021');
   });
 });

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -59,7 +59,7 @@ export default function GoalForm({
   }));
 
   const goalDefaults = useMemo(() => ({
-    goalName: '',
+    name: '',
     endDate: null,
     status: 'Draft',
     grants: possibleGrants.length === 1 ? [possibleGrants[0]] : [],
@@ -77,7 +77,7 @@ export default function GoalForm({
   // this is for the topic options returned from the API
   const [topicOptions, setTopicOptions] = useState([]);
 
-  const [goalName, setGoalName] = useState(goalDefaults.goalName);
+  const [goalName, setGoalName] = useState(goalDefaults.name);
   const [endDate, setEndDate] = useState(goalDefaults.endDate);
   const [selectedGrants, setSelectedGrants] = useState(goalDefaults.grants);
 
@@ -112,7 +112,7 @@ export default function GoalForm({
         const goal = await goalByIdAndRecipient(id, recipient.id.toString());
 
         // for these, the API sends us back things in a format we expect
-        setGoalName(goal.goalName);
+        setGoalName(goal.name);
         setStatus(goal.status);
         setEndDate(goal.endDate ? moment(goal.endDate, 'MM/DD/YYYY').format('YYYY-MM-DD') : '');
         setDatePickerKey(goal.endDate ? `DPK-${goal.endDate}` : '00');
@@ -359,9 +359,9 @@ export default function GoalForm({
     setIsLoading(true);
     try {
       const gs = createdGoals.reduce((acc, goal) => {
-        const newGoals = goal.grantIds.map((g) => ({
-          grantId: g,
-          name: goal.goalName,
+        const newGoals = goal.grants.map((grant) => ({
+          grantId: grant.id,
+          name: goal.name,
           status,
           endDate: goal.endDate && goal.endDate !== 'Invalid date' ? goal.endDate : null,
           regionId: parseInt(regionId, DECIMAL_BASE),
@@ -436,7 +436,7 @@ export default function GoalForm({
 
   const clearForm = () => {
     // clear our form fields
-    setGoalName(goalDefaults.goalName);
+    setGoalName(goalDefaults.name);
     setEndDate(goalDefaults.endDate);
     setStatus(goalDefaults.status);
     setSelectedGrants(goalDefaults.grants);
@@ -463,7 +463,18 @@ export default function GoalForm({
       }));
 
       const goals = [
-        ...createdGoals,
+        ...createdGoals.reduce((acc, goal) => {
+          const g = goal.grants.map((grant) => ({
+            grantId: grant.id,
+            name: goal.name,
+            status,
+            endDate: goal.endDate && goal.endDate !== 'Invalid date' ? goal.endDate : null,
+            regionId: parseInt(regionId, DECIMAL_BASE),
+            recipientId: recipient.id,
+            objectives: goal.objectives,
+          }));
+          return [...acc, ...g];
+        }, []),
         ...newGoals,
       ];
 
@@ -502,7 +513,7 @@ export default function GoalForm({
     setCreatedGoals(newCreatedGoals);
 
     // then repopulate the form
-    setGoalName(goal.goalName);
+    setGoalName(goal.name);
     setEndDate(goal.endDate);
     setStatus(goal.status);
     setGoalNumber(goal.number);

--- a/frontend/src/components/Navigator/__tests__/index.js
+++ b/frontend/src/components/Navigator/__tests__/index.js
@@ -208,7 +208,7 @@ describe('Navigator', () => {
       },
       goals: [],
       goalEndDate: '09/01/2020',
-      goalName: 'goal name',
+      name: 'goal name',
       'goalForEditing.objectives': [{
         title: 'objective',
         topics: ['test'],

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/GoalForm.js
@@ -75,7 +75,7 @@ describe('GoalForm', () => {
     renderGoalForm(goalId);
     expect(fetchMock.called()).toBe(false);
 
-    const endDate = await screen.findByText(/estimated close date/i);
+    const endDate = await screen.findByText(/anticipated close date/i);
     expect(endDate).toBeVisible();
   });
 });

--- a/src/services/createOrUpdateGoals.test.js
+++ b/src/services/createOrUpdateGoals.test.js
@@ -169,7 +169,7 @@ describe('createOrUpdateGoals', () => {
 
     const [, updatedGoal] = newGoals;
     expect(updatedGoal.status).toBe('Not Started');
-    expect(updatedGoal.goalName).toBe('This is some serious goal text');
+    expect(updatedGoal.name).toBe('This is some serious goal text');
     expect(updatedGoal.grantIds.length).toBe(1);
     expect(updatedGoal.grantIds).toContain(grants[0].id);
 
@@ -219,7 +219,7 @@ describe('createOrUpdateGoals', () => {
 
     const newGoal = newGoals.find((g) => g.id !== goal.id);
     expect(newGoal.status).toBe('Draft');
-    expect(newGoal.goalName).toBe('This is some serious goal text');
+    expect(newGoal.name).toBe('This is some serious goal text');
     expect(newGoal.grant.id).toBe(grants[1].id);
     expect(newGoal.grant.regionId).toBe(1);
     expect(newGoal.grant.recipientId).toBe(recipient.id);

--- a/src/services/goalServices/goalByIdAndRecipient.test.js
+++ b/src/services/goalServices/goalByIdAndRecipient.test.js
@@ -134,7 +134,7 @@ describe('goalById', () => {
     const goal = await goalByIdAndRecipient(goalOnActivityReport.id, grantRecipient.id);
     // seems to be something with the aliasing attributes that requires
     // them to be accessed in this way
-    expect(goal.dataValues.goalName).toBe('Goal on activity report');
+    expect(goal.dataValues.name).toBe('Goal on activity report');
     expect(goal.objectives.length).toBe(1);
     expect(goal.objectives[0].activityReports.length).toBe(1);
     expect(goal.objectives[0].topics.length).toBe(1);

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -22,7 +22,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
   attributes: [
     'id',
     'endDate',
-    ['name', 'goalName'],
+    'name',
     'status',
     [sequelize.col('grant.regionId'), 'regionId'],
     [sequelize.col('grant.recipient.id'), 'recipientId'],
@@ -252,7 +252,7 @@ function reduceObjectives(newObjectives, currentObjectives = []) {
  * @returns {Object[]} array of deduped goals
  */
 function reduceGoals(goals) {
-  return goals.reduce((previousValue, currentValue) => {
+  const r = goals.reduce((previousValue, currentValue) => {
     const existingGoal = previousValue.find((g) => (
       g.name === currentValue.name && g.status === currentValue.status
     ));
@@ -266,6 +266,7 @@ function reduceGoals(goals) {
           ...currentValue.grant.dataValues,
           recipient: currentValue.grant.recipient.dataValues,
           name: currentValue.grant.name,
+          goalId: currentValue.id,
         },
       ];
       existingGoal.grantIds = [...existingGoal.grantIds, currentValue.grant.id];
@@ -282,6 +283,7 @@ function reduceGoals(goals) {
           ...currentValue.grant.dataValues,
           recipient: currentValue.grant.recipient.dataValues,
           name: currentValue.grant.name,
+          goalId: currentValue.id,
         },
       ],
       grantIds: [currentValue.grant.id],
@@ -291,6 +293,8 @@ function reduceGoals(goals) {
 
     return [...previousValue, goal];
   }, []);
+
+  return r;
 }
 
 /**


### PR DESCRIPTION
## Description of change
Fixes bug described below in "how to test"
Also change "estimated close date" to "anticipated close date"

## How to test
On the RTR, select an existing goal, add or edit objective, save, and then "add another goal". On dev currently, this doesn't work (causes a 500 response on the server). This change fixes that by properly formatting our API response.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-942


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
