### PR TITLE
[TTAHUB-1029] Fix blank 'Last TTA' field

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -36,13 +36,7 @@ function GoalCard({
     previousStatus,
   } = goal;
 
-  const endDates = useMemo(() => objectives.reduce((prev, curr) => [
-    ...prev,
-    ...curr.activityReports.map((ar) => ar.endDate),
-  ], []).sort((a, b) => moment(a, 'MM/DD/YYYY') - moment(b, 'MM/DD/YYYY')), [objectives]);
-
-  const lastTTA = endDates.pop();
-
+  const lastTTA = useMemo(() => objectives.reduce((prev, curr) => (prev > curr.endDate ? prev : curr.endDate), ''), [objectives]);
   const history = useHistory();
 
   const goalNumbers = goal.goalNumbers.join(', ');

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -302,7 +302,8 @@ describe('Goals Table', () => {
       // Objective 1.
       await screen.findByText(/objective 1 title/i);
       await screen.findByRole('link', { name: /ar-number-1/i });
-      await screen.findByText('06/14/2021');
+      const lastTTa = screen.queryAllByText('06/14/2021');
+      expect(lastTTa.length).toBe(2);
       await screen.findByText(/monitoring | deficiency/i);
 
       // Objective 2.


### PR DESCRIPTION
## Description of change

The 'Last TTA' field on goals table was showing as blank if it only had one AR.

## How to test

Create a goal and objective and use them on a single AR. View the goals table you should now see the last tta field populated.

Note: Draft goals wont have a last tta date.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1029


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
