### PR TITLE
[TTAHUB-977] Add grant state code with test

### DIFF
--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -310,6 +310,7 @@ const arTransformers = [
   transformDate('approvedAt'),
   transformGrantModel('programSpecialistName'),
   transformGrantModel('recipientInfo'),
+  transformGrantModel('stateCode'),
 ];
 
 /**

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -159,28 +159,28 @@ describe('activityReportToCsvRecord', () => {
       id: 4,
       grantId: 4,
       grant: {
-        name: 'test4', programSpecialistName: 'Program Specialist 4', recipientId: 4, number: 'grant number 4', recipient: { id: 4, name: 'test4' },
+        name: 'test4', programSpecialistName: 'Program Specialist 4', recipientId: 4, number: 'grant number 4', stateCode: 'NY', recipient: { id: 4, name: 'test4' },
       },
     },
     {
       id: 1,
       grantId: 1,
       grant: {
-        name: 'test1', programSpecialistName: 'Program Specialist 1', recipientId: 1, number: 'grant number 1', recipient: { id: 1, name: 'test1' },
+        name: 'test1', programSpecialistName: 'Program Specialist 1', recipientId: 1, number: 'grant number 1', stateCode: 'NY', recipient: { id: 1, name: 'test1' },
       },
     },
     {
       id: 2,
       grantId: 2,
       grant: {
-        name: 'test2', programSpecialistName: 'Program Specialist 2', recipientId: 2, number: 'grant number 2', recipient: { id: 2, name: 'test2' },
+        name: 'test2', programSpecialistName: 'Program Specialist 2', recipientId: 2, number: 'grant number 2', stateCode: 'CT', recipient: { id: 2, name: 'test2' },
       },
     },
     {
       id: 3,
       grantId: 3,
       grant: {
-        name: 'test3', programSpecialistName: 'Program Specialist 1', recipientId: 3, number: 'grant number 3', recipient: { id: 3, name: 'test3' },
+        name: 'test3', programSpecialistName: 'Program Specialist 1', recipientId: 3, number: 'grant number 3', stateCode: 'MA', recipient: { id: 3, name: 'test3' },
       },
     },
   ];
@@ -345,7 +345,13 @@ describe('activityReportToCsvRecord', () => {
     });
     const output = await activityReportToCsvRecord(report);
     const {
-      creatorName, lastUpdatedBy, collaborators, programSpecialistName, approvers, recipientInfo,
+      creatorName,
+      lastUpdatedBy,
+      collaborators,
+      programSpecialistName,
+      approvers,
+      recipientInfo,
+      stateCode,
     } = output;
     expect(creatorName).toEqual('Arthur, GS');
     expect(lastUpdatedBy).toEqual('Arthur');
@@ -353,6 +359,7 @@ describe('activityReportToCsvRecord', () => {
     expect(programSpecialistName).toEqual('Program Specialist 1\nProgram Specialist 2\nProgram Specialist 4');
     expect(approvers).toEqual('Test Approver 1\nTest Approver 2\nTest Approver 3');
     expect(recipientInfo).toEqual('test1 - grant number 1 - 1\ntest2 - grant number 2 - 2\ntest3 - grant number 3 - 3\ntest4 - grant number 4 - 4');
+    expect(stateCode).toEqual('CT\nMA\nNY');
   });
 
   it('transforms goals and objectives into many values', () => {

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -191,6 +191,10 @@ async function sendActivityReportCSV(reports, res) {
           key: 'recipientInfo',
           header: 'Recipient name - Grant number - Recipient ID',
         },
+        {
+          key: 'stateCode',
+          header: 'State code',
+        },
       ],
     };
 


### PR DESCRIPTION
## Description of change

Added grant state code's to the csv export.

## How to test

Export both regular and legacy reports. We should now show a state code column with the distinct state codes for the grant.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-977


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
