### PR TITLE
[TTAHUB-1066] Prevent Approving Report with No Approvers

### DIFF
--- a/src/models/hooks/activityReportApprover.js
+++ b/src/models/hooks/activityReportApprover.js
@@ -8,12 +8,12 @@ const { APPROVER_STATUSES, REPORT_STATUSES } = require('../../constants');
  */
 const calculateReportStatusFromApprovals = (approvals) => {
   const approved = (status) => status === APPROVER_STATUSES.APPROVED;
-  if (approvals.every(approved)) {
+  if (approvals.length && approvals.every(approved)) {
     return REPORT_STATUSES.APPROVED;
   }
 
   const needsAction = (status) => status === APPROVER_STATUSES.NEEDS_ACTION;
-  if (approvals.some(needsAction)) {
+  if (approvals.length && approvals.some(needsAction)) {
     return REPORT_STATUSES.NEEDS_ACTION;
   }
 


### PR DESCRIPTION
## Description of change

This change makes sure we have atleast one approver before setting it to 'approved' status.

Right now this is exposed through a "Race" condition. But it might also prevent any unforeseen slowness issues.

## How to test

To reproduce the issue do the following:

1. Create new report with a handful of recipients and atleast one goal with two objectives (to buy you some time).
2. Set yourself as the approver and click Submit.
3. As soon as you return to the AR landing **immediately** click the report link in the alert.
4. Notice that you do not receive the standard approve report screen.
5. Click the 'Review and Submit' page notice it says 'Approved' in the top right corner.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1066


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
