### PR TITLE
[TTAHUB-980] Change string comparison operator for goal topics filters/scope

### DIFF
--- a/src/scopes/goals/topics.js
+++ b/src/scopes/goals/topics.js
@@ -32,7 +32,7 @@ const topicFilter = (options) => {
 export function withTopics(topics, options) {
   return {
     [Op.or]: [
-      filterAssociation(topicFilter(options), topics, false),
+      filterAssociation(topicFilter(options), topics, false, 'ILIKE'),
     ],
   };
 }
@@ -40,7 +40,7 @@ export function withTopics(topics, options) {
 export function withoutTopics(topics, options) {
   return {
     [Op.and]: [
-      filterAssociation(topicFilter(options), topics, true),
+      filterAssociation(topicFilter(options), topics, true, 'ILIKE'),
     ],
   };
 }


### PR DESCRIPTION
## Description of change
Change the string comparison used by the goal topics filters/scope

## How to test

To reproduce bug on main:
1) Go to RTR
2) Goals and Objectives tab
3) Select Goals topics is or is not a topic containing a parentheses. Note that the data is not filtered (it helps if you can see a goal with that topic, so you might query the DB first to find an appropriate recipient)

Works on this branch

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-980


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
