### PR TITLE
[TTAHUB-1029] Fix auto save error conditions

### DIFF
--- a/frontend/src/components/HeaderUserMenu.js
+++ b/frontend/src/components/HeaderUserMenu.js
@@ -142,6 +142,7 @@ function HeaderUserMenu() {
       buttonText={user.name}
       showApplyButton={false}
       direction="left"
+      className="no-print"
     >
       <div className="user-menu-dropdown" data-testid="user-menu-dropdown">
         <h4 className="margin-0 display-flex flex-align-center padding-2 border-bottom border-gray-10">

--- a/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
@@ -126,7 +126,8 @@ describe('next steps', () => {
     userEvent.click(newEntryButtons[1]);
 
     // When the user presses cancel to change their mind
-    const cancelBtn = await screen.findByRole('button', { name: /remove recipient next steps 3/i });
+
+    const cancelBtn = await screen.findByRole('button', { name: /remove recipient's next steps 3/i });
     userEvent.click(cancelBtn);
 
     // Then we see there is no more input box

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -18,6 +18,7 @@ const DEFAULT_STEP_HEIGHT = 80;
 export default function NextStepsRepeater({
   name,
   ariaName,
+  recipientType,
 }) {
   const [heights, setHeights] = useState([]);
   const [blurStepValidations, setBlurStepValidations] = useState([]);
@@ -93,9 +94,10 @@ export default function NextStepsRepeater({
   };
 
   const stepType = name === 'specialistNextSteps' ? 'specialist' : 'recipient';
+  const recipientLabel = recipientType === 'recipient' ? 'recipient' : 'other entity';
 
   const dateLabel = (index) => (stepType === 'recipient'
-    ? `When does the recipient anticipate completing step ${index + 1}?`
+    ? `When does the ${recipientLabel} anticipate completing step ${index + 1}?`
     : `When do you anticipate completing step ${index + 1}?`);
 
   return (
@@ -214,4 +216,9 @@ export default function NextStepsRepeater({
 NextStepsRepeater.propTypes = {
   name: PropTypes.string.isRequired,
   ariaName: PropTypes.string.isRequired,
+  recipientType: PropTypes.string,
+};
+
+NextStepsRepeater.defaultProps = {
+  recipientType: '',
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -94,6 +94,10 @@ export default function NextStepsRepeater({
 
   const stepType = name === 'specialistNextSteps' ? 'specialist' : 'recipient';
 
+  const dateLabel = (index) => (stepType === 'recipient'
+    ? `When does the recipient anticipate completing step ${index + 1}?`
+    : `When do you anticipate completing step ${index + 1}?`);
+
   return (
     <>
       <div className="ttahub-next-steps-repeater">
@@ -159,7 +163,7 @@ export default function NextStepsRepeater({
               <Label
                 htmlFor={`${stepType}-next-step-date-${index + 1}`}
               >
-                {`When do you anticipate completing step ${index + 1}?`}
+                {dateLabel(index)}
                 <span className="smart-hub--form-required font-family-sans font-ui-xs text-secondary-dark">
                   {' '}
                   *

--- a/frontend/src/pages/ActivityReport/Pages/components/objectiveValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/objectiveValidator.js
@@ -3,7 +3,7 @@ import { unfinishedObjectives } from './goalValidator';
 
 import { OBJECTIVES_EMPTY } from '../../../../components/GoalForm/constants';
 
-export const validateObjectives = (objectives, setError = () => {}) => {
+export const validateObjectives = (objectives = [], setError = () => {}) => {
   if (objectives.length < 1) {
     return OBJECTIVES_EMPTY;
   }

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -48,7 +48,8 @@ const NextSteps = ({ activityRecipientType }) => {
         <NextStepsRepeater
           id="recipient-next-steps-repeater-id"
           name="recipientNextSteps"
-          ariaName="Recipient Next Steps"
+          ariaName={`${labelDisplayName} next steps`}
+          recipientType={activityRecipientType}
         />
       </Fieldset>
     </>

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.js
@@ -10,7 +10,7 @@ export default function ApprovedReportSection({
   className,
 }) {
   return (
-    <div className={className}>
+    <div className={`ttahub-approved-report-section-container ${className}`}>
       <h2 className="font-serif-xl margin-y-3">{title}</h2>
       {sections.map((section) => {
         const subheadings = Object.keys(section.data);

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
@@ -16,6 +16,10 @@
   padding: 0;
 }
 
+.ttahub-approved-report-section div[id^="rdw-wrapper-tta-objective"]{
+  font-weight: bold;
+}
+
 @media screen {
   .ttahub-approved-report-section__striped {
     background-color: $gray-two;
@@ -28,6 +32,13 @@
   .ttahub-approved-report-section {
     padding: 0;
     margin-bottom: 2rem;
+    page-break-inside: avoid;
+  }
+  .ttahub-activity-report-view {
+    margin-top: 0;
+  }
+  .ttahub-activity-report-view > div.padding-x-5.padding-y-5 {
+    padding-top: 0;
   }
 }
 

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -170,7 +170,8 @@ export default function ApprovedReportV2({ data }) {
 
   // next steps table
   const specialistNextSteps = formatNextSteps(data.specialistNextSteps, 'Specialist\'s next steps', true);
-  const recipientNextSteps = formatNextSteps(data.recipientNextSteps, 'Recipient\'s next steps', false);
+  const nextStepsLabel = recipientType === 'Recipient' ? 'Recipient\'s next steps' : 'Other entities next steps';
+  const recipientNextSteps = formatNextSteps(data.recipientNextSteps, nextStepsLabel, false);
   const approvedAt = data.approvedAt ? moment(data.approvedAt).format(DATE_DISPLAY_FORMAT) : '';
   const createdAt = moment(data.createdAt).format(DATE_DISPLAY_FORMAT);
 

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -11,16 +11,14 @@ import {
 } from '../helpers';
 
 function formatNextSteps(nextSteps, heading, striped) {
-  const data = nextSteps.reduce((acc, step, index) => ({
-    ...acc,
-    [`Step ${index + 1}`]: step.note,
-    'Anticipated completion': step.completeDate,
-  }), {});
-  return {
-    heading,
-    data,
+  return nextSteps.map((step, index) => ({
+    heading: index === 0 ? heading : '',
+    data: {
+      [`Step ${index + 1}`]: step.note,
+      'Anticipated completion': step.completeDate,
+    },
     striped,
-  };
+  }));
 }
 
 function formatObjectiveLinks(resources) {
@@ -215,7 +213,7 @@ export default function ApprovedReportV2({ data }) {
 
       <ApprovedReportSection
         key={`activity-summary-${reportId}`}
-        title="Activity Summary"
+        title="Activity summary"
         sections={[
           {
             heading: 'Who was the activity for?',
@@ -293,8 +291,8 @@ export default function ApprovedReportV2({ data }) {
         key={`next-steps${reportId}`}
         title="Next steps"
         sections={[
-          specialistNextSteps,
-          recipientNextSteps,
+          ...specialistNextSteps,
+          ...recipientNextSteps,
         ]}
       />
 

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
@@ -28,7 +28,8 @@ describe('PrintGoals', () => {
       goalText: 'This is goal text 1.',
       goalTopics: ['Human Resources', 'Safety Practices', 'Program Planning and Services'],
       objectiveCount: 5,
-      goalNumber: 'G-4598',
+      goalNumbers: ['G-4598'],
+      grantNumbers: ['Rattaché au programme'], // copilot came up with this, I hope its not profane
       reasons: ['Monitoring | Deficiency', 'Monitoring | Noncompliance'],
       objectives: [],
     },
@@ -39,7 +40,8 @@ describe('PrintGoals', () => {
       goalText: 'This is goal text 2.',
       goalTopics: ['Human Resources', 'Safety Practices'],
       objectiveCount: 5,
-      goalNumber: 'G-4598',
+      goalNumbers: ['G-4598'],
+      grantNumbers: ['Rattaché au programme'],
       reasons: ['Monitoring | Deficiency', 'Monitoring | Noncompliance'],
       objectives: [
         {
@@ -49,6 +51,18 @@ describe('PrintGoals', () => {
           endDate: '01/01/02',
           reasons: ['Empathy', 'Generosity', 'Friendship'],
           status: 'Complete',
+          activityReports: [
+            {
+              id: 1,
+              displayId: '1234',
+              legacyId: null,
+            },
+            {
+              id: 2,
+              displayId: '1234',
+              legacyId: 'r-1234',
+            },
+          ],
         },
       ],
     },

--- a/frontend/src/pages/RecipientRecord/pages/components/PrintableGoal.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/PrintableGoal.js
@@ -10,11 +10,11 @@ export default function PrintableGoal({ goal }) {
   const { icon } = STATUSES[key] ? STATUSES[key] : STATUSES['Needs Status'];
 
   return (
-    <div className="ttahub-printable-goal padding-x-3 padding-top-3 padding-bottom-2 margin-top-5">
+    <div className="ttahub-printable-goal padding-x-3 padding-top-3 padding-bottom-2 margin-top-5 no-break-within">
       <h2 className="margin-top-0 padding-bottom-1 border-bottom-1px">
         Goal
         {' '}
-        {goal.goalNumber}
+        {goal.goalNumbers.join(', ')}
       </h2>
       <div className={ROW_CLASS}>
         <p className={FIRST_COLUMN_CLASS}>Goal status</p>
@@ -25,7 +25,7 @@ export default function PrintableGoal({ goal }) {
       </div>
       <div className={ROW_CLASS}>
         <p className={FIRST_COLUMN_CLASS}>Grant numbers</p>
-        <p className={SECOND_COLUMN_CLASS}>{goal.grantNumber}</p>
+        <p className={SECOND_COLUMN_CLASS}>{goal.grantNumbers.join(', ')}</p>
       </div>
       <div className={ROW_CLASS}>
         <p className={FIRST_COLUMN_CLASS}>Recipient&apos;s goal</p>
@@ -35,6 +35,13 @@ export default function PrintableGoal({ goal }) {
         <p className={FIRST_COLUMN_CLASS}>Topics</p>
         <List className={SECOND_COLUMN_CLASS} list={goal.goalTopics} />
       </div>
+      { goal.objectives.length > 0 ? (
+        <h3 className="padding-x-1">
+          Objectives for goal
+          {' '}
+          {goal.goalNumbers.join(', ')}
+        </h3>
+      ) : null }
       {goal.objectives.map(((objective) => (
         <PrintableObjective
           key={objective.id}
@@ -47,9 +54,9 @@ export default function PrintableGoal({ goal }) {
 
 PrintableGoal.propTypes = {
   goal: PropTypes.shape({
-    goalNumber: PropTypes.string,
+    goalNumbers: PropTypes.arrayOf(PropTypes.string),
     goalStatus: PropTypes.string,
-    grantNumber: PropTypes.string,
+    grantNumbers: PropTypes.arrayOf(PropTypes.string),
     goalText: PropTypes.string,
     goalTopics: PropTypes.arrayOf(PropTypes.string),
     objectives: PropTypes.arrayOf(PropTypes.shape({})),

--- a/frontend/src/pages/RecipientRecord/pages/components/PrintableObjective.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/PrintableObjective.js
@@ -4,25 +4,43 @@ import { ROW_CLASS, FIRST_COLUMN_CLASS, SECOND_COLUMN_CLASS } from './constants'
 import { STATUSES } from '../../../../components/GoalCards/components/StatusDropdown';
 import List from './List';
 
+const ActivityReports = ({ reports }) => (
+  <ul className="usa-list usa-list--unstyled">
+    {reports.map((report) => {
+      const link = report.legacyId ? `/activity-reports/legacy/${report.legacyId}` : `/activity-reports/view/${report.id}`;
+      return (
+        <li key={report.id}>
+          <a href={link}>
+            {report.displayId}
+          </a>
+        </li>
+      );
+    })}
+  </ul>
+);
+
+ActivityReports.propTypes = {
+  reports: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    displayId: PropTypes.string,
+  })).isRequired,
+};
 export default function PrintableObjective({ objective }) {
   const key = objective.status || 'Needs Status';
   const { icon } = STATUSES[key] ? STATUSES[key] : STATUSES['Needs Status'];
 
   const rowClass = `ttahub-printable-objective ${ROW_CLASS}`;
-
   return (
-    <div className="margin-bottom-1 margin-top-2">
+    <div className="margin-bottom-1 margin-top-3">
       <div className={rowClass}>
         <p className={FIRST_COLUMN_CLASS}>Objective</p>
         <p className={SECOND_COLUMN_CLASS}>{objective.title}</p>
       </div>
       <div className={rowClass}>
         <p className={FIRST_COLUMN_CLASS}>Activity reports</p>
-        <p className={SECOND_COLUMN_CLASS}>{objective.arId}</p>
-      </div>
-      <div className={rowClass}>
-        <p className={FIRST_COLUMN_CLASS}>Grant numbers</p>
-        <p className={SECOND_COLUMN_CLASS}>{objective.grantNumber}</p>
+        <p className={SECOND_COLUMN_CLASS}>
+          <ActivityReports reports={objective.activityReports} />
+        </p>
       </div>
       <div className={rowClass}>
         <p className={FIRST_COLUMN_CLASS}>End date</p>
@@ -46,7 +64,10 @@ export default function PrintableObjective({ objective }) {
 PrintableObjective.propTypes = {
   objective: PropTypes.shape({
     title: PropTypes.string,
-    arId: PropTypes.number,
+    activityReports: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      displayId: PropTypes.string,
+    })),
     grantNumber: PropTypes.string,
     endDate: PropTypes.string,
     reasons: PropTypes.arrayOf(PropTypes.string),

--- a/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableGoal.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableGoal.js
@@ -12,9 +12,9 @@ describe('PrintableGoal', () => {
   it('will display a goal with an uncertain status', async () => {
     const goal = {
       goalStatus: 'Uncertain',
-      goalNumber: '2',
+      goalNumbers: ['2'],
       goalText: 'asdfasdf',
-      grantNumber: '3',
+      grantNumbers: ['3'],
       goalTopics: ['Topic'],
       objectives: [],
     };
@@ -24,9 +24,9 @@ describe('PrintableGoal', () => {
 
   it('will display a goal with no status', async () => {
     const goal = {
-      goalNumber: '2',
+      goalNumbers: ['2'],
       goalText: 'asdfasdf',
-      grantNumber: '3',
+      grantNumbers: ['3'],
       goalTopics: ['Topic'],
       objectives: [],
     };

--- a/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableObjective.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableObjective.js
@@ -19,6 +19,7 @@ describe('PrintableObjective', () => {
       grantNumber: '3',
       endDate: '2020-01-01',
       reasons: [],
+      activityReports: [],
     };
     renderPrintableObjective(objective);
     expect(await screen.findByText('Uncertain')).toBeInTheDocument();
@@ -31,6 +32,7 @@ describe('PrintableObjective', () => {
       grantNumber: '3',
       endDate: '2020-01-01',
       reasons: [],
+      activityReports: [],
     };
     renderPrintableObjective(objective);
     expect(await screen.findByText(/Needs Status/i)).toBeInTheDocument();

--- a/frontend/src/pages/RecipientRecord/pages/components/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/constants.js
@@ -1,3 +1,3 @@
-export const ROW_CLASS = 'display-flex padding-1 no-break-within';
+export const ROW_CLASS = 'display-flex padding-1';
 export const FIRST_COLUMN_CLASS = 'text-bold width-card-lg margin-0';
 export const SECOND_COLUMN_CLASS = 'flex-1 margin-0';

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -181,6 +181,7 @@ describe('Goals DB service', () => {
 
       await saveGoalsForReport([existingGoal], { id: 1 });
       expect(existingGoalUpdate).toHaveBeenCalledWith({
+        endDate: null,
         goalIds: [1],
         name: 'name',
         status: 'Draft',

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1254,6 +1254,10 @@ async function createObjectivesForGoal(goal, objectives, report) {
      All subsequent Objective status updates should come from the AR Hook using end date.
   */
 
+  if (!objectives) {
+    return [];
+  }
+
   // we don't want to create objectives with blank titles
   return Promise.all(objectives.filter((o) => o.title).map(async (objective) => {
     const {
@@ -1353,6 +1357,7 @@ export async function saveGoalsForReport(goals, report) {
     let newGoals = [];
     const status = goal.status ? goal.status : 'Draft';
     const goalIds = goal.goalIds ? goal.goalIds : [];
+    const endDate = goal.endDate && goal.endDate.toLowerCase() !== 'invalid date' ? goal.endDate : null;
 
     // Check if these goals exist.
     const existingGoals = await Goal.findAll({
@@ -1371,6 +1376,7 @@ export async function saveGoalsForReport(goals, report) {
         status: discardedStatus,
         onApprovedAR,
         createdVia,
+        endDate: discardedEndDate,
         ...fields
       } = goal;
 
@@ -1394,6 +1400,10 @@ export async function saveGoalsForReport(goals, report) {
           },
         });
 
+        if (!newGoal.onApprovedAR && endDate && endDate !== 'Invalid date') {
+          await newGoal.update({ endDate }, { individualHooks: true });
+        }
+
         await cacheGoalMetadata(newGoal, report.id);
 
         const newGoalObjectives = await createObjectivesForGoal(newGoal, objectives, report);
@@ -1410,6 +1420,7 @@ export async function saveGoalsForReport(goals, report) {
         grantId,
         id, // this is unique and we can't trying to set this
         onApprovedAR, // we don't want to set this manually
+        endDate: discardedEndDate, // get this outta here
         createdVia,
         ...fields
       } = goal;
@@ -1417,7 +1428,7 @@ export async function saveGoalsForReport(goals, report) {
       const { goalTemplateId } = existingGoals[0];
 
       await Promise.all(existingGoals.map(async (existingGoal) => {
-        await existingGoal.update({ status, ...fields }, { individualHooks: true });
+        await existingGoal.update({ status, endDate, ...fields }, { individualHooks: true });
         // eslint-disable-next-line max-len
         const existingGoalObjectives = await createObjectivesForGoal(existingGoal, objectives, report);
         currentObjectives = [...currentObjectives, ...existingGoalObjectives];
@@ -1445,7 +1456,9 @@ export async function saveGoalsForReport(goals, report) {
           defaults: { ...fields, status },
         });
 
-        await newGoal.update({ ...fields, status, createdVia: createdVia || 'activityReport' }, { individualHooks: true });
+        await newGoal.update({
+          ...fields, status, endDate, createdVia: createdVia || 'activityReport',
+        }, { individualHooks: true });
 
         await cacheGoalMetadata(newGoal, report.id);
 

--- a/src/services/objectives.js
+++ b/src/services/objectives.js
@@ -17,14 +17,8 @@ export async function saveObjectivesForReport(objectives, report) {
   const updatedObjectives = await Promise.all(objectives.map(async (objective) => Promise
     .all(objective.recipientIds.map(async (otherEntityId) => {
       const {
-        roles: roleNames, topics, files, resources,
+        roles, topics, files, resources,
       } = objective;
-
-      const roles = await Role.findAll({
-        where: {
-          fullName: roleNames,
-        },
-      });
 
       // Determine if this objective already exists.
       let existingObjective;

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { uniqBy } from 'lodash';
+import { uniq, uniqBy } from 'lodash';
 import moment from 'moment';
 import {
   Grant,
@@ -381,7 +381,7 @@ export async function getGoalsByActivityRecipient(
       existingGoal.goalNumbers = [...existingGoal.goalNumbers, current.goalNumber];
       existingGoal.objectives = reduceObjectives(current, existingGoal);
       existingGoal.objectiveCount = existingGoal.objectives.length;
-
+      existingGoal.grantNumbers = uniq([...existingGoal.grantNumbers, current.grant.number]);
       return {
         goalRows: previous.goalRows,
       };
@@ -399,6 +399,7 @@ export async function getGoalsByActivityRecipient(
       reasons: [],
       previousStatus: calculatePreviousStatus(current),
       objectives: [],
+      grantNumbers: [current.grant.number],
     };
 
     goalToAdd.objectives = reduceObjectives(current, goalToAdd);


### PR DESCRIPTION
## Description of change
Solve issues with incomplete goals not saving properly when the autosave is triggered. 
Also cleanup error message on success, so that the "you had a database error" does not persist.
Change 'you' to 'recipient' on next steps for recipient date label 

Make changes to print preview for approved AR's
- 'Activity Summary' should be sentence case
- Remove user first initial from print preview
- Bold the Objective name
- Fix "if Next Steps has two steps the second step is missing the Date (check for both specialist and recipient)"
- Prevent splitting at header onto next page 

Make changes to Print Preview for Goals

- Remove user first initial from print
- Prevent splitting at header (as above)
- The fields 'Activity Report' and 'Grant Numbers' are blank. Removed grant numbers from objectives.
- Update Objective title and break (spacing)

## How to test
Test activity report auto-saving at each step of the process for the create goals form (no goal, goal with no title, goal with  no date, and so forth for objectives)

Check that the visual bugs above are resolved

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1029


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
