### PR TITLE
[TTAHUB-1040] Update ARO status only via Activity Report

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -150,7 +150,7 @@ export default function ApprovedActivityReport({ match, user }) {
     );
   }
   const {
-    reportId,
+    id: reportId,
     displayId,
     author,
     startDate,

--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -177,9 +177,11 @@ const determineObjectiveStatus = async (activityReportId, sequelize) => {
         where: {
           objectiveId: objectiveIds,
         },
+        required: true,
         include: [{
           model: sequelize.models.Objective,
           as: 'objective',
+          required: true,
         }],
       },
     ],
@@ -210,6 +212,7 @@ const determineObjectiveStatus = async (activityReportId, sequelize) => {
       const relevantARs = approvedReports.filter(
         (a) => a.activityReportObjectives.find((aro) => aro.objectiveId === o),
       );
+
       // Get latest report by end date.
       const latestAR = relevantARs.reduce((r, a) => (r.endDate > a.endDate ? r : a));
 
@@ -470,29 +473,6 @@ const automaticGoalObjectiveStatusCachingOnApproval = async (sequelize, instance
     await Promise.all(goals
       .map(async (goal) => sequelize.models.ActivityReportGoal.update(
         { status: goal.status },
-        {
-          where: {
-            activityReportId: instance.id,
-          },
-          transaction: options.transaction,
-          individualHooks: true,
-        },
-      )));
-
-    const objectives = await sequelize.models.Objective.findAll({
-      include: [{
-        model: sequelize.models.ActivityReport,
-        as: 'activityReports',
-        required: true,
-        where: { id: instance.id },
-      }],
-      transaction: options.transaction,
-    });
-
-    // Update Objective status to 'In Progress'.
-    await Promise.all(objectives
-      .map(async (objective) => sequelize.models.ActivityReportObjective.update(
-        { status: objective.status },
         {
           where: {
             activityReportId: instance.id,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -424,6 +424,12 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
         && objective.activityReportObjectives[0].ttaProvided
       ? objective.activityReportObjectives[0].ttaProvided : null;
 
+    // the same is true for statuses as is true for TTA provided
+    const status = objective.activityReportObjectives
+        && objective.activityReportObjectives[0]
+        && objective.activityReportObjectives[0].status
+      ? objective.activityReportObjectives[0].status : 'Not Started';
+
     const id = objective.getDataValue('id') ? objective.getDataValue('id') : objective.getDataValue('value');
 
     return [...objectives, {
@@ -431,6 +437,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
       value: id,
       ids: [id],
       ttaProvided,
+      status,
       isNew: false,
 
       // for the associated models, we need to return not the direct associations
@@ -1267,7 +1274,7 @@ async function createObjectivesForGoal(goal, objectives, report) {
     // the goals passed we need to save the objectives.
     const createNewObjectives = objective.goalId !== goal.id;
     const updatedObjective = {
-      ...updatedFields, title, status, goalId: goal.id,
+      ...updatedFields, title, goalId: goal.id,
     };
 
     // Check if objective exists.
@@ -1332,6 +1339,7 @@ async function createObjectivesForGoal(goal, objectives, report) {
       report.id,
       {
         ...metadata,
+        status,
         ttaProvided: objective.ttaProvided,
       },
     );

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -428,7 +428,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
     const status = objective.activityReportObjectives
         && objective.activityReportObjectives[0]
         && objective.activityReportObjectives[0].status
-      ? objective.activityReportObjectives[0].status : 'Not Started';
+      ? objective.activityReportObjectives[0].status : objective.status;
 
     const id = objective.getDataValue('id') ? objective.getDataValue('id') : objective.getDataValue('value');
 

--- a/src/services/reportCache.js
+++ b/src/services/reportCache.js
@@ -69,7 +69,7 @@ const cacheTopics = async (activityReportObjectiveId, topics = []) => Promise.al
 
 const cacheObjectiveMetadata = async (objective, reportId, metadata) => {
   const {
-    files, resources, roles, topics, ttaProvided,
+    files, resources, roles, topics, ttaProvided, status,
   } = metadata;
   const objectiveId = objective.id;
   const [aro] = await ActivityReportObjective.findOrCreate({
@@ -82,7 +82,7 @@ const cacheObjectiveMetadata = async (objective, reportId, metadata) => {
   return Promise.all([
     await ActivityReportObjective.update({
       title: objective.title,
-      status: objective.status,
+      status,
       ttaProvided,
     }, {
       where: { id: activityReportObjectiveId },


### PR DESCRIPTION
## Description of change
On an activity report, the status of the objective display should be derived from the activity report objective. The objective status is changed only on the RTR and at the time of Activity Report approval.

## How to test
- Create a report (set the end date to sometime in the past) with a new goal & objective, approve it. 
- Create a second report, with a newer end date, using the same goal and objective. The objective should have a different status. Before you submit it, view the database and make sure the values are correct for both the objective and the activity report objective. Leave and come back to the report, refresh and clear local storage. The values shown in the UI and the database should be correct.
- Submit and approve the second report, re-verify in the database. The objective status should be derived from the report with the most recent end date, the activity report objectives should reflect what was saved on the report.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1040


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
