### PR TITLE
[TTAHUB-854] add auto expand functionality to text areas

### DIFF
--- a/frontend/src/components/AutomaticResizingTextarea.js
+++ b/frontend/src/components/AutomaticResizingTextarea.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Textarea,
+} from '@trussworks/react-uswds';
+
+const DEFAULT_TEXTAREA_HEIGHT = 160;
+
+export default function AutomaticResizingTextarea({
+  onUpdateText, onBlur, inputName, disabled, value,
+}) {
+  const [height, setHeight] = useState(`${DEFAULT_TEXTAREA_HEIGHT}px`);
+  const onChange = (e) => {
+    if (e.target && e.target.scrollHeight && e.target.scrollHeight > DEFAULT_TEXTAREA_HEIGHT) {
+      setHeight(`${e.target.scrollHeight}px`);
+    }
+    onUpdateText(e);
+  };
+
+  return (
+    <Textarea
+      onBlur={onBlur}
+      id={inputName}
+      name={inputName}
+      value={value}
+      onChange={onChange}
+      required
+      disabled={disabled}
+      style={{ height }}
+    />
+  );
+}
+
+AutomaticResizingTextarea.propTypes = {
+  onUpdateText: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  inputName: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  value: PropTypes.string.isRequired,
+};
+
+AutomaticResizingTextarea.defaultProps = {
+  disabled: false,
+};

--- a/frontend/src/components/GoalForm/GoalText.js
+++ b/frontend/src/components/GoalForm/GoalText.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  FormGroup, Label, Textarea,
+  FormGroup, Label,
 } from '@trussworks/react-uswds';
+import AutomaticResizingTextarea from '../AutomaticResizingTextarea';
 
 export default function GoalText({
   error,
@@ -26,16 +27,14 @@ export default function GoalText({
       ) : (
         <>
           {error}
-          <Textarea
+          <AutomaticResizingTextarea
+            onUpdateText={onUpdateText}
             onBlur={() => {
               validateGoalName();
             }}
-            id={inputName}
-            name={inputName}
-            value={goalName}
-            onChange={onUpdateText}
-            required
+            inputName={inputName}
             disabled={isLoading}
+            value={goalName}
           />
         </>
       )}

--- a/frontend/src/components/GoalForm/ObjectiveTitle.js
+++ b/frontend/src/components/GoalForm/ObjectiveTitle.js
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
-  FormGroup, Label, Textarea,
+  FormGroup, Label,
 } from '@trussworks/react-uswds';
+import AutomaticResizingTextarea from '../AutomaticResizingTextarea';
 
 export default function ObjectiveTitle({
   error,
@@ -35,14 +36,12 @@ export default function ObjectiveTitle({
       ) : (
         <>
           {error}
-          <Textarea
-            id={inputName}
-            name={inputName}
-            value={title}
-            onChange={onChangeTitle}
+          <AutomaticResizingTextarea
+            onUpdateText={onChangeTitle}
             onBlur={validateObjectiveTitle}
-            required
+            inputName={inputName}
             disabled={isLoading}
+            value={title}
           />
         </>
       )}

--- a/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ObjectiveTitle.js
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
-  FormGroup, Label, Textarea,
+  FormGroup, Label,
 } from '@trussworks/react-uswds';
+import AutomaticResizingTextarea from '../../../../components/AutomaticResizingTextarea';
 
 export default function ObjectiveTitle({
   error,
@@ -43,15 +44,13 @@ export default function ObjectiveTitle({
       ) : (
         <>
           {error}
-          <Textarea
+          <AutomaticResizingTextarea
             key={inputName}
-            id={inputName}
-            name={inputName}
-            value={title}
-            onChange={onChangeTitle}
+            onUpdateText={onChangeTitle}
             onBlur={validateObjectiveTitle}
-            required
+            inputName={inputName}
             disabled={isLoading}
+            value={title}
           />
         </>
       )}


### PR DESCRIPTION
## Description of change
Some of our text area auto-expanded when large amounts of text is pasted in, some did not. This change adds that functionality to the goal name fields and the objective title fields.

## How to test
Paste a large chunk of text into the objective title and goal name fields. The field will grow. 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-854

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
