### PR TITLE
[TTAHUB-1029] migration proofing for the goals and objectives form

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -41,7 +41,13 @@ export default function Objective({
   initialObjectiveStatus,
   reportId,
 }) {
-  const [selectedObjective, setSelectedObjective] = useState(objective);
+  const initialObjective = (() => ({
+    ...objective,
+    id: objective.id,
+    value: objective.id,
+    label: objective.label || objective.title,
+  }))();
+  const [selectedObjective, setSelectedObjective] = useState(initialObjective);
   const { getValues } = useFormContext();
 
   /**
@@ -229,12 +235,16 @@ export default function Objective({
 
   const onRemove = () => remove(index);
 
+  const objectiveOptions = uniqBy(
+    [...options, selectedObjective], 'id',
+  );
+
   return (
     <>
       <ObjectiveSelect
         onChange={onChangeObjective}
         selectedObjectives={selectedObjective}
-        options={options}
+        options={objectiveOptions}
         onRemove={onRemove}
       />
       <ObjectiveTitle

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -43,8 +43,8 @@ export default function Objective({
 }) {
   const initialObjective = (() => ({
     ...objective,
-    id: objective.id,
-    value: objective.id,
+    id: objective.id || objective.value,
+    value: objective.id || objective.value,
     label: objective.label || objective.title,
   }))();
   const [selectedObjective, setSelectedObjective] = useState(initialObjective);
@@ -235,16 +235,12 @@ export default function Objective({
 
   const onRemove = () => remove(index);
 
-  const objectiveOptions = uniqBy(
-    [...options, selectedObjective], 'id',
-  );
-
   return (
     <>
       <ObjectiveSelect
         onChange={onChangeObjective}
         selectedObjectives={selectedObjective}
-        options={objectiveOptions}
+        options={options}
         onRemove={onRemove}
       />
       <ObjectiveTitle

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -41,10 +41,12 @@ export default function Objective({
   initialObjectiveStatus,
   reportId,
 }) {
+  // the below is a concession to the fact that the objective may
+  // exist pre-migration to the new UI, and might not have complete data
   const initialObjective = (() => ({
     ...objective,
     id: objective.id || objective.value,
-    value: objective.id || objective.value,
+    value: objective.value || objective.id,
     label: objective.label || objective.title,
   }))();
   const [selectedObjective, setSelectedObjective] = useState(initialObjective);

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objectives.js
@@ -86,8 +86,10 @@ describe('Objectives', () => {
       topics: [],
       roles: [],
       status: 'Not Started',
+      id: 3,
     },
     {
+      id: 4,
       value: 4,
       label: 'Test objective 2',
       title: 'Test objective 2',
@@ -126,8 +128,10 @@ describe('Objectives', () => {
       topics: [],
       roles: [],
       status: 'In Progress',
+      id: 3,
     },
     {
+      id: 4,
       value: 4,
       label: 'Test objective 2',
       title: 'Test objective 2',


### PR DESCRIPTION
## Description of change
Added a little bit of code to handle the cost of switching branch to branch. Before this, there was a bug with the goals and objectives form where a pre-migration report would have a missing value in the objective selector. Although the title and TTA provided would be preserved, if a user tried to select something in that selector it would potentially lead to data loss.

## How to test
- Checkout main, make sure DB reflects the schema in main
- Create a draft report, add a goal, objective, and some TTA provided
- Switch to this branch, run the database migrations. Return to the the report and the goals & objectives section. You may have to click edit to reopen the form. The objective selection form field should have a value which matches your objective. All other fields will behave as expected, although you will need to enter additional info to pass the new validation.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1029


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
