### PR TITLE
[TTAHUB-1029] Show all AR's on goals & objectives page, show all topics on approved reports table

### DIFF
--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -236,7 +236,7 @@ export const DATE_DISPLAY_FORMAT = 'MM/DD/YYYY';
 export const DATEPICKER_VALUE_FORMAT = 'YYYY-MM-DD';
 export const EARLIEST_INC_FILTER_DATE = moment('2020-08-31');
 
-const LOCAL_STORAGE_CACHE_NUMBER = '0.1';
+const LOCAL_STORAGE_CACHE_NUMBER = '0.2';
 export const LOCAL_STORAGE_DATA_KEY = (id) => `ar-form-data-${id}-${LOCAL_STORAGE_CACHE_NUMBER}`;
 export const LOCAL_STORAGE_ADDITIONAL_DATA_KEY = (id) => `ar-additional-data-${id}-${LOCAL_STORAGE_CACHE_NUMBER}`;
 export const LOCAL_STORAGE_EDITABLE_KEY = (id) => `ar-can-edit-${id}-${LOCAL_STORAGE_CACHE_NUMBER}`;

--- a/frontend/src/__tests__/localStorageCleanup.js
+++ b/frontend/src/__tests__/localStorageCleanup.js
@@ -38,12 +38,12 @@ describe('localStorageCleanup', () => {
 
       const calls = [
         '__storage_test__',
-        'ar-form-data-2-0.1',
-        'ar-additional-data-2-0.1',
-        'ar-can-edit-2-0.1',
-        'ar-form-data-3-0.1',
-        'ar-additional-data-3-0.1',
-        'ar-can-edit-3-0.1',
+        'ar-form-data-2-0.2',
+        'ar-additional-data-2-0.2',
+        'ar-can-edit-2-0.2',
+        'ar-form-data-3-0.2',
+        'ar-additional-data-3-0.2',
+        'ar-can-edit-3-0.2',
       ];
 
       calls.forEach((call) => {

--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -23,7 +23,7 @@ function ReportRow({
     displayId,
     activityRecipients,
     startDate,
-    topics,
+    sortedTopics: topics,
     lastSaved,
     calculatedStatus,
     approvedAt,
@@ -161,7 +161,7 @@ export const reportPropTypes = PropTypes.shape({
   approvedAt: PropTypes.string,
   createdAt: PropTypes.string,
   startDate: PropTypes.string.isRequired,
-  topics: PropTypes.arrayOf(PropTypes.string).isRequired,
+  sortedTopics: PropTypes.arrayOf(PropTypes.string).isRequired,
   activityReportCollaborators: PropTypes.arrayOf(
     PropTypes.shape({
       user: PropTypes.shape({

--- a/frontend/src/components/ActivityReportsTable/mocks.js
+++ b/frontend/src/components/ActivityReportsTable/mocks.js
@@ -6,6 +6,7 @@ const activityReports = [
     displayId: 'R14-AR-1',
     regionId: 14,
     topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+    sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
     calculatedStatus: 'draft',
     pendingApprovals: '1 of 3',
     approvers: [{ User: { fullName: 'Approver Manager 1' } }, { User: { fullName: 'Approver Manager 2' } }, { User: { fullName: 'Approver Manager 3' } }],
@@ -82,6 +83,7 @@ const activityReports = [
     displayId: 'R14-AR-2',
     regionId: 14,
     topics: [],
+    sortedTopics: [],
     pendingApprovals: '2 of 2',
     approvers: [{ User: { fullName: 'Approver Manager 4' } }, { User: { fullName: 'Approver Manager 5' } }],
     calculatedStatus: 'needs_action',
@@ -134,6 +136,7 @@ export const activityReportsSorted = [
     displayId: 'R14-AR-2',
     regionId: 14,
     topics: [],
+    sortedTopics: [],
     calculatedStatus: 'needs_action',
     creatorName: 'Kiwi, GS',
     activityRecipients: [
@@ -182,6 +185,7 @@ export const activityReportsSorted = [
     displayId: 'R14-AR-1',
     regionId: 14,
     topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+    sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
     calculatedStatus: 'draft',
     creatorName: 'Kiwi, TTAC',
     activityRecipients: [
@@ -263,6 +267,7 @@ export const generateXFakeReports = (count, status = []) => {
         displayId: 'R14-AR-1',
         regionId: 14,
         topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+        sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
         calculatedStatus: status[i] || 'draft',
         activityRecipients: [
           {

--- a/frontend/src/components/GoalCards/ObjectiveCard.js
+++ b/frontend/src/components/GoalCards/ObjectiveCard.js
@@ -94,9 +94,6 @@ function ObjectiveCard({
     return <NoStatus />;
   })();
 
-  console.log(endDate);
-  console.log(activityReports);
-
   return (
     <ul className="ttahub-goal-card__objective-list usa-list usa-list--unstyled padding-2 margin-top-2 bg-base-lightest radius-lg" hidden={!objectivesExpanded}>
       <li className="display-flex padding-bottom-05 flex-align-start">
@@ -110,11 +107,11 @@ function ObjectiveCard({
             const viewOrEditLink = `/activity-reports/view/${report.id}`;
             const linkToAr = report.legacyId ? `/activity-reports/legacy/${report.legacyId}` : viewOrEditLink;
             return (
-              <li key={report.id}>
+              <li key={`AR-${report.id}`}>
                 <Link
                   to={linkToAr}
                 >
-                  {report.number}
+                  {report.displayId}
                 </Link>
               </li>
             );

--- a/frontend/src/components/GoalCards/ObjectiveCard.js
+++ b/frontend/src/components/GoalCards/ObjectiveCard.js
@@ -94,6 +94,9 @@ function ObjectiveCard({
     return <NoStatus />;
   })();
 
+  console.log(endDate);
+  console.log(activityReports);
+
   return (
     <ul className="ttahub-goal-card__objective-list usa-list usa-list--unstyled padding-2 margin-top-2 bg-base-lightest radius-lg" hidden={!objectivesExpanded}>
       <li className="display-flex padding-bottom-05 flex-align-start">
@@ -128,7 +131,7 @@ function ObjectiveCard({
       </li>
       <li className="display-flex padding-bottom-05 flex-align-start">
         <span className="margin-right-3 minw-15">Reasons</span>
-        {reasons && displayReasonsList(reasons.sort())}
+        {reasons && displayReasonsList(reasons)}
       </li>
       <li className="display-flex padding-bottom-05 flex-align-start">
         <span className="margin-right-3 minw-15">Objective status </span>

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -127,7 +127,7 @@ const goalWithObjectives = [{
     grantNumbers: ['1'],
     activityReports: [{
       id: 1,
-      number: 'ar-number-1',
+      displayId: 'ar-number-1',
       legacyId: null,
       endDate: '06/14/2021',
     }],
@@ -142,7 +142,7 @@ const goalWithObjectives = [{
     grantNumbers: ['1'],
     activityReports: [{
       id: 2,
-      number: 'ar-number-2',
+      displayId: 'ar-number-2',
       legacyId: null,
       endDate: '01/14/2020',
     }],
@@ -157,7 +157,7 @@ const goalWithObjectives = [{
     grantNumbers: ['1'],
     activityReports: [{
       id: 3,
-      number: 'ar-number-3',
+      displayId: 'ar-number-3',
       legacyId: null,
       endDate: '02/14/2020',
     }],
@@ -172,7 +172,7 @@ const goalWithObjectives = [{
     grantNumbers: ['200342cat'],
     activityReports: [{
       id: 4,
-      number: 'ar-number-4',
+      displayId: 'ar-number-4',
       legacyId: null,
       endDate: '03/14/2020',
     }],
@@ -187,7 +187,7 @@ const goalWithObjectives = [{
     grantNumbers: ['1'],
     activityReports: [{
       id: 5,
-      number: 'ar-number-5',
+      displayId: 'ar-number-5',
       legacyId: null,
       endDate: '04/14/2020',
     }],

--- a/frontend/src/fetchers/__tests__/activityReports.js
+++ b/frontend/src/fetchers/__tests__/activityReports.js
@@ -16,7 +16,9 @@ import {
 } from '../activityReports';
 import { REPORTS_PER_PAGE } from '../../Constants';
 
-const response = { rows: [], count: 0, recipients: [] };
+const response = {
+  rows: [], count: 0, recipients: [], topics: [],
+};
 const alerts = { alertsCount: 0, alerts: [], recipients: [] };
 
 describe('activityReports fetcher', () => {

--- a/frontend/src/pages/Landing/__tests__/index.js
+++ b/frontend/src/pages/Landing/__tests__/index.js
@@ -62,10 +62,12 @@ describe('Landing Page', () => {
   });
   beforeEach(async () => {
     fetchMock.get(base, response);
+
     fetchMock.get(baseAlerts, {
       alertsCount: 0,
       alerts: [],
       recipients: [],
+      topics: [],
     });
     fetchMock.get(defaultOverviewUrl, overviewRegionOne);
     const user = {
@@ -77,7 +79,6 @@ describe('Landing Page', () => {
         },
       ],
     };
-
     renderLanding(user);
     await screen.findByText('Activity reports');
   });
@@ -538,9 +539,12 @@ describe('handleApplyAlertFilters', () => {
       count: 0,
       rows: [],
       recipients: [],
+      topics: [],
     });
     fetchMock.get(`${defaultOverviewUrl}&${inTest}`, overviewRegionOne);
-    fetchMock.get(`${baseAlerts}&${inTest}`, { alertsCount: 0, alerts: [], recipients: [] });
+    fetchMock.get(`${baseAlerts}&${inTest}`, {
+      alertsCount: 0, alerts: [], recipients: [], topics: [],
+    });
   });
 
   afterEach(() => fetchMock.restore());

--- a/frontend/src/pages/Landing/mocks.js
+++ b/frontend/src/pages/Landing/mocks.js
@@ -6,6 +6,7 @@ const activityReports = [
     displayId: 'R14-AR-1',
     regionId: 14,
     topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+    sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
     calculatedStatus: 'draft',
     pendingApprovals: '1 of 3',
     approvers: [{ User: { fullName: 'Approver Manager 1' } }, { User: { fullName: 'Approver Manager 2' } }, { User: { fullName: 'Approver Manager 3' } }],
@@ -82,6 +83,7 @@ const activityReports = [
     displayId: 'R14-AR-2',
     regionId: 14,
     topics: [],
+    sortedTopics: [],
     pendingApprovals: '2 of 2',
     approvers: [{ User: { fullName: 'Approver Manager 4' } }, { User: { fullName: 'Approver Manager 5' } }],
     calculatedStatus: 'needs_action',
@@ -134,6 +136,7 @@ export const activityReportsSorted = [
     displayId: 'R14-AR-2',
     regionId: 14,
     topics: [],
+    sortedTopics: [],
     calculatedStatus: 'needs_action',
     creatorName: 'Kiwi, GS',
     activityRecipients: [
@@ -182,6 +185,7 @@ export const activityReportsSorted = [
     displayId: 'R14-AR-1',
     regionId: 14,
     topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+    sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
     calculatedStatus: 'draft',
     creatorName: 'Kiwi, TTAC',
     activityRecipients: [
@@ -263,6 +267,7 @@ export const generateXFakeReports = (count) => {
         displayId: 'R14-AR-1',
         regionId: 14,
         topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+        sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
         calculatedStatus: 'draft',
         activityRecipients: [
           {

--- a/frontend/src/pages/RecipientRecord/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/__tests__/index.js
@@ -120,8 +120,8 @@ describe('recipient record page', () => {
     fetchMock.get(`/api/widgets/overview?startDate.win=${yearToDate}&region.in[]=45&recipientId.ctn[]=1`, overview);
     fetchMock.get('/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10', { count: 0, rows: [] });
     fetchMock.get(`/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&startDate.win=${yearToDate}&region.in[]=45&recipientId.ctn[]=1`, { count: 0, rows: [] });
-    fetchMock.get('/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&region.in[]=45&recipientId.ctn[]=1', { count: 0, rows: [] });
-    fetchMock.get(`/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&startDate.win=${yearToDate}`, { count: 0, rows: [] });
+    fetchMock.get('/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&region.in[]=45&recipientId.ctn[]=1', { count: 0, rows: [], topics: [] });
+    fetchMock.get(`/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&startDate.win=${yearToDate}`, { count: 0, rows: [], topics: [] });
     fetchMock.get('/api/widgets/frequencyGraph', 200);
     fetchMock.get(`/api/widgets/frequencyGraph?startDate.win=${yearToDate}&region.in[]=45&recipientId.ctn[]=1`, 200);
     fetchMock.get('/api/widgets/frequencyGraph?region.in[]=45&recipientId.ctn[]=1', 200);

--- a/frontend/src/testHelpers.js
+++ b/frontend/src/testHelpers.js
@@ -15,6 +15,7 @@ export const convertToResponse = (
     [isAlerts ? 'alerts' : 'rows']: [...previous[isAlerts ? 'alerts' : 'rows'], report],
     recipients: [...previous.recipients, ...recipients],
     [isAlerts ? 'alertsCount' : 'count']: count,
+    topics: [],
   };
 }, { [isAlerts ? 'alertsCount' : 'count']: count, [isAlerts ? 'alerts' : 'rows']: [], recipients: [] });
 

--- a/frontend/src/testHelpers.js
+++ b/frontend/src/testHelpers.js
@@ -17,7 +17,9 @@ export const convertToResponse = (
     [isAlerts ? 'alertsCount' : 'count']: count,
     topics: [],
   };
-}, { [isAlerts ? 'alertsCount' : 'count']: count, [isAlerts ? 'alerts' : 'rows']: [], recipients: [] });
+}, {
+  [isAlerts ? 'alertsCount' : 'count']: count, [isAlerts ? 'alerts' : 'rows']: [], recipients: [], topics: [],
+});
 
 export const withText = (text) => (content, node) => {
   const hasText = (n) => n.textContent === text;

--- a/src/models/activityReport.js
+++ b/src/models/activityReport.js
@@ -222,6 +222,7 @@ module.exports = (sequelize, DataTypes) => {
         if (!this.topics) {
           return [];
         }
+
         return this.topics.sort((a, b) => {
           if (a < b) {
             return -1;

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -173,8 +173,6 @@ function reduceObjectives(response, goal) {
     topics,
     reasons,
   } = response.objectives.reduce((acc, objective) => {
-    console.log('objective reports', objective.activityReports);
-
     const { t, r, endDate } = objective.activityReports.reduce((a, report) => ({
       t: [...a.t, ...report.topics],
       r: [...a.r, ...report.reason],
@@ -327,6 +325,7 @@ export async function getGoalsByActivityRecipient(
               'calculatedStatus',
               'legacyId',
               'regionId',
+              'displayId',
             ],
             model: ActivityReport,
             as: 'activityReports',

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -1,4 +1,5 @@
 import { Op } from 'sequelize';
+import { uniqBy } from 'lodash';
 import moment from 'moment';
 import {
   Grant,
@@ -166,102 +167,66 @@ export async function recipientsByName(query, scopes, sortBy, direction, offset)
   };
 }
 
-export function dedupeAndSortObjectivesAndReports(objectives) {
-  return objectives.reduce((previous, objective) => {
-    // eslint-disable-next-line max-len
-    const existingObjective = previous.find((o) => (o.title.trim() === objective.title.trim() && o.status === objective.status));
-
-    if (existingObjective) {
-      // if the objective exists, we also have to make sure all
-      // the reports are combined into one list
-
-      // eslint-disable-next-line max-len
-      existingObjective.activityReports = objective.activityReports.reduce((existingReports, currentReport) => {
-        const existingReport = existingReports.find((report) => report.id === currentReport.id);
-        if (existingReport) {
-          return existingReports;
-        }
-
-        return [...existingReports, currentReport];
-      }, existingObjective.activityReports);
-      return previous;
-    }
-
-    return [
-      ...previous,
-      { ...objective, title: objective.title.trim() },
-    ];
-  }, []).sort((a, b) => ((
-    a.endDate === b.endDate ? a.id < b.id
-      : a.endDate < b.endDate) ? 1 : -1)); // we also have to sort the objectives
-}
-
 function reduceObjectives(response, goal) {
-  const current = goal;
+  const {
+    objectives,
+    topics,
+    reasons,
+  } = response.objectives.reduce((acc, objective) => {
+    console.log('objective reports', objective.activityReports);
 
-  const objectives = response.objectives.map((objective) => {
-    // Activity Report.
-    let activityReport;
-    if (objective.activityReports && objective.activityReports.length > 0) {
-      // eslint-disable-next-line prefer-destructuring
-      activityReport = objective.activityReports[0];
-      /* TODO: Switch for New Goal Creation (Remove). */
-      current.goalTopics = Array.from(
-        new Set([...goal.goalTopics, ...activityReport.topics]),
+    const { t, r, endDate } = objective.activityReports.reduce((a, report) => ({
+      t: [...a.t, ...report.topics],
+      r: [...a.r, ...report.reason],
+      endDate: report.endDate > a.endDate ? report.endDate : a.endDate,
+    }), { t: [], r: [], endDate: '' });
+
+    const existing = acc.objectives.find((o) => (
+      o.title.trim() === objective.getDataValue('title').trim() && o.status === objective.status
+    ));
+
+    if (existing) {
+      existing.activityReports = uniqBy([...existing.activityReports, ...objective.activityReports], 'id');
+      existing.reasons = Array.from(
+        new Set([...existing.reasons, ...r]),
       );
 
-      current.reasons = Array.from(
-        new Set([...goal.reasons, ...activityReport.reason]),
-      );
-    }
-
-    // eslint-disable-next-line max-len
-    const existingObjective = goal.objectives.find((o) => (o.title.trim() === objective.title.trim() && o.status === objective.status));
-
-    if (existingObjective) {
-      // eslint-disable-next-line max-len
-      const existingReport = existingObjective.activityReports.find((ar) => ar.id === activityReport.id);
-      if (existingReport) {
-        return {
-          ...existingObjective,
-          grantNumbers: [...existingObjective.grantNumbers, response.grant.number],
-        };
-      }
-
-      return {
-        ...existingObjective,
-        activityReports: [
-          ...existingObjective.activityReports,
-          {
-            id: activityReport ? activityReport.id : null,
-            legacyId: activityReport ? activityReport.legacyId : null,
-            number: activityReport ? activityReport.displayId : null,
-            endDate: activityReport ? activityReport.endDate : null,
-          },
-        ],
-        grantNumbers: [...existingObjective.grantNumbers, response.grant.number],
-      };
+      existing.reasons.sort();
+      return acc;
     }
 
     return {
-      id: objective.id,
-      title: objective.title.trim(),
-      endDate: activityReport ? activityReport.endDate : null,
-      reasons: activityReport ? activityReport.reason : null,
-      status: objective.status,
-      grantNumbers: [response.grant.number],
-      activityReports: [{
-        id: activityReport ? activityReport.id : null,
-        legacyId: activityReport ? activityReport.legacyId : null,
-        number: activityReport ? activityReport.displayId : null,
-        endDate: activityReport ? activityReport.endDate : null,
+      objectives: [...acc.objectives, {
+        ...objective.dataValues,
+        endDate,
+        grantNumbers: [response.grant.number],
+        reasons: Array.from(
+          new Set(r),
+        ),
       }],
+      reasons: [...acc.reasons, ...r].sort(),
+      topics: [...acc.topics, ...t],
     };
+  }, {
+    objectives: [],
+    topics: [],
+    reasons: [],
   });
 
-  // this is to dedupe (our first pass dedupes objectives from rolled up goals,
-  // this dedupes objectives from the same goal)
-  return dedupeAndSortObjectivesAndReports(objectives);
+  const current = goal;
+  current.goalTopics = Array.from(
+    new Set([...goal.goalTopics, ...topics]),
+  );
+
+  current.reasons = Array.from(
+    new Set([...goal.reasons, ...reasons]),
+  );
+
+  current.reasons.sort();
+
+  return objectives.sort((a, b) => ((
+    a.endDate === b.endDate ? a.id < b.id
+      : a.endDate < b.endDate) ? 1 : -1));
 }
 
 function calculatePreviousStatus(goal) {

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -3,7 +3,7 @@ import {
   Recipient, Grant, Program, sequelize,
 } from '../models';
 import {
-  allRecipients, recipientById, recipientsByName, dedupeAndSortObjectivesAndReports,
+  allRecipients, recipientById, recipientsByName,
 } from './recipient';
 import filtersToScopes from '../scopes';
 
@@ -538,60 +538,6 @@ describe('Recipient DB service', () => {
       expect(foundRecipients.rows.length).toBe(2);
       expect(foundRecipients.rows.map((g) => g.id)).toContain(70);
       expect(foundRecipients.rows.map((g) => g.id)).toContain(71);
-    });
-  });
-
-  describe('dedupeAndSortObjectivesAndReports', () => {
-    it('dedupes objectives and reports', async () => {
-      const preduped = [
-        {
-          title: 'A Title ',
-          status: 'Active',
-          endDate: 1,
-          activityReports: [{ id: 1 }],
-        },
-        {
-          title: 'A Title',
-          status: 'Active',
-          endDate: 2,
-          activityReports: [{ id: 2 }],
-        },
-        {
-          title: 'A Title',
-          status: 'Inactive',
-          endDate: 3,
-          activityReports: [{ id: 3 }],
-        },
-        {
-          title: 'Another title',
-          status: 'Active',
-          endDate: 4,
-          activityReports: [{ id: 1 }],
-        },
-      ];
-
-      const deduped = dedupeAndSortObjectivesAndReports(preduped);
-      expect(deduped.length).toBe(3);
-      expect(deduped).toStrictEqual([
-        {
-          title: 'Another title',
-          status: 'Active',
-          endDate: 4,
-          activityReports: [{ id: 1 }],
-        },
-        {
-          title: 'A Title',
-          status: 'Inactive',
-          endDate: 3,
-          activityReports: [{ id: 3 }],
-        },
-        {
-          title: 'A Title',
-          status: 'Active',
-          endDate: 1,
-          activityReports: [{ id: 1 }, { id: 2 }],
-        },
-      ]);
     });
   });
 });


### PR DESCRIPTION
## Description of change

Fixes the following bugs:
- Objectives on the RTR page seem to only show one AR under "Activity Reports" even though they have been included on multiple ARs.
- Topics for newly created objectives do not display in the approved reports table, only the "legacy" topics field

## How to test

Reuse an existing goal and objective (that already has a report) on a new activity report, then approve it. You will see topics in the approved report table for the objective you created. Look up that goal & objective in the RTR. You will see both reports.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1029

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
