### PR TITLE
[TTAHUB-1002] Update Objectives when Recipients Change

### DIFF
--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -388,7 +388,7 @@ function ActivityReport({
           }
         }
 
-        //
+        // Update form data.
         if (shouldUpdateFromNetwork && activityReportId !== 'new') {
           updateFormData({ ...formData, ...report }, true);
         } else {
@@ -565,6 +565,14 @@ function ActivityReport({
           reportId.current, { ...updatedFields, approverUserIds: approverIds }, {},
         );
 
+        // Update goals from saved report.
+        const grantIds = updatedReport.activityRecipientType === 'recipient'
+          && updatedReport.activityRecipients
+          ? updatedReport.activityRecipients.map(({ id }) => id)
+          : [];
+        const goals = convertGoalsToFormData(updatedReport.goalsAndObjectives, grantIds);
+
+        updateFormData({ ...formData, goals });
         setConnectionActive(true);
         updateCreatorRoleWithName(updatedReport.creatorNameWithRole);
       }

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -233,7 +233,7 @@ describe('Goals DB service', () => {
         id: 1,
         name: 'name',
         objectives: [{
-          title: 'title', id: 1, status: 'Closed', roles: [],
+          title: 'title', id: 1, status: 'Closed', roles: [], goalId: 1,
         }],
         update: jest.fn(),
         grantIds: [1],

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -151,6 +151,7 @@ describe('Goals DB service', () => {
       expect(Goal.findOrCreate).toHaveBeenCalledWith({
         defaults: {
           createdVia: 'activityReport',
+          grantId: 1,
           name: 'name',
           status: 'Closed',
         },
@@ -180,6 +181,7 @@ describe('Goals DB service', () => {
 
       await saveGoalsForReport([existingGoal], { id: 1 });
       expect(existingGoalUpdate).toHaveBeenCalledWith({
+        goalIds: [1],
         name: 'name',
         status: 'Not Started',
       }, { individualHooks: true });

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -950,7 +950,6 @@ describe('saveGoalsForReport (more tests)', () => {
     await saveGoalsForReport([
       {
         ...newGoal,
-        grantId: addingRecipientGrantOne.id,
         grantIds: [addingRecipientGrantOne.id, addingRecipientGrantTwo.id],
       }], savedReport);
 

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -47,6 +47,13 @@ describe('saveGoalsForReport (more tests)', () => {
   let secondTopic;
   let role;
 
+  // Adding a recipient.
+  let addingRecipientReport;
+  let addingRecipientGrantOne;
+  let addingRecipientGrantTwo;
+  let addingRecipientGoal;
+  let addingRecipientObjective;
+
   beforeAll(async () => {
     await User.create(mockUser);
     const recipientOne = await Recipient.create(
@@ -65,7 +72,23 @@ describe('saveGoalsForReport (more tests)', () => {
       },
     );
 
-    recipients = [recipientOne, recipientTwo];
+    const addingRecipientOne = await Recipient.create(
+      {
+        id: faker.datatype.number({ min: 90000 }),
+        name: faker.company.companyName(),
+        uei: faker.datatype.string(12),
+      },
+    );
+
+    const addingRecipientTwo = await Recipient.create(
+      {
+        id: faker.datatype.number({ min: 90000 }),
+        name: faker.company.companyName(),
+        uei: faker.datatype.string(12),
+      },
+    );
+
+    recipients = [recipientOne, recipientTwo, addingRecipientOne, addingRecipientTwo];
 
     grantOne = await Grant.create(
       {
@@ -82,7 +105,22 @@ describe('saveGoalsForReport (more tests)', () => {
       },
     );
 
-    grants = [grantOne, grantTwo];
+    addingRecipientGrantOne = await Grant.create(
+      {
+        id: addingRecipientOne.id,
+        number: faker.datatype.number({ min: 90000 }),
+        recipientId: addingRecipientOne.id,
+      },
+    );
+    addingRecipientGrantTwo = await Grant.create(
+      {
+        id: addingRecipientTwo.id,
+        number: faker.datatype.number({ min: 90000 }),
+        recipientId: addingRecipientTwo.id,
+      },
+    );
+
+    grants = [grantOne, grantTwo, addingRecipientGrantOne, addingRecipientGrantTwo];
 
     // Activity report for adding a new goal
     activityReportForNewGoal = await ActivityReport.create({
@@ -100,6 +138,14 @@ describe('saveGoalsForReport (more tests)', () => {
       activityRecipientType: 'recipient',
     });
 
+    // Activity report for adding a new recipient.
+    addingRecipientReport = await ActivityReport.create({
+      submissionStatus: REPORT_STATUSES.DRAFT,
+      regionId: 1,
+      userId: mockUser.id,
+      activityRecipientType: 'recipient',
+    });
+
     reportWeArentWorryingAbout = await ActivityReport.create({
       submissionStatus: REPORT_STATUSES.DRAFT,
       regionId: 1,
@@ -111,6 +157,7 @@ describe('saveGoalsForReport (more tests)', () => {
       activityReportForNewGoal,
       multiRecipientReport,
       reportWeArentWorryingAbout,
+      addingRecipientReport,
     ];
 
     await ActivityRecipient.create({
@@ -133,6 +180,11 @@ describe('saveGoalsForReport (more tests)', () => {
       grantId: grantOne.id,
     });
 
+    await ActivityRecipient.create({
+      activityReportId: addingRecipientReport.id,
+      grantId: addingRecipientGrantOne.id,
+    });
+
     goal = await Goal.create({
       name: 'This is an existing goal',
       status: 'In Progress',
@@ -148,10 +200,24 @@ describe('saveGoalsForReport (more tests)', () => {
       previousStatus: null,
     });
 
+    // This is a initial goal for adding recipient report.
+    addingRecipientGoal = await Goal.create({
+      name: 'This is a goal on a saved report',
+      status: 'Not Started',
+      grantId: addingRecipientGrantOne.id,
+      previousStatus: null,
+    });
+
     await ActivityReportGoal.create({
       goalId: goal.id,
       activityReportId: reportWeArentWorryingAbout.id,
       status: goal.status,
+    });
+
+    await ActivityReportGoal.create({
+      goalId: addingRecipientGoal.id,
+      activityReportId: addingRecipientReport.id,
+      status: addingRecipientGoal.status,
     });
 
     topic = await Topic.create({
@@ -173,6 +239,13 @@ describe('saveGoalsForReport (more tests)', () => {
       goalId: existingGoal.id,
       status: 'Not Started',
       title: 'This is a second existing objective',
+    });
+
+    // Objective for report adding recipient.
+    addingRecipientObjective = await Objective.create({
+      goalId: addingRecipientGoal.id,
+      status: 'In Progress',
+      title: 'Objective for adding recipient',
     });
 
     await ObjectiveTopic.create({
@@ -197,6 +270,31 @@ describe('saveGoalsForReport (more tests)', () => {
       activityReportId: reportWeArentWorryingAbout.id,
       objectiveId: objective.id,
       status: objective.status,
+    });
+
+    // Create adding recipient objective values.
+    await ObjectiveTopic.create({
+      objectiveId: addingRecipientObjective.id,
+      topicId: topic.id,
+    });
+
+    role = await Role.findOne();
+
+    await ObjectiveRole.create({
+      objectiveId: addingRecipientObjective.id,
+      roleId: role.id,
+    });
+
+    await ObjectiveResource.create({
+      objectiveId: addingRecipientObjective.id,
+      userProvidedUrl: 'http://www.testgov.com',
+    });
+
+    await ActivityReportObjective.create({
+      ttaProvided: 'Adding recipient tta',
+      activityReportId: addingRecipientReport.id,
+      objectiveId: addingRecipientObjective.id,
+      status: addingRecipientObjective.status,
     });
   });
 
@@ -255,7 +353,11 @@ describe('saveGoalsForReport (more tests)', () => {
 
     const goalsToDestroy = await Goal.findAll({
       where: {
-        grantId: [grantOne.id, grantTwo.id],
+        grantId: [
+          grantOne.id,
+          grantTwo.id,
+          addingRecipientGrantOne.id,
+          addingRecipientGrantTwo.id],
       },
     });
 
@@ -813,5 +915,92 @@ describe('saveGoalsForReport (more tests)', () => {
 
     expect(afterActivityReportObjectiveRoles.length).toBe(1);
     expect(afterActivityReportObjectiveRoles[0].roleId).toBe(role.id);
+  });
+
+  it('adds a new recipient', async () => {
+    const beforeGoals = await ActivityReportGoal.findAll({
+      where: {
+        activityReportId: addingRecipientReport.id,
+      },
+    });
+
+    expect(beforeGoals.length).toBe(1);
+
+    const beforeObjectives = await ActivityReportObjective.findAll({
+      where: {
+        activityReportId: addingRecipientReport.id,
+      },
+    });
+
+    expect(beforeObjectives.length).toBe(1);
+
+    const [
+      savedReport,
+      activityRecipients,
+      goalsAndObjectives,
+    ] = await activityReportAndRecipientsById(
+      addingRecipientReport.id,
+    );
+    expect(activityRecipients.length).toBe(1);
+
+    const {
+      goalNumbers, grants: oldGrants, isNew, ...newGoal
+    } = goalsAndObjectives[0];
+
+    await saveGoalsForReport([
+      {
+        ...newGoal,
+        grantId: addingRecipientGrantOne.id,
+        grantIds: [addingRecipientGrantOne.id, addingRecipientGrantTwo.id],
+      }], savedReport);
+
+    const afterReportGoals = await ActivityReportGoal.findAll({
+      where: {
+        activityReportId: addingRecipientReport.id,
+      },
+    });
+
+    expect(afterReportGoals.length).toBe(2);
+
+    afterReportGoals.forEach((g) => {
+      expect(g.name).toBe(addingRecipientGoal.name);
+    });
+
+    const goalIds = afterReportGoals.map((o) => o.goalId);
+    const afterGoals = await Goal.findAll({
+      where: {
+        id: goalIds,
+      },
+    });
+
+    afterGoals.forEach((g) => {
+      expect(g.name).toBe(addingRecipientGoal.name);
+    });
+
+    expect(afterGoals.length).toBe(2);
+
+    const afterReportObjectives = await ActivityReportObjective.findAll({
+      where: {
+        activityReportId: addingRecipientReport.id,
+      },
+    });
+    expect(afterReportObjectives.length).toBe(2);
+
+    afterReportObjectives.forEach((o) => {
+      expect(o.title).toBe(addingRecipientObjective.title);
+    });
+
+    const objectives = afterReportObjectives.map((o) => o.objectiveId);
+    const afterObjectives = await Objective.findAll({
+      where: {
+        id: objectives,
+      },
+    });
+
+    expect(afterObjectives.length).toBe(2);
+
+    afterObjectives.forEach((o) => {
+      expect(o.title).toBe(addingRecipientObjective.title);
+    });
   });
 });

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1247,7 +1247,7 @@ async function createObjectivesForGoal(goal, objectives, report) {
     // the goals passed we need to save the objectives.
     const createNewObjectives = objective.goalId !== goal.id;
     const updatedObjective = {
-      ...updatedFields, title, status, isNew, goalId: goal.id,
+      ...updatedFields, title, status, goalId: goal.id,
     };
 
     let savedObjective;

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1344,8 +1344,6 @@ export async function saveGoalsForReport(goals, report) {
       },
     });
 
-    console.log('\n\n\n---------------------- Existing Goal: ', existingGoals);
-    console.log('\n\n\n---------------------- Goal: ', goal.isNew, !existingGoals.length);
     // we have a param to determine if goals are new
     if (goal.isNew || !existingGoals.length) {
       const {

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1344,6 +1344,8 @@ export async function saveGoalsForReport(goals, report) {
       },
     });
 
+    console.log('\n\n\n---------------------- Existing Goal: ', existingGoals);
+    console.log('\n\n\n---------------------- Goal: ', goal.isNew, !existingGoals.length);
     // we have a param to determine if goals are new
     if (goal.isNew || !existingGoals.length) {
       const {


### PR DESCRIPTION
## Description of change

This fixes two bugs when a recipient is added to an existing AR report.
- When it attempts to find a existing goal it excludes null template ids.
- If the goal id doesn't match the objective goal id we need to create a new objective.


## How to test

Create a recipient report and add a goal and objective(s). The go back to the 'Summary' page and add a new recipient. The goals, objectives, and ARO tables should all properly have a new item added for the new recipient.

It should also work as it did before for removing a recipient.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1002


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [x] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
