### PR TITLE
[TTAHUB-996] Prevent Duplicate Goals when Saving Draft

### DIFF
--- a/frontend/src/components/Navigator/__tests__/index.js
+++ b/frontend/src/components/Navigator/__tests__/index.js
@@ -282,4 +282,34 @@ describe('Navigator', () => {
     fetchMock.post('/api/activity-reports/goals', []);
     expect(fetchMock.called('/api/activity-reports/goals')).toBe(false);
   });
+
+  it('runs the autosave on the other entity objectives page', async () => {
+    const onSubmit = jest.fn();
+    const onSave = jest.fn();
+    const updatePage = jest.fn();
+    const updateForm = jest.fn();
+    const pages = [{
+      position: 1,
+      path: 'goals-objectives',
+      label: 'first page',
+      review: false,
+      render: () => (
+        <>
+          <h1>OE Objectives test</h1>
+        </>
+      ),
+    }];
+
+    const oeData = {
+      ...initialData,
+      activityRecipientType: 'other-entity',
+    };
+
+    renderNavigator('goals-objectives', onSubmit, onSave, updatePage, updateForm, pages, oeData);
+    fetchMock.restore();
+    expect(fetchMock.called()).toBe(false);
+    jest.advanceTimersByTime(1000 * 60 * 2);
+    fetchMock.post('api/activity-reports/objectives', []);
+    expect(fetchMock.called('api/activity-reports/objectives')).toBe(false);
+  });
 });

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -177,6 +177,7 @@ function Navigator({
       // Find the goal we are editing and put it back with updated values.
       const goalBeingEdited = allGoals.find((g) => g.name === goal.name);
       setValue('goalForEditing', goalBeingEdited);
+      updateLastSaveTime(moment());
     } catch (error) {
       updateErrorMessage('A network error has prevented us from saving your activity report to our database. Your work is safely saved to your web browser in the meantime.');
     } finally {
@@ -202,6 +203,7 @@ function Navigator({
       );
       // Set updated objectives.
       setValue('objectivesWithoutGoals', newObjectives);
+      updateLastSaveTime(moment());
     } catch (error) {
       updateErrorMessage('A network error has prevented us from saving your activity report to our database. Your work is safely saved to your web browser in the meantime.');
     } finally {

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -1,4 +1,6 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, {
+  useEffect, useState, useMemo, useContext,
+} from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { v4 as uuid } from 'uuid';
@@ -12,6 +14,8 @@ import {
   GOAL_NAME_ERROR,
 } from '../../../../components/GoalForm/constants';
 import { NO_ERROR, ERROR_FORMAT } from './constants';
+import Loader from '../../../../components/Loader';
+import GoalFormContext from '../../../../GoalFormContext';
 
 export default function GoalForm({
   goal,
@@ -21,6 +25,9 @@ export default function GoalForm({
 }) {
   // pull the errors out of the form context
   const { errors, watch } = useFormContext();
+
+  // Goal Form Context.
+  const { isLoading } = useContext(GoalFormContext);
 
   /**
    * add controllers for all the controlled fields
@@ -112,6 +119,7 @@ export default function GoalForm({
 
   return (
     <>
+      <Loader loading={isLoading} loadingLabel="Loading" text="Saving" />
       <GoalText
         error={errors.goalName ? ERROR_FORMAT(errors.goalName.message) : NO_ERROR}
         goalName={goalText}
@@ -119,6 +127,7 @@ export default function GoalForm({
         onUpdateText={onUpdateText}
         inputName={goalTextInputName}
         isOnReport={goal.onApprovedAR || false}
+        isLoading={isLoading}
       />
 
       <GoalDate
@@ -128,6 +137,7 @@ export default function GoalForm({
         validateEndDate={onBlurDate}
         datePickerKey={datePickerKey}
         inputName={goalEndDateInputName}
+        isLoading={isLoading}
       />
 
       <Objectives

--- a/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, {
+  useState, useEffect, useMemo, useContext,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useFormContext, useFieldArray } from 'react-hook-form/dist/index.ie11';
 import { Alert } from '@trussworks/react-uswds';
@@ -6,6 +8,8 @@ import Objective from './Objective';
 import { getTopics } from '../../../../fetchers/topics';
 import PlusButton from '../../../../components/GoalForm/PlusButton';
 import { NEW_OBJECTIVE } from './constants';
+import Loader from '../../../../components/Loader';
+import GoalFormContext from '../../../../GoalFormContext';
 
 const OBJECTIVE_LABEL = 'objectivesWithoutGoals';
 
@@ -13,6 +17,8 @@ export default function OtherEntity({ roles, recipientIds }) {
   const { errors } = useFormContext();
   const defaultRoles = useMemo(() => (roles.length === 1 ? roles : []), [roles]);
   const [topicOptions, setTopicOptions] = useState([]);
+
+  const { isLoading } = useContext(GoalFormContext);
 
   // for fetching topic options from API
   useEffect(() => {
@@ -54,6 +60,7 @@ export default function OtherEntity({ roles, recipientIds }) {
         </p>
         <p className="usa-prose margin-bottom-0">Create at least one objective for this activity.</p>
       </Alert>
+      <Loader loading={isLoading} loadingLabel="Loading" text="Saving" />
       {objectives.map((objective, index) => {
         const objectiveErrors = errors[OBJECTIVE_LABEL]
           && errors[OBJECTIVE_LABEL][index]

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -223,6 +223,8 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
     if (exists) {
       const id = objective.getDataValue('id') ? objective.getDataValue('id') : objective.getDataValue('value');
       exists.ids = [...exists.ids, id];
+      // Make sure we pass back a list of recipient ids for subsequent saves.
+      exists.recipientIds = [...exists.recipientIds, objective.getDataValue('otherEntityId')];
       return objectives;
     }
 
@@ -242,6 +244,8 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
       ...objective.dataValues,
       value: id,
       ids: [id],
+      // Make sure we pass back a list of recipient ids for subsequent saves.
+      recipientIds: [objective.getDataValue('otherEntityId')],
       ttaProvided,
       isNew: false,
       roles,

--- a/src/services/objectives.js
+++ b/src/services/objectives.js
@@ -14,43 +14,66 @@ import {
 import { removeUnusedGoalsObjectivesFromReport, reduceObjectives } from './goals';
 
 export async function saveObjectivesForReport(objectives, report) {
-  const updatedObjectives = await Promise.all(objectives.map(async (objective) => Promise
-    .all(objective.recipientIds.map(async (otherEntityId) => {
-      // Determine if this objective already exists.
-      const existingObjective = await Objective.findOne({
-        where: {
-          title: objective.title,
-          otherEntityId,
-          status: { [Op.not]: 'Complete' },
-        },
-      });
+  const updatedObjectives = await Promise.all(
+    objectives.filter((o) => o.title).map(async (objective) => Promise
+      .all(objective.recipientIds.map(async (otherEntityId) => {
+        // Check for existing objective:
+        let existingObjective;
+        // 1. Find existing by id and entity and id.
+        if (objective.ids
+            && objective.ids.length) {
+          const validIdsToCheck = objective.ids.filter((id) => typeof id === 'number');
+          existingObjective = await Objective.findOne({
+            where: {
+            // We are checking all objective id's but only one should link to the entity.
+              id: validIdsToCheck,
+              otherEntityId,
+              status: { [Op.not]: 'Complete' },
+            },
+          });
+        }
 
-      // If it already exists update the status else create it.
-      let savedObjective;
-      if (existingObjective) {
-        await existingObjective.update({
-          status: objective.status,
-        }, { individualHooks: true });
-        savedObjective = existingObjective;
-      } else {
+        // 2. Find by title and 'entity' id.
+        if (!existingObjective) {
+          // Determine if this objective already exists.
+          existingObjective = await Objective.findOne({
+            where: {
+              title: objective.title,
+              otherEntityId,
+              status: { [Op.not]: 'Complete' },
+            },
+          });
+        }
+
+        // If it already exists update the status else create it.
+        let savedObjective;
+        if (existingObjective) {
+          await existingObjective.update({
+            status: objective.status,
+            title: objective.title,
+          }, { individualHooks: true });
+          savedObjective = existingObjective;
+        } else {
         // To prevent validation error exclude id.
         // In this case the user might have changed the title for objective.
-        const { id, ...ObjPros } = objective;
-        savedObjective = await Objective.create({
-          ...ObjPros,
+          const { id, ...ObjPros } = objective;
+          savedObjective = await Objective.create({
+            ...ObjPros,
+            otherEntityId,
+          });
+        }
+        // Find or create and activity report objective.
+        const [aro] = await ActivityReportObjective.findOrCreate({
+          where: {
+            objectiveId: savedObjective.id,
+            activityReportId: report.id,
+          },
         });
-      }
-      // Find or create and activity report objective.
-      const [aro] = await ActivityReportObjective.findOrCreate({
-        where: {
-          objectiveId: savedObjective.id,
-          activityReportId: report.id,
-        },
-      });
-      // Update activity report objective tta.
-      await aro.update({ ttaProvided: objective.ttaProvided }, { individualHooks: true });
-      return savedObjective;
-    }))));
+        // Update activity report objective tta.
+        await aro.update({ ttaProvided: objective.ttaProvided }, { individualHooks: true });
+        return savedObjective;
+      }))),
+  );
 
   const currentObjectives = updatedObjectives.flat();
   return removeUnusedGoalsObjectivesFromReport(report.id, currentObjectives);

--- a/src/services/objectives.test.js
+++ b/src/services/objectives.test.js
@@ -9,6 +9,7 @@ import db, {
   Grant,
   Goal,
   Recipient,
+  OtherEntity,
 } from '../models';
 import { REPORT_STATUSES } from '../constants';
 
@@ -49,6 +50,10 @@ const mockRecipient = {
   recipientType: 'Community Action Agency (CAA)',
 };
 
+const mockOtherEntity = {
+  name: 'Mock Other Entity for OE Objectives',
+};
+
 describe('Objectives DB service', () => {
   let report;
   let objective;
@@ -59,6 +64,11 @@ describe('Objectives DB service', () => {
   let grantInfo;
   let recipientInfo;
   let goalInfo;
+
+  let otherEntity;
+
+  let findObjectiveById;
+  let findObjectiveByTitle;
 
   const objectives = [
     {
@@ -118,18 +128,39 @@ describe('Objectives DB service', () => {
         ids: [objective.id],
       }], report);
     });
-
+    otherEntity = await OtherEntity.create({ ...mockOtherEntity, id: 685497 });
     recipientInfo = await Recipient.create({ ...mockRecipient });
     grantInfo = await Grant.create({ ...mockGrant, recipientId: recipientInfo.id });
     goalInfo = await Goal.create({ name: 'sample goal for obj info', grantId: grantInfo.id });
     objectiveInfo = await Objective.create({ title: 'sample obj for info', goalId: goalInfo.id });
+    findObjectiveById = await Objective.create({
+      id: 598742,
+      title: 'i already exist with an id',
+      status: 'In Progress',
+      otherEntityId: 1,
+    });
+    findObjectiveByTitle = await Objective.create({
+      id: 594743,
+      title: 'there are many titles but this one is mine',
+      status: 'In Progress',
+      otherEntityId: 1,
+    });
   });
 
   afterAll(async () => {
     const aros = await ActivityReportObjective.findAll({ where: { activityReportId: report.id } });
     const objectiveIds = aros.map((aro) => aro.objectiveId);
     await ActivityReportObjective.destroy({ where: { activityReportId: report.id } });
-    await Objective.destroy({ where: { id: [...objectiveIds, objective.id, secondObjective.id] } });
+    await Objective.destroy({
+      where: {
+        id:
+      [...objectiveIds,
+        objective.id,
+        secondObjective.id,
+        findObjectiveById.id,
+        findObjectiveByTitle.id],
+      },
+    });
     await ActivityRecipient.destroy({ where: { activityReportId: report.id } });
     await ActivityReport.destroy({ where: { id: report.id } });
 
@@ -137,7 +168,7 @@ describe('Objectives DB service', () => {
     await Goal.destroy({ where: { id: goalInfo.id } });
     await Grant.destroy({ where: { id: grantInfo.id } });
     await Recipient.destroy({ where: { id: recipientInfo.id } });
-
+    await OtherEntity.destroy({ where: { id: otherEntity.id } });
     await User.destroy({ where: { id: mockUser.id } });
     await db.sequelize.close();
   });
@@ -186,6 +217,39 @@ describe('Objectives DB service', () => {
       expect(objs.length).toBe(3);
       expect(objs.map((o) => o.title).sort())
         .toEqual([objective, ...objectives].map((o) => o.title).sort());
+    });
+    it('finds existing objective by id', async () => {
+      expect(findObjectiveById).not.toBeNull();
+
+      await sequelize.transaction(async () => {
+        await saveObjectivesForReport([{
+          ...findObjectiveById,
+          ids: [findObjectiveById.id],
+          recipientIds: [1],
+          otherEntityId: 1,
+          status: 'In Progress',
+          title: 'i have a new title but same id',
+        }], report);
+      });
+      const foundObj = await getObjectiveById(findObjectiveById.id);
+      expect(foundObj.title).toBe('i have a new title but same id');
+    });
+
+    it('finds existing objective by title and entity', async () => {
+      expect(findObjectiveByTitle).not.toBeNull();
+
+      await sequelize.transaction(async () => {
+        await saveObjectivesForReport([{
+          ...findObjectiveByTitle,
+          recipientIds: [1],
+          otherEntityId: 1,
+          status: 'Not Started',
+          title: 'there are many titles but this one is mine',
+        }], report);
+      });
+      const foundObj = await getObjectiveById(findObjectiveByTitle.id);
+      expect(foundObj.title).toBe('there are many titles but this one is mine');
+      expect(foundObj.status).toBe('Not Started');
     });
   });
 });


### PR DESCRIPTION
## Description of change

We need to prevent creating duplicate goals and objectives if an auto save occurs when the user is still editing.

We also need to add saving of draft other-entity objectives while preventing the same case.

## How to test

Create goals and objectives for both **recipient** and **other-entity** reports. Allow auto save to occur at various steps (CRUD) to ensure we are not creating duplicate goals and objectives in the database. You should be able to finalize goal and objective creation and submit the report as before.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-996


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
