### PR TITLE
[TTAHUB-975] Fix chart and table discrepancy

### DIFF
--- a/frontend/src/components/GoalsTable/GoalDataController.js
+++ b/frontend/src/components/GoalsTable/GoalDataController.js
@@ -1,0 +1,170 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  memo,
+} from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from '@trussworks/react-uswds';
+import { filtersToQueryString } from '../../utils';
+import GoalsTable from './GoalsTable';
+import { GoalStatusChart } from '../../widgets/GoalStatusGraph';
+import { GOALS_PER_PAGE } from '../../Constants';
+import './GoalTable.scss';
+import { getRecipientGoals } from '../../fetchers/recipient';
+
+import useSessionSort from '../../hooks/useSessionSort';
+import FilterContext from '../../FilterContext';
+
+import { GOALS_OBJECTIVES_FILTER_KEY } from '../../pages/RecipientRecord/pages/constants';
+
+const Graph = memo(GoalStatusChart);
+
+function GoalDataController({
+  filters,
+  recipientId,
+  regionId,
+  hasActiveGrants,
+  showNewGoals,
+}) {
+  // Goal Data.
+  const [data, setData] = useState({
+    statuses: {
+      total: 0,
+      'Not started': 0,
+      'In progress': 0,
+      Closed: 0,
+      Suspended: 0,
+    },
+    rows: [],
+    count: 0,
+  });
+
+  const queryString = useRef(filtersToQueryString(filters));
+
+  // Page Behavior.
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const defaultSort = showNewGoals
+    ? {
+      sortBy: 'createdOn',
+      direction: 'desc',
+    }
+    : {
+      sortBy: 'goalStatus',
+      direction: 'asc',
+    };
+
+  // Grid and Paging.
+  const [sortConfig, setSortConfig] = useSessionSort({
+    ...defaultSort,
+    activePage: 1,
+    offset: 0,
+  }, `goalsTable/${recipientId}/${regionId}`);
+
+  useEffect(() => {
+    async function fetchGoals(query) {
+      setLoading(true);
+      try {
+        const response = await getRecipientGoals(
+          recipientId,
+          regionId,
+          sortConfig.sortBy,
+          sortConfig.direction,
+          sortConfig.offset,
+          GOALS_PER_PAGE,
+          query,
+        );
+        setData(response);
+        setError('');
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        setError('Unable to fetch goals');
+      }
+      setLoading(false);
+    }
+    const filterQuery = filtersToQueryString(filters);
+    if (filterQuery !== queryString.current) {
+      setSortConfig({ ...sortConfig, activePage: 1, offset: 0 });
+      queryString.current = filterQuery;
+      return;
+    }
+    fetchGoals(filterQuery);
+  }, [sortConfig, filters, recipientId, regionId, showNewGoals, setSortConfig]);
+
+  const handlePageChange = (pageNumber) => {
+    if (!loading) {
+      setSortConfig({
+        ...sortConfig, activePage: pageNumber, offset: (pageNumber - 1) * GOALS_PER_PAGE,
+      });
+    }
+  };
+
+  const requestSort = (sortBy) => {
+    let direction = 'asc';
+    if (
+      sortConfig
+      && sortConfig.sortBy === sortBy
+      && sortConfig.direction === 'asc'
+    ) {
+      direction = 'desc';
+    }
+    setSortConfig({
+      ...sortConfig, sortBy, direction, activePage: 1, offset: 0,
+    });
+  };
+
+  const displayGoals = useMemo(() => (
+    data.goalRows && data.goalRows.length ? data.goalRows : []),
+  [data.goalRows]);
+
+  const setGoals = (goals) => setData({ ...data, goalRows: goals });
+
+  return (
+    <div>
+      <Grid row>
+        <Grid desktop={{ col: 6 }} mobileLg={{ col: 12 }}>
+          <Graph data={data.statuses} loading={loading} />
+        </Grid>
+      </Grid>
+      <FilterContext.Provider value={{ filterKey: GOALS_OBJECTIVES_FILTER_KEY }}>
+        <GoalsTable
+          recipientId={recipientId}
+          regionId={regionId}
+          filters={filters}
+          hasActiveGrants={hasActiveGrants}
+          showNewGoals={showNewGoals || false}
+          goals={displayGoals}
+          error={error}
+          goalsCount={data.count}
+          handlePageChange={handlePageChange}
+          requestSort={requestSort}
+          sortConfig={sortConfig}
+          setGoals={setGoals}
+          loading={loading}
+        />
+      </FilterContext.Provider>
+    </div>
+
+  );
+}
+GoalDataController.propTypes = {
+  recipientId: PropTypes.string.isRequired,
+  regionId: PropTypes.string.isRequired,
+  filters: PropTypes.arrayOf(
+    PropTypes.shape({
+      condition: PropTypes.string,
+      id: PropTypes.string,
+      query: PropTypes.string,
+      topic: PropTypes.string,
+    }),
+  ).isRequired,
+  hasActiveGrants: PropTypes.bool.isRequired,
+  showNewGoals: PropTypes.bool.isRequired,
+};
+
+export default GoalDataController;

