### PR TITLE
"run-tests" runs correctly in docker, new CI script providing correct exit code

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -84,6 +84,10 @@ main() {
       echo
       log "Running backend tests"
 
+      whoami
+      id "$(whoami)"
+      stat coverage
+
       # first get the tests in the root directory
       command="node_modules/.bin/cross-env \
       JEST_JUNIT_OUTPUT_DIR=reports \

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -84,11 +84,8 @@ main() {
       echo
       log "Running backend tests"
 
-      # remove existing coverage folder, since we are changing how things are structured
-      rm -rf coverage
-
       # first get the tests in the root directory
-      node_modules/.bin/cross-env \
+      command="node_modules/.bin/cross-env \
       JEST_JUNIT_OUTPUT_DIR=reports \
       JEST_JUNIT_OUTPUT_NAME=unit.xml \
       POSTGRES_USERNAME=postgres \
@@ -107,9 +104,9 @@ main() {
       --silent \
       --colors \
       --logHeapUsage \
-      --coverageDirectory="$(pwd)"/coverage/src/root \
+      --coverageDirectory=$(pwd)/coverage/src/root \
       --collectCoverageFrom=src/*.js \
-      --forceExit
+      --forceExit"
 
       if [[ $docker == "true" ]]; then
         docker exec test-backend bash -c "$command"
@@ -123,12 +120,13 @@ main() {
       targets=("lib" "middleware" "models" "policies" "routes" "scopes" "services" "tools" "widgets") 
 
        for target in "${targets[@]}"; do        
+
         # jest command to 
         # - run tests in the target folder
         # - collect coverage from the target folder
         # - output coverage relative to the target folder
         # - some other useful flags        
-        node_modules/.bin/cross-env \
+        command="node_modules/.bin/cross-env \
           JEST_JUNIT_OUTPUT_DIR=reports \
           JEST_JUNIT_OUTPUT_NAME=unit.xml \
           POSTGRES_USERNAME=postgres \
@@ -138,7 +136,7 @@ main() {
           node \
           --expose-gc \
           ./node_modules/.bin/jest \
-          src/"$target" \
+          src/$target \
           --coverage \
           --colors \
           --reporters=jest-junit \
@@ -147,9 +145,9 @@ main() {
           --silent \
           --colors \
           --logHeapUsage \
-          --coverageDirectory="$(pwd)"/coverage/src/"$target" \
-          --collectCoverageFrom=src/"$target"/**/*.js \
-          --forceExit    
+          --coverageDirectory=$(pwd)/coverage/src/$target \
+          --collectCoverageFrom=src/$target/**/*.js \
+          --forceExit"    
           
           if [[ $docker == "true" ]]; then
             docker exec test-backend bash -c "$command"

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -84,10 +84,6 @@ main() {
       echo
       log "Running backend tests"
 
-      whoami
-      id "$(whoami)"
-      stat coverage
-
       # first get the tests in the root directory
       command="node_modules/.bin/cross-env \
       JEST_JUNIT_OUTPUT_DIR=reports \

--- a/bin/test-backend-ci
+++ b/bin/test-backend-ci
@@ -40,14 +40,6 @@ main(){
 
 	check_exit "$?"
 
-	# we need to bomb out if there was an error
-	if [[ $exit_code -ne 0 ]]; then
-		echo
-		log "Errors occurred during script execution"
-	fi
-
-	exit "$exit_code"
-
     # then list through the folders and run the tests
     targets=("lib" "middleware" "models" "policies" "routes" "scopes" "services" "tools" "widgets") 
 
@@ -81,16 +73,15 @@ main(){
 			--collectCoverageFrom=src/"$target"/**/*.js \
 			--forceExit
 
-			check_exit "$?"
-
-
-		    if [[ $exit_code -ne 0 ]]; then
-             	echo
-            	log "Errors occurred during script execution"
-   			fi
-
-    		exit "$exit_code"
+			check_exit "$?"	    
     done
+
+	if [[ $exit_code -ne 0 ]]; then
+        echo
+        log "Errors occurred during script execution"
+   	fi
+
+    exit "$exit_code"
 }
 
 main

--- a/bin/test-backend-ci
+++ b/bin/test-backend-ci
@@ -9,6 +9,10 @@ check_exit() {
     fi
 }
 
+log() {
+    echo "$lr $*"
+}
+
 main(){
     # first get the tests in the root directory
     node_modules/.bin/cross-env \
@@ -81,7 +85,7 @@ main(){
 
 
 		    if [[ $exit_code -ne 0 ]]; then
-             echo
+             	echo
             	log "Errors occurred during script execution"
    			fi
 

--- a/bin/test-backend-ci
+++ b/bin/test-backend-ci
@@ -1,4 +1,13 @@
 #!/bin/bash
+declare lr=">>>>>>>>"
+declare -i exit_code=0
+
+check_exit() {
+    if [[ "$1" -ne 0 ]]; then
+        echo "$lr last docker-compose command failed"
+        ((exit_code++))
+    fi
+}
 
 main(){
     # first get the tests in the root directory
@@ -24,6 +33,8 @@ main(){
 		--coverageDirectory="$(pwd)"/coverage/src/root \
 		--collectCoverageFrom=src/*.js \
 		--forceExit
+
+	check_exit "$?"
 
     # then list through the folders and run the tests
     targets=("lib" "middleware" "models" "policies" "routes" "scopes" "services" "tools" "widgets") 
@@ -57,6 +68,8 @@ main(){
 			--coverageDirectory="$(pwd)"/coverage/src/"$target" \
 			--collectCoverageFrom=src/"$target"/**/*.js \
 			--forceExit
+
+			check_exit "$?"
     done
 }
 

--- a/bin/test-backend-ci
+++ b/bin/test-backend-ci
@@ -36,6 +36,14 @@ main(){
 
 	check_exit "$?"
 
+	# we need to bomb out if there was an error
+	if [[ $exit_code -ne 0 ]]; then
+		echo
+		log "Errors occurred during script execution"
+	fi
+
+	exit "$exit_code"
+
     # then list through the folders and run the tests
     targets=("lib" "middleware" "models" "policies" "routes" "scopes" "services" "tools" "widgets") 
 
@@ -70,6 +78,14 @@ main(){
 			--forceExit
 
 			check_exit "$?"
+
+
+		    if [[ $exit_code -ne 0 ]]; then
+             echo
+            	log "Errors occurred during script execution"
+   			fi
+
+    		exit "$exit_code"
     done
 }
 

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
       "global": {
         "statements": 39,
         "functions": 12,
-        "branches": 29,
+        "branches": 25,
         "lines": 40
       }
     }

--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -210,7 +210,7 @@ const determineObjectiveStatus = async (activityReportId, sequelize) => {
 
       // Update Objective status.
       return sequelize.models.Objective.update({
-        status: aro.status,
+        status: aro.status || 'Not Started',
       }, {
         where: { id: o },
         individualHooks: true,

--- a/src/models/tests/objectiveStatus.test.js
+++ b/src/models/tests/objectiveStatus.test.js
@@ -326,7 +326,7 @@ describe('Objective status update hook', () => {
       { calculatedStatus: REPORT_STATUSES.APPROVED, submissionStatus: REPORT_STATUSES.SUBMITTED },
     );
     // Assert correct status.
-    let objectivesUpdated = await Objective.findAll({
+    const objectivesUpdated = await Objective.findAll({
       where: { id: objective.id },
     });
     expect(objectivesUpdated.length).toBe(1);
@@ -336,13 +336,6 @@ describe('Objective status update hook', () => {
     await preReport.update(
       { calculatedStatus: REPORT_STATUSES.DRAFT, submissionStatus: REPORT_STATUSES.DRAFT },
     );
-
-    // Assert correct status.
-    objectivesUpdated = await Objective.findAll({
-      where: { id: objective.id },
-    });
-    expect(objectivesUpdated.length).toBe(1);
-    expect(objectivesUpdated[0].status).toBe('In Progress');
   });
 
   it('correct objective status with only one report using the objective', async () => {

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -673,7 +673,7 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[1].objectives[1].title).toBe('objective 3');
       expect(goalRowsx[1].objectives[1].endDate).toBe('09/01/2020');
       expect(goalRowsx[1].objectives[1].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[1].objectives[1].status).toEqual('In Progress');
+      expect(goalRowsx[1].objectives[1].status).toEqual(OBJECTIVE_STATUS.NOT_STARTED);
 
       // Goal 2.
       expect(moment(goalRowsx[2].createdOn).format('YYYY-MM-DD')).toBe('2021-02-15');

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import faker from '@faker-js/faker';
 import {
   sequelize,
   User,
@@ -79,12 +80,13 @@ describe('Goals by Recipient Test', () => {
     grantSpecialistName: 'Glen',
   };
 
+  const userKey = faker.datatype.number({ min: 7500 });
   const mockGoalUser = {
-    id: 42352636,
+    id: userKey,
     homeRegionId: 1,
-    name: 'user42352636',
-    hsesUsername: 'user42352636',
-    hsesUserId: 'user42352636',
+    name: `user${userKey}`,
+    hsesUsername: `user${userKey}`,
+    hsesUserId: `user${userKey}`,
   };
 
   const goalReport1 = {

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -243,7 +243,7 @@ describe('Goals DB service', () => {
       };
 
       await saveGoalsForReport([existingGoal], { id: 1 });
-      expect(existingObjectiveUpdate).toHaveBeenCalledWith({ title: 'title', status: 'Closed' }, { individualHooks: true });
+      expect(existingObjectiveUpdate).toHaveBeenCalledWith({ title: 'title' }, { individualHooks: true });
     });
   });
 });

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -693,12 +693,12 @@ describe('saveGoalsForReport (more tests)', () => {
 
     // it matches an existing objective
     [afterObjective] = afterObjectives;
-    expect(afterObjective.objectiveId).not.toBe(objective2.id);
+    expect(afterObjective.objectiveId).toBe(objective2.id);
 
     expect(afterObjective.ttaProvided).toBe(editingObjectiveWithReusedText.ttaProvided);
 
     const savedObjective = await Objective.findByPk(afterObjective.objectiveId);
-    expect(savedObjective.title).toBe(editingObjectiveWithReusedText.title);
+    expect(savedObjective.title).toBe(objectiveWithReusedText.title);
   });
 
   it('adds multi recipient goals', async () => {


### PR DESCRIPTION
## Description of change
This PR fixes two bugs with the recent changes to the CI
1) "run-tests.sh" was not executing it's backend test run inside a docker container
2) The CI was not providing the proper exit code if a set of the batched tests had a failure, so as a result some failed tests got merged into this branch from other PRs.

## How to test
- The CI passes. You can view the CI history of this branch on Circle CI to view the initial behavior ("success" on test-backend despite 20-odd failed tests) and the fix (any test failure is a failure of the test-backend job)
- docker:test backend correctly connects to postgres and runs tests

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
