### PR TITLE
Fix owasp/docker-stable to an image that works 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "test-owasp-image-update"
+    default: "main-ar-redesign"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "kw-fix-uei"
@@ -314,7 +314,7 @@ jobs:
           command: ./bin/prod-style-server
       - run:
           name: Pull OWASP ZAP docker image
-          command: docker pull owasp/zap2docker-weekly
+          command: docker pull owasp/zap2docker-stable:s2022-08-01
       - run:
           name: Make reports directory group writeable
           command: chmod g+w reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
           POSTGRES_DB: ttasmarthub
   machine-executor:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
 commands:
   create_combined_yarnlock:
     description: "Concatenate all yarn.json files into single file.
@@ -182,7 +182,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "TTAHUB-926/kw-remove-extra-data"
+    default: "test-owasp-image-update"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "kw-fix-uei"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
           command: ./bin/prod-style-server
       - run:
           name: Pull OWASP ZAP docker image
-          command: docker pull owasp/zap2docker-stable:s2022-08-01
+          command: docker pull owasp/zap2docker-stable:2.11.1
       - run:
           name: Make reports directory group writeable
           command: chmod g+w reports

--- a/bin/run-owasp-scan
+++ b/bin/run-owasp-scan
@@ -24,6 +24,6 @@ docker run \
   --rm \
   --user zap:$(id -g) \
   --network=$network \
-  -t owasp/zap2docker-stable:s2022-08-01 zap-baseline.py \
+  -t owasp/zap2docker-stable:2.11.1 zap-baseline.py \
   -t http://server:8080 \
   -c zap.conf -I -i -r owasp_report.html

--- a/bin/run-owasp-scan
+++ b/bin/run-owasp-scan
@@ -24,6 +24,6 @@ docker run \
   --rm \
   --user zap:$(id -g) \
   --network=$network \
-  -t owasp/zap2docker-weekly zap-baseline.py \
+  -t owasp/zap2docker-stable:s2022-08-01 zap-baseline.py \
   -t http://server:8080 \
   -c zap.conf -I -i -r owasp_report.html


### PR DESCRIPTION
## Description of change
Update which owasp docker image bin/run-owasp-scan and circleci/config.yml use to get around incompatibilities between circle CI and the linux distro owasp now uses

## How to test
CI passes

## Issue(s)

* ~https://ocio-jira.acf.hhs.gov/browse/TTAHUB~ NO PR


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
