### PR TITLE
Disable Recipient updates in non-prod environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ parameters:
     default: "main-ar-redesign"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "kw-monthly-cron"
+    default: "kw-disable-non-prod-updates"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -95,7 +95,7 @@ export default function runCronJobs() {
   // Run only on one instance
   if (process.env.CF_INSTANCE_INDEX === '0' && process.env.NODE_ENV === 'production') {
     // disable updates for non-production environments
-    if (!process.env.TTA_SMARTHUB_URI.endsWith('app.cloud.gov')) {
+    if (process.env.TTA_SMART_HUB_URI && !process.env.TTA_SMART_HUB_URI.endsWith('app.cloud.gov')) {
       const job = new CronJob(schedule, () => runJob(), null, true, timezone);
       job.start();
     }

--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -94,8 +94,11 @@ const runMonthlyEmailJob = () => {
 export default function runCronJobs() {
   // Run only on one instance
   if (process.env.CF_INSTANCE_INDEX === '0' && process.env.NODE_ENV === 'production') {
-    const job = new CronJob(schedule, () => runJob(), null, true, timezone);
-    job.start();
+    // disable updates for non-production environments
+    if (!process.env.TTA_SMARTHUB_URI.endsWith('app.cloud.gov')) {
+      const job = new CronJob(schedule, () => runJob(), null, true, timezone);
+      job.start();
+    }
     const dailyJob = new CronJob(dailySched, () => runDailyEmailJob(), null, true, timezone);
     dailyJob.start();
     const weeklyJob = new CronJob(weeklySched, () => runWeeklyEmailJob(), null, true, timezone);


### PR DESCRIPTION
## Description of change
The Recipient updates were still happening in non-prod environments. This PR disables it.


## How to test
- look at the code
- changes were deployed to Sandbox yesterday. Verify that the Recipients and Grants are not real.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1077


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
