### PR TITLE
[TTAHUB-1005] Fix objective file uploader not handling multiple file uploads

### DIFF
--- a/frontend/src/components/FileUploader/FileRejections.js
+++ b/frontend/src/components/FileUploader/FileRejections.js
@@ -7,13 +7,14 @@
 // rules https://github.com/react-dropzone/react-dropzone
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import PropTypes from 'prop-types';
 
 const FileRejections = ({
   fileRejections,
 }) => {
   const fileRejectionItems = fileRejections.map(({ file, errors }) => (
-    <span key={file.path}>
+    <span key={uuidv4()}>
       <strong>{file.path}</strong>
       {` (${(file.size / 1000000).toFixed(2)} MB)`}
       <span>
@@ -30,9 +31,7 @@ const FileRejections = ({
 
   return (
     <div>
-      {
-          fileRejectionItems
-        }
+      { fileRejectionItems }
     </div>
   );
 };

--- a/frontend/src/components/FileUploader/ObjectiveFileUploader.js
+++ b/frontend/src/components/FileUploader/ObjectiveFileUploader.js
@@ -33,33 +33,21 @@ const ObjectiveFileUploader = ({
   };
 
   const handleDrop = async (e) => {
-    const newFiles = await Promise.all(
-      e.map((file) => upload(file, objective, setError, index)),
-    );
+    const newFiles = await upload(e, objective, setError, index);
 
-    let objectives;
-    let setObjectives;
-    let objectiveIndex;
+    // this is entirely a concession to the inability to accurately
+    // mock the upload function in the tests
+    const updatedInfo = newFiles || {};
 
-    const values = newFiles.map((file) => {
-      if (!objectives) {
-        objectives = file.objectives;
-      }
+    const {
+      setObjectives,
+      objectives,
+      index: objectiveIndex,
+      objectiveIds,
+      ...data
+    } = updatedInfo;
 
-      if (!setObjectives) {
-        setObjectives = file.setObjectives;
-      }
-
-      if (!objectiveIndex) {
-        objectiveIndex = file.index;
-      }
-
-      const {
-        objectives: a, setObjectives: b, index: c, ...fields
-      } = file;
-
-      return fields;
-    });
+    const values = Object.values(data);
 
     const allFilesIncludingTheNewOnes = [...files, ...values];
 

--- a/frontend/src/components/FileUploader/ObjectiveFileUploader.js
+++ b/frontend/src/components/FileUploader/ObjectiveFileUploader.js
@@ -14,14 +14,22 @@ import Dropzone from './Dropzone';
 import './FileUploader.scss';
 
 const ObjectiveFileUploader = ({
-  onChange, files, objective, id, upload, index, inputName, onBlur, setError,
+  onChange,
+  files,
+  objective,
+  id,
+  upload,
+  index,
+  inputName,
+  onBlur,
+  setError,
 }) => {
   const onFileRemoved = async (removedFileIndex) => {
     const file = files[removedFileIndex];
 
-    if (file.id && file.objectiveIds) {
+    if (file.id && file.objectiveIds && file.objectiveIds.length) {
       await deleteObjectiveFile(file.id, file.objectiveIds);
-    } else if (file.id && objective.ids) {
+    } else if (file.id && objective.ids && objective.ids.length) {
       await deleteObjectiveFile(file.id, objective.ids);
     } else if (file.id) {
       await deleteFile(file.id);
@@ -55,10 +63,7 @@ const ObjectiveFileUploader = ({
     if (objectives && setObjectives) {
       const copyOfObjectives = objectives.map((o) => ({ ...o }));
       copyOfObjectives[objectiveIndex].files = allFilesIncludingTheNewOnes;
-      copyOfObjectives[objectiveIndex].ids = allFilesIncludingTheNewOnes
-        .filter((f) => f.objectiveIds)
-        .map((f) => f.objectiveIds)
-        .flat();
+      copyOfObjectives[objectiveIndex].ids = objectiveIds;
       setObjectives(copyOfObjectives);
     } else {
       // else we just update the files array for local display

--- a/frontend/src/components/FileUploader/__tests__/ObjectiveFileUploader.js
+++ b/frontend/src/components/FileUploader/__tests__/ObjectiveFileUploader.js
@@ -8,6 +8,14 @@ import {
 import ObjectiveFileUploader from '../ObjectiveFileUploader';
 
 describe('ObjectiveFileUploader', () => {
+  beforeEach(async () => {
+    fetchMock.post('/api/files/objectives', [{ objectiveIds: [] }]);
+  });
+
+  afterEach(async () => {
+    fetchMock.restore();
+  });
+
   const dispatchEvt = (node, type, data) => {
     const event = new Event(type, { bubbles: true });
     Object.assign(event, data);

--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -44,7 +44,7 @@ export default function Form({
   fetchError,
   goalNumber,
   clearEmptyObjectiveError,
-  onUploadFile,
+  onUploadFiles,
 }) {
   const { isLoading } = useContext(GoalFormLoadingContext);
 
@@ -171,7 +171,7 @@ export default function Form({
           errors={objectiveErrors[i] || OBJECTIVE_DEFAULT_ERRORS}
           setObjective={(data) => setObjective(data, i)}
           topicOptions={topicOptions}
-          onUploadFile={onUploadFile}
+          onUploadFiles={onUploadFiles}
           goalStatus={status}
         />
       ))}
@@ -242,7 +242,7 @@ Form.propTypes = {
   fetchError: PropTypes.string.isRequired,
   goalNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   clearEmptyObjectiveError: PropTypes.func.isRequired,
-  onUploadFile: PropTypes.func.isRequired,
+  onUploadFiles: PropTypes.func.isRequired,
   validateGoalNameAndRecipients: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -14,7 +14,7 @@ export default function ObjectiveFiles({
   isOnApprovedReport,
   status,
   isOnReport,
-  onUploadFile,
+  onUploadFiles,
   index,
   inputName,
   onBlur,
@@ -103,7 +103,7 @@ export default function ObjectiveFiles({
                           files={files}
                           onChange={onChangeFiles}
                           objective={objective}
-                          upload={onUploadFile}
+                          upload={onUploadFiles}
                           id={`files-${objectiveId}`}
                           index={index}
                           onBlur={onBlur}
@@ -165,7 +165,7 @@ ObjectiveFiles.propTypes = {
   isOnApprovedReport: PropTypes.bool.isRequired,
   isOnReport: PropTypes.bool.isRequired,
   status: PropTypes.string.isRequired,
-  onUploadFile: PropTypes.func.isRequired,
+  onUploadFiles: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,
   inputName: PropTypes.string,
   onBlur: PropTypes.func,

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   Label, Radio, Fieldset, FormGroup, ErrorMessage,
@@ -20,11 +20,17 @@ export default function ObjectiveFiles({
   onBlur,
 }) {
   const objectiveId = objective.id;
-  const hasFiles = files && files.length > 0;
+  const hasFiles = useMemo(() => files && files.length > 0, [files]);
   const [useFiles, setUseFiles] = useState(hasFiles);
   const [fileError, setFileError] = useState();
 
   const readOnly = isOnApprovedReport || status === 'Complete' || (status === 'Not Started' && isOnReport);
+
+  useEffect(() => {
+    if (!useFiles && hasFiles) {
+      setUseFiles(true);
+    }
+  }, [useFiles, hasFiles]);
 
   if (readOnly) {
     if (!hasFiles) {

--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -30,7 +30,7 @@ export default function ObjectiveForm({
   setObjective,
   errors,
   topicOptions,
-  onUploadFile,
+  onUploadFiles,
   goalStatus,
 }) {
   // the parent objective data from props
@@ -182,7 +182,7 @@ export default function ObjectiveForm({
           isOnReport={isOnReport || false}
           status={status}
           isLoading={isLoading}
-          onUploadFile={onUploadFile}
+          onUploadFiles={onUploadFiles}
           index={index}
         />
       )}
@@ -234,7 +234,7 @@ ObjectiveForm.propTypes = {
     label: PropTypes.string,
     value: PropTypes.number,
   })).isRequired,
-  onUploadFile: PropTypes.func.isRequired,
+  onUploadFiles: PropTypes.func.isRequired,
 };
 
 ObjectiveForm.defaultProps = {

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -415,7 +415,7 @@ export default function GoalForm({
     }
   };
 
-  const onUploadFile = async (file, objective, setFileUploadErrorMessage, index) => {
+  const onUploadFiles = async (files, objective, setFileUploadErrorMessage, index) => {
     // The first thing we need to know is... does this objective need to be created?
     setIsLoading(true);
 
@@ -465,7 +465,10 @@ export default function GoalForm({
       // in the case that it has been rolled up to match a goal for multiple grants
       const data = new FormData();
       data.append('objectiveIds', JSON.stringify(objectiveIds));
-      data.append('file', file);
+      files.forEach((file) => {
+        data.append('file', file);
+      });
+
       const response = await uploadObjectivesFile(data);
       setFileUploadErrorMessage(null);
 
@@ -477,7 +480,7 @@ export default function GoalForm({
         index,
       };
     } catch (error) {
-      setFileUploadErrorMessage(`${file.name} failed to upload`);
+      setFileUploadErrorMessage('File(s) could not be uploaded');
     } finally {
       setIsLoading(false);
     }
@@ -723,7 +726,7 @@ export default function GoalForm({
               isOnApprovedReport={isOnApprovedReport}
               status={status || 'Needs status'}
               goalNumber={goalNumber}
-              onUploadFile={onUploadFile}
+              onUploadFiles={onUploadFiles}
             />
             )}
 

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -412,7 +412,13 @@ function Navigator({
                 <Form
                   className="smart-hub--form-large"
                 >
-                  {page.render(additionalData, formData, reportId)}
+                  {page.render(
+                    additionalData,
+                    formData,
+                    reportId,
+                    onSaveDraftGoal,
+                    onSaveDraftOetObjectives,
+                  )}
                   <div className="display-flex">
                     { showSaveGoalsAndObjButton
                       ? (

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -22,6 +22,7 @@ export default function GoalForm({
   topicOptions,
   roles,
   reportId,
+  onSaveDraft,
 }) {
   // pull the errors out of the form context
   const { errors, watch } = useFormContext();
@@ -150,6 +151,7 @@ export default function GoalForm({
         roles={roles}
         noObjectiveError={errors.goalForEditing && errors.goalForEditing.objectives
           ? ERROR_FORMAT(errors.goalForEditing.objectives.message) : NO_ERROR}
+        onSaveDraft={onSaveDraft}
       />
     </>
   );
@@ -181,4 +183,5 @@ GoalForm.propTypes = {
   })).isRequired,
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
   reportId: PropTypes.number.isRequired,
+  onSaveDraft: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.js
@@ -36,7 +36,7 @@ const components = {
 };
 
 const GoalPicker = ({
-  availableGoals, roles, grantIds, reportId,
+  availableGoals, roles, grantIds, reportId, onSaveDraft,
 }) => {
   const {
     control, setValue, watch,
@@ -143,6 +143,7 @@ const GoalPicker = ({
               roles={roles}
               goal={goalForEditing}
               reportId={reportId}
+              onSaveDraft={onSaveDraft}
             />
           </div>
         ) : null}
@@ -165,6 +166,7 @@ GoalPicker.propTypes = {
     PropTypes.number,
     PropTypes.string,
   ]).isRequired,
+  onSaveDraft: PropTypes.func.isRequired,
 };
 
 export default GoalPicker;

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
-import { useController } from 'react-hook-form/dist/index.ie11';
+import {
+  useController, useFormContext,
+} from 'react-hook-form/dist/index.ie11';
 import ObjectiveTitle from './ObjectiveTitle';
 import { REPORT_STATUSES } from '../../../../Constants';
 import SpecialistRole from '../../../../components/GoalForm/SpecialistRole';
@@ -12,6 +14,7 @@ import ObjectiveTta from './ObjectiveTta';
 import ObjectiveStatus from './ObjectiveStatus';
 import ObjectiveSelect from './ObjectiveSelect';
 import { OBJECTIVE_PROP, NO_ERROR, ERROR_FORMAT } from './constants';
+import { uploadObjectivesFile } from '../../../../fetchers/File';
 import {
   OBJECTIVE_TITLE,
   OBJECTIVE_ROLE,
@@ -21,7 +24,6 @@ import {
 } from './goalValidator';
 import { validateListOfResources } from '../../../../components/GoalForm/constants';
 import './Objective.scss';
-import { uploadOnlyFile } from '../../../../fetchers/File';
 
 export default function Objective({
   objective,
@@ -33,8 +35,10 @@ export default function Objective({
   errors,
   roles,
   onObjectiveChange,
+  onSaveDraft,
 }) {
   const [selectedObjective, setSelectedObjective] = useState(objective);
+  const { getValues } = useFormContext();
 
   /**
    * add controllers for all the controlled fields
@@ -178,6 +182,31 @@ export default function Objective({
     onObjectiveChange(newObjective, index); // Call parent on objective change.
   };
 
+  const onUploadFile = async (files, _objective, setError) => {
+    // we save draft one of two ways, depending on whether it is a
+    // recipient report or not
+    await onSaveDraft();
+
+    // we also need to access the updated form data to
+    // get the correct objective ids to attach to our API post
+    const objectivesField = getValues(fieldArrayName);
+    const objectiveToAttach = objectivesField[index];
+
+    // handle file upload
+    try {
+      const data = new FormData();
+      data.append('objectiveIds', JSON.stringify(objectiveToAttach.ids));
+      files.forEach((file) => {
+        data.append('file', file);
+      });
+
+      return uploadObjectivesFile(data);
+    } catch (error) {
+      setError('There was an error uploading your file(s).');
+      return null;
+    }
+  };
+
   // we need to auto select an objective role if there is only one available
   useEffect(() => {
     if (defaultRoles.length === 1 && !objectiveRoles.length) {
@@ -196,17 +225,6 @@ export default function Objective({
   const resourcesForRepeater = objectiveResources && objectiveResources.length ? objectiveResources : [{ key: uuidv4(), value: '' }];
 
   const onRemove = () => remove(index);
-
-  const onUploadFile = (file, _objective, setError) => {
-    try {
-      const data = new FormData();
-      data.append('file', file);
-      return uploadOnlyFile(data);
-    } catch (error) {
-      setError('File failed to upload');
-      return null;
-    }
-  };
 
   return (
     <>
@@ -274,7 +292,7 @@ export default function Objective({
         isOnApprovedReport={isOnApprovedReport || false}
         status={objectiveStatus}
         isOnReport={isOnReport || false}
-        onUploadFile={onUploadFile}
+        onUploadFiles={onUploadFile}
         index={index}
         onBlur={onBlurFiles}
         inputName={objectiveFilesInputName}
@@ -331,4 +349,5 @@ Objective.propTypes = {
   fieldArrayName: PropTypes.string.isRequired,
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
   onObjectiveChange: PropTypes.func.isRequired,
+  onSaveDraft: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -179,6 +179,7 @@ export default function Objective({
     onChangeStatus(newObjective.status);
     onChangeRoles(newObjective.roles || []);
     onChangeTopics(newObjective.topics);
+    onChangeFiles(newObjective.files || []);
     onObjectiveChange(newObjective, index); // Call parent on objective change.
   };
 

--- a/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
@@ -11,6 +11,7 @@ export default function Objectives({
   topicOptions,
   roles,
   noObjectiveError,
+  onSaveDraft,
 }) {
   const { errors, getValues, setValue } = useFormContext();
 
@@ -125,6 +126,7 @@ export default function Objectives({
               fieldArrayName={fieldArrayName}
               roles={roles}
               onObjectiveChange={onObjectiveChange}
+              onSaveDraft={onSaveDraft}
             />
           );
         })}
@@ -143,4 +145,5 @@ Objectives.propTypes = {
   ).isRequired,
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
   noObjectiveError: PropTypes.node.isRequired,
+  onSaveDraft: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
@@ -13,7 +13,7 @@ import GoalFormContext from '../../../../GoalFormContext';
 
 const OBJECTIVE_LABEL = 'objectivesWithoutGoals';
 
-export default function OtherEntity({ roles, recipientIds }) {
+export default function OtherEntity({ roles, recipientIds, onSaveDraft }) {
   const { errors } = useFormContext();
   const defaultRoles = useMemo(() => (roles.length === 1 ? roles : []), [roles]);
   const [topicOptions, setTopicOptions] = useState([]);
@@ -78,6 +78,7 @@ export default function OtherEntity({ roles, recipientIds }) {
             remove={remove}
             fieldArrayName={OBJECTIVE_LABEL}
             roles={roles}
+            onSaveDraft={onSaveDraft}
           />
         );
       })}
@@ -89,4 +90,5 @@ export default function OtherEntity({ roles, recipientIds }) {
 OtherEntity.propTypes = {
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
   recipientIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  onSaveDraft: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -23,7 +23,11 @@ import OtherEntity from './components/OtherEntity';
 import GoalFormContext from '../../../GoalFormContext';
 import ReadOnlyOtherEntityObjectives from '../../../components/GoalForm/ReadOnlyOtherEntityObjectives';
 
-const GoalsObjectives = ({ reportId }) => {
+const GoalsObjectives = ({
+  reportId,
+  onSaveDraftGoal,
+  onSaveDraftOetObjectives,
+}) => {
   const {
     watch, setValue, getValues, setError,
   } = useFormContext();
@@ -229,6 +233,7 @@ const GoalsObjectives = ({ reportId }) => {
       <OtherEntity
         roles={roles}
         recipientIds={activityRecipientIds}
+        onSaveDraft={onSaveDraftOetObjectives}
       />
       )}
       {/**
@@ -277,6 +282,7 @@ const GoalsObjectives = ({ reportId }) => {
                 availableGoals={availableGoals}
                 roles={roles}
                 reportId={reportId}
+                onSaveDraft={onSaveDraftGoal}
               />
             </Fieldset>
           </>
@@ -300,6 +306,8 @@ const GoalsObjectives = ({ reportId }) => {
 
 GoalsObjectives.propTypes = {
   reportId: PropTypes.number.isRequired,
+  onSaveDraftOetObjectives: PropTypes.func.isRequired,
+  onSaveDraftGoal: PropTypes.func.isRequired,
 };
 
 const ReviewSection = () => {
@@ -345,10 +353,12 @@ export default {
     return activityRecipientType !== 'recipient' || validateGoals(formData.goals) === true;
   },
   reviewSection: () => <ReviewSection />,
-  render: (_additionalData, _formData, reportId) => (
+  render: (_additionalData, _formData, reportId, onSaveDraftGoal, onSaveDraftOetObjectives) => (
 
     <GoalsObjectives
       reportId={reportId}
+      onSaveDraftGoal={onSaveDraftGoal}
+      onSaveDraftOetObjectives={onSaveDraftOetObjectives}
     />
   ),
 };

--- a/src/policies/objective.js
+++ b/src/policies/objective.js
@@ -18,9 +18,22 @@ export default class Objective {
   }
 
   canUpdate() {
+    const regionId = (() => {
+      // if the objective is submitted from an activity report,
+      // this will necessarily have something in it, since all objectives
+      // submitted that way are saved in advance (the reason we check this way is
+      // other entities do not have a clear relationship with a region in our data
+      // structure)
+      if (this.objective.activityReports && this.objective.activityReports.length) {
+        return this.objective.activityReports[0].regionId;
+      }
+
+      // otherwise, the RTR is only for recipients and thus the objective will have a goal & a grant
+      return this.objective.goal.grant.regionId;
+    })();
+
     if (!this.objective.onApprovedAR
-        && (this.canWriteInRegion(this.objective.goal.grant.regionId)
-            || this.objective.otherEntityId)) {
+        && (this.canWriteInRegion(regionId))) {
       return true;
     }
     return false;

--- a/src/policies/objective.js
+++ b/src/policies/objective.js
@@ -18,22 +18,9 @@ export default class Objective {
   }
 
   canUpdate() {
-    const regionId = (() => {
-      // if the objective is submitted from an activity report,
-      // this will necessarily have something in it, since all objectives
-      // submitted that way are saved in advance (the reason we check this way is
-      // other entities do not have a clear relationship with a region in our data
-      // structure)
-      if (this.objective.activityReports && this.objective.activityReports.length) {
-        return this.objective.activityReports[0].regionId;
-      }
-
-      // otherwise, the RTR is only for recipients and thus the objective will have a goal & a grant
-      return this.objective.goal.grant.regionId;
-    })();
-
     if (!this.objective.onApprovedAR
-        && (this.canWriteInRegion(regionId))) {
+        && (this.objective.otherEntityId
+          || this.canWriteInRegion(this.objective.goal.grant.regionId))) {
       return true;
     }
     return false;

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -13,7 +13,6 @@ import {
   createActivityReportObjectiveFileMetaData,
   createObjectiveFileMetaData,
   createObjectiveTemplateFileMetaData,
-  createFileMetaData,
   createObjectivesFileMetaData,
 } from '../../services/files';
 import { ActivityReportObjective } from '../../models';
@@ -223,68 +222,6 @@ const determineFileTypeFromPath = async (filePath) => {
   return altFileType || type;
 };
 
-const onlyFileUploadHandler = async (req, res) => {
-  const [, files] = await parseFormPromise(req);
-  let buffer;
-  let metadata;
-  let fileName;
-  let fileTypeToUse;
-
-  try {
-    const user = await userById(req.session.userId);
-
-    const policy = new Users(user);
-    if (!policy.canWriteInAtLeastOneRegion) {
-      return res.status(400).send({ error: 'Write permissions required' });
-    }
-
-    if (!files.file) {
-      return res.status(400).send({ error: 'file required' });
-    }
-    const { path, originalFilename, size } = files.file[0];
-    if (!size) {
-      return res.status(400).send({ error: 'fileSize required' });
-    }
-    buffer = fs.readFileSync(path);
-    /*
-      * NOTE: file-type: https://github.com/sindresorhus/file-type
-      * This package is for detecting binary-based file formats,
-      * !NOT text-based formats like .txt, .csv, .svg, etc.
-      * We need to handle TXT and CSV in our code.
-      */
-
-    fileTypeToUse = await determineFileTypeFromPath(path);
-    if (!fileTypeToUse) {
-      return res.status(500).send('Could not determine file type');
-    }
-    fileName = `${uuidv4()}${fileTypeToUse.ext}`;
-
-    metadata = await createFileMetaData(originalFilename, fileName, size);
-  } catch (error) {
-    return handleErrors(req, res, error, logContext);
-  }
-
-  try {
-    const uploadedFile = await uploadFile(buffer, fileName, fileTypeToUse);
-    const url = getPresignedURL(uploadedFile.key);
-    await updateStatus(metadata.id, UPLOADED);
-    res.status(200).send({ ...metadata, url });
-  } catch (err) {
-    if (metadata) {
-      await updateStatus(metadata.id, UPLOAD_FAILED);
-    }
-    return handleErrors(req, res, err, logContext);
-  }
-  try {
-    await addToScanQueue({ key: metadata.key });
-    return updateStatus(metadata.id, QUEUED);
-  } catch (err) {
-    auditLogger.error(`${logContext} Failed to queue ${metadata.originalFileName}. Error: ${err}`);
-    await updateStatus(metadata.id, QUEUEING_FAILED);
-    return handleErrors(req, res, err, logContext);
-  }
-};
-
 const uploadHandler = async (req, res) => {
   const [fields, files] = await parseFormPromise(req);
   const {
@@ -394,83 +331,84 @@ const uploadHandler = async (req, res) => {
 
 const uploadObjectivesFile = async (req, res) => {
   const [fields, files] = await parseFormPromise(req);
-  let {
-    objectiveIds,
-  } = fields;
-  let buffer;
-  let metadata;
-  let fileName;
-  let fileTypeToUse;
+  let { objectiveIds } = fields;
 
   const user = await userById(req.session.userId);
 
+  objectiveIds = JSON.parse(objectiveIds);
+  const metadata = [];
+
+  if (!objectiveIds || !objectiveIds.length) {
+    return res.status(400).send({ error: 'objective ids are required' });
+  }
   try {
     if (!files.file) {
       return res.status(400).send({ error: 'file required' });
     }
-    const { path, originalFilename, size } = files.file[0];
-    if (!size) {
-      return res.status(400).send({ error: 'fileSize required' });
-    }
-
-    objectiveIds = JSON.parse(objectiveIds);
-
-    if (!objectiveIds || !objectiveIds.length) {
-      return res.status(400).send({ error: 'objective ids are required' });
-    }
-    buffer = fs.readFileSync(path);
-
-    fileTypeToUse = await determineFileTypeFromPath(path);
-    if (!fileTypeToUse) {
-      return res.status(400).send('Could not determine file type');
-    }
-
-    fileName = `${uuidv4()}${fileTypeToUse.ext}`;
-
-    const authorizations = await Promise.all(objectiveIds.map(async (objectiveId) => {
-      const objective = await getObjectiveById(objectiveId);
-      const objectivePolicy = new ObjectivePolicy(objective, user);
-      if (!objectivePolicy.canUpdate()) {
-        const admin = await validateUserAuthForAdmin(req.session.userId);
-        if (!admin) {
-          return false;
-        }
+    await Promise.all(files.file.map(async (f) => {
+      const { path, originalFilename, size } = f;
+      if (!size) {
+        return res.status(400).send({ error: 'fileSize required' });
       }
-      return true;
+      const buffer = fs.readFileSync(path);
+      const fileTypeToUse = await determineFileTypeFromPath(path);
+      if (!fileTypeToUse) {
+        return res.status(400).send('Could not determine file type');
+      }
+      const fileName = `${uuidv4()}${fileTypeToUse.ext}`;
+      const authorizations = await Promise.all(objectiveIds.map(async (objectiveId) => {
+        const objective = await getObjectiveById(objectiveId);
+        const objectivePolicy = new ObjectivePolicy(objective, user);
+        if (!objectivePolicy.canUpdate()) {
+          const admin = await validateUserAuthForAdmin(req.session.userId);
+          if (!admin) {
+            return false;
+          }
+        }
+        return true;
+      }));
+
+      if (!authorizations.every((auth) => auth)) {
+        return res.sendStatus(403);
+      }
+
+      const data = await createObjectivesFileMetaData(
+        originalFilename,
+        fileName,
+        objectiveIds,
+        size,
+      );
+      try {
+        const uploadedFile = await uploadFile(buffer, fileName, fileTypeToUse);
+        const url = getPresignedURL(uploadedFile.key);
+        await updateStatus(metadata.id, UPLOADED);
+        metadata.push({ ...data, url });
+
+        return data;
+      } catch (err) {
+        if (data) {
+          await updateStatus(metadata.id, UPLOAD_FAILED);
+        }
+        return handleErrors(req, res, err, logContext);
+      }
     }));
-
-    if (!authorizations.every((auth) => auth)) {
-      return res.sendStatus(403);
-    }
-
-    metadata = await createObjectivesFileMetaData(
-      originalFilename,
-      fileName,
-      objectiveIds,
-      size,
-    );
+    res.status(200).send(metadata);
   } catch (err) {
     return handleErrors(req, res, err, logContext);
   }
 
-  try {
-    const uploadedFile = await uploadFile(buffer, fileName, fileTypeToUse);
-    const url = getPresignedURL(uploadedFile.key);
-    await updateStatus(metadata.id, UPLOADED);
-    res.status(200).send({ ...metadata, url });
-  } catch (err) {
-    if (metadata) {
-      await updateStatus(metadata.id, UPLOAD_FAILED);
+  return Promise.all(metadata.map(async (m) => {
+    try {
+      if (!m.key || !m.id) {
+        throw new Error('Missing key or id for file status update');
+      }
+      await addToScanQueue({ key: m.key });
+      return updateStatus(multiparty.id, QUEUED);
+    } catch (err) {
+      auditLogger.error(`${logContext} Failed to queue ${m.originalFileName}. Error: ${err}`);
+      return updateStatus(m.id, QUEUEING_FAILED);
     }
-    return handleErrors(req, res, err, logContext);
-  }
-  try {
-    await addToScanQueue({ key: metadata.key });
-    return updateStatus(metadata.id, QUEUED);
-  } catch (err) {
-    auditLogger.error(`${logContext} Failed to queue ${metadata.originalFileName}. Error: ${err}`);
-    return updateStatus(metadata.id, QUEUEING_FAILED);
-  }
+  }));
 };
 
 const deleteObjectiveFileHandler = async (req, res) => {
@@ -522,7 +460,6 @@ export {
   deleteHandler,
   linkHandler,
   uploadHandler,
-  onlyFileUploadHandler,
   deleteOnlyFile,
   uploadObjectivesFile,
   deleteObjectiveFileHandler,

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -17,7 +17,6 @@ import * as scanQueue from '../../services/scanQueue';
 import { REPORT_STATUSES, FILE_STATUSES } from '../../constants';
 import ActivityReportPolicy from '../../policies/activityReport';
 import ObjectivePolicy from '../../policies/objective';
-import UserPolicy from '../../policies/user';
 import * as Files from '../../services/files';
 import { validateUserAuthForAdmin } from '../../services/accessValidation';
 
@@ -299,82 +298,6 @@ describe('File Upload', () => {
       const of = await ObjectiveFile.findOne({ where: { fileId } });
       expect(of.objectiveId).toBe(objective.dataValues.id);
       expect(validate(uuid)).toBe(true);
-    });
-
-    describe('lonely file', () => {
-      let lonelyFileId;
-      let lonelyFileId2;
-
-      it('upload and delete', async () => {
-        UserPolicy.mockImplementation(() => ({
-          canWriteInAtLeastOneRegion: () => true,
-        }));
-        uploadFile.mockResolvedValue({ key: 'key' });
-        const response = await request(app)
-          .post('/api/files/upload')
-          .attach('file', `${__dirname}/testfiles/testfile.pdf`)
-          .expect(200);
-
-        lonelyFileId = response.body.id;
-
-        expect(uploadFile).toHaveBeenCalled();
-        expect(mockAddToScanQueue).toHaveBeenCalled();
-
-        await waitFor(async () => {
-          const lonelyFile = await File.findByPk(lonelyFileId);
-
-          expect(lonelyFile).not.toBeNull();
-          expect(lonelyFile.dataValues.id).toBe(lonelyFileId);
-          expect(lonelyFile.dataValues.status).not.toBe(null);
-          expect(lonelyFile.dataValues.originalFileName).toBe('testfile.pdf');
-        });
-
-        await request(app)
-          .delete(`/api/files/${lonelyFileId}`)
-          .expect(204);
-
-        expect(deleteFileFromS3).toHaveBeenCalled();
-
-        await waitFor(async () => {
-          const lonelyFile = await File.findByPk(lonelyFileId);
-          expect(lonelyFile).toBeNull();
-        });
-      });
-
-      it('won\'t delete if associated with other data', async () => {
-        UserPolicy.mockImplementation(() => ({
-          canWriteInAtLeastOneRegion: () => true,
-        }));
-        uploadFile.mockResolvedValue({ key: 'key' });
-        const secondResponse = await request(app)
-          .post('/api/files/upload')
-          .attach('file', `${__dirname}/testfiles/testfile.pdf`)
-          .expect(200);
-
-        lonelyFileId2 = secondResponse.body.id;
-
-        await waitFor(async () => {
-          const lonelyFile2 = await File.findByPk(lonelyFileId2);
-          await ObjectiveFile.create({
-            fileId: lonelyFile2.id,
-            objectiveId: secondTestObjective.dataValues.id,
-          });
-        });
-
-        await request(app)
-          .delete(`/api/files/${lonelyFileId2}`)
-          .expect(204);
-
-        expect(deleteFileFromS3).not.toHaveBeenCalled();
-
-        await waitFor(async () => {
-          const lonelyFile2 = await File.findByPk(lonelyFileId2);
-          expect(lonelyFile2).not.toBeNull();
-          expect(lonelyFile2.dataValues.id).toBe(lonelyFileId2);
-          expect(lonelyFile2.dataValues.status).not.toBe(null);
-          expect(lonelyFile2.dataValues.originalFileName).toBe('testfile.pdf');
-        });
-      });
     });
 
     it('allows an admin to upload a objective file', async () => {

--- a/src/routes/files/index.js
+++ b/src/routes/files/index.js
@@ -4,7 +4,6 @@ import {
   linkHandler,
   deleteHandler,
   deleteObjectiveFileHandler,
-  onlyFileUploadHandler,
   deleteOnlyFile,
   uploadObjectivesFile,
 } from './handlers';
@@ -23,7 +22,6 @@ const router = express.Router();
  */
 router.post('/link/', transactionWrapper(linkHandler));
 router.post('/', transactionWrapper(uploadHandler));
-router.post('/upload', transactionWrapper(onlyFileUploadHandler));
 router.post('/objectives', transactionWrapper(uploadObjectivesFile));
 router.delete('/:fileId?', checkFileIdParam, transactionWrapper(deleteOnlyFile));
 router.delete('/r/:reportId?/:fileId?', checkReportIdParam, checkFileIdParam, transactionWrapper(deleteHandler));

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -351,7 +351,6 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
       ? objective.activityReportObjectives[0].ttaProvided : null;
 
     const roles = objective.roles.map((role) => role.fullName);
-
     const id = objective.getDataValue('id') ? objective.getDataValue('id') : objective.getDataValue('value');
 
     return [...objectives, {
@@ -578,6 +577,10 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
           {
             model: Role,
             as: 'roles',
+          },
+          {
+            model: File,
+            as: 'files',
           },
           {
             model: Topic,

--- a/src/services/objectives.js
+++ b/src/services/objectives.js
@@ -8,7 +8,6 @@ import {
   Topic,
   File,
   ObjectiveResource,
-  ActivityReport,
 } from '../models';
 import { removeUnusedGoalsObjectivesFromReport, reduceObjectives, saveObjectiveAssociations } from './goals';
 import { cacheObjectiveMetadata } from './reportCache';
@@ -98,17 +97,17 @@ export async function saveObjectivesForReport(objectives, report) {
 
 export async function getObjectiveById(objectiveId) {
   return Objective.findOne({
-    attributes: ['id', 'title', 'status', 'onApprovedAR'],
+    attributes: [
+      'id',
+      'title',
+      'status',
+      'onApprovedAR',
+      'otherEntityId',
+    ],
     where: {
       id: objectiveId,
     },
     include: [
-      {
-        model: ActivityReport,
-        as: 'activityReports',
-        attributes: ['regionId'],
-        required: false,
-      },
       {
         model: Goal,
         as: 'goal',

--- a/src/services/objectives.js
+++ b/src/services/objectives.js
@@ -8,6 +8,7 @@ import {
   Topic,
   File,
   ObjectiveResource,
+  ActivityReport,
 } from '../models';
 import { removeUnusedGoalsObjectivesFromReport, reduceObjectives, saveObjectiveAssociations } from './goals';
 import { cacheObjectiveMetadata } from './reportCache';
@@ -97,11 +98,17 @@ export async function saveObjectivesForReport(objectives, report) {
 
 export async function getObjectiveById(objectiveId) {
   return Objective.findOne({
-    attributes: ['id', 'title', 'status'],
+    attributes: ['id', 'title', 'status', 'onApprovedAR'],
     where: {
       id: objectiveId,
     },
     include: [
+      {
+        model: ActivityReport,
+        as: 'activityReports',
+        attributes: ['regionId'],
+        required: false,
+      },
       {
         model: Goal,
         as: 'goal',


### PR DESCRIPTION
## Description of change

Refactor the refactor; since we needed to heavily rewrite the file uploader to conditionally create an objective, we introduced bugs to make uploading multiple files fail or create multiple extra goals and objectives

## How to test

File uploads on objectives (RTR and AR) should continue to work with single files and now work for uploading multiple files.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1005


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