--- a/frontend/src/components/GoalsTable/GoalDataController.js
+++ b/frontend/src/components/GoalsTable/GoalDataController.js
@@ -81,11 +81,10 @@ function GoalDataController({
         setData(response);
         setError('');
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
         setError('Unable to fetch goals');
+      } finally {
+        setLoading(false);
       }
-      setLoading(false);
     }
     const filterQuery = filtersToQueryString(filters);
     if (filterQuery !== queryString.current) {
@@ -97,11 +96,9 @@ function GoalDataController({
   }, [sortConfig, filters, recipientId, regionId, showNewGoals, setSortConfig]);
 
   const handlePageChange = (pageNumber) => {
-    if (!loading) {
-      setSortConfig({
-        ...sortConfig, activePage: pageNumber, offset: (pageNumber - 1) * GOALS_PER_PAGE,
-      });
-    }
+    setSortConfig({
+      ...sortConfig, activePage: pageNumber, offset: (pageNumber - 1) * GOALS_PER_PAGE,
+    });
   };
 
   const requestSort = (sortBy) => {

--- a/frontend/src/components/GoalsTable/GoalsTableHeader.js
+++ b/frontend/src/components/GoalsTable/GoalsTableHeader.js
@@ -32,7 +32,7 @@ export default function GoalsTableHeader({
   recipientId,
   regionId,
   hasActiveGrants,
-  selectedGoals,
+  sortConfig,
 }) {
   const history = useHistory();
   const { user } = useContext(UserContext);
@@ -42,7 +42,7 @@ export default function GoalsTableHeader({
 
   const onPrint = () => {
     history.push(`/recipient-tta-records/${recipientId}/region/${regionId}/goals-objectives/print${window.location.search}`, {
-      selectedGoals,
+      sortConfig,
     });
   };
 
@@ -117,7 +117,12 @@ GoalsTableHeader.propTypes = {
   regionId: PropTypes.string.isRequired,
   recipientId: PropTypes.string.isRequired,
   hasActiveGrants: PropTypes.bool.isRequired,
-  selectedGoals: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.number })).isRequired,
+  sortConfig: PropTypes.shape({
+    sortBy: PropTypes.string,
+    direction: PropTypes.string,
+    activePage: PropTypes.number,
+    offset: PropTypes.number,
+  }).isRequired,
 };
 
 GoalsTableHeader.defaultProps = {

--- a/frontend/src/components/GoalsTable/__tests__/GoalsTable.js
+++ b/frontend/src/components/GoalsTable/__tests__/GoalsTable.js
@@ -5,7 +5,8 @@ import {
 } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
 import fetchMock from 'fetch-mock';
 import UserContext from '../../../UserContext';
 import AriaLiveContext from '../../../AriaLiveContext';
@@ -193,10 +194,11 @@ const goalWithObjectives = [{
 const handlePageChange = jest.fn();
 const requestSort = jest.fn();
 const setGoals = jest.fn();
+const history = createMemoryHistory();
 
 const renderTable = ({ goals, goalsCount }, user, hasActiveGrants = true) => {
   render(
-    <MemoryRouter>
+    <Router history={history}>
       <AriaLiveContext.Provider value={{ announce: mockAnnounce }}>
         <UserContext.Provider value={{ user }}>
           <GoalsTable
@@ -221,7 +223,7 @@ const renderTable = ({ goals, goalsCount }, user, hasActiveGrants = true) => {
           />
         </UserContext.Provider>
       </AriaLiveContext.Provider>
-    </MemoryRouter>,
+    </Router>,
   );
 };
 
@@ -469,6 +471,7 @@ describe('Goals Table', () => {
     });
 
     it('Sets goal status without reason', async () => {
+      history.push = jest.fn();
       fetchMock.reset();
       fetchMock.put('/api/goals/changeStatus', [{
         id: 65479,
@@ -494,6 +497,12 @@ describe('Goals Table', () => {
       // Verify goal status change.
       await waitFor(() => expect(fetchMock.called()).toBeTruthy());
       expect(setGoals).toHaveBeenCalled();
+
+      // print goals
+      const printButton = await screen.findByRole('button', { name: /Preview and print/i });
+      userEvent.click(printButton);
+
+      expect(history.push).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/pages/ActivityReport/Pages/components/RecipientReviewSection.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/RecipientReviewSection.js
@@ -27,7 +27,7 @@ const RecipientReviewSection = () => {
       {goals.map((goal) => {
         const objectives = goal.objectives || [];
         return (
-          <div key={goal.id}>
+          <div key={`review-${goal.id}`}>
             <div className="grid-row margin-bottom-3 desktop:margin-bottom-0 margin-top-2">
               <span>
                 <span className="text-bold">Goal:</span>

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -1,17 +1,14 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from '@trussworks/react-uswds';
 import { Helmet } from 'react-helmet';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import useSessionFiltersAndReflectInUrl from '../../../hooks/useSessionFiltersAndReflectInUrl';
 import FilterPanel from '../../../components/filter/FilterPanel';
 import { expandFilters } from '../../../utils';
 import { getGoalsAndObjectivesFilterConfig, GOALS_OBJECTIVES_FILTER_KEY } from './constants';
-import GoalStatusGraph from '../../../widgets/GoalStatusGraph';
-import GoalsTable from '../../../components/GoalsTable/GoalsTable';
 import UserContext from '../../../UserContext';
 import { getUserRegions } from '../../../permissions';
-import FilterContext from '../../../FilterContext';
+import GoalDataController from '../../../components/GoalsTable/GoalDataController';
 
 export default function GoalsObjectives({
   recipientId, regionId, recipient, location,
@@ -36,19 +33,7 @@ export default function GoalsObjectives({
     }
   };
 
-  const filtersToApply = [
-    ...expandFilters(filters),
-    {
-      topic: 'region',
-      condition: 'is',
-      query: regionId,
-    },
-    {
-      topic: 'recipientId',
-      condition: 'contains',
-      query: recipientId,
-    },
-  ];
+  const filtersToApply = expandFilters(filters);
 
   let hasActiveGrants = false;
   if (recipient.grants.find((g) => g.status === 'Active')) {
@@ -73,20 +58,13 @@ export default function GoalsObjectives({
             allUserRegions={regions}
           />
         </div>
-        <Grid row>
-          <Grid desktop={{ col: 6 }} mobileLg={{ col: 12 }}>
-            <GoalStatusGraph filters={filtersToApply} />
-          </Grid>
-        </Grid>
-        <FilterContext.Provider value={{ filterKey: GOALS_OBJECTIVES_FILTER_KEY }}>
-          <GoalsTable
-            recipientId={recipientId}
-            regionId={regionId}
-            filters={expandFilters(filters)}
-            hasActiveGrants={hasActiveGrants}
-            showNewGoals={showNewGoals || false}
-          />
-        </FilterContext.Provider>
+        <GoalDataController
+          filters={filtersToApply}
+          recipientId={recipientId}
+          regionId={regionId}
+          hasActiveGrants={hasActiveGrants}
+          showNewGoals={showNewGoals || false}
+        />
       </div>
     </>
   );

--- a/frontend/src/pages/RecipientRecord/pages/PrintGoals.js
+++ b/frontend/src/pages/RecipientRecord/pages/PrintGoals.js
@@ -14,9 +14,14 @@ export default function PrintGoals({ location, recipientId, regionId }) {
   const [, setError] = useState('');
 
   useEffect(() => {
-    const sortConfig = location.state && location.state.selectedGoals
-      ? location.state.selectedGoals
-      : [];
+    const sortConfig = location.state && location.state.sortConfig
+      ? location.state.sortConfig
+      : {
+        sortBy: 'goalStatus',
+        direction: 'asc',
+        activePage: 1,
+        offset: 0,
+      };
 
     async function fetchGoals(query) {
       setLoading(true);
@@ -60,7 +65,7 @@ export default function PrintGoals({ location, recipientId, regionId }) {
     <div className="margin-top-2 margin-left-2 ttahub-print-goals">
       <PrintToPdf />
       <div className="bg-white radius-md shadow-2 margin-right-2">
-        {goals.map((goal) => <PrintableGoal key={goal.id} goal={goal} />)}
+        {goals.map((goal) => <PrintableGoal key={`printable-goal-${goal.id}`} goal={goal} />)}
       </div>
     </div>
   );

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -18,6 +18,14 @@ import { mockWindowProperty } from '../../../../testHelpers';
 const memoryHistory = createMemoryHistory();
 const yearToDate = encodeURIComponent(formatDateRange({ yearToDate: true, forDateTime: true }));
 
+const defaultStatuses = {
+  total: 0,
+  'Not started': 0,
+  'In progress': 0,
+  Closed: 0,
+  Suspended: 0,
+};
+
 describe('Goals and Objectives', () => {
   const goals = [{
     id: 4598,
@@ -120,28 +128,17 @@ describe('Goals and Objectives', () => {
     fetchMock.reset();
     // Default.
     const goalsUrl = `/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=10&createDate.win=${yearToDate}`;
-    fetchMock.get(goalsUrl, { count: 1, goalRows: goals });
+    fetchMock.get(goalsUrl, { count: 1, goalRows: goals, statuses: defaultStatuses });
 
     // Filters Status.
     const filterStatusUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=10&status.in[]=Not%20started';
-    fetchMock.get(filterStatusUrl, { count: 1, goalRows: filterStatusGoals });
+    fetchMock.get(filterStatusUrl, {
+      count: 1, goalRows: filterStatusGoals, statuses: defaultStatuses,
+    });
 
     // No Filters.
     const noFilterUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=10';
-    fetchMock.get(noFilterUrl, { count: 2, goalRows: noFilterGoals });
-
-    const statusRes = {
-      total: 0, 'Not started': 0, 'In progress': 0, Closed: 0, Suspended: 0,
-    };
-
-    const goalStatusGraph = `/api/widgets/goalStatusGraph?createDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`;
-    fetchMock.get(goalStatusGraph, statusRes);
-
-    const goalStatusGraphWStatus = '/api/widgets/goalStatusGraph?status.in[]=Not%20started&region.in[]=1&recipientId.ctn[]=401';
-    fetchMock.get(goalStatusGraphWStatus, statusRes);
-
-    const goalStatusGraphUnfiltered = '/api/widgets/goalStatusGraph?region.in[]=1&recipientId.ctn[]=401';
-    fetchMock.get(goalStatusGraphUnfiltered, statusRes);
+    fetchMock.get(noFilterUrl, { count: 2, goalRows: noFilterGoals, statuses: defaultStatuses });
   });
 
   afterEach(() => {
@@ -162,7 +159,8 @@ describe('Goals and Objectives', () => {
   it('renders correctly when filter is changed', async () => {
     // Default with 2 Rows.
     const goalsUrl = `/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5&createDate.win=${yearToDate}`;
-    fetchMock.get(goalsUrl, { count: 2, goalRows: noFilterGoals }, { overwriteRoutes: true });
+    fetchMock.get(goalsUrl,
+      { count: 2, goalRows: noFilterGoals, statuses: defaultStatuses }, { overwriteRoutes: true });
 
     act(() => renderGoalsAndObjectives());
 
@@ -216,6 +214,7 @@ describe('Goals and Objectives', () => {
         { id: 2, ...goals[0] },
         { id: 3, ...goals[0] },
       ],
+      statuses: defaultStatuses,
     });
     act(() => renderGoalsAndObjectives([1]));
     // If api request contains 3 we know it included the desired sort.

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
@@ -86,10 +86,11 @@ describe('PrintGoals', () => {
   };
 
   const filters = [{ topic: 'status', condition: 'is', query: ['Closed'] }];
-  const filteredMockURL = `/api/recipient/${RECIPIENT_ID}/region/${REGION_ID}/goals?sortBy=updatedAt&sortDir=desc&offset=0&limit=false&${filtersToQueryString(filters)}`;
+  const baseMock = `/api/recipient/${RECIPIENT_ID}/region/${REGION_ID}/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=false`;
+  const filteredMockURL = `${baseMock}&${filtersToQueryString(filters)}`;
 
   beforeAll(async () => {
-    fetchMock.get(`/api/recipient/${RECIPIENT_ID}/region/${REGION_ID}/goals?sortBy=updatedAt&sortDir=desc&offset=0&limit=false`, { count: 5, goalRows: goals });
+    fetchMock.get(baseMock, { count: 5, goalRows: goals });
     fetchMock.get(filteredMockURL, { count: 0, goalRows: [] });
   });
 
@@ -112,7 +113,18 @@ describe('PrintGoals', () => {
 
   it('builds a URL to query based on filters provided by window.location.search', async () => {
     delete window.location;
-    window.location = { search: filtersToQueryString(filters) };
+    // console.log(filters);
+    window.location = {
+      search: filtersToQueryString(filters),
+      state: {
+        sortConfig: {
+          sortBy: 'goalStatus',
+          direction: 'asc',
+          activePage: 1,
+          offset: 0,
+        },
+      },
+    };
 
     act(renderPrintGoals);
 

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -12,8 +12,8 @@ import VanillaModal from '../components/VanillaModal';
 const GOAL_STATUSES = [
   'Not started',
   'In progress',
-  'Closed',
   'Suspended',
+  'Closed',
 ];
 
 const STATUS_COLORS = [

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -77,7 +77,12 @@ export function GoalStatusChart({ data, loading }) {
   // we only need to recompute this when the data changes, not when the
   // bars or display type are changed
   const accessibleRows = useMemo(
-    () => GOAL_STATUSES.map((status) => ({ data: [status, data[status]] })), [data],
+    () => {
+      if (!data) {
+        return [];
+      }
+      return GOAL_STATUSES.map((status) => ({ data: [status, data[status]] }));
+    }, [data],
   );
 
   const modalRef = useRef();

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -104,6 +104,10 @@ export function GoalStatusChart({ data, loading }) {
     updateShowAccessibleData((current) => !current);
   }
 
+  if (!data) {
+    return null;
+  }
+
   return (
     <Container className="ttahub--goal-status-graph" padding={3} loading={loading} loadingLabel="goal statuses by number loading">
       <Grid row className="position-relative margin-bottom-1">

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -19,8 +19,8 @@ const GOAL_STATUSES = [
 const STATUS_COLORS = [
   colors.ttahubOrange,
   colors.ttahubMediumBlue,
-  colors.success,
   colors.error,
+  colors.success,
 ];
 
 function Bar({

--- a/frontend/src/widgets/__tests__/GoalStatusGraph.js
+++ b/frontend/src/widgets/__tests__/GoalStatusGraph.js
@@ -55,4 +55,9 @@ describe('GoalStatusChart', () => {
     userEvent.click(closeButton);
     expect(modal.classList.contains('is-hidden')).toBe(true);
   });
+
+  it('falsy data', async () => {
+    renderGoalStatusChart(0);
+    expect(screen.queryByRole('button', { name: /display goal statuses by number as a table/i })).toBeNull();
+  });
 });

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -315,7 +315,7 @@ export async function getGoalsByActivityRecipient(
       'previousStatus',
       'onApprovedAR',
       // [sequelize.fn('ARRAY_AGG', sequelize.col('"grant"."number"')), 'grantNumbers'],
-      [sequelize.literal('CASE WHEN COALESCE("Goal"."status",\'\')  = \'\' OR "Goal"."status" = \'Needs Status\' THEN 1 WHEN "Goal"."status" = \'Not Started\' THEN 2 WHEN "Goal"."status" = \'In Progress\' THEN 3  WHEN "Goal"."status" = \'Closed\' THEN 4 WHEN "Goal"."status" = \'Suspended\' THEN 5 ELSE 6 END'), 'status_sort'],
+      [sequelize.literal('CASE WHEN COALESCE("Goal"."status",\'\')  = \'\' OR "Goal"."status" = \'Needs Status\' THEN 1 WHEN "Goal"."status" = \'Not Started\' THEN 2 WHEN "Goal"."status" = \'In Progress\' THEN 3  WHEN "Goal"."status" = \'Suspended\' THEN 4 WHEN "Goal"."status" = \'Closed\' THEN 5 ELSE 6 END'), 'status_sort'],
     ],
     where: {
       [Op.or]: [

--- a/src/widgets/goalStatusGraph.js
+++ b/src/widgets/goalStatusGraph.js
@@ -23,7 +23,6 @@ const STATUSES_TO_INCLUDE = [
 export default async function goalStatusGraph(scopes) {
   const goalsFromDb = await Goal.findAll({
     where: {
-      onApprovedAR: true,
       [Op.and]: [
         scopes.goal,
         {
@@ -45,7 +44,9 @@ export default async function goalStatusGraph(scopes) {
         ), 'int'),
         'count'],
       'status'],
-    group: ['"Goal".status'],
+    group: [
+      '"Goal".status',
+    ],
     includeIgnoreAttributes: false,
     raw: true,
     include: [{


### PR DESCRIPTION
## Description of change
Unify DB querying for these two components (the goals table and the goal status chart) so they don't continuously fall out of sync

## How to test
View the goals and objectives tab and try a few different filter combinations. The goal statuses and the goals table should show the same number for counts, both total and for individual goal statuses.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-975


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
