### PR TITLE
[TTAHUB-977] Show all state codes in order of grants

### DIFF
--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -146,6 +146,7 @@ function transformApproversModel(prop) {
 }
 
 function transformGrantModel(prop, sortBy = null) {
+  // If 'sortBy' is set we will no longer return a distinct list.
   function transformer(instance) {
     const obj = {};
     const values = instance.activityRecipients;

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -145,19 +145,29 @@ function transformApproversModel(prop) {
   return transformer;
 }
 
-function transformGrantModel(prop) {
+function transformGrantModel(prop, sortBy = null) {
   function transformer(instance) {
     const obj = {};
     const values = instance.activityRecipients;
     if (values) {
-      const distinctValues = [
-        ...new Set(
-          values.filter(
+      let grantValueList;
+      if (!sortBy) {
+        const distinctValues = [
+          ...new Set(
+            values.filter(
+              (recipient) => recipient.grant && recipient.grant[prop] !== null,
+            ).map((r) => r.grant[prop]).flat(),
+          ),
+        ];
+        grantValueList = distinctValues.sort().join('\n');
+      } else {
+        const grantValues = [
+          ...values.filter(
             (recipient) => recipient.grant && recipient.grant[prop] !== null,
-          ).map((r) => r.grant[prop]).flat(),
-        ),
-      ];
-      const grantValueList = distinctValues.sort().join('\n');
+          ).map((r) => ({ value: r.grant[prop], sortValue: r.grant[sortBy] })).flat(),
+        ];
+        grantValueList = grantValues.sort((a, b) => ((a.sortValue > b.sortValue) ? 1 : -1)).map((r) => r.value).join('\n');
+      }
       Object.defineProperty(obj, prop, {
         value: grantValueList,
         enumerable: true,
@@ -310,7 +320,7 @@ const arTransformers = [
   transformDate('approvedAt'),
   transformGrantModel('programSpecialistName'),
   transformGrantModel('recipientInfo'),
-  transformGrantModel('stateCode'),
+  transformGrantModel('stateCode', 'recipientInfo'),
 ];
 
 /**

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -359,7 +359,7 @@ describe('activityReportToCsvRecord', () => {
     expect(programSpecialistName).toEqual('Program Specialist 1\nProgram Specialist 2\nProgram Specialist 4');
     expect(approvers).toEqual('Test Approver 1\nTest Approver 2\nTest Approver 3');
     expect(recipientInfo).toEqual('test1 - grant number 1 - 1\ntest2 - grant number 2 - 2\ntest3 - grant number 3 - 3\ntest4 - grant number 4 - 4');
-    expect(stateCode).toEqual('CT\nMA\nNY');
+    expect(stateCode).toEqual('NY\nCT\nMA\nNY');
   });
 
   it('transforms goals and objectives into many values', () => {


### PR DESCRIPTION
## Description of change

We want to show all state codes (even duplicates) in the same order as the grants.

## How to test

Export the CSV ensure that all state codes show in the same order as the grants.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-977


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
