### PR TITLE
[TTAHUB-828] Activity summary duration input validation

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/__tests__/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/activitySummary.js
@@ -38,18 +38,18 @@ const RenderActivitySummary = () => {
 
 describe('activity summary', () => {
   describe('duration validation', () => {
-    it('shows an error for negative values', async () => {
+    it('shows an error for values < 0.5', async () => {
       const { container } = render(<RenderActivitySummary />);
       const input = container.querySelector('#duration');
-      userEvent.type(input, '-1');
-      expect(await screen.findByText('Duration can not be negative')).toBeInTheDocument();
+      userEvent.type(input, '0');
+      expect(await screen.findByText('Duration must be greater than 0 hours')).toBeInTheDocument();
     });
 
-    it('shows an error for numbers higher than 99.5', async () => {
+    it('shows an error for numbers > 99', async () => {
       const { container } = render(<RenderActivitySummary />);
       const input = container.querySelector('#duration');
-      userEvent.type(input, '100');
-      expect(await screen.findByText('Duration must be less than 100 hours')).toBeInTheDocument();
+      userEvent.type(input, '99.5');
+      expect(await screen.findByText('Duration must be less than or equal to 99 hours')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/ActivityReport/Pages/__tests__/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/activitySummary.js
@@ -1,0 +1,55 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
+import NetworkContext from '../../../../NetworkContext';
+import activitySummary from '../activitySummary';
+
+const RenderActivitySummary = () => {
+  const hookForm = useForm({
+    mode: 'onChange',
+    defaultValues: {
+      goals: [],
+      objectivesWithoutGoals: [],
+      participants: [],
+      activityRecipients: [],
+      targetPopulations: [],
+      activityReportCollaborators: [],
+      reason: [],
+    },
+  });
+
+  const additionalData = {
+    recipients: { grants: [], otherEntities: [] },
+    collaborators: [],
+    availableApprovers: [],
+  };
+
+  return (
+    <NetworkContext.Provider value={{ connectionActive: true, localStorageAvailable: true }}>
+      <FormProvider {...hookForm}>
+        {activitySummary.render(additionalData)}
+      </FormProvider>
+    </NetworkContext.Provider>
+  );
+};
+
+describe('activity summary', () => {
+  describe('duration validation', () => {
+    it('shows an error for negative values', async () => {
+      const { container } = render(<RenderActivitySummary />);
+      const input = container.querySelector('#duration');
+      userEvent.type(input, '-1');
+      expect(await screen.findByText('Duration can not be negative')).toBeInTheDocument();
+    });
+
+    it('shows an error for numbers higher than 99.5', async () => {
+      const { container } = render(<RenderActivitySummary />);
+      const input = container.querySelector('#duration');
+      userEvent.type(input, '100');
+      expect(await screen.findByText('Duration must be less than 100 hours')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -303,8 +303,8 @@ const ActivitySummary = ({
                       required: 'Please enter the duration of the activity',
                       valueAsNumber: true,
                       pattern: { value: /^\d+(\.[0,5]{1})?$/, message: 'Duration must be rounded to the nearest half hour' },
-                      min: { value: 0, message: 'Duration can not be negative' },
-                      max: { value: 99.5, message: 'Duration must be less than 100 hours' },
+                      min: { value: 0.5, message: 'Duration must be greater than 0 hours' },
+                      max: { value: 99, message: 'Duration must be less than or equal to 99 hours' },
                     })
                   }
                 />

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -296,6 +296,7 @@ const ActivitySummary = ({
                   name="duration"
                   type="number"
                   min={0}
+                  max={99.5}
                   step={0.5}
                   inputRef={
                     register({
@@ -303,6 +304,7 @@ const ActivitySummary = ({
                       valueAsNumber: true,
                       pattern: { value: /^\d+(\.[0,5]{1})?$/, message: 'Duration must be rounded to the nearest half hour' },
                       min: { value: 0, message: 'Duration can not be negative' },
+                      max: { value: 99.5, message: 'Duration must be less than 100 hours' },
                     })
                   }
                 />


### PR DESCRIPTION
## Description of change

- Define `max` prop on duration input so that keyboard uparrow input prevents values of >99.5.
- Input value >= 100 shows a validation error message that reads: "Duration must be less than 100 hours".
- Add a test for two duration validation errors: 1) negative values and 2) >= 100 values


## How to test

In the duration field of the activity summary form:

- When incrementing by either scrolling with the mousewheel or using the uparrow keys, max value should be clamped to 99.5:

https://user-images.githubusercontent.com/17074357/183146487-fba03025-abcb-4f16-aa87-7bb617d345a8.mov

- When input is by another means set to a value > 99.5, a helpful validation error message should be visible:

https://user-images.githubusercontent.com/17074357/183146686-f021c332-77e0-44a1-b5fb-9149ca208310.mov

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-828


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
