### PR TITLE
TTAHUB-1026 Add `logout` route

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,6 +31,7 @@ import RecipientRecord from './pages/RecipientRecord';
 import RecipientSearch from './pages/RecipientSearch';
 import AppWrapper from './components/AppWrapper';
 import AccountManagement from './pages/AccountManagement';
+import Logout from './pages/Logout';
 
 import { getReportsForLocalStorageCleanup } from './fetchers/activityReports';
 import { storageAvailable } from './hooks/helpers';
@@ -188,6 +189,11 @@ function App() {
               <AccountManagement updateUser={updateUser} />
             </AppWrapper>
           )}
+        />
+        <Route
+          exact
+          path="/logout"
+          render={() => <Logout />}
         />
         {admin && (
         <Route

--- a/frontend/src/components/HeaderUserMenu.js
+++ b/frontend/src/components/HeaderUserMenu.js
@@ -33,7 +33,7 @@ UserMenuNav.propTypes = {
 };
 
 function HeaderUserMenu() {
-  const { user, logout } = useContext(UserContext);
+  const { user } = useContext(UserContext);
   const userIsAdmin = isAdmin(user);
 
   const menuItems = useMemo(() => [
@@ -62,7 +62,6 @@ function HeaderUserMenu() {
       key: 7,
       label: 'Log out',
       to: '/logout',
-      fn: () => logout(false),
     },
   ].map(({
     key,
@@ -89,7 +88,7 @@ function HeaderUserMenu() {
       };
     }
     return { key, element: <NavLink key={key} to={to} fn={fn}>{label}</NavLink> };
-  }).filter(Boolean), [userIsAdmin, logout]);
+  }).filter(Boolean), [userIsAdmin]);
 
   /** If we don't have a user context, don't show the user menu. */
   if (!user) {

--- a/frontend/src/components/SiteNav.js
+++ b/frontend/src/components/SiteNav.js
@@ -42,7 +42,7 @@ const SiteNav = ({
       setShowActivityReportSurveyButton(false);
     }
 
-    setShowSidebar(!(location.pathname === '/logout' && authenticated));
+    setShowSidebar(!(location.pathname === '/logout'));
   }, [location.pathname, authenticated]);
 
   if (!showSidebar) return null;

--- a/frontend/src/components/SiteNav.js
+++ b/frontend/src/components/SiteNav.js
@@ -33,6 +33,7 @@ const SiteNav = ({
   location,
 }) => {
   const [showActivityReportSurveyButton, setShowActivityReportSurveyButton] = useState(false);
+  const [showSidebar, setShowSidebar] = useState(true);
 
   useEffect(() => {
     if (location.pathname === '/activity-reports' && authenticated) {
@@ -40,7 +41,11 @@ const SiteNav = ({
     } else {
       setShowActivityReportSurveyButton(false);
     }
+
+    setShowSidebar(!(location.pathname === '/logout' && authenticated));
   }, [location.pathname, authenticated]);
+
+  if (!showSidebar) return null;
 
   return (
     <div>

--- a/frontend/src/components/__tests__/Logout.js
+++ b/frontend/src/components/__tests__/Logout.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import UserContext from '../../UserContext';
+import Logout from '../../pages/Logout';
+
+describe('Logout', () => {
+  const logout = jest.fn();
+
+  const renderLogout = () => {
+    render(
+      <UserContext.Provider value={{ logout }}>
+        <Logout />
+      </UserContext.Provider>,
+    );
+  };
+
+  it('renders the logout page and calls logout from context', () => {
+    renderLogout();
+    expect(logout).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/Logout.js
+++ b/frontend/src/components/__tests__/Logout.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import UserContext from '../../UserContext';
 import Logout from '../../pages/Logout';

--- a/frontend/src/components/__tests__/Logout.js
+++ b/frontend/src/components/__tests__/Logout.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import UserContext from '../../UserContext';
 import Logout from '../../pages/Logout';

--- a/frontend/src/pages/Logout/index.js
+++ b/frontend/src/pages/Logout/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import { useEffect, useContext } from 'react';
 import UserContext from '../../UserContext';
 
 function Logout() {

--- a/frontend/src/pages/Logout/index.js
+++ b/frontend/src/pages/Logout/index.js
@@ -1,0 +1,14 @@
+import React, { useEffect, useContext } from 'react';
+import UserContext from '../../UserContext';
+
+function Logout() {
+  const { logout } = useContext(UserContext);
+
+  useEffect(() => {
+    logout(false);
+  }, [logout]);
+
+  return null;
+}
+
+export default Logout;


### PR DESCRIPTION
## Description of change

Adds a route handler for `/logout` that mounts a very simple component that basically just calls `logout()`. To prevent split-second sidebar flickering, `SiteNav` is updated to not render when the route is `/logout`.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
