### PR TITLE
[TTAHUB-1071] Fix Topics Tooltip and Row Spacing

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.scss
+++ b/frontend/src/components/GoalCards/GoalCard.scss
@@ -24,7 +24,7 @@ $max-width-date-column: 50%;
 }
 
 .ttahub-goal-card__goal-topics-tool-tip {
-  display :none;
+  display: none;
 }
 
 .ttahub-goal-card__goal-topics-csv {
@@ -34,14 +34,6 @@ $max-width-date-column: 50%;
 @media(min-width: 627px) {
   .ttahub-goal-card__goal-column:not(:nth-child(n+3):nth-child(-n+5)) {
     margin-bottom: 16px;
-  }
-
-  .ttahub-goal-card__goal-topics-csv {
-    display: block;
-  }
-
-  .ttahub-goal-card__goal-topics-tool-tip {
-    display: none;
   }
 }
 
@@ -60,14 +52,6 @@ $max-width-date-column: 50%;
 
   .ttahub-goal-card__goal-column:not(:nth-child(n+3):nth-child(-n+5)) {
     margin-bottom: 16px;
-  }
-
-  .ttahub-goal-card__goal-topics-tool-tip {
-    display: none;
-  }
-
-  .ttahub-goal-card__goal-topics-csv {
-    display: block;
   }
 
   .ttahub-goal-card__goal-column__goal-text {

--- a/frontend/src/components/GoalCards/GoalCard.scss
+++ b/frontend/src/components/GoalCards/GoalCard.scss
@@ -1,7 +1,7 @@
 @use '../../colors' as *;
 
 $min-width-text-column: 428px;
-$min-width-topics-column: 200px;
+$min-width-topics-column: 220px;
 $min-width-date-column: 140px;
 $max-width-date-column: 50%;
 
@@ -10,6 +10,7 @@ $max-width-date-column: 50%;
 .ttahub-goal-card .smart-hub-tooltip .smart-hub--ellipsis {
   font-size: 1.06rem;
 }
+
 .ttahub-goal-card .smart-hub--menu-button .fa-ellipsis {
   font-size: 1.5rem;
 }
@@ -18,29 +19,83 @@ $max-width-date-column: 50%;
   flex-basis: clamp($min-width-text-column, 100%, 100%);
 }
 
-.ttahub-goal-card__goal-column__goal-topics {
-  flex-basis: clamp($min-width-topics-column, 100%, 100%);
-  text-overflow: ellipsis;
+.ttahub-goal-card__goal-column:not(:last-child) {
+  margin-bottom: 16px;
 }
 
-.ttahub-goal-card__goal-column__created-on, 
+.ttahub-goal-card__goal-topics-tool-tip {
+  display :none;
+}
+
+.ttahub-goal-card__goal-topics-csv {
+  display: block;
+}
+
+@media(min-width: 627px) {
+  .ttahub-goal-card__goal-column:not(:nth-child(n+3):nth-child(-n+5)) {
+    margin-bottom: 16px;
+  }
+
+  .ttahub-goal-card__goal-topics-csv {
+    display: block;
+  }
+
+  .ttahub-goal-card__goal-topics-tool-tip {
+    display: none;
+  }
+}
+
+.ttahub-goal-card__goal-column__goal-topics {
+  flex-basis: clamp($min-width-topics-column, 100%, 100%);
+
+}
+
+.ttahub-goal-card__goal-column__created-on,
 .ttahub-goal-card__goal-column__last-tta,
-.ttahub-goal-card__goal-column__last-reviewed  {
+.ttahub-goal-card__goal-column__last-reviewed {
   flex-basis: clamp(33%, 33%, 50%);
 }
 
 @media(min-width: 1215px) {
+
+  .ttahub-goal-card__goal-column:not(:nth-child(n+3):nth-child(-n+5)) {
+    margin-bottom: 16px;
+  }
+
+  .ttahub-goal-card__goal-topics-tool-tip {
+    display: none;
+  }
+
+  .ttahub-goal-card__goal-topics-csv {
+    display: block;
+  }
+
   .ttahub-goal-card__goal-column__goal-text {
     flex-basis: clamp($min-width-text-column, 60%, 100%);
   }
-      
+
   .ttahub-goal-card__goal-column__goal-topics {
     flex-basis: clamp(200px, 40%, 100%);
   }
 }
 
-
 @media(min-width: 1475px) {
+
+  .ttahub-goal-card__goal-column__goal-topics p {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 220px;
+  }
+
+  .ttahub-goal-card__goal-topics-csv {
+    display: none;
+  }
+
+  .ttahub-goal-card__goal-topics-tool-tip {
+    display: block;
+  }
+
   .ttahub-goal-card__goal-column__goal-text {
     flex-basis: clamp($min-width-text-column, 40%, 100%);
   }
@@ -49,9 +104,9 @@ $max-width-date-column: 50%;
     flex-basis: clamp($min-width-topics-column, 20%, $min-width-topics-column);
   }
 
-  .ttahub-goal-card__goal-column__created-on, 
+  .ttahub-goal-card__goal-column__created-on,
   .ttahub-goal-card__goal-column__last-tta,
-  .ttahub-goal-card__goal-column__last-reviewed  {
+  .ttahub-goal-card__goal-column__last-reviewed {
     flex-basis: clamp($min-width-date-column, 10%, $max-width-date-column);
   }
 }

--- a/frontend/src/components/GoalCards/components/Topics.js
+++ b/frontend/src/components/GoalCards/components/Topics.js
@@ -14,9 +14,10 @@ export default function Topics({ topics }) {
 
   return (
     <>
-      <p className="usa-prose margin-y-0">{topics[0]}</p>
+      <p className="usa-prose margin-y-0 ttahub-goal-card__goal-topics-csv">{topics.join(', ')}</p>
+      <p className="usa-prose margin-y-0 ttahub-goal-card__goal-topics-tool-tip">{topics[0]}</p>
       <Tooltip
-        className="usa-prose"
+        className="usa-prose ttahub-goal-card__goal-topics-tool-tip"
         screenReadDisplayText={false}
         displayText="View all topics"
         buttonLabel={topics.join(' ')}


### PR DESCRIPTION
## Description of change
Issues found on Goal RTR card.

- We should always maintain row spacing 16px regardless of view port size.
- Topics at the largest break point should show tool tip. Every smaller break point should show CSV.
- Topics should show at one line with ellipsis at largest break point.


## How to test

Above issues are fixed.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1071


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [x] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
