### PR TITLE
TTAHUB-992 readonly bug / CTA button order / "add next step"

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
@@ -136,16 +136,7 @@ const Draft = ({
         <div className="margin-top-3">
           <ApproverStatusList approverStatus={approverStatusList} />
         </div>
-        <Button
-          outline
-          type="button"
-          onClick={async () => {
-            await onSaveForm(false);
-            updateShowSavedDraft(true);
-          }}
-        >
-          Save Draft
-        </Button>
+        <Button disabled={!connectionActive} type="submit">Submit for approval</Button>
         { !connectionActive && (
         <Alert type="warning" noIcon>
           There&#39;s an issue with your connection.
@@ -159,7 +150,16 @@ const Draft = ({
           .
         </Alert>
         )}
-        <Button disabled={!connectionActive} type="submit">Submit for approval</Button>
+        <Button
+          outline
+          type="button"
+          onClick={async () => {
+            await onSaveForm(false);
+            updateShowSavedDraft(true);
+          }}
+        >
+          Save Draft
+        </Button>
       </Form>
       <DismissingComponentWrapper
         shown={showSavedDraft}

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -159,7 +159,7 @@ export default function NextStepsRepeater({
               </div>
             </FormGroup>
             <FormGroup
-              className="margin-top-1 margin-bottom-3"
+              className="margin-top-1 margin-bottom-2"
               error={blurDateValidations[index] || (errors[name] && errors[name][index]
                 && errors[name][index].completeDate)}
             >

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -111,7 +111,6 @@ export default function NextStepsRepeater({
     }
   };
 
-
   return (
     <>
       <div className="ttahub-next-steps-repeater">

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -194,7 +194,7 @@ export default function NextStepsRepeater({
         type="button"
         unstyled
         onClick={onAddNewStep}
-        className="ttahub-next-steps__add-step-button"
+        className="ttahub-next-steps__add-step-button margin-bottom-2"
         data-testid={
           `${name === 'specialistNextSteps'
             ? 'specialist' : 'recipient'}NextSteps-button`

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import {
@@ -36,6 +36,8 @@ export default function NextStepsRepeater({
     keyName: 'key', // because 'id' is the default key switch it to use 'key'.
   });
 
+  const stepType = name === 'specialistNextSteps' ? 'specialist' : 'recipient';
+
   useEffect(() => {
     const allValues = getValues();
     const fieldArray = allValues[name] || [];
@@ -54,6 +56,16 @@ export default function NextStepsRepeater({
       append({ id: null, note: '', completeDate: null });
     }
   };
+
+  useLayoutEffect(() => {
+    if (fields.length) {
+      const el = document.getElementById(`step-${stepType}-${fields.length - 1}`);
+      // Not using el.scrollIntoView because it doesn't accept a vertical offset (for the header).
+      const rect = el.getBoundingClientRect();
+      const offsetTop = rect.top + window.pageYOffset - 80;
+      window.scrollTo({ top: offsetTop, behavior: 'smooth' });
+    }
+  }, [fields.length, stepType]);
 
   const onRemoveStep = (index) => {
     // Remove from Array.
@@ -99,13 +111,12 @@ export default function NextStepsRepeater({
     }
   };
 
-  const stepType = name === 'specialistNextSteps' ? 'specialist' : 'recipient';
 
   return (
     <>
       <div className="ttahub-next-steps-repeater">
         {fields.map((item, index) => (
-          <div key={item.key}>
+          <div key={item.key} id={`step-${stepType}-${index}`}>
             <FormGroup
               className="margin-top-2 margin-bottom-2"
               error={blurStepValidations[index] || (errors[name] && errors[name][index]

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import {
@@ -36,8 +36,6 @@ export default function NextStepsRepeater({
     keyName: 'key', // because 'id' is the default key switch it to use 'key'.
   });
 
-  const stepType = name === 'specialistNextSteps' ? 'specialist' : 'recipient';
-
   useEffect(() => {
     const allValues = getValues();
     const fieldArray = allValues[name] || [];
@@ -56,16 +54,6 @@ export default function NextStepsRepeater({
       append({ id: null, note: '', completeDate: null });
     }
   };
-
-  useLayoutEffect(() => {
-    if (fields.length) {
-      const el = document.getElementById(`step-${stepType}-${fields.length - 1}`);
-      // Not using el.scrollIntoView because it doesn't accept a vertical offset (for the header).
-      const rect = el.getBoundingClientRect();
-      const offsetTop = rect.top + window.pageYOffset - 80;
-      window.scrollTo({ top: offsetTop, behavior: 'smooth' });
-    }
-  }, [fields.length, stepType]);
 
   const onRemoveStep = (index) => {
     // Remove from Array.
@@ -111,11 +99,13 @@ export default function NextStepsRepeater({
     }
   };
 
+  const stepType = name === 'specialistNextSteps' ? 'specialist' : 'recipient';
+
   return (
     <>
       <div className="ttahub-next-steps-repeater">
         {fields.map((item, index) => (
-          <div key={item.key} id={`step-${stepType}-${index}`}>
+          <div key={item.key}>
             <FormGroup
               className="margin-top-2 margin-bottom-2"
               error={blurStepValidations[index] || (errors[name] && errors[name][index]

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import {
@@ -22,7 +22,6 @@ export default function NextStepsRepeater({
   const [heights, setHeights] = useState([]);
   const [blurStepValidations, setBlurStepValidations] = useState([]);
   const [blurDateValidations, setBlurDateValidations] = useState([]);
-  const [showAddStepButton, setShowStepButton] = useState(false);
 
   const todaysDate = moment().format(DATE_DISPLAY_FORMAT);
 
@@ -36,24 +35,7 @@ export default function NextStepsRepeater({
     keyName: 'key', // because 'id' is the default key switch it to use 'key'.
   });
 
-  useEffect(() => {
-    const allValues = getValues();
-    const fieldArray = allValues[name] || [];
-    setShowStepButton(fieldArray.every((field) => field.note !== ''
-      && (field.completeDate && moment(field.completeDate, 'MM/DD/YYYY').isValid())));
-  }, [fields, getValues, name]);
-
   const canDelete = fields.length > 1;
-
-  const onAddNewStep = () => {
-    const allValues = getValues();
-    const fieldArray = allValues[name] || [];
-    const canAdd = fieldArray.every((field) => field.note !== ''
-      && (field.completeDate && moment(field.completeDate, 'MM/DD/YYYY').isValid()));
-    if (canAdd) {
-      append({ id: null, note: '', completeDate: null });
-    }
-  };
 
   const onRemoveStep = (index) => {
     // Remove from Array.
@@ -96,6 +78,17 @@ export default function NextStepsRepeater({
     if (e.target && e.target.scrollHeight && e.target.scrollHeight > DEFAULT_STEP_HEIGHT) {
       existingHeights[index] = `${e.target.scrollHeight}px`;
       setHeights(existingHeights);
+    }
+  };
+
+  const onAddNewStep = () => {
+    validateStepOnBlur();
+    const allValues = getValues();
+    const fieldArray = allValues[name] || [];
+    const canAdd = fieldArray.every((field) => field.note !== ''
+      && (field.completeDate && moment(field.completeDate, 'MM/DD/YYYY').isValid()));
+    if (canAdd) {
+      append({ id: null, note: '', completeDate: null });
     }
   };
 
@@ -197,25 +190,19 @@ export default function NextStepsRepeater({
         ))}
       </div>
 
-      {
-        showAddStepButton
-          ? (
-            <Button
-              type="button"
-              unstyled
-              onClick={onAddNewStep}
-              className="ttahub-next-steps__add-step-button"
-              data-testid={
-                `${name === 'specialistNextSteps'
-                  ? 'specialist' : 'recipient'}NextSteps-button`
-              }
-            >
-              <FontAwesomeIcon className="margin-right-1" color={colors.ttahubMediumBlue} icon={faPlusCircle} />
-              Add next step
-            </Button>
-          )
-          : null
+      <Button
+        type="button"
+        unstyled
+        onClick={onAddNewStep}
+        className="ttahub-next-steps__add-step-button"
+        data-testid={
+          `${name === 'specialistNextSteps'
+            ? 'specialist' : 'recipient'}NextSteps-button`
         }
+      >
+        <FontAwesomeIcon className="margin-right-1" color={colors.ttahubMediumBlue} icon={faPlusCircle} />
+        Add next step
+      </Button>
     </>
   );
 }

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.scss
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.scss
@@ -6,8 +6,7 @@
 }
 
 .usa-button.ttahub-next-steps__add-step-button {
-  margin-top: 2px;
-  margin-bottom: 12px;
+  margin-top: 0;
 }
 
 /* Outline a blank step onBlur or form Validation */

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.scss
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.scss
@@ -6,7 +6,8 @@
 }
 
 .usa-button.ttahub-next-steps__add-step-button {
-  margin-top: 0;
+  margin-top: 2px;
+  margin-bottom: 12px;
 }
 
 /* Outline a blank step onBlur or form Validation */

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -36,6 +36,8 @@ export default function Objective({
   roles,
   onObjectiveChange,
   onSaveDraft,
+  parentGoal,
+  initialObjectiveStatus,
 }) {
   const [selectedObjective, setSelectedObjective] = useState(objective);
   const { getValues } = useFormContext();
@@ -243,9 +245,9 @@ export default function Objective({
         title={objectiveTitle}
         onChangeTitle={onChangeTitle}
         validateObjectiveTitle={onBlurTitle}
-        status={objectiveStatus}
         inputName={objectiveTitleInputName}
-        isOnReport={isOnReport || false} // todo - fix this for being on AR
+        parentGoal={parentGoal}
+        initialObjectiveStatus={initialObjectiveStatus}
       />
       <SpecialistRole
         isOnApprovedReport={isOnApprovedReport || false}
@@ -351,4 +353,9 @@ Objective.propTypes = {
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
   onObjectiveChange: PropTypes.func.isRequired,
   onSaveDraft: PropTypes.func.isRequired,
+  parentGoal: PropTypes.shape({
+    id: PropTypes.number,
+    status: PropTypes.string,
+  }).isRequired,
+  initialObjectiveStatus: PropTypes.string.isRequired,
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
@@ -26,7 +26,7 @@ export default function ObjectiveTitle({
         { !readOnly ? <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span> : null }
       </Label>
       { readOnly && title ? (
-        <p className="margin-top-0 usa-prose">{title}</p>
+        <p className="margin-top-0 usa-prose" data-testid="readonly-objective-text">{title}</p>
       ) : (
         <>
           {error}

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
@@ -15,8 +15,15 @@ export default function ObjectiveTitle({
   inputName,
   isLoading,
 }) {
-  const readOnly = useMemo(() => (isOnApprovedReport || status === 'Completed' || status === 'Suspended' || (status === 'Not Started' && isOnReport) || (status === 'In Progress' && isOnReport)),
-    [isOnApprovedReport, isOnReport, status]);
+  const readOnly = useMemo(() => {
+    if (isOnApprovedReport) {
+      if (status === 'Completed' || status === 'Suspended') {
+        return true;
+      }
+    }
+
+    return false;
+  }, [isOnApprovedReport, status]);
 
   return (
     <FormGroup className="margin-top-1" error={error.props.children}>

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
@@ -7,23 +7,29 @@ import {
 export default function ObjectiveTitle({
   error,
   isOnApprovedReport,
-  isOnReport,
   title,
   onChangeTitle,
   validateObjectiveTitle,
-  status,
   inputName,
   isLoading,
+  parentGoal,
+  initialObjectiveStatus,
 }) {
   const readOnly = useMemo(() => {
     if (isOnApprovedReport) {
-      if (status === 'Completed' || status === 'Suspended') {
-        return true;
-      }
+      return true;
+    }
+
+    if (parentGoal && parentGoal.status === 'Closed') {
+      return true;
+    }
+
+    if (initialObjectiveStatus === 'Completed' || initialObjectiveStatus === 'Suspended') {
+      return true;
     }
 
     return false;
-  }, [isOnApprovedReport, status]);
+  }, [isOnApprovedReport, initialObjectiveStatus, parentGoal]);
 
   return (
     <FormGroup className="margin-top-1" error={error.props.children}>
@@ -56,13 +62,16 @@ export default function ObjectiveTitle({
 ObjectiveTitle.propTypes = {
   error: PropTypes.node.isRequired,
   isOnApprovedReport: PropTypes.bool.isRequired,
-  isOnReport: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
   validateObjectiveTitle: PropTypes.func.isRequired,
   onChangeTitle: PropTypes.func.isRequired,
-  status: PropTypes.string.isRequired,
   inputName: PropTypes.string,
   isLoading: PropTypes.bool,
+  parentGoal: PropTypes.shape({
+    id: PropTypes.number,
+    status: PropTypes.string,
+  }).isRequired,
+  initialObjectiveStatus: PropTypes.string.isRequired,
 };
 
 ObjectiveTitle.defaultProps = {

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
@@ -15,7 +15,7 @@ export default function ObjectiveTitle({
   inputName,
   isLoading,
 }) {
-  const readOnly = useMemo(() => (isOnApprovedReport || status === 'Complete' || status === 'Suspended' || (status === 'Not Started' && isOnReport) || (status === 'In Progress' && isOnReport)),
+  const readOnly = useMemo(() => (isOnApprovedReport || status === 'Completed' || status === 'Suspended' || (status === 'Not Started' && isOnReport) || (status === 'In Progress' && isOnReport)),
     [isOnApprovedReport, isOnReport, status]);
 
   return (

--- a/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
@@ -127,6 +127,8 @@ export default function Objectives({
               roles={roles}
               onObjectiveChange={onObjectiveChange}
               onSaveDraft={onSaveDraft}
+              parentGoal={getValues('goalForEditing')}
+              initialObjectiveStatus={objective.status}
             />
           );
         })}

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectiveTitle.js
@@ -43,6 +43,8 @@ const RenderObjectiveTitle = ({
         validateObjectiveTitle={jest.fn()}
         onChangeTitle={jest.fn()}
         status="Complete"
+        initialObjectiveStatus="In Progress"
+        parentGoal={{ status: 'Open' }}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...rest}
       />
@@ -52,15 +54,22 @@ const RenderObjectiveTitle = ({
 };
 const readonlyStateMap = [
   { isOnApprovedReport: true },
-  { status: 'Completed' },
+  { status: 'Complete', isOnApprovedReport: true },
   { status: 'Suspended' },
   { status: 'Not Started', isOnReport: true, isOnApprovedReport: true },
   { status: 'In Progress', isOnReport: true, isOnApprovedReport: true },
+  { initialObjectiveStatus: 'Completed', isOnApprovedReport: false },
+  { initialObjectiveStatus: 'Suspended', isOnApprovedReport: false },
+  { parentGoal: { status: 'Closed' }, isOnApprovedReport: false },
 ];
 
 const writableStateMap = [
   { status: 'Not Started', isOnReport: false, isOnApprovedReport: false },
   { status: 'In Progress', isOnReport: false, isOnApprovedReport: false },
+  { status: 'Complete', isOnApprovedReport: false },
+  { status: 'Suspended', isOnApprovedReport: false },
+  { initialObjectiveStatus: 'Not Started', isOnApprovedReport: false },
+  { parentGoal: { status: 'Open' }, isOnApprovedReport: false },
 ];
 
 describe('ObjectiveTitle', () => {

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectiveTitle.js
@@ -10,6 +10,7 @@ import ObjectiveTitle from '../ObjectiveTitle';
 const RenderObjectiveTitle = ({
   goalId = 12,
   collaborators = [],
+  ...rest
 }) => {
   let goalForEditing = null;
 
@@ -42,15 +43,43 @@ const RenderObjectiveTitle = ({
         validateObjectiveTitle={jest.fn()}
         onChangeTitle={jest.fn()}
         status="Complete"
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
       />
       <button type="button">blur me</button>
     </FormProvider>
   );
 };
+const readonlyStateMap = [
+  { isOnApprovedReport: true },
+  { status: 'Completed' },
+  { status: 'Suspended' },
+  { status: 'Not Started', isOnReport: true, isOnApprovedReport: true },
+  { status: 'In Progress', isOnReport: true, isOnApprovedReport: true },
+];
+
+const writableStateMap = [
+  { status: 'Not Started', isOnReport: false, isOnApprovedReport: false },
+  { status: 'In Progress', isOnReport: false, isOnApprovedReport: false },
+];
 
 describe('ObjectiveTitle', () => {
   it('shows the read only view', async () => {
     render(<RenderObjectiveTitle />);
     expect(await screen.findByText('Objective title')).toBeVisible();
+  });
+
+  test.each(readonlyStateMap)('should be readonly when %o', async (state) => {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    render(<RenderObjectiveTitle {...state} />);
+    expect(await screen.findByText('Objective title')).toBeVisible();
+    expect(screen.getByTestId('readonly-objective-text')).toBeVisible();
+  });
+
+  test.each(writableStateMap)('should be writable when %o', async (state) => {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    render(<RenderObjectiveTitle {...state} />);
+    expect(await screen.findByText('Objective title')).toBeVisible();
+    expect(screen.queryByTestId('readonly-objective-text')).toBeNull();
   });
 });


### PR DESCRIPTION
## Description of change



## How to test

- The spacing around "Add next step" buttons should match the figma prototype:

![Screen Shot 2022-09-19 at 11 33 47 AM](https://user-images.githubusercontent.com/17074357/191078581-b0319c2d-29dd-4060-97b3-9c155134821b.png)


- The `TTA objective` textarea should be readonly when:
  - The objective's parent goal status is 'Closed'.
  - The objective's initial status when loaded is 'Completed' or 'Suspended'.
  - When the objective is on an approved report.

Possible readonly/writable combinations are tested:

https://github.com/HHS/Head-Start-TTADP/blob/5cc9c442012d36ec868d3179ac6d3a4d6ed9981b/frontend/src/pages/ActivityReport/Pages/components/__tests__/ObjectiveTitle.js#L55-L73

- The CTA buttons on the review and submit stage should be swapped:

![Screen Shot 2022-09-16 at 2 52 45 PM](https://user-images.githubusercontent.com/17074357/190733087-eb483988-5e9e-4a59-a1dd-4a73a665e9b5.png)

.. is now ..

![Screen Shot 2022-09-16 at 2 54 23 PM](https://user-images.githubusercontent.com/17074357/190733148-07c99573-3f4b-4f40-99a0-270a819d3924.png)

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
