### PR TITLE
[TTAHUB-1029] Fix bugs reported on ar redesign/create goals

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -190,7 +190,7 @@ ObjectiveFiles.propTypes = {
   })),
   onChangeFiles: PropTypes.func.isRequired,
   goalStatus: PropTypes.string.isRequired,
-  isOnReport: PropTypes.bool.isRequired,
+  isOnReport: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]).isRequired,
   status: PropTypes.string.isRequired,
   onUploadFiles: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,

--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -120,7 +120,10 @@ ObjectiveTopics.propTypes = {
   inputName: PropTypes.string,
   isLoading: PropTypes.bool,
   goalStatus: PropTypes.string.isRequired,
-  isOnReport: PropTypes.bool.isRequired,
+  isOnReport: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+  ]).isRequired,
 };
 
 ObjectiveTopics.defaultProps = {

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -147,7 +147,10 @@ ResourceRepeater.propTypes = {
   error: PropTypes.node.isRequired,
   validateResources: PropTypes.func.isRequired,
   status: PropTypes.string.isRequired,
-  isOnReport: PropTypes.bool.isRequired,
+  isOnReport: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+  ]).isRequired,
   isLoading: PropTypes.bool,
   goalStatus: PropTypes.string.isRequired,
 };

--- a/frontend/src/components/GoalForm/SpecialistRole.js
+++ b/frontend/src/components/GoalForm/SpecialistRole.js
@@ -118,7 +118,10 @@ SpecialistRole.propTypes = {
     value: PropTypes.string,
   })).isRequired,
   goalStatus: PropTypes.string.isRequired,
