### PR TITLE
[TTAHUB-1057] Loading for Objective Retrieve

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -96,15 +96,23 @@ export default function GoalForm({
   }, [defaultEndDate, goal.endDate, onUpdateDate]);
 
   const [objectives, setObjectives] = useState([]);
-
+  const [loadingObjectives, setLoadingObjectives] = useState(false);
+  const [loadingLabel, setLoadingLabel] = useState('Saving');
   /*
    * this use effect fetches
    * associated goal data
    */
   useEffect(() => {
     async function fetchData() {
-      const data = await goalsByIdsAndActivityReport(goal.goalIds, reportId);
-      setObjectives(data[0].objectives);
+      try {
+        setLoadingObjectives(true);
+        setLoadingLabel('Loading');
+        const data = await goalsByIdsAndActivityReport(goal.goalIds, reportId);
+        setObjectives(data[0].objectives);
+      } finally {
+        setLoadingObjectives(false);
+        setLoadingLabel('Saving');
+      }
     }
 
     const shouldIFetchData = (
@@ -126,7 +134,7 @@ export default function GoalForm({
 
   return (
     <>
-      <Loader loading={isLoading} loadingLabel="Loading" text="Saving" />
+      <Loader loading={isLoading || loadingObjectives} loadingLabel="Loading" text={loadingLabel} />
       <GoalText
         error={errors.goalName ? ERROR_FORMAT(errors.goalName.message) : NO_ERROR}
         goalName={goalText}
@@ -135,7 +143,7 @@ export default function GoalForm({
         inputName={goalTextInputName}
         isOnReport={goal.onApprovedAR || false}
         goalStatus={status}
-        isLoading={isLoading}
+        isLoading={isLoading || loadingObjectives}
       />
 
       <GoalDate
@@ -146,7 +154,7 @@ export default function GoalForm({
         key={datePickerKey} // force a re-render when the a new goal is picked
         inputName={goalEndDateInputName}
         goalStatus={status}
-        isLoading={isLoading}
+        isLoading={isLoading || loadingObjectives}
       />
 
       <Objectives

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -568,6 +568,7 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
         include: [
           {
             model: ObjectiveResource,
+            separate: true,
             as: 'resources',
             attributes: [
               ['userProvidedUrl', 'value'],
@@ -581,6 +582,7 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
           },
           {
             model: ActivityReportObjective,
+            separate: true,
             as: 'activityReportObjectives',
             attributes: [
               'ttaProvided',


### PR DESCRIPTION
## Description of change

Sometimes the retrieval of Objectives can be a little slow to smooth things out for the user lets display a loader.

This change also includes a potential speed increase by applying separate to some of the joins.

## How to test

Create a report, when selecting an existing goal or switching between goals. We should display a "Loading' message until the objectives come back.

Saving loader should work as it did before.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1057


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
