### PR TITLE
[TTAHUB-970] Fix Auto Focus Issue on Objective Title

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { useFormContext } from 'react-hook-form/dist/index.ie11';
 import {
   FormGroup, Label, Textarea,
 } from '@trussworks/react-uswds';
@@ -16,10 +15,6 @@ export default function ObjectiveTitle({
   inputName,
   isLoading,
 }) {
-  const {
-    register,
-  } = useFormContext();
-
   const readOnly = useMemo(() => (isOnApprovedReport || status === 'Complete' || status === 'Suspended' || (status === 'Not Started' && isOnReport) || (status === 'In Progress' && isOnReport)),
     [isOnApprovedReport, isOnReport, status]);
 
@@ -39,12 +34,11 @@ export default function ObjectiveTitle({
             key={inputName}
             id={inputName}
             name={inputName}
-            defaultValue={title}
+            value={title}
             onChange={onChangeTitle}
             onBlur={validateObjectiveTitle}
             required
             disabled={isLoading}
-            inputRef={register({ required: true })}
           />
         </>
       )}


### PR DESCRIPTION
## Description of change

When creating or adding an existing goal the form is setting focus on the Objective title.

## How to test

Creating or adding an existing objective should NOT auto focus on the title.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-970


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