-  isOnReport: PropTypes.bool.isRequired,
+  isOnReport: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+  ]).isRequired,
 };
 
 SpecialistRole.defaultProps = {

--- a/frontend/src/components/HeaderUserMenu.js
+++ b/frontend/src/components/HeaderUserMenu.js
@@ -142,6 +142,7 @@ function HeaderUserMenu() {
       buttonText={user.name}
       showApplyButton={false}
       direction="left"
+      className="no-print"
     >
       <div className="user-menu-dropdown" data-testid="user-menu-dropdown">
         <h4 className="margin-0 display-flex flex-align-center padding-2 border-bottom border-gray-10">

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -173,12 +173,12 @@ export default function GoalForm({
 
 GoalForm.propTypes = {
   goal: PropTypes.shape({
-    goalIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+    goalIds: PropTypes.arrayOf(PropTypes.number),
     value: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
     ]),
-    oldGrantIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+    oldGrantIds: PropTypes.arrayOf(PropTypes.number),
     label: PropTypes.string,
     name: PropTypes.string,
     endDate: PropTypes.string,

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -173,12 +173,6 @@ export default function GoalForm({
 
 GoalForm.propTypes = {
   goal: PropTypes.shape({
-    id: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.shape({
-        value: PropTypes.number,
-        label: PropTypes.string,
-      })), PropTypes.string,
-    ]).isRequired,
     goalIds: PropTypes.arrayOf(PropTypes.number).isRequired,
     value: PropTypes.oneOfType([
       PropTypes.number,
@@ -196,8 +190,11 @@ GoalForm.propTypes = {
     value: PropTypes.number,
     label: PropTypes.string,
   })).isRequired,
-  roles: PropTypes.arrayOf(PropTypes.string).isRequired,
-  reportId: PropTypes.number.isRequired,
+  roles: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    fullName: PropTypes.string,
+  })).isRequired,
+  reportId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   onSaveDraft: PropTypes.func.isRequired,
   datePickerKey: PropTypes.string.isRequired,
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.js
@@ -173,7 +173,10 @@ GoalPicker.propTypes = {
       value: PropTypes.number,
     }),
   ).isRequired,
-  roles: PropTypes.arrayOf(PropTypes.string).isRequired,
+  roles: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    fullName: PropTypes.string,
+  })).isRequired,
   reportId: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -94,6 +94,10 @@ export default function NextStepsRepeater({
 
   const stepType = name === 'specialistNextSteps' ? 'specialist' : 'recipient';
 
+  const dateLabel = (index) => (stepType === 'recipient'
+    ? `When does the recipient anticipate completing step ${index + 1}?`
+    : `When do you anticipate completing step ${index + 1}?`);
+
   return (
     <>
       <div className="ttahub-next-steps-repeater">
@@ -159,7 +163,7 @@ export default function NextStepsRepeater({
               <Label
                 htmlFor={`${stepType}-next-step-date-${index + 1}`}
               >
-                {`When do you anticipate completing step ${index + 1}?`}
+                {dateLabel(index)}
                 <span className="smart-hub--form-required font-family-sans font-ui-xs text-secondary-dark">
                   {' '}
                   *

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -260,7 +260,7 @@ export default function Objective({
         inputName={objectiveRolesInputName}
         validateSpecialistRole={onBlurRoles}
         roleOptions={roleOptions}
-        goalStatus={parentGoal.status}
+        goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
       />
       <ObjectiveTopics
         error={errors.topics
@@ -275,7 +275,7 @@ export default function Objective({
         onChangeTopics={onChangeTopics}
         inputName={objectiveTopicsInputName}
         status={objectiveStatus}
-        goalStatus={parentGoal.status}
+        goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
       />
       <ResourceRepeater
         resources={isOnApprovedReport ? [] : resourcesForRepeater}
@@ -288,7 +288,7 @@ export default function Objective({
         savedResources={savedResources}
         status={objectiveStatus}
         inputName={objectiveResourcesInputName}
-        goalStatus={parentGoal.status}
+        goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
       />
       <ObjectiveFiles
         objective={objective}
@@ -301,7 +301,7 @@ export default function Objective({
         onBlur={onBlurFiles}
         inputName={objectiveFilesInputName}
         reportId={reportId}
-        goalStatus={parentGoal.status}
+        goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
       />
       <ObjectiveTta
         ttaProvided={objectiveTta}

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { uniqBy } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import {
   useController, useFormContext,
@@ -33,7 +34,7 @@ export default function Objective({
   remove,
   fieldArrayName,
   errors,
-  roles,
+  roleOptions,
   onObjectiveChange,
   onSaveDraft,
   parentGoal,
@@ -114,9 +115,7 @@ export default function Objective({
     defaultValue: objective.files || [],
   });
 
-  const defaultRoles = useMemo(() => (
-    roles.length === 1 ? roles : objective.roles
-  ), [objective.roles, roles]);
+  const defaultRoles = uniqBy([...roleOptions, ...objective.roles], 'id').length === 1 ? roleOptions : objective.roles;
 
   const {
     field: {
@@ -260,7 +259,8 @@ export default function Objective({
         selectedRoles={objectiveRoles}
         inputName={objectiveRolesInputName}
         validateSpecialistRole={onBlurRoles}
-        roleOptions={roles}
+        roleOptions={roleOptions}
+        goalStatus={parentGoal.status}
       />
       <ObjectiveTopics
         error={errors.topics
@@ -275,6 +275,7 @@ export default function Objective({
         onChangeTopics={onChangeTopics}
         inputName={objectiveTopicsInputName}
         status={objectiveStatus}
+        goalStatus={parentGoal.status}
       />
       <ResourceRepeater
         resources={isOnApprovedReport ? [] : resourcesForRepeater}
@@ -287,6 +288,7 @@ export default function Objective({
         savedResources={savedResources}
         status={objectiveStatus}
         inputName={objectiveResourcesInputName}
+        goalStatus={parentGoal.status}
       />
       <ObjectiveFiles
         objective={objective}
@@ -299,6 +301,7 @@ export default function Objective({
         onBlur={onBlurFiles}
         inputName={objectiveFilesInputName}
         reportId={reportId}
+        goalStatus={parentGoal.status}
       />
       <ObjectiveTta
         ttaProvided={objectiveTta}
@@ -350,7 +353,10 @@ Objective.propTypes = {
   ).isRequired,
   remove: PropTypes.func.isRequired,
   fieldArrayName: PropTypes.string.isRequired,
-  roles: PropTypes.arrayOf(PropTypes.string).isRequired,
+  roleOptions: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    fullName: PropTypes.string,
+  })).isRequired,
   onObjectiveChange: PropTypes.func.isRequired,
   onSaveDraft: PropTypes.func.isRequired,
   parentGoal: PropTypes.shape({

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveSelect.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveSelect.js
@@ -5,15 +5,8 @@ import { Label, ModalToggleButton } from '@trussworks/react-uswds';
 import Req from '../../../../components/Req';
 import selectOptionsReset from '../../../../components/selectOptionsReset';
 import { OBJECTIVE_PROP } from './constants';
-import Option from './ObjectiveOption';
-import SingleValue from './ObjectiveValue';
 import './ObjectiveSelect.css';
 import Modal from '../../../../components/Modal';
-
-const components = {
-  Option,
-  SingleValue,
-};
 
 export default function ObjectiveSelect({
   onChange,
@@ -52,7 +45,6 @@ export default function ObjectiveSelect({
           styles={selectOptionsReset}
           placeholder="- Select -"
           value={selectedObjectives}
-          components={components}
         />
       </Label>
 

--- a/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objectives.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { uniqBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { useFieldArray, useFormContext } from 'react-hook-form/dist/index.ie11';
 import Objective from './Objective';
@@ -19,6 +20,8 @@ export default function Objectives({
   const fieldArrayName = 'goalForEditing.objectives';
   const objectivesForGoal = getValues(fieldArrayName);
   const defaultValues = objectivesForGoal || [];
+
+  const [roleOptions, setRoleOptions] = useState(roles);
 
   /**
    * we can use the useFieldArray hook from react hook form to
@@ -56,13 +59,19 @@ export default function Objectives({
   };
 
   const onInitialObjSelect = (objective) => {
-    const defaultRoles = roles.length === 1 ? roles : objective.roles;
+    const defaultRoles = uniqBy([
+      ...roles,
+      ...objective.roles,
+    ], 'id');
+
     append({
       ...objective, roles: defaultRoles,
     });
 
     // If fields have changed get updated list of used Objective ID's.
     setUpdatedUsedObjectiveIds();
+
+    setRoleOptions(defaultRoles);
   };
 
   const onObjectiveChange = (objective, index) => {
@@ -132,7 +141,7 @@ export default function Objectives({
               errors={objectiveErrors}
               remove={removeObjective}
               fieldArrayName={fieldArrayName}
-              roles={roles}
+              roleOptions={roleOptions}
               onObjectiveChange={onObjectiveChange}
               onSaveDraft={onSaveDraft}
               parentGoal={getValues('goalForEditing')}
@@ -154,7 +163,10 @@ Objectives.propTypes = {
   objectives: PropTypes.arrayOf(
     OBJECTIVE_PROP,
   ).isRequired,
-  roles: PropTypes.arrayOf(PropTypes.string).isRequired,
+  roles: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    fullName: PropTypes.string,
+  })).isRequired,
   noObjectiveError: PropTypes.node.isRequired,
   onSaveDraft: PropTypes.func.isRequired,
   reportId: PropTypes.number.isRequired,

--- a/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
@@ -80,7 +80,7 @@ export default function OtherEntity({
             errors={objectiveErrors}
             remove={remove}
             fieldArrayName={OBJECTIVE_LABEL}
-            roles={roles}
+            roleOptions={roles}
             onSaveDraft={onSaveDraft}
             reportId={parseInt(reportId, DECIMAL_BASE)}
           />

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
@@ -55,8 +55,13 @@ const RenderObjective = ({
         goalIndex={0}
         objectiveIndex={0}
         status="In progress"
-        roles={['Central office']}
+        roleOptions={[{ fullName: 'Central office', id: 1234 }]}
         errors={{}}
+        onObjectiveChange={jest.fn()}
+        onSaveDraft={jest.fn()}
+        parentGoal={{ status: 'In Progress' }}
+        initialObjectiveStatus="Not Started"
+        reportId={98123}
       />
     </FormProvider>
   );

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
@@ -17,6 +17,7 @@ const RenderObjectives = ({ objectiveOptions, goalId = 12, collaborators = [] })
     goalForEditing = {
       id: goalId,
       objectives: [],
+      status: 'Not Started',
     };
   }
 
@@ -30,6 +31,10 @@ const RenderObjectives = ({ objectiveOptions, goalId = 12, collaborators = [] })
       goalForEditing,
     },
   });
+
+  const { setValue } = hookForm;
+
+  setValue('goalForEditing', goalForEditing);
 
   const topicOptions = [
     {
@@ -48,10 +53,12 @@ const RenderObjectives = ({ objectiveOptions, goalId = 12, collaborators = [] })
       <Objectives
         objectives={objectiveOptions}
         topicOptions={topicOptions}
-        roles={['Central office']}
+        roles={[{ fullName: 'Central office', id: 1 }]}
         goalId={goalId}
         noObjectiveError={<></>}
         goalStatus="In Progress"
+        reportId={12}
+        onSaveDraft={jest.fn()}
       />
       <button type="button">blur me</button>
     </FormProvider>

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/OtherEntity.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/OtherEntity.js
@@ -8,7 +8,7 @@ import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
 import OtherEntity from '../OtherEntity';
 
 // eslint-disable-next-line react/prop-types
-const RenderOtherEntity = ({ objectivesWithoutGoals, roles = ['Central Office'] }) => {
+const RenderOtherEntity = ({ objectivesWithoutGoals, roles = [{ id: 1, fullName: 'Central Office' }] }) => {
   const hookForm = useForm({
     mode: 'onChange',
     defaultValues: {
@@ -18,7 +18,7 @@ const RenderOtherEntity = ({ objectivesWithoutGoals, roles = ['Central Office'] 
 
   return (
     <FormProvider {...hookForm}>
-      <OtherEntity roles={roles} />
+      <OtherEntity roles={roles} recipientIds={[]} onSaveDraft={jest.fn()} reportId="123" />
     </FormProvider>
   );
 };
@@ -48,7 +48,7 @@ describe('OtherEntity', () => {
     fetchMock.get('/api/topic', []);
   });
   it('renders created objectives', async () => {
-    render(<RenderOtherEntity objectivesWithoutGoals={objectives} />);
+    render(<RenderOtherEntity objectivesWithoutGoals={objectives} roles={[]} />);
 
     const title = await screen.findByText('title', { selector: 'textarea' });
     expect(title).toBeVisible();
@@ -61,7 +61,7 @@ describe('OtherEntity', () => {
   });
 
   it('the button adds a new objective', async () => {
-    render(<RenderOtherEntity objectivesWithoutGoals={[]} />);
+    render(<RenderOtherEntity objectivesWithoutGoals={[]} roles={[]} />);
     const button = await screen.findByRole('button', { name: /Add new objective/i });
     userEvent.click(button);
     expect(screen.queryAllByText(/objective status/i).length).toBe(1);

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -301,7 +301,7 @@ const GoalsObjectives = ({
 };
 
 GoalsObjectives.propTypes = {
-  reportId: PropTypes.number.isRequired,
+  reportId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   onSaveDraftOetObjectives: PropTypes.func.isRequired,
   onSaveDraftGoal: PropTypes.func.isRequired,
 };

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.js
@@ -10,7 +10,7 @@ export default function ApprovedReportSection({
   className,
 }) {
   return (
-    <div className={className}>
+    <div className={`ttahub-approved-report-section-container ${className}`}>
       <h2 className="font-serif-xl margin-y-3">{title}</h2>
       {sections.map((section) => {
         const subheadings = Object.keys(section.data);

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
@@ -16,6 +16,10 @@
   padding: 0;
 }
 
+.ttahub-approved-report-section div[id^="rdw-wrapper-tta-objective"]{
+  font-weight: bold;
+}
+
 @media screen {
   .ttahub-approved-report-section__striped {
     background-color: $gray-two;
@@ -28,6 +32,13 @@
   .ttahub-approved-report-section {
     padding: 0;
     margin-bottom: 2rem;
+    page-break-inside: avoid;
+  }
+  .ttahub-activity-report-view {
+    margin-top: 0;
+  }
+  .ttahub-activity-report-view > div.padding-x-5.padding-y-5 {
+    padding-top: 0;
   }
 }
 

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -11,16 +11,14 @@ import {
 } from '../helpers';
 
 function formatNextSteps(nextSteps, heading, striped) {
-  const data = nextSteps.reduce((acc, step, index) => ({
-    ...acc,
-    [`Step ${index + 1}`]: step.note,
-    'Anticipated completion': step.completeDate,
-  }), {});
-  return {
-    heading,
-    data,
+  return nextSteps.map((step, index) => ({
+    heading: index === 0 ? heading : '',
+    data: {
+      [`Step ${index + 1}`]: step.note,
+      'Anticipated completion': step.completeDate,
+    },
     striped,
-  };
+  }));
 }
 
 function formatObjectiveLinks(resources) {
@@ -215,7 +213,7 @@ export default function ApprovedReportV2({ data }) {
 
       <ApprovedReportSection
         key={`activity-summary-${reportId}`}
-        title="Activity Summary"
+        title="Activity summary"
         sections={[
           {
             heading: 'Who was the activity for?',
@@ -293,8 +291,8 @@ export default function ApprovedReportV2({ data }) {
         key={`next-steps${reportId}`}
         title="Next steps"
         sections={[
-          specialistNextSteps,
-          recipientNextSteps,
+          ...specialistNextSteps,
+          ...recipientNextSteps,
         ]}
       />
 

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
@@ -28,7 +28,8 @@ describe('PrintGoals', () => {
       goalText: 'This is goal text 1.',
       goalTopics: ['Human Resources', 'Safety Practices', 'Program Planning and Services'],
       objectiveCount: 5,
-      goalNumber: 'G-4598',
+      goalNumbers: ['G-4598'],
+      grantNumbers: ['Rattaché au programme'], // copilot came up with this, I hope its not profane
       reasons: ['Monitoring | Deficiency', 'Monitoring | Noncompliance'],
       objectives: [],
     },
@@ -39,7 +40,8 @@ describe('PrintGoals', () => {
       goalText: 'This is goal text 2.',
       goalTopics: ['Human Resources', 'Safety Practices'],
       objectiveCount: 5,
-      goalNumber: 'G-4598',
+      goalNumbers: ['G-4598'],
+      grantNumbers: ['Rattaché au programme'],
       reasons: ['Monitoring | Deficiency', 'Monitoring | Noncompliance'],
       objectives: [
         {
@@ -49,6 +51,18 @@ describe('PrintGoals', () => {
           endDate: '01/01/02',
           reasons: ['Empathy', 'Generosity', 'Friendship'],
           status: 'Complete',
+          activityReports: [
+            {
+              id: 1,
+              displayId: '1234',
+              legacyId: null,
+            },
+            {
+              id: 2,
+              displayId: '1234',
+              legacyId: 'r-1234',
+            },
+          ],
         },
       ],
     },

--- a/frontend/src/pages/RecipientRecord/pages/components/PrintableGoal.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/PrintableGoal.js
@@ -10,11 +10,11 @@ export default function PrintableGoal({ goal }) {
   const { icon } = STATUSES[key] ? STATUSES[key] : STATUSES['Needs Status'];
 
   return (
-    <div className="ttahub-printable-goal padding-x-3 padding-top-3 padding-bottom-2 margin-top-5">
+    <div className="ttahub-printable-goal padding-x-3 padding-top-3 padding-bottom-2 margin-top-5 no-break-within">
       <h2 className="margin-top-0 padding-bottom-1 border-bottom-1px">
         Goal
         {' '}
-        {goal.goalNumber}
+        {goal.goalNumbers.join(', ')}
       </h2>
       <div className={ROW_CLASS}>
         <p className={FIRST_COLUMN_CLASS}>Goal status</p>
@@ -25,7 +25,7 @@ export default function PrintableGoal({ goal }) {
       </div>
       <div className={ROW_CLASS}>
         <p className={FIRST_COLUMN_CLASS}>Grant numbers</p>
-        <p className={SECOND_COLUMN_CLASS}>{goal.grantNumber}</p>
+        <p className={SECOND_COLUMN_CLASS}>{goal.grantNumbers.join(', ')}</p>
       </div>
       <div className={ROW_CLASS}>
         <p className={FIRST_COLUMN_CLASS}>Recipient&apos;s goal</p>
@@ -35,6 +35,13 @@ export default function PrintableGoal({ goal }) {
         <p className={FIRST_COLUMN_CLASS}>Topics</p>
         <List className={SECOND_COLUMN_CLASS} list={goal.goalTopics} />
       </div>
+      { goal.objectives.length > 0 ? (
+        <h3 className="padding-x-1">
+          Objectives for goal
+          {' '}
+          {goal.goalNumbers.join(', ')}
+        </h3>
+      ) : null }
       {goal.objectives.map(((objective) => (
         <PrintableObjective
           key={objective.id}
@@ -47,9 +54,9 @@ export default function PrintableGoal({ goal }) {
 
 PrintableGoal.propTypes = {
   goal: PropTypes.shape({
-    goalNumber: PropTypes.string,
+    goalNumbers: PropTypes.arrayOf(PropTypes.string),
     goalStatus: PropTypes.string,
-    grantNumber: PropTypes.string,
+    grantNumbers: PropTypes.arrayOf(PropTypes.string),
     goalText: PropTypes.string,
     goalTopics: PropTypes.arrayOf(PropTypes.string),
     objectives: PropTypes.arrayOf(PropTypes.shape({})),

--- a/frontend/src/pages/RecipientRecord/pages/components/PrintableObjective.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/PrintableObjective.js
@@ -4,25 +4,43 @@ import { ROW_CLASS, FIRST_COLUMN_CLASS, SECOND_COLUMN_CLASS } from './constants'
 import { STATUSES } from '../../../../components/GoalCards/components/StatusDropdown';
 import List from './List';
 
+const ActivityReports = ({ reports }) => (
+  <ul className="usa-list usa-list--unstyled">
+    {reports.map((report) => {
+      const link = report.legacyId ? `/activity-reports/legacy/${report.legacyId}` : `/activity-reports/view/${report.id}`;
+      return (
+        <li key={report.id}>
+          <a href={link}>
+            {report.displayId}
+          </a>
+        </li>
+      );
+    })}
+  </ul>
+);
+
+ActivityReports.propTypes = {
+  reports: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    displayId: PropTypes.string,
+  })).isRequired,
+};
 export default function PrintableObjective({ objective }) {
   const key = objective.status || 'Needs Status';
   const { icon } = STATUSES[key] ? STATUSES[key] : STATUSES['Needs Status'];
 
   const rowClass = `ttahub-printable-objective ${ROW_CLASS}`;
-
   return (
-    <div className="margin-bottom-1 margin-top-2">
+    <div className="margin-bottom-1 margin-top-3">
       <div className={rowClass}>
         <p className={FIRST_COLUMN_CLASS}>Objective</p>
         <p className={SECOND_COLUMN_CLASS}>{objective.title}</p>
       </div>
       <div className={rowClass}>
         <p className={FIRST_COLUMN_CLASS}>Activity reports</p>
-        <p className={SECOND_COLUMN_CLASS}>{objective.arId}</p>
-      </div>
-      <div className={rowClass}>
-        <p className={FIRST_COLUMN_CLASS}>Grant numbers</p>
-        <p className={SECOND_COLUMN_CLASS}>{objective.grantNumber}</p>
+        <p className={SECOND_COLUMN_CLASS}>
+          <ActivityReports reports={objective.activityReports} />
+        </p>
       </div>
       <div className={rowClass}>
         <p className={FIRST_COLUMN_CLASS}>End date</p>
@@ -46,7 +64,10 @@ export default function PrintableObjective({ objective }) {
 PrintableObjective.propTypes = {
   objective: PropTypes.shape({
     title: PropTypes.string,
-    arId: PropTypes.number,
+    activityReports: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      displayId: PropTypes.string,
+    })),
     grantNumber: PropTypes.string,
     endDate: PropTypes.string,
     reasons: PropTypes.arrayOf(PropTypes.string),

--- a/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableGoal.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableGoal.js
@@ -12,9 +12,9 @@ describe('PrintableGoal', () => {
   it('will display a goal with an uncertain status', async () => {
     const goal = {
       goalStatus: 'Uncertain',
-      goalNumber: '2',
+      goalNumbers: ['2'],
       goalText: 'asdfasdf',
-      grantNumber: '3',
+      grantNumbers: ['3'],
       goalTopics: ['Topic'],
       objectives: [],
     };
@@ -24,9 +24,9 @@ describe('PrintableGoal', () => {
 
   it('will display a goal with no status', async () => {
     const goal = {
-      goalNumber: '2',
+      goalNumbers: ['2'],
       goalText: 'asdfasdf',
-      grantNumber: '3',
+      grantNumbers: ['3'],
       goalTopics: ['Topic'],
       objectives: [],
     };

--- a/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableObjective.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/__tests__/PrintableObjective.js
@@ -19,6 +19,7 @@ describe('PrintableObjective', () => {
       grantNumber: '3',
       endDate: '2020-01-01',
       reasons: [],
+      activityReports: [],
     };
     renderPrintableObjective(objective);
     expect(await screen.findByText('Uncertain')).toBeInTheDocument();
@@ -31,6 +32,7 @@ describe('PrintableObjective', () => {
       grantNumber: '3',
       endDate: '2020-01-01',
       reasons: [],
+      activityReports: [],
     };
     renderPrintableObjective(objective);
     expect(await screen.findByText(/Needs Status/i)).toBeInTheDocument();

--- a/frontend/src/pages/RecipientRecord/pages/components/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/constants.js
@@ -1,3 +1,3 @@
-export const ROW_CLASS = 'display-flex padding-1 no-break-within';
+export const ROW_CLASS = 'display-flex padding-1';
 export const FIRST_COLUMN_CLASS = 'text-bold width-card-lg margin-0';
 export const SECOND_COLUMN_CLASS = 'flex-1 margin-0';

--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -687,6 +687,8 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[1].objectiveCount).toBe(2);
       expect(goalRowsx[1].reasons).toEqual(['COVID-19 response', 'Complaint']);
       expect(goalRowsx[1].goalTopics).toEqual(['Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
+      expect(goalRowsx[1].grantNumbers.length).toBe(1);
+      expect(goalRowsx[1].grantNumbers[0]).toBe('12345');
 
       // Goal 3 Objectives.
       expect(goalRowsx[1].objectives.length).toBe(2);

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -316,9 +316,6 @@ export async function getGoalsByActivityRecipient(
         model: Objective,
         as: 'objectives',
         required: false,
-        where: {
-          onApprovedAR: true,
-        },
         include: [
           {
             model: Topic,
@@ -337,7 +334,7 @@ export async function getGoalsByActivityRecipient(
             ],
             model: ActivityReport,
             as: 'activityReports',
-            required: true,
+            required: false,
             where: {
               calculatedStatus: REPORT_STATUSES.APPROVED,
             },

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { uniqBy } from 'lodash';
+import { uniq, uniqBy } from 'lodash';
 import moment from 'moment';
 import {
   Grant,
@@ -381,7 +381,7 @@ export async function getGoalsByActivityRecipient(
       existingGoal.goalNumbers = [...existingGoal.goalNumbers, current.goalNumber];
       existingGoal.objectives = reduceObjectives(current, existingGoal);
       existingGoal.objectiveCount = existingGoal.objectives.length;
-
+      existingGoal.grantNumbers = uniq([...existingGoal.grantNumbers, current.grant.number]);
       return {
         goalRows: previous.goalRows,
       };
@@ -399,6 +399,7 @@ export async function getGoalsByActivityRecipient(
       reasons: [],
       previousStatus: calculatePreviousStatus(current),
       objectives: [],
+      grantNumbers: [current.grant.number],
     };
 
     goalToAdd.objectives = reduceObjectives(current, goalToAdd);


### PR DESCRIPTION
## Description of change
- Removed the objective ID from the dropdown, as it "...was never in the design and most likely will have no value to the user"
- Include objectives that aren't on approved reports (fixes the bug described as: When creating goal (G-37481) for the first time, it had 3 topics and 1 objective, but after submitting goal, and going back to the goal table, objective and topics did not display)
- Objectives on the AR load more roles than the collaborator/creator roles; it also loads the roles selected on the RTR. (fixes: "In AR form, Specialist roles is defaulting to Central Office - when a different role was added via Create Goal form in RTR") 

## How to test

Review the three bugs above and confirm that they are fixed.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1029


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
