### PR TITLE
[TTAHUB-1011] Fix Available Objectives

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
@@ -91,6 +91,13 @@ export default function Objectives({
     ),
   ];
 
+  const removeObjective = (index) => {
+    // Remove the objective.
+    remove(index);
+    // Update this list of available objectives.
+    setUpdatedUsedObjectiveIds();
+  };
+
   return (
     <>
       {/*
@@ -123,7 +130,7 @@ export default function Objectives({
               topicOptions={topicOptions}
               options={options}
               errors={objectiveErrors}
-              remove={remove}
+              remove={removeObjective}
               fieldArrayName={fieldArrayName}
               roles={roles}
               onObjectiveChange={onObjectiveChange}

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
@@ -107,6 +107,55 @@ describe('Objectives', () => {
     await selectEvent.select(select, ['Test objective 2']);
     await screen.findByLabelText(/test objective 2/i);
   });
+
+  it('removing an existing objective add it back to the list of available objectives', async () => {
+    const objectiveOptions = [{
+      value: 3,
+      label: 'Test objective 1',
+      title: 'Test objective 1',
+      ttaProvided: '<p>hello</p>',
+      activityReports: [],
+      resources: [],
+      topics: [],
+      roles: [],
+      status: 'In Progress',
+    },
+    {
+      value: 4,
+      label: 'Test objective 2',
+      title: 'Test objective 2',
+      ttaProvided: '<p>hello 2</p>',
+      activityReports: [],
+      resources: [],
+      topics: [],
+      roles: [],
+      status: 'Not Started',
+    }];
+    render(<RenderObjectives objectiveOptions={objectiveOptions} />);
+    let select = await screen.findByLabelText(/Select TTA objective/i);
+
+    // Initial objective select.
+    await selectEvent.select(select, ['Test objective 1']);
+    await waitFor(() => expect(screen.queryByText(/objective status/i)).not.toBeNull());
+
+    // Add second objective.
+    const addObjBtn = screen.getByRole('button', { name: /add new objective/i });
+    userEvent.click(addObjBtn);
+    select = screen.queryAllByLabelText(/Select TTA objective/i);
+    await selectEvent.select(select[1], ['Test objective 2']);
+
+    // Remove first objective.
+    const removeObjBtns = screen.queryAllByRole('button', { name: /remove this objective/i });
+    userEvent.click(removeObjBtns[0]);
+    const removeBtns = screen.queryAllByRole('button', { name: /this button will remove the objective from the activity report/i, hidden: true });
+    userEvent.click(removeBtns[0]);
+
+    // Attempt to select objective 1 now available.
+    select = await screen.findByLabelText(/Select TTA objective/i);
+    await selectEvent.select(select, ['Test objective 1']);
+    expect(await screen.findByText('In Progress')).toBeVisible();
+  });
+
   it('the button adds a new objective', async () => {
     const objectiveOptions = [{
       value: 3,


### PR DESCRIPTION
## Description of change

If the user removes a goals objective it should return to the list of available objectives.

## How to test

Create an AR using a goal with some objectives. Add some of the existing objectives. Removing the existing objectives should return them to the drop down list of available objectives.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1011


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
