### PR TITLE
Update goal status based on objective status

### DIFF
--- a/src/models/hooks/activityReport.test.js
+++ b/src/models/hooks/activityReport.test.js
@@ -1,0 +1,203 @@
+import faker from '@faker-js/faker';
+import { APPROVER_STATUSES, REPORT_STATUSES } from '../../constants';
+import db, {
+  ActivityReport,
+  ActivityReportGoal,
+  ActivityReportApprover,
+  ActivityRecipient,
+  ActivityReportObjective,
+  Goal,
+  Objective,
+  Recipient,
+  Grant,
+  User,
+} from '..';
+
+describe('activity report model hooks', () => {
+  describe('automatic goal status changes', () => {
+    let recipient;
+    let grant;
+    let goal;
+    let report;
+    let mockUser;
+    let mockApprover;
+    let objective;
+
+    beforeAll(async () => {
+      recipient = await Recipient.create({
+        id: faker.datatype.number(),
+        name: faker.name.firstName(),
+      });
+
+      mockUser = await User.create({
+        id: faker.datatype.number(),
+        homeRegionId: 1,
+        hsesUsername: faker.datatype.string(),
+        hsesUserId: faker.datatype.string(),
+      });
+
+      mockApprover = await User.create({
+        id: faker.datatype.number(),
+        homeRegionId: 1,
+        hsesUsername: faker.datatype.string(),
+        hsesUserId: faker.datatype.string(),
+      });
+
+      grant = await Grant.create({
+        id: faker.datatype.number(),
+        number: faker.datatype.string(),
+        recipientId: recipient.id,
+        regionId: 1,
+      });
+
+      goal = await Goal.create({
+        name: 'Goal 1',
+        status: 'Draft',
+        endDate: null,
+        isFromSmartsheetTtaPlan: false,
+        onApprovedAR: false,
+        grantId: grant.id,
+        createdVia: 'rtr',
+      });
+
+      report = await ActivityReport.create({
+        userId: mockUser.id,
+        regionId: 1,
+        submissionStatus: REPORT_STATUSES.DRAFT,
+        calculatedStatus: REPORT_STATUSES.DRAFT,
+        numberOfParticipants: 1,
+        deliveryMethod: 'virtual',
+        duration: 10,
+        endDate: '2000-01-01T12:00:00Z',
+        startDate: '2000-01-01T12:00:00Z',
+        activityRecipientType: 'something',
+        requester: 'requester',
+        targetPopulations: ['pop'],
+        reason: ['reason'],
+        participants: ['participants'],
+        topics: ['topics'],
+        ttaType: ['type'],
+        creatorRole: 'TTAC',
+      });
+
+      await ActivityReportGoal.create({
+        activityReportId: report.id,
+        goalId: goal.id,
+      });
+
+      await ActivityRecipient.create({
+        activityReportId: report.id,
+        grantId: grant.id,
+      });
+    });
+
+    afterAll(async () => {
+      await ActivityReportApprover.destroy({
+        where: {
+          activityReportId: report.id,
+        },
+        force: true,
+      });
+
+      await ActivityRecipient.destroy({
+        where: {
+          activityReportId: report.id,
+        },
+      });
+
+      await ActivityReportGoal.destroy({
+        where: {
+          activityReportId: report.id,
+        },
+      });
+
+      await ActivityReportObjective.destroy({
+        where: {
+          activityReportId: report.id,
+        },
+      });
+
+      await Objective.destroy({
+        where: {
+          id: objective.id,
+        },
+      });
+
+      await ActivityReport.destroy({
+        where: {
+          id: report.id,
+        },
+      });
+
+      await Goal.destroy({
+        where: {
+          id: goal.id,
+        },
+      });
+
+      await Grant.destroy({
+        where: {
+          id: grant.id,
+        },
+      });
+
+      await Recipient.destroy({
+        where: {
+          id: recipient.id,
+        },
+      });
+
+      await User.destroy({
+        where: {
+          id: [mockUser.id, mockApprover.id],
+        },
+      });
+      await db.sequelize.close();
+    });
+
+    it('saving objectives should not change goal status if the goal is in draft', async () => {
+      objective = await Objective.create({
+        title: 'Objective 1',
+        goalId: goal.id,
+        status: 'In Progress',
+      });
+
+      await ActivityReportObjective.create({
+        activityReportId: report.id,
+        objectiveId: objective.id,
+      });
+
+      const testGoal = await Goal.findByPk(goal.id);
+      expect(testGoal.status).toEqual('Draft');
+    });
+
+    it('submitting the report should not set the goal status', async () => {
+      const testReport = await ActivityReport.findByPk(report.id);
+
+      await testReport.update({
+        submissionStatus: REPORT_STATUSES.SUBMITTED,
+        calculatedStatus: REPORT_STATUSES.SUBMITTED,
+      });
+
+      const testGoal = await Goal.findByPk(goal.id);
+      expect(testGoal.status).toEqual('Draft');
+    });
+
+    it('approving the report should set the goal to "in progress"', async () => {
+      let testReport = await ActivityReport.findByPk(report.id);
+      expect(testReport.calculatedStatus).toEqual(REPORT_STATUSES.SUBMITTED);
+
+      await ActivityReportApprover.create({
+        activityReportId: report.id,
+        userId: mockApprover.id,
+        status: APPROVER_STATUSES.APPROVED,
+      });
+
+      testReport = await ActivityReport.findByPk(report.id);
+      expect(testReport.calculatedStatus).toEqual(REPORT_STATUSES.APPROVED);
+
+      const testGoal = await Goal.findByPk(goal.id);
+      expect(testGoal.status).toEqual('In Progress');
+    });
+  });
+});

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -201,7 +201,7 @@ const updateParentGoalStatus = async (sequelize, instance) => {
         {
           // assumption: we only want to auto update the goal status if it is
           // on an activity report, otherwise it should be updated by the
-          // RTR form logic...
+          // RTR form logic or the RTR page
           createdVia: 'activityReport',
         },
         {

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -212,7 +212,9 @@ const updateParentGoalStatus = async (sequelize, instance) => {
       newStatus = 'In Progress';
     }
 
-    await goal.update({ status: newStatus });
+    if (newStatus) {
+      await goal.update({ status: newStatus });
+    }
   }
 };
 

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -229,7 +229,8 @@ const updateParentGoalStatus = async (sequelize, instance) => {
     // and so forth
     let newStatus;
 
-    if (atLeastOneObjectiveIsNotStarted) {
+    // we don't want any automatic regressions from "not started" to "in progress"
+    if (atLeastOneObjectiveIsNotStarted && goal.status !== 'In Progress') {
       newStatus = 'Not Started';
     }
 

--- a/src/models/hooks/objective.test.js
+++ b/src/models/hooks/objective.test.js
@@ -90,17 +90,16 @@ describe('objective model hooks', () => {
   });
 
   it('updates when the goal matches the qualifications', async () => {
-    await Goal.update({ createdVia: 'activityReport' }, { where: { id: goal.id } });
-
     let testGoal = await Goal.findByPk(goal.id);
     expect(testGoal.status).toEqual('Draft');
-    expect(testGoal.createdVia).toEqual('activityReport');
     expect(testGoal.id).toEqual(goal.id);
+
+    await Goal.update({ status: 'Not Started' }, { where: { id: goal.id } });
 
     objective2 = await Objective.create({
       title: 'Objective 2',
       goalId: goal.id,
-      status: 'Draft',
+      status: 'Not Started',
     }, { individualHooks: true });
     objective3 = await Objective.create({
       title: 'Objective 3',
@@ -128,6 +127,6 @@ describe('objective model hooks', () => {
     });
 
     testGoal = await Goal.findByPk(goal.id);
-    expect(testGoal.status).toEqual('Closed');
+    expect(testGoal.status).toEqual('In Progress');
   });
 });

--- a/src/models/hooks/objective.test.js
+++ b/src/models/hooks/objective.test.js
@@ -1,0 +1,133 @@
+import faker from '@faker-js/faker';
+import db, {
+  Goal,
+  Objective,
+  Recipient,
+  Grant,
+} from '..';
+
+describe('objective model hooks', () => {
+  let recipient;
+  let grant;
+  let goal;
+
+  let objective1;
+  let objective2;
+  let objective3;
+
+  beforeAll(async () => {
+    recipient = await Recipient.create({
+      id: faker.datatype.number(),
+      name: faker.name.firstName(),
+    });
+
+    grant = await Grant.create({
+      id: faker.datatype.number(),
+      number: faker.datatype.string(),
+      recipientId: recipient.id,
+      regionId: 1,
+    });
+
+    goal = await Goal.create({
+      name: 'Goal 1',
+      status: 'Draft',
+      endDate: null,
+      isFromSmartsheetTtaPlan: false,
+      onApprovedAR: false,
+      grantId: grant.id,
+      createdVia: 'rtr',
+    });
+  });
+
+  afterAll(async () => {
+    await Objective.destroy({
+      where: {
+        id: [objective1.id, objective2.id, objective3.id],
+      },
+    });
+
+    await Goal.destroy({
+      where: {
+        id: goal.id,
+      },
+    });
+
+    await Grant.destroy({
+      where: {
+        id: grant.id,
+      },
+    });
+
+    await Recipient.destroy({
+      where: {
+        id: recipient.id,
+      },
+    });
+    await db.sequelize.close();
+  });
+
+  it('does not update when the goal does not match the qualifications', async () => {
+    objective1 = await Objective.create({
+      title: 'Objective 1',
+      goalId: goal.id,
+      status: 'Draft',
+    }, { individualHooks: true });
+
+    let testGoal = await Goal.findByPk(goal.id);
+    expect(testGoal.status).toEqual('Draft');
+
+    await Objective.update({ status: 'In Progress' }, {
+      where: {
+        id: objective1.id,
+      },
+      individualHooks: true,
+    });
+
+    testGoal = await Goal.findByPk(goal.id);
+    expect(testGoal.status).toEqual('Draft');
+
+    await Objective.destroy({ where: { id: objective1.id } });
+  });
+
+  it('updates when the goal matches the qualifications', async () => {
+    await Goal.update({ createdVia: 'activityReport' }, { where: { id: goal.id } });
+
+    let testGoal = await Goal.findByPk(goal.id);
+    expect(testGoal.status).toEqual('Draft');
+    expect(testGoal.createdVia).toEqual('activityReport');
+    expect(testGoal.id).toEqual(goal.id);
+
+    objective2 = await Objective.create({
+      title: 'Objective 2',
+      goalId: goal.id,
+      status: 'Draft',
+    }, { individualHooks: true });
+    objective3 = await Objective.create({
+      title: 'Objective 3',
+      goalId: goal.id,
+      status: 'Not Started',
+    }, { individualHooks: true });
+
+    testGoal = await Goal.findByPk(goal.id);
+    expect(testGoal.status).toEqual('Not Started');
+
+    await Objective.update({ status: 'In Progress' }, {
+      where: {
+        id: objective2.id,
+      },
+      individualHooks: true,
+    });
+
+    testGoal = await Goal.findByPk(goal.id);
+    expect(testGoal.status).toEqual('In Progress');
+
+    await Objective.update({ status: 'Completed' }, {
+      where: { id: [objective3.id, objective2.id] },
+      individualHooks: true,
+
+    });
+
+    testGoal = await Goal.findByPk(goal.id);
+    expect(testGoal.status).toEqual('Closed');
+  });
+});

--- a/src/models/objective.js
+++ b/src/models/objective.js
@@ -1,7 +1,7 @@
 const {
   Model,
 } = require('sequelize');
-const { beforeValidate, afterUpdate } = require('./hooks/objective');
+const { beforeValidate, afterUpdate, afterCreate } = require('./hooks/objective');
 
 /**
  * Objective table. Stores objectives for goals.
@@ -108,6 +108,7 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'Objective',
     hooks: {
       beforeValidate: async (instance, options) => beforeValidate(sequelize, instance, options),
+      afterCreate: async (instance, options) => afterCreate(sequelize, instance, options),
       afterUpdate: async (instance, options) => afterUpdate(sequelize, instance, options),
     },
   });

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -675,12 +675,16 @@ describe('Goals by Recipient Test', () => {
   describe('Retrieves All Goals', () => {
     it('Uses default sorting', async () => {
       const { goalRows } = await getGoalsByActivityRecipient(recipient.id, 1, { sortDir: 'asc' });
-      expect(goalRows[0].goalText).toBe('Goal 1');
+      expect(goalRows[0].goalText).toBe('Goal 2');
+      // not goal 1 because the goal 2 had it's status updated to 'Not Started' when
+      // objectives were saved for it
     });
 
     it('honors offset', async () => {
       const { goalRows } = await getGoalsByActivityRecipient(recipient.id, 1, { offset: 1, sortDir: 'asc' });
-      expect(goalRows[0].goalText).toBe('Goal 2');
+      // see comment in previous text, the goal 2 was updated to 'Not Started' when
+      // objectives were saved, which flips their order in the query
+      expect(goalRows[0].goalText).toBe('Goal 1');
     });
 
     it('honors limit', async () => {

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -6,15 +6,9 @@ import {
   Recipient,
   Grant,
   ActivityRecipient,
-  // GrantGoal,
-  // GoalTemplate,
   Goal,
   ActivityReportObjective,
-  // ObjectiveTemplate,
   Objective,
-  /* TODO: Switch for New Goal Creation. */
-  // ObjectiveTopic,
-  // Topic,
 } from '../../models';
 
 import { getGoalsByActivityRecipient } from '../recipient';
@@ -216,10 +210,6 @@ describe('Goals by Recipient Test', () => {
 
   let objectiveIds = [];
   let goalIds = [];
-
-  /* TODO: Switch for New Goal Creation. */
-  // let topicIds = [];
-  // let objectiveTopicIds = [];
 
   beforeAll(async () => {
     // Create User.
@@ -503,44 +493,6 @@ describe('Goals by Recipient Test', () => {
     // Get Objective Ids for Delete.
     objectiveIds = objectives.map((o) => o.id);
 
-    /* TODO: Switch for New Goal Creation. */
-    /*
-    // Create Objective Topics.
-    const topics = await Promise.all([
-      Topic.create({
-        name: 'objective topic 1',
-      }),
-      Topic.create({
-        name: 'objective topic 2',
-      }),
-      Topic.create({
-        name: 'objective topic 3',
-      }),
-    ]);
-
-    topicIds = topics.map((o) => o.id);
-
-    // Assign Objective Topics.
-    const objectiveTopics = await Promise.all(
-      [
-        await ObjectiveTopic.create({
-          topicId: topicIds[0],
-          objectiveId: objectiveIds[0],
-        }),
-        await ObjectiveTopic.create({
-          topicId: topicIds[1],
-          objectiveId: objectiveIds[2],
-        }),
-        await ObjectiveTopic.create({
-          topicId: topicIds[2],
-          objectiveId: objectiveIds[3],
-        }),
-      ],
-    );
-
-    objectiveTopicIds = objectiveTopics.map((o) => o.id);
-      */
-
     // AR Objectives.
     await Promise.all(
       [
@@ -637,22 +589,6 @@ describe('Goals by Recipient Test', () => {
       },
     });
 
-    /* TODO: Switch for New Goal Creation. */
-    /*
-    // Delete Objective Topics.
-    await ObjectiveTopic.destroy({
-      where: {
-        id: objectiveTopicIds,
-      },
-    });
-
-    // Delete Topics.
-    await Topic.destroy({
-      where: {
-        id: topicIds,
-      },
-    });
-    */
     // Delete Goals.
     await Goal.destroy({
       where: {
@@ -685,16 +621,12 @@ describe('Goals by Recipient Test', () => {
   describe('Retrieves All Goals', () => {
     it('Uses default sorting', async () => {
       const { goalRows } = await getGoalsByActivityRecipient(recipient.id, 1, { sortDir: 'asc' });
-      expect(goalRows[0].goalText).toBe('Goal 2');
-      // not goal 1 because the goal 2 had it's status updated to 'Not Started' when
-      // objectives were saved for it
+      expect(goalRows[0].goalText).toBe('Goal 1');
     });
 
     it('honors offset', async () => {
       const { goalRows } = await getGoalsByActivityRecipient(recipient.id, 1, { offset: 1, sortDir: 'asc' });
-      // see comment in previous text, the goal 2 was updated to 'Not Started' when
-      // objectives were saved, which flips their order in the query
-      expect(goalRows[0].goalText).toBe('Goal 1');
+      expect(goalRows[0].goalText).toBe('Goal 2');
     });
 
     it('honors limit', async () => {

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -19,7 +19,6 @@ import {
 
 import { getGoalsByActivityRecipient } from '../recipient';
 import { REPORT_STATUSES } from '../../constants';
-import { auditLogger } from '../../logger';
 
 const NEEDLE = 'This objective title should not appear in recipient 3';
 
@@ -100,7 +99,7 @@ describe('Goals by Recipient Test', () => {
     regionId: 1,
     lastUpdatedById: mockGoalUser.id,
     ECLKCResourcesUsed: ['test'],
-    activityRecipients: [{ grantId: 300 }],
+    activityRecipients: [{ grantId: grant1.id }],
     submissionStatus: REPORT_STATUSES.APPROVED,
     calculatedStatus: REPORT_STATUSES.APPROVED,
     oldApprovingManagerId: 1,
@@ -123,7 +122,7 @@ describe('Goals by Recipient Test', () => {
     regionId: 1,
     lastUpdatedById: mockGoalUser.id,
     ECLKCResourcesUsed: ['test'],
-    activityRecipients: [{ grantId: 301 }],
+    activityRecipients: [{ grantId: grant2.id }],
     submissionStatus: REPORT_STATUSES.APPROVED,
     calculatedStatus: REPORT_STATUSES.APPROVED,
     oldApprovingManagerId: 1,
@@ -146,7 +145,7 @@ describe('Goals by Recipient Test', () => {
     regionId: 1,
     lastUpdatedById: mockGoalUser.id,
     ECLKCResourcesUsed: ['test'],
-    activityRecipients: [{ grantId: 302 }],
+    activityRecipients: [{ grantId: grant3.id }],
     submissionStatus: REPORT_STATUSES.APPROVED,
     calculatedStatus: REPORT_STATUSES.APPROVED,
     oldApprovingManagerId: 1,
@@ -394,7 +393,7 @@ describe('Goals by Recipient Test', () => {
           timeframe: '1 month',
           isFromSmartsheetTtaPlan: false,
           grantId: grant4.id,
-          createdAt: '2021-01-10T19:16:15.842Z',
+          createdAt: '2021-02-10T19:16:15.842Z',
           onApprovedAR: true,
         }),
 
@@ -405,7 +404,7 @@ describe('Goals by Recipient Test', () => {
           timeframe: '1 month',
           isFromSmartsheetTtaPlan: true,
           grantId: grant4.id,
-          createdAt: '2021-01-10T19:16:15.842Z',
+          createdAt: '2021-03-10T19:16:15.842Z',
           onApprovedAR: false,
         }),
       ],
@@ -754,10 +753,8 @@ describe('Goals by Recipient Test', () => {
 
       const countx = count;
       const goalRowsx = goalRows;
-      auditLogger.error(JSON.stringify(goalRowsx));
       expect(countx).toBe(3);
       expect(goalRowsx.length).toBe(3);
-      expect(goalRowsx[2].objectiveCount).toBe(0);
     });
 
     it('associates objectives with the proper recipients', async () => {

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -181,7 +181,7 @@ describe('Goals DB service', () => {
       await saveGoalsForReport([existingGoal], { id: 1 });
       expect(existingGoalUpdate).toHaveBeenCalledWith({
         name: 'name',
-        status: 'Not Started',
+        status: 'Draft',
       }, { individualHooks: true });
     });
 

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1329,7 +1329,7 @@ export async function saveGoalsForReport(goals, report) {
   let currentObjectives = [];
   const currentGoals = await Promise.all((goals.map(async (goal) => {
     let newGoals = [];
-    const status = goal.status ? goal.status : 'Not Started';
+    const status = goal.status ? goal.status : 'Draft';
 
     // we have a param to determine if goals are new
     if (goal.isNew) {


### PR DESCRIPTION
## Description of change

Use sequelize's "afterCreate" and "afterUpdate" hooks to automatically move a goal through the statuses based [on this logical diagram](https://app.mural.co/t/adhoccorporateworkspace2583/m/adhoccorporateworkspace2583/1647548115774/d89d9477fdc3555b8b39b382311d8f2d1f2bacfc?sender=u775286a3a84f5c5204174211).

This is necessary for MVP since the only way to change the goal status in the UI is via the RTR.

## How to test
Verify that the following statements are true:
- Create a goal on the Create Goals form by filling out the form and clicking Save Draft but DO NOT submit. The goal status should be "Draft"
- Make sure all the objectives are "Not Started" and click submit. The status should then be "Not Started"
- Repeat the steps above, but set one objective to "In Progress." The goal status should be "In Progress."
- On an activity report, a new goal should be "Draft" until the report is approved. Then, it becomes "In Progress."
- A "Not Started" goal created on the Create Goals form, if used on an Activity Report, should be moved to "In Progress" regardless of objective status.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1004

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
