### PR TITLE
Only show specialist roles when creating an objective from RTR

### DIFF
--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -195,7 +195,7 @@ export default function GoalForm({
   useEffect(() => {
     async function fetchRoles() {
       try {
-        const roles = await getRoles();
+        const roles = await getRoles(true);
         setRoleOptions(roles);
       } catch (err) {
         setFetchError('There was an error loading roles');

--- a/frontend/src/fetchers/roles.js
+++ b/frontend/src/fetchers/roles.js
@@ -2,7 +2,7 @@
 import join from 'url-join';
 import { get } from './index';
 
-export const getRoles = async () => {
-  const roles = await get((join('/', 'api', 'role')));
+export const getRoles = async (onlySpecialist = false) => {
+  const roles = await get((join('/', 'api', 'role', `?onlySpecialist=${onlySpecialist}`)));
   return roles.json();
 };

--- a/src/routes/roles/handlers.js
+++ b/src/routes/roles/handlers.js
@@ -2,6 +2,7 @@ import { getAllRoles } from '../../services/roles';
 
 /* eslint-disable import/prefer-default-export */
 export async function allRoles(req, res) {
-  const topics = await getAllRoles();
+  const { onlySpecialist } = req.query;
+  const topics = await getAllRoles(onlySpecialist);
   res.json(topics);
 }

--- a/src/services/roles.js
+++ b/src/services/roles.js
@@ -1,8 +1,17 @@
+import { Op } from 'sequelize';
 import { Role } from '../models';
 
 /* eslint-disable import/prefer-default-export */
-export async function getAllRoles() {
+export async function getAllRoles(onlySpecialistRoles = false) {
+  let where = { deletedAt: { [Op.eq]: null } };
+  if (onlySpecialistRoles) {
+    where = {
+      ...where,
+      isSpecialist: true,
+    };
+  }
   return Role.findAll({
     raw: true,
+    where,
   });
 }

--- a/src/services/roles.test.js
+++ b/src/services/roles.test.js
@@ -1,0 +1,52 @@
+import db, { Role } from '../models';
+import {
+  getAllRoles,
+} from './roles';
+
+describe('roles service', () => {
+  afterAll(async () => {
+    await db.sequelize.close();
+  });
+
+  let nonSpecialistRole1;
+  let nonSpecialistRole2;
+  let specialistRole1;
+
+  describe('retrieveRoles', () => {
+    beforeAll(async () => {
+      [nonSpecialistRole1] = await Role.findOrCreate({
+        where: { name: 'Non Specialist Role 1' }, defaults: { isSpecialist: false },
+      });
+      [nonSpecialistRole2] = await Role.findOrCreate({
+        where: { name: 'Non Specialist Role 2' }, defaults: { isSpecialist: false },
+      });
+      [specialistRole1] = await Role.findOrCreate({
+        where: { name: 'Specialist Role 1' }, defaults: { isSpecialist: true },
+      });
+    });
+
+    afterAll(async () => {
+      const rolesToDelete = [
+        nonSpecialistRole1.id,
+        nonSpecialistRole2.id,
+        specialistRole1.id,
+      ];
+      await Role.destroy({
+        where: {
+          id: rolesToDelete,
+        },
+      });
+    });
+
+    it('Retrives all roles', async () => {
+      const allRoles = await getAllRoles();
+      const filteredRoles = allRoles.filter((r) => r.name !== 'NC' && r.name !== 'CSC');
+      expect(filteredRoles.length).toBe(3);
+    });
+
+    it('retrieves only specialist roles', async () => {
+      const allRoles = await getAllRoles(true);
+      expect(allRoles.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description of change

Only show specialist roles when creating an objective from RTR.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
