### PR TITLE
[TTAHUB-1046] Fix bug that creates dummy objective

### DIFF
--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -219,7 +219,9 @@ const determineObjectiveStatus = async (activityReportId, sequelize, isResetToDr
   } else if (isResetToDraft) {
     // If there are no Approved reports set Objective status back to 'Not Started'.
     const currentReport = allObjectiveReports.find((r) => r.id === activityReportId);
-    const objectiveIdsToReset = currentReport.activityReportObjectives.map((a) => a.objectiveId);
+    const objectiveIdsToReset = currentReport && currentReport.activityReportObjectives
+      ? currentReport.activityReportObjectives.map((a) => a.objectiveId)
+      : [];
     await sequelize.models.Objective.update({
       status: OBJECTIVE_STATUS.NOT_STARTED,
     }, {

--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -155,7 +155,7 @@ const propogateSubmissionStatus = async (sequelize, instance, options) => {
   }
 };
 
-const determineObjectiveStatus = async (activityReportId, sequelize, isResetToDraft) => {
+const determineObjectiveStatus = async (activityReportId, sequelize, isUnlocked) => {
   // Get all AR Objective Id's.
   const objectives = await sequelize.models.ActivityReportObjective.findAll(
     {
@@ -216,7 +216,7 @@ const determineObjectiveStatus = async (activityReportId, sequelize, isResetToDr
         individualHooks: true,
       });
     }));
-  } else if (isResetToDraft) {
+  } else if (isUnlocked) {
     // If there are no Approved reports set Objective status back to 'Not Started'.
     const currentReport = allObjectiveReports.find((r) => r.id === activityReportId);
     const objectiveIdsToReset = currentReport && currentReport.activityReportObjectives

--- a/src/models/tests/objectiveStatus.test.js
+++ b/src/models/tests/objectiveStatus.test.js
@@ -368,12 +368,11 @@ describe('Objective status update hook', () => {
     );
 
     // Assert correct status.
-    // For now don't roll objective status back.
     objectivesUpdated = await Objective.findAll({
       where: { id: [objectiveTwo.id, objectiveTwoB.id] },
     });
     expect(objectivesUpdated.length).toBe(2);
-    expect(objectivesUpdated[0].status).toBe('Complete');
-    expect(objectivesUpdated[1].status).toBe('Complete');
+    expect(objectivesUpdated[0].status).toBe('Not Started');
+    expect(objectivesUpdated[1].status).toBe('Not Started');
   });
 });

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -221,7 +221,7 @@ describe('Goals DB service', () => {
       expect(Objective.create).toHaveBeenCalledWith({
         goalId: 1,
         title: 'title',
-        status: '',
+        status: 'Not Started',
       });
     });
 

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1309,7 +1309,7 @@ async function createObjectivesForGoal(goal, objectives, report) {
         savedObjective = await Objective.create({
           ...updatedObjective,
           title: objectiveTitle,
-          status,
+          status: OBJECTIVE_STATUS.NOT_STARTED, // Only the hook should set status.
         });
       } else {
         savedObjective = existingObjective;


### PR DESCRIPTION
## Description of change

Fix bug that creates dummy objective.

## How to test

**Steps to Reproduce:** 

    1. Create a Goal from RTR with one Objective
    2. Create a AR with the same recipient used above and any other recipient (2 total)
    3. Add the Goal and Objective created above
    4. Set the objective to 'Complete' and Save
    5. Edit the Goal
    6. Set the Objective to 'In Progress' and Save
    This seems to be when going from 'Complete' > 'In Progress'.
    
    After the fix there should no longer be an extra objective.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1046


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [x] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
