### PR TITLE
[TTAHUB-970] Correctly Display Available Objectives

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -19,9 +19,6 @@ export default function ObjectiveFiles({
   const [useFiles, setUseFiles] = useState(hasFiles);
   const readOnly = isOnApprovedReport || status === 'Complete' || (status === 'Not Started' && isOnReport);
 
-  console.log('\n\n\n------------------ Readonly: ', readOnly);
-  console.log('\n\n\n------------------ hasFiles: ', hasFiles);
-
   if (readOnly) {
     if (!hasFiles) {
       return null;

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -19,6 +19,9 @@ export default function ObjectiveFiles({
   const [useFiles, setUseFiles] = useState(hasFiles);
   const readOnly = isOnApprovedReport || status === 'Complete' || (status === 'Not Started' && isOnReport);
 
+  console.log('\n\n\n------------------ Readonly: ', readOnly);
+  console.log('\n\n\n------------------ hasFiles: ', hasFiles);
+
   if (readOnly) {
     if (!hasFiles) {
       return null;
@@ -38,50 +41,41 @@ export default function ObjectiveFiles({
 
   return (
     <>
-      {
-      readOnly && hasFiles
-        ? (
-          <>
-            <p className="usa-prose margin-bottom-0 text-bold">Resources</p>
-            <p className="usa-prose margin-top-0">{files.map((f) => f.originalFileName).join(', ')}</p>
-          </>
-        )
-        : (
-          <Fieldset className="ttahub-objective-files margin-top-1">
-            <legend>
-              Do you plan to use any TTA resources that aren&apos;t available as a link?
-              {' '}
-              <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
-              <QuestionTooltip
-                text={(
-                  <div>
-                    Examples include:
-                    <ul className="usa-list">
-                      <li>Presentation slides from PD events</li>
-                      <li>PDF&apos;s you created from multiple tta resources</li>
-                      <li>Other OHS-provided resources</li>
-                    </ul>
-                  </div>
-)}
-              />
-            </legend>
-            <Radio
-              label="Yes"
-              id="add-objective-files-yes"
-              key="add-objective-files-yes"
-              name="lock-add-objective-files"
-              checked={useFiles}
-              onChange={() => setUseFiles(true)}
-            />
-            <Radio
-              label="No"
-              id="add-objective-files-no"
-              key="add-objective-files-no"
-              name="lock-add-objective-files"
-              checked={!useFiles}
-              onChange={() => setUseFiles(false)}
-            />
-            {
+      <Fieldset className="ttahub-objective-files margin-top-1">
+        <legend>
+          Do you plan to use any TTA resources that aren&apos;t available as a link?
+          {' '}
+          <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
+          <QuestionTooltip
+            text={(
+              <div>
+                Examples include:
+                <ul className="usa-list">
+                  <li>Presentation slides from PD events</li>
+                  <li>PDF&apos;s you created from multiple tta resources</li>
+                  <li>Other OHS-provided resources</li>
+                </ul>
+              </div>
+                )}
+          />
+        </legend>
+        <Radio
+          label="Yes"
+          id="add-objective-files-yes"
+          key="add-objective-files-yes"
+          name="lock-add-objective-files"
+          checked={useFiles}
+          onChange={() => setUseFiles(true)}
+        />
+        <Radio
+          label="No"
+          id="add-objective-files-no"
+          key="add-objective-files-no"
+          name="lock-add-objective-files"
+          checked={!useFiles}
+          onChange={() => setUseFiles(false)}
+        />
+        {
                 useFiles
                   ? (
                     <>
@@ -94,9 +88,7 @@ export default function ObjectiveFiles({
                   )
                   : null
         }
-          </Fieldset>
-        )
-      }
+      </Fieldset>
     </>
   );
 }

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
@@ -6,7 +6,7 @@ import {
 import ObjectiveTopics from '../ObjectiveTopics';
 
 describe('ObjectiveTopics', () => {
-  const renderObjectiveTopics = () => render((
+  const renderObjectiveTopics = (isOnApprovedReport = false) => render((
     <ObjectiveTopics
       error={<></>}
       topicOptions={[]}
@@ -26,7 +26,7 @@ describe('ObjectiveTopics', () => {
       onChangeTopics={jest.fn()}
       status="In Progress"
       isOnReport={false}
-      isOnApprovedReport={false}
+      isOnApprovedReport={isOnApprovedReport}
     />
   ));
 
@@ -37,6 +37,15 @@ describe('ObjectiveTopics', () => {
     expect(screen.getByText(/add more topics/i)).toBeVisible();
     const fastDancing = await screen.findByRole('listitem');
     expect(fastDancing).toHaveTextContent('Dancing but too fast');
-    expect(screen.getByText(/dancing but too slow/i)).toBeVisible();
+    expect(screen.getByText(/dancing but too slow/i)).toBeVisible();;
+  });
+
+  it('displays the correct data on approved report', async () => {
+    renderObjectiveTopics(true);
+    const label = await screen.findByText('Topics');
+    expect(label).toBeVisible();
+
+    expect(await screen.findByText(/dancing but too slow/i)).toBeVisible();
+    expect(await screen.findByText(/dancing but too fast/i)).toBeVisible();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
@@ -37,7 +37,7 @@ describe('ObjectiveTopics', () => {
     expect(screen.getByText(/add more topics/i)).toBeVisible();
     const fastDancing = await screen.findByRole('listitem');
     expect(fastDancing).toHaveTextContent('Dancing but too fast');
-    expect(screen.getByText(/dancing but too slow/i)).toBeVisible();;
+    expect(screen.getByText(/dancing but too slow/i)).toBeVisible();
   });
 
   it('displays the correct data on approved report', async () => {

--- a/frontend/src/components/GoalForm/__tests__/ReadOnlyGoal.js
+++ b/frontend/src/components/GoalForm/__tests__/ReadOnlyGoal.js
@@ -3,31 +3,44 @@ import React from 'react';
 import {
   render, screen,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ReadOnlyGoal from '../ReadOnlyGoal';
 
+const createdGoal = {
+  goalName: 'Sample goal',
+  grant: [],
+  objectives: [],
+  endDate: null,
+};
+
+// eslint-disable-next-line react/prop-types
+const RenderReadOnlyGoal = ({ hideEdit = false }) => (
+  <ReadOnlyGoal
+    onEdit={jest.fn()}
+    onRemove={jest.fn()}
+    hideEdit={hideEdit}
+    goal={createdGoal}
+    index={0}
+  />
+);
+
 describe('ReadOnlyGoal', () => {
-  const createdGoal = {
-    goalName: 'Sample goal',
-    grant: [],
-    objectives: [],
-    endDate: null,
-  };
-
-  const renderReadOnlyGoal = () => {
-    render((
-      <ReadOnlyGoal
-        onEdit={jest.fn()}
-        onRemove={jest.fn()}
-        hideEdit={false}
-        goal={createdGoal}
-        index={0}
-      />
-    ));
-  };
-
   it('can render with a goal', async () => {
-    renderReadOnlyGoal();
+    render(<RenderReadOnlyGoal />);
     expect(await screen.findByRole('heading', { name: /goal summary/i })).toBeVisible();
     expect(await screen.findByText('Sample goal')).toBeVisible();
+  });
+
+  it('can hide edit', async () => {
+    render(<RenderReadOnlyGoal hideEdit />);
+    expect(await screen.findByRole('heading', { name: /goal summary/i })).toBeVisible();
+    expect(await screen.findByText('Sample goal')).toBeVisible();
+
+    const contextMenu = await screen.findByRole('button', { name: /actions for goal undefined/i });
+    userEvent.click(contextMenu);
+
+    expect(await screen.findByText(/remove/i)).toBeVisible();
+    const edit = screen.queryByText(/edit/i);
+    expect(edit).toBeNull();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ReadOnlyObjective.js
+++ b/frontend/src/components/GoalForm/__tests__/ReadOnlyObjective.js
@@ -12,7 +12,7 @@ const createdObjective = {
   files: [{ originalFileName: 'test1.txt' },
     { originalFileName: 'test2.txt' }],
   roles: [],
-  ttaProvided: '',
+  ttaProvided: '<p>sample tta provided</p>',
   status: '',
 };
 
@@ -28,5 +28,6 @@ describe('ReadOnlyObjective', () => {
     expect(await screen.findByText('Sample Objective')).toBeVisible();
     expect(await screen.findByText('test1.txt')).toBeVisible();
     expect(await screen.findByText('test2.txt')).toBeVisible();
+    expect(await screen.findByText('sample tta provided')).toBeVisible();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ReadOnlyObjective.js
+++ b/frontend/src/components/GoalForm/__tests__/ReadOnlyObjective.js
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render, screen,
+} from '@testing-library/react';
+import ReadOnlyObjective from '../ReadOnlyObjective';
+
+const createdObjective = {
+  title: 'Sample Objective',
+  topics: [],
+  resources: [],
+  files: [{ originalFileName: 'test1.txt' },
+    { originalFileName: 'test2.txt' }],
+  roles: [],
+  ttaProvided: '',
+  status: '',
+};
+
+// eslint-disable-next-line react/prop-types
+const RenderReadOnlyObjective = () => (
+  <ReadOnlyObjective objective={createdObjective} />
+);
+
+describe('ReadOnlyObjective', () => {
+  it('can render with a objective', async () => {
+    render(<RenderReadOnlyObjective />);
+    expect(await screen.findByRole('heading', { name: /objective summary/i })).toBeVisible();
+    expect(await screen.findByText('Sample Objective')).toBeVisible();
+    expect(await screen.findByText('test1.txt')).toBeVisible();
+    expect(await screen.findByText('test2.txt')).toBeVisible();
+  });
+});

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render, screen,
+} from '@testing-library/react';
+import ResourceRepeater from '../ResourceRepeater';
+
+describe('ResourceRepeater', () => {
+  const createdResources = [
+    { key: 1, value: 'resource 1', isOnApprovedReport: false },
+    { key: 2, value: 'resource 2', isOnApprovedReport: true },
+  ];
+
+  const renderReadOnly = () => {
+    render((
+      <ResourceRepeater
+        resources={createdResources}
+        setResources={jest.fn()}
+        validateResources={jest.fn()}
+        error={<></>}
+        isOnReport={false}
+        isOnApprovedReport={false}
+        status="Not Started"
+        isLoading={false}
+      />
+    ));
+  };
+
+  it('can render with resources', async () => {
+    renderReadOnly();
+    expect(await screen.findByRole('textbox', { name: /resource 1/i })).toBeVisible();
+    expect(await screen.findByText(/resource 2/i)).toBeVisible();
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -30,6 +30,7 @@ export default function Objective({
   fieldArrayName,
   errors,
   roles,
+  onObjectiveChange,
 }) {
   const [selectedObjective, setSelectedObjective] = useState(objective);
 
@@ -160,6 +161,7 @@ export default function Objective({
     onChangeStatus(newObjective.status);
     onChangeRoles(newObjective.roles || []);
     onChangeTopics(newObjective.topics);
+    onObjectiveChange(newObjective, index); // Call parent on objective change.
   };
 
   // we need to auto select an objective role if there is only one available
@@ -291,4 +293,5 @@ Objective.propTypes = {
   remove: PropTypes.func.isRequired,
   fieldArrayName: PropTypes.string.isRequired,
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onObjectiveChange: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -31,7 +31,7 @@ export default function Objective({
   errors,
   roles,
 }) {
-  const [selectedObjectives, setSelectedObjectives] = useState(objective);
+  const [selectedObjective, setSelectedObjective] = useState(objective);
 
   /**
    * add controllers for all the controlled fields
@@ -153,7 +153,13 @@ export default function Objective({
   ), [objective.activityReports]);
 
   const onChangeObjective = (newObjective) => {
-    setSelectedObjectives(newObjective);
+    setSelectedObjective(newObjective);
+    onChangeResources(newObjective.resources);
+    onChangeTitle(newObjective.title);
+    onChangeTta(newObjective.ttaProvided || '');
+    onChangeStatus(newObjective.status);
+    onChangeRoles(newObjective.roles || []);
+    onChangeTopics(newObjective.topics);
   };
 
   // we need to auto select an objective role if there is only one available
@@ -162,32 +168,6 @@ export default function Objective({
       onChangeRoles(defaultRoles);
     }
   }, [defaultRoles, objectiveRoles.length, onChangeRoles]);
-
-  useEffect(() => {
-    // firing these off as side effects updates all the fields
-    // and seems a little less janky visually than handling it all in
-    // "onChangeObjective". Note that react hook form v7 offers an "update"
-    // function w/ useFieldArray, so this can be removed and the above function
-    // simplified if we get around to moving to that
-    onChangeResources(selectedObjectives.resources);
-    onChangeRoles(selectedObjectives.roles || []);
-    onChangeTitle(selectedObjectives.title);
-    onChangeTta(selectedObjectives.ttaProvided || '');
-    onChangeStatus(selectedObjectives.status);
-    onChangeTopics(selectedObjectives.topics);
-  }, [
-    onChangeResources,
-    onChangeRoles,
-    onChangeStatus,
-    onChangeTitle,
-    onChangeTopics,
-    onChangeTta,
-    fieldArrayName,
-    index,
-    selectedObjectives,
-    // this last value is the only thing that should be changing, when a new objective is
-    // selected from the dropdown. the others, I would assume, are refs that won't be changing
-  ]);
 
   let savedTopics = [];
   let savedResources = [];
@@ -205,7 +185,7 @@ export default function Objective({
     <>
       <ObjectiveSelect
         onChange={onChangeObjective}
-        selectedObjectives={selectedObjectives}
+        selectedObjectives={selectedObjective}
         options={options}
         onRemove={onRemove}
       />

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import { useController } from 'react-hook-form/dist/index.ie11';
-import ObjectiveTitle from '../../../../components/GoalForm/ObjectiveTitle';
+import ObjectiveTitle from './ObjectiveTitle';
 import { REPORT_STATUSES } from '../../../../Constants';
 import SpecialistRole from '../../../../components/GoalForm/SpecialistRole';
 import ObjectiveTopics from '../../../../components/GoalForm/ObjectiveTopics';

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
@@ -1,0 +1,70 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import {
+  FormGroup, Label, Textarea,
+} from '@trussworks/react-uswds';
+
+export default function ObjectiveTitle({
+  error,
+  isOnApprovedReport,
+  isOnReport,
+  title,
+  onChangeTitle,
+  validateObjectiveTitle,
+  status,
+  inputName,
+  isLoading,
+}) {
+  const {
+    register,
+  } = useFormContext();
+
+  const readOnly = useMemo(() => (isOnApprovedReport || status === 'Complete' || status === 'Suspended' || (status === 'Not Started' && isOnReport) || (status === 'In Progress' && isOnReport)),
+    [isOnApprovedReport, isOnReport, status]);
+
+  return (
+    <FormGroup className="margin-top-1" error={error.props.children}>
+      <Label htmlFor={inputName} className={readOnly ? 'text-bold' : ''}>
+        TTA objective
+        {' '}
+        { !readOnly ? <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span> : null }
+      </Label>
+      { readOnly && title ? (
+        <p className="margin-top-0 usa-prose">{title}</p>
+      ) : (
+        <>
+          {error}
+          <Textarea
+            key={inputName}
+            id={inputName}
+            name={inputName}
+            defaultValue={title}
+            onChange={onChangeTitle}
+            onBlur={validateObjectiveTitle}
+            required
+            disabled={isLoading}
+            inputRef={register({ required: true })}
+          />
+        </>
+      )}
+    </FormGroup>
+  );
+}
+
+ObjectiveTitle.propTypes = {
+  error: PropTypes.node.isRequired,
+  isOnApprovedReport: PropTypes.bool.isRequired,
+  isOnReport: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  validateObjectiveTitle: PropTypes.func.isRequired,
+  onChangeTitle: PropTypes.func.isRequired,
+  status: PropTypes.string.isRequired,
+  inputName: PropTypes.string,
+  isLoading: PropTypes.bool,
+};
+
+ObjectiveTitle.defaultProps = {
+  inputName: 'objectiveTitle',
+  isLoading: false,
+};

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTta.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTta.js
@@ -40,7 +40,6 @@ export default function ObjectiveTta(
         <div className="smart-hub--text-area__resize-vertical margin-top-1">
           <input type="hidden" name={inputName} value={ttaProvided} />
           <RichEditor
-            value={ttaProvided}
             ariaLabel="TTA provided for objective"
             defaultValue={ttaProvided}
             onChange={onChangeTTA}

--- a/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
@@ -30,6 +30,7 @@ export default function Objectives({
     remove,
   } = useFieldArray({
     name: fieldArrayName,
+    keyName: 'key', // because 'id' is the default key switch it to use 'key'.
     defaultValues,
   });
 

--- a/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useFieldArray, useFormContext } from 'react-hook-form/dist/index.ie11';
 import Objective from './Objective';
@@ -12,7 +12,7 @@ export default function Objectives({
   roles,
   noObjectiveError,
 }) {
-  const { errors, getValues } = useFormContext();
+  const { errors, getValues, setValue } = useFormContext();
 
   const fieldArrayName = 'goalForEditing.objectives';
   const objectivesForGoal = getValues(fieldArrayName);
@@ -34,12 +34,52 @@ export default function Objectives({
     defaultValues,
   });
 
-  const objectiveIds = fields ? fields.map(({ value }) => value) : [];
+  const [usedObjectiveIds, setUsedObjectiveIds] = useState(
+    fields ? fields.map(({ value }) => value) : [],
+  );
+
+  const onAddNew = () => {
+    const defaultRoles = roles.length === 1 ? roles : [];
+    append({ ...NEW_OBJECTIVE(), roles: defaultRoles });
+  };
+
+  const setUpdatedUsedObjectiveIds = () => {
+    // If fields have changed get updated list of used Objective ID's.
+    const allValues = getValues();
+    const fieldArrayGoals = allValues.goalForEditing || [];
+    const updatedIds = fieldArrayGoals.objectives
+      ? fieldArrayGoals.objectives.map(({ value }) => value)
+      : [];
+    setUsedObjectiveIds(updatedIds);
+  };
+
+  const onInitialObjSelect = (objective) => {
+    const defaultRoles = roles.length === 1 ? roles : objective.roles;
+    append({
+      ...objective, roles: defaultRoles,
+    });
+
+    // If fields have changed get updated list of used Objective ID's.
+    setUpdatedUsedObjectiveIds();
+  };
+
+  const onObjectiveChange = (objective, index) => {
+    // 'id','ids','value', and 'label' are not tracked on the form.
+    // We need to update these with the new Objective ID.
+    const ObjId = objective.id;
+    setValue(`${fieldArrayName}[${index}].id`, ObjId);
+    setValue(`${fieldArrayName}[${index}].value`, ObjId);
+    setValue(`${fieldArrayName}[${index}].label`, objective.label);
+    setValue(`${fieldArrayName}[${index}].ids`, objective.ids);
+
+    // If fields have changed get updated list of used Objective ID's.
+    setUpdatedUsedObjectiveIds();
+  };
 
   const options = [
     NEW_OBJECTIVE(),
     // filter out used objectives and return them in them in a format that react-select understands
-    ...objectives.filter((objective) => !objectiveIds.includes(objective.value)).map(
+    ...objectives.filter((objective) => !usedObjectiveIds.includes(objective.value)).map(
       (objective) => ({
         ...objective,
         label: objective.title,
@@ -48,16 +88,6 @@ export default function Objectives({
       }),
     ),
   ];
-
-  const onAddNew = () => {
-    const defaultRoles = roles.length === 1 ? roles : [];
-    append({ ...NEW_OBJECTIVE(), roles: defaultRoles });
-  };
-
-  const onSelect = (objective) => {
-    const defaultRoles = roles.length === 1 ? roles : objective.roles;
-    append({ ...objective, roles: defaultRoles });
-  };
 
   return (
     <>
@@ -70,7 +100,7 @@ export default function Objectives({
       {fields.length < 1
         ? (
           <ObjectiveSelect
-            onChange={onSelect}
+            onChange={onInitialObjSelect}
             options={options}
             selectedObjectives={[]}
             noObjectiveError={noObjectiveError}
@@ -86,7 +116,7 @@ export default function Objectives({
           return (
             <Objective
               index={index}
-              key={objective.value}
+              key={objective.key}
               objective={objective}
               topicOptions={topicOptions}
               options={options}
@@ -94,6 +124,7 @@ export default function Objectives({
               remove={remove}
               fieldArrayName={fieldArrayName}
               roles={roles}
+              onObjectiveChange={onObjectiveChange}
             />
           );
         })}

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectiveTitle.js
@@ -1,0 +1,56 @@
+/* eslint-disable react/prop-types */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
+import {
+  render, screen,
+} from '@testing-library/react';
+import ObjectiveTitle from '../ObjectiveTitle';
+
+const RenderObjectiveTitle = ({
+  goalId = 12,
+  collaborators = [],
+}) => {
+  let goalForEditing = null;
+
+  if (goalId) {
+    goalForEditing = {
+      id: goalId,
+      objectives: [],
+    };
+  }
+
+  const hookForm = useForm({
+    mode: 'onBlur',
+    defaultValues: {
+      collaborators,
+      author: {
+        role: 'Central office',
+      },
+      goalForEditing,
+    },
+  });
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <FormProvider {...hookForm}>
+      <ObjectiveTitle
+        error={<></>}
+        isOnApprovedReport
+        isOnReport
+        title="Objective title"
+        validateObjectiveTitle={jest.fn()}
+        onChangeTitle={jest.fn()}
+        status="Complete"
+      />
+      <button type="button">blur me</button>
+    </FormProvider>
+  );
+};
+
+describe('ObjectiveTitle', () => {
+  it('shows the read only view', async () => {
+    render(<RenderObjectiveTitle />);
+    expect(await screen.findByText('Objective title')).toBeVisible();
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  render, screen, waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
@@ -65,12 +67,23 @@ describe('Objectives', () => {
     await selectEvent.select(select, ['Create a new objective']);
     await waitFor(() => expect(screen.queryByText(/objective status/i)).not.toBeNull());
   });
-  it('allows for the selection of an objective', async () => {
+  it('allows for the selection and changing of an objective', async () => {
     const objectiveOptions = [{
       value: 3,
-      label: 'Test objective',
-      title: 'Test objective',
+      label: 'Test objective 1',
+      title: 'Test objective 1',
       ttaProvided: '<p>hello</p>',
+      activityReports: [],
+      resources: [],
+      topics: [],
+      roles: [],
+      status: 'Not Started',
+    },
+    {
+      value: 4,
+      label: 'Test objective 2',
+      title: 'Test objective 2',
+      ttaProvided: '<p>hello 2</p>',
       activityReports: [],
       resources: [],
       topics: [],
@@ -78,15 +91,20 @@ describe('Objectives', () => {
       status: 'Not Started',
     }];
     render(<RenderObjectives objectiveOptions={objectiveOptions} />);
-    const select = await screen.findByLabelText(/Select TTA objective/i);
+    let select = await screen.findByLabelText(/Select TTA objective/i);
     expect(screen.queryByText(/objective status/i)).toBeNull();
-    await selectEvent.select(select, ['Test objective']);
 
+    // Initial objective select.
+    await selectEvent.select(select, ['Test objective 1']);
     const r = await screen.findByLabelText(/resource 1/i);
     userEvent.type(r, 'GARG');
     userEvent.click(await screen.findByText(/blur me/i));
-
     await waitFor(() => expect(screen.queryByText(/objective status/i)).not.toBeNull());
+
+    // Change Objective.
+    select = await screen.findByLabelText(/Select TTA objective/i);
+    await selectEvent.select(select, ['Test objective 2']);
+    await screen.findByLabelText(/test objective 2/i);
   });
   it('the button adds a new objective', async () => {
     const objectiveOptions = [{

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1097,6 +1097,11 @@ async function createObjectivesForGoal(goal, objectives, report) {
     } else {
       const objectiveTitle = updatedObjective.title ? updatedObjective.title.trim() : '';
 
+      // Reuse an existing Objective:
+      // - It is on the same goal.
+      // - Has the same title.
+      // - And status is not completed.
+      // Note: Values like 'Topics' will be pulled in from the existing objective.
       const existingObjective = await Objective.findOne({
         where: {
           goalId: updatedObjective.goalId,
@@ -1184,6 +1189,11 @@ export async function saveGoalsForReport(goals, report) {
         ...fields
       } = goal;
 
+      // Reuse an existing Goal:
+      // - Has the same name.
+      // - Grant Id.
+      // - And status is not closed.
+      // Note: The existing goal should be used regardless if it was created new.
       newGoals = await Promise.all(goal.grantIds.map(async (grantId) => {
         const [newGoal] = await Goal.findOrCreate({
           where: {


### PR DESCRIPTION
## Description of change

When using existing goals the objective drop down does not correctly reflect the available objectives.

## How to test

1. From the RTR create a goal  with multiple objectives.
2. Create a new AR
3. On the goal created page select the Goal you created in the first step
4. Select one of the existing objectives you created
5. When you click the objective drop down again it should reflect the available objectives
6. Changing the selected objective should refresh the drop down with the correct available objectives

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-970


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
