### PR TITLE
[TTAHUB-983] Before Validate Hooks Not Working on Update

### DIFF
--- a/src/models/goal.js
+++ b/src/models/goal.js
@@ -1,7 +1,7 @@
 const { Model } = require('sequelize');
 const { CLOSE_SUSPEND_REASONS } = require('../constants');
 const { formatDate } = require('../lib/modelHelpers');
-const { beforeValidate, afterUpdate } = require('./hooks/goal');
+const { beforeValidate, beforeUpdate, afterUpdate } = require('./hooks/goal');
 
 /**
  * Goals table. Stores goals for tta.
@@ -125,6 +125,7 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'Goal',
     hooks: {
       beforeValidate: async (instance, options) => beforeValidate(sequelize, instance, options),
+      beforeUpdate: async (instance, options) => beforeUpdate(sequelize, instance, options),
       afterUpdate: async (instance, options) => afterUpdate(sequelize, instance, options),
     },
   });

--- a/src/models/goalTemplate.js
+++ b/src/models/goalTemplate.js
@@ -1,6 +1,6 @@
 const { Model } = require('sequelize');
 const { CREATION_METHOD } = require('../constants');
-const { beforeValidate, afterUpdate } = require('./hooks/goalTemplate');
+const { beforeValidate, beforeUpdate, afterUpdate } = require('./hooks/goalTemplate');
 // const { auditLogger } = require('../logger');
 
 module.exports = (sequelize, DataTypes) => {
@@ -61,6 +61,7 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'GoalTemplate',
     hooks: {
       beforeValidate: async (instance, options) => beforeValidate(sequelize, instance, options),
+      beforeUpdate: async (instance, options) => beforeUpdate(sequelize, instance, options),
       afterUpdate: async (instance, options) => afterUpdate(sequelize, instance, options),
     },
   });

--- a/src/models/goalTemplate.js
+++ b/src/models/goalTemplate.js
@@ -60,7 +60,7 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     modelName: 'GoalTemplate',
     hooks: {
-      beforeValidate: async (instance) => beforeValidate(sequelize, instance),
+      beforeValidate: async (instance, options) => beforeValidate(sequelize, instance, options),
       afterUpdate: async (instance, options) => afterUpdate(sequelize, instance, options),
     },
   });

--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -57,6 +57,7 @@ const moveDraftGoalsToNotStartedOnSubmission = async (sequelize, instance, optio
             },
           },
           transaction: options.transaction,
+          individualHooks: true,
         },
       );
     } catch (error) {
@@ -102,6 +103,7 @@ const propogateSubmissionStatus = async (sequelize, instance, options) => {
         {
           where: { id: goal.id },
           transaction: options.transaction,
+          individualHooks: true,
         },
       )));
     } catch (e) {

--- a/src/models/hooks/goal.js
+++ b/src/models/hooks/goal.js
@@ -41,7 +41,7 @@ const autoPopulateOnApprovedAR = (sequelize, instance, options) => {
   if (instance.onApprovedAR === undefined
     || instance.onApprovedAR === null) {
     instance.set('onApprovedAR', false);
-    if (!options.fields.contains('onApprovedAR')) {
+    if (!options.fields.includes('onApprovedAR')) {
       options.fields.push('onApprovedAR');
     }
   }
@@ -74,12 +74,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstNotStartedAt === null
           || instance.firstNotStartedAt === undefined) {
           instance.set('firstNotStartedAt', now);
-          if (!options.fields.contains('firstNotStartedAt')) {
+          if (!options.fields.includes('firstNotStartedAt')) {
             options.fields.push('firstNotStartedAt');
           }
         }
         instance.set('lastNotStartedAt', now);
-        if (!options.fields.contains('lastNotStartedAt')) {
+        if (!options.fields.includes('lastNotStartedAt')) {
           options.fields.push('lastNotStartedAt');
         }
         break;
@@ -87,12 +87,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstInProgressAt === null
           || instance.firstInProgressAt === undefined) {
           instance.set('firstInProgressAt', now);
-          if (!options.fields.contains('firstInProgressAt')) {
+          if (!options.fields.includes('firstInProgressAt')) {
             options.fields.push('firstInProgressAt');
           }
         }
         instance.set('lastInProgressAt', now);
-        if (!options.fields.contains('lastInProgressAt')) {
+        if (!options.fields.includes('lastInProgressAt')) {
           options.fields.push('lastInProgressAt');
         }
         break;
@@ -100,12 +100,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstSuspendedAt === null
           || instance.firstSuspendedAt === undefined) {
           instance.set('firstSuspendedAt', now);
-          if (!options.fields.contains('firstSuspendedAt')) {
+          if (!options.fields.includes('firstSuspendedAt')) {
             options.fields.push('firstSuspendedAt');
           }
         }
         instance.set('lastSuspendedAt', now);
-        if (!options.fields.contains('lastSuspendedAt')) {
+        if (!options.fields.includes('lastSuspendedAt')) {
           options.fields.push('lastSuspendedAt');
         }
         break;
@@ -113,12 +113,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstClosedAt === null
           || instance.firstClosedAt === undefined) {
           instance.set('firstClosedAt', now);
-          if (!options.fields.contains('firstClosedAt')) {
+          if (!options.fields.includes('firstClosedAt')) {
             options.fields.push('firstClosedAt');
           }
         }
         instance.set('lastClosedAt', now);
-        if (!options.fields.contains('lastClosedAt')) {
+        if (!options.fields.includes('lastClosedAt')) {
           options.fields.push('lastClosedAt');
         }
         break;

--- a/src/models/hooks/goal.js
+++ b/src/models/hooks/goal.js
@@ -37,10 +37,13 @@ const findOrCreateGoalTemplate = async (sequelize, transaction, regionId, name, 
 //   }
 // };
 
-const autoPopulateOnApprovedAR = (sequelize, instance) => {
+const autoPopulateOnApprovedAR = (sequelize, instance, options) => {
   if (instance.onApprovedAR === undefined
     || instance.onApprovedAR === null) {
     instance.set('onApprovedAR', false);
+    if (!options.fields.contains('onApprovedAR')) {
+      options.fields.push('onApprovedAR');
+    }
   }
 };
 
@@ -55,7 +58,7 @@ const preventNamChangeWhenOnApprovedAR = (sequelize, instance) => {
   }
 };
 
-const autoPopulateStatusChangeDates = (sequelize, instance) => {
+const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed)
     && changed.includes('status')) {
@@ -71,29 +74,53 @@ const autoPopulateStatusChangeDates = (sequelize, instance) => {
         if (instance.firstNotStartedAt === null
           || instance.firstNotStartedAt === undefined) {
           instance.set('firstNotStartedAt', now);
+          if (!options.fields.contains('firstNotStartedAt')) {
+            options.fields.push('firstNotStartedAt');
+          }
         }
         instance.set('lastNotStartedAt', now);
+        if (!options.fields.contains('lastNotStartedAt')) {
+          options.fields.push('lastNotStartedAt');
+        }
         break;
       case GOAL_STATUS.IN_PROGRESS:
         if (instance.firstInProgressAt === null
           || instance.firstInProgressAt === undefined) {
           instance.set('firstInProgressAt', now);
+          if (!options.fields.contains('firstInProgressAt')) {
+            options.fields.push('firstInProgressAt');
+          }
         }
         instance.set('lastInProgressAt', now);
+        if (!options.fields.contains('lastInProgressAt')) {
+          options.fields.push('lastInProgressAt');
+        }
         break;
       case GOAL_STATUS.SUSPENDED:
         if (instance.firstSuspendedAt === null
           || instance.firstSuspendedAt === undefined) {
           instance.set('firstSuspendedAt', now);
+          if (!options.fields.contains('firstSuspendedAt')) {
+            options.fields.push('firstSuspendedAt');
+          }
         }
         instance.set('lastSuspendedAt', now);
+        if (!options.fields.contains('lastSuspendedAt')) {
+          options.fields.push('lastSuspendedAt');
+        }
         break;
       case GOAL_STATUS.CLOSED:
         if (instance.firstClosedAt === null
           || instance.firstClosedAt === undefined) {
           instance.set('firstClosedAt', now);
+          if (!options.fields.contains('firstClosedAt')) {
+            options.fields.push('firstClosedAt');
+          }
         }
         instance.set('lastClosedAt', now);
+        if (!options.fields.contains('lastClosedAt')) {
+          options.fields.push('lastClosedAt');
+        }
         break;
       default:
         throw new Error(`Goal status changed to invalid value of "${status}".`);
@@ -118,11 +145,11 @@ const propagateName = async (sequelize, instance, options) => {
   }
 };
 
-const beforeValidate = async (sequelize, instance) => {
+const beforeValidate = async (sequelize, instance, options) => {
   // await autoPopulateGoalTemplateId(sequelize, instance, options);
-  autoPopulateOnApprovedAR(sequelize, instance);
-  preventNamChangeWhenOnApprovedAR(sequelize, instance);
-  autoPopulateStatusChangeDates(sequelize, instance);
+  autoPopulateOnApprovedAR(sequelize, instance, options);
+  preventNamChangeWhenOnApprovedAR(sequelize, instance, options);
+  autoPopulateStatusChangeDates(sequelize, instance, options);
 };
 
 const afterUpdate = async (sequelize, instance, options) => {

--- a/src/models/hooks/goal.js
+++ b/src/models/hooks/goal.js
@@ -97,16 +97,16 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         }
         break;
       case GOAL_STATUS.SUSPENDED:
-        if (instance.firstSuspendedAt === null
-          || instance.firstSuspendedAt === undefined) {
-          instance.set('firstSuspendedAt', now);
-          if (!options.fields.includes('firstSuspendedAt')) {
-            options.fields.push('firstSuspendedAt');
+        if (instance.firstCeasedSuspendedAt === null
+          || instance.firstCeasedSuspendedAt === undefined) {
+          instance.set('firstCeasedSuspendedAt', now);
+          if (!options.fields.includes('firstCeasedSuspendedAt')) {
+            options.fields.push('firstCeasedSuspendedAt');
           }
         }
-        instance.set('lastSuspendedAt', now);
-        if (!options.fields.includes('lastSuspendedAt')) {
-          options.fields.push('lastSuspendedAt');
+        instance.set('lastCeasedSuspendedAt', now);
+        if (!options.fields.includes('lastCeasedSuspendedAt')) {
+          options.fields.push('lastCeasedSuspendedAt');
         }
         break;
       case GOAL_STATUS.CLOSED:
@@ -146,8 +146,16 @@ const propagateName = async (sequelize, instance, options) => {
 };
 
 const beforeValidate = async (sequelize, instance, options) => {
+  if (!Array.isArray(options.fields)) {
+    options.fields = []; //eslint-disable-line
+  }
   // await autoPopulateGoalTemplateId(sequelize, instance, options);
   autoPopulateOnApprovedAR(sequelize, instance, options);
+  preventNamChangeWhenOnApprovedAR(sequelize, instance, options);
+  autoPopulateStatusChangeDates(sequelize, instance, options);
+};
+
+const beforeUpdate = async (sequelize, instance, options) => {
   preventNamChangeWhenOnApprovedAR(sequelize, instance, options);
   autoPopulateStatusChangeDates(sequelize, instance, options);
 };
@@ -164,5 +172,6 @@ export {
   autoPopulateStatusChangeDates,
   propagateName,
   beforeValidate,
+  beforeUpdate,
   afterUpdate,
 };

--- a/src/models/hooks/goalTemplate.js
+++ b/src/models/hooks/goalTemplate.js
@@ -68,6 +68,11 @@ const beforeValidate = (sequelize, instance, options) => {
   autoPopulateCreationMethod(sequelize, instance, options);
 };
 
+const beforeUpdate = (sequelize, instance, options) => {
+  autoPopulateHash(sequelize, instance, options);
+  autoPopulateTemplateNameModifiedAt(sequelize, instance, options);
+};
+
 const afterUpdate = async (sequelize, instance, options) => {
   await propagateTemplateName(sequelize, instance, options);
 };
@@ -78,5 +83,6 @@ export {
   autoPopulateCreationMethod,
   propagateTemplateName,
   beforeValidate,
+  beforeUpdate,
   afterUpdate,
 };

--- a/src/models/hooks/goalTemplate.js
+++ b/src/models/hooks/goalTemplate.js
@@ -1,33 +1,42 @@
 import { Op } from 'sequelize';
 import { AUTOMATIC_CREATION } from '../../constants';
 
-const autoPopulateHash = (sequelize, instance) => {
+const autoPopulateHash = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed)
     && changed.includes('templateName')
     && instance.templateName !== null
     && instance.templateName !== undefined) {
     instance.set('hash', sequelize.fn('md5', sequelize.fn('TRIM', instance.templateName)));
+    if (!options.fields.contains('hash')) {
+      options.fields.push('hash');
+    }
   }
 };
 
-const autoPopulateTemplateNameModifiedAt = (sequelize, instance) => {
+const autoPopulateTemplateNameModifiedAt = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed)
     && changed.includes('templateName')
     && instance.templateName !== null
     && instance.templateName !== undefined) {
     instance.set('templateNameModifiedAt', new Date());
+    if (!options.fields.contains('templateNameModifiedAt')) {
+      options.fields.push('templateNameModifiedAt');
+    }
   }
 };
 
-const autoPopulateCreationMethod = (sequelize, instance) => {
+const autoPopulateCreationMethod = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed)
         && (!changed.includes('creationMethod')
         || instance.creationMethod === null
         || instance.creationMethod === undefined)) {
     instance.set('creationMethod', AUTOMATIC_CREATION); // 'Automatic'
+    if (!options.fields.contains('creationMethod')) {
+      options.fields.push('creationMethod');
+    }
   }
 };
 
@@ -53,10 +62,10 @@ const propagateTemplateName = async (sequelize, instance, options) => {
   }
 };
 
-const beforeValidate = (sequelize, instance) => {
-  autoPopulateHash(sequelize, instance);
-  autoPopulateTemplateNameModifiedAt(sequelize, instance);
-  autoPopulateCreationMethod(sequelize, instance);
+const beforeValidate = (sequelize, instance, options) => {
+  autoPopulateHash(sequelize, instance, options);
+  autoPopulateTemplateNameModifiedAt(sequelize, instance, options);
+  autoPopulateCreationMethod(sequelize, instance, options);
 };
 
 const afterUpdate = async (sequelize, instance, options) => {

--- a/src/models/hooks/goalTemplate.js
+++ b/src/models/hooks/goalTemplate.js
@@ -8,7 +8,7 @@ const autoPopulateHash = (sequelize, instance, options) => {
     && instance.templateName !== null
     && instance.templateName !== undefined) {
     instance.set('hash', sequelize.fn('md5', sequelize.fn('TRIM', instance.templateName)));
-    if (!options.fields.contains('hash')) {
+    if (!options.fields.includes('hash')) {
       options.fields.push('hash');
     }
   }
@@ -21,7 +21,7 @@ const autoPopulateTemplateNameModifiedAt = (sequelize, instance, options) => {
     && instance.templateName !== null
     && instance.templateName !== undefined) {
     instance.set('templateNameModifiedAt', new Date());
-    if (!options.fields.contains('templateNameModifiedAt')) {
+    if (!options.fields.includes('templateNameModifiedAt')) {
       options.fields.push('templateNameModifiedAt');
     }
   }
@@ -34,7 +34,7 @@ const autoPopulateCreationMethod = (sequelize, instance, options) => {
         || instance.creationMethod === null
         || instance.creationMethod === undefined)) {
     instance.set('creationMethod', AUTOMATIC_CREATION); // 'Automatic'
-    if (!options.fields.contains('creationMethod')) {
+    if (!options.fields.includes('creationMethod')) {
       options.fields.push('creationMethod');
     }
   }

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -189,6 +189,7 @@ const propogateStatusToParentGoal = async (sequelize, instance, options) => {
           previousStatus: 'Not Started',
         }, {
           transaction: options.transaction,
+          individualHooks: true,
         });
       }
     }
@@ -263,6 +264,11 @@ const beforeValidate = async (sequelize, instance, options) => {
   autoPopulateStatusChangeDates(sequelize, instance, options);
 };
 
+const beforeUpdate = async (sequelize, instance, options) => {
+  preventTitleChangeWhenOnApprovedAR(sequelize, instance, options);
+  autoPopulateStatusChangeDates(sequelize, instance, options);
+};
+
 const afterUpdate = async (sequelize, instance, options) => {
   await propagateTitle(sequelize, instance, options);
   await propagateMetadataToTemplate(sequelize, instance, options);
@@ -282,6 +288,7 @@ export {
   linkObjectiveGoalTemplates,
   propagateTitle,
   beforeValidate,
+  beforeUpdate,
   afterUpdate,
   afterCreate,
 };

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -29,7 +29,7 @@ const autoPopulateOnApprovedAR = (sequelize, instance, options) => {
   if (instance.onApprovedAR === undefined
     || instance.onApprovedAR === null) {
     instance.set('onApprovedAR', false);
-    if (!options.fields.contains('onApprovedAR')) {
+    if (!options.fields.includes('onApprovedAR')) {
       options.fields.push('onApprovedAR');
     }
   }
@@ -57,12 +57,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstNotStartedAt === null
           || instance.firstNotStartedAt === undefined) {
           instance.set('firstNotStartedAt', now);
-          if (!options.fields.contains('firstNotStartedAt')) {
+          if (!options.fields.includes('firstNotStartedAt')) {
             options.fields.push('firstNotStartedAt');
           }
         }
         instance.set('lastNotStartedAt', now);
-        if (!options.fields.contains('lastNotStartedAt')) {
+        if (!options.fields.includes('lastNotStartedAt')) {
           options.fields.push('lastNotStartedAt');
         }
         break;
@@ -70,12 +70,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstInProgressAt === null
           || instance.firstInProgressAt === undefined) {
           instance.set('firstInProgressAt', now);
-          if (!options.fields.contains('firstInProgressAt')) {
+          if (!options.fields.includes('firstInProgressAt')) {
             options.fields.push('firstInProgressAt');
           }
         }
         instance.set('lastInProgressAt', now);
-        if (!options.fields.contains('lastInProgressAt')) {
+        if (!options.fields.includes('lastInProgressAt')) {
           options.fields.push('lastInProgressAt');
         }
         break;
@@ -83,12 +83,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstSuspendedAt === null
           || instance.firstSuspendedAt === undefined) {
           instance.set('firstSuspendedAt', now);
-          if (!options.fields.contains('firstSuspendedAt')) {
+          if (!options.fields.includes('firstSuspendedAt')) {
             options.fields.push('firstSuspendedAt');
           }
         }
         instance.set('lastSuspendedAt', now);
-        if (!options.fields.contains('lastSuspendedAt')) {
+        if (!options.fields.includes('lastSuspendedAt')) {
           options.fields.push('lastSuspendedAt');
         }
         break;
@@ -96,12 +96,12 @@ const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
         if (instance.firstCompleteAt === null
           || instance.firstCompleteAt === undefined) {
           instance.set('firstCompleteAt', now);
-          if (!options.fields.contains('firstCompleteAt')) {
+          if (!options.fields.includes('firstCompleteAt')) {
             options.fields.push('firstCompleteAt');
           }
         }
         instance.set('lastCompleteAt', now);
-        if (!options.fields.contains('lastCompleteAt')) {
+        if (!options.fields.includes('lastCompleteAt')) {
           options.fields.push('lastCompleteAt');
         }
         break;

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -24,11 +24,14 @@ const findOrCreateObjectiveTemplate = async (
   return objectiveTemplate[0].id;
 };
 
-const autoPopulateOnApprovedAR = (sequelize, instance) => {
+const autoPopulateOnApprovedAR = (sequelize, instance, options) => {
   // eslint-disable-next-line no-prototype-builtins
   if (instance.onApprovedAR === undefined
     || instance.onApprovedAR === null) {
     instance.set('onApprovedAR', false);
+    if (!options.fields.contains('onApprovedAR')) {
+      options.fields.push('onApprovedAR');
+    }
   }
 };
 
@@ -43,7 +46,7 @@ const preventTitleChangeWhenOnApprovedAR = (sequelize, instance) => {
   }
 };
 
-const autoPopulateStatusChangeDates = (sequelize, instance) => {
+const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed) && changed.includes('status')) {
     const now = new Date();
@@ -54,29 +57,53 @@ const autoPopulateStatusChangeDates = (sequelize, instance) => {
         if (instance.firstNotStartedAt === null
           || instance.firstNotStartedAt === undefined) {
           instance.set('firstNotStartedAt', now);
+          if (!options.fields.contains('firstNotStartedAt')) {
+            options.fields.push('firstNotStartedAt');
+          }
         }
         instance.set('lastNotStartedAt', now);
+        if (!options.fields.contains('lastNotStartedAt')) {
+          options.fields.push('lastNotStartedAt');
+        }
         break;
       case OBJECTIVE_STATUS.IN_PROGRESS:
         if (instance.firstInProgressAt === null
           || instance.firstInProgressAt === undefined) {
           instance.set('firstInProgressAt', now);
+          if (!options.fields.contains('firstInProgressAt')) {
+            options.fields.push('firstInProgressAt');
+          }
         }
         instance.set('lastInProgressAt', now);
+        if (!options.fields.contains('lastInProgressAt')) {
+          options.fields.push('lastInProgressAt');
+        }
         break;
       case OBJECTIVE_STATUS.SUSPENDED:
         if (instance.firstSuspendedAt === null
           || instance.firstSuspendedAt === undefined) {
           instance.set('firstSuspendedAt', now);
+          if (!options.fields.contains('firstSuspendedAt')) {
+            options.fields.push('firstSuspendedAt');
+          }
         }
         instance.set('lastSuspendedAt', now);
+        if (!options.fields.contains('lastSuspendedAt')) {
+          options.fields.push('lastSuspendedAt');
+        }
         break;
       case OBJECTIVE_STATUS.COMPLETE:
         if (instance.firstCompleteAt === null
           || instance.firstCompleteAt === undefined) {
           instance.set('firstCompleteAt', now);
+          if (!options.fields.contains('firstCompleteAt')) {
+            options.fields.push('firstCompleteAt');
+          }
         }
         instance.set('lastCompleteAt', now);
+        if (!options.fields.contains('lastCompleteAt')) {
+          options.fields.push('lastCompleteAt');
+        }
         break;
       default:
         throw new Error(`Objective status changed to invalid value of "${instance.status}".`);
@@ -229,11 +256,11 @@ const propagateMetadataToTemplate = async (sequelize, instance, options) => {
   }
 };
 
-const beforeValidate = async (sequelize, instance) => {
+const beforeValidate = async (sequelize, instance, options) => {
   // await autoPopulateObjectiveTemplateId(sequelize, instance, options);
-  autoPopulateOnApprovedAR(sequelize, instance);
-  preventTitleChangeWhenOnApprovedAR(sequelize, instance);
-  autoPopulateStatusChangeDates(sequelize, instance);
+  autoPopulateOnApprovedAR(sequelize, instance, options);
+  preventTitleChangeWhenOnApprovedAR(sequelize, instance, options);
+  autoPopulateStatusChangeDates(sequelize, instance, options);
 };
 
 const afterUpdate = async (sequelize, instance, options) => {

--- a/src/models/hooks/objective.test.js
+++ b/src/models/hooks/objective.test.js
@@ -95,7 +95,13 @@ describe('objective model hooks', () => {
     expect(testGoal.status).toEqual('Draft');
     expect(testGoal.id).toEqual(goal.id);
 
-    await Goal.update({ status: 'Not Started' }, { where: { id: goal.id } });
+    await Goal.update(
+      { status: 'Not Started' },
+      {
+        where: { id: goal.id },
+        individualHooks: true,
+      },
+    );
 
     objective2 = await Objective.create({
       title: 'Objective 2',

--- a/src/models/hooks/objectiveTemplate.js
+++ b/src/models/hooks/objectiveTemplate.js
@@ -68,6 +68,11 @@ const beforeValidate = (sequelize, instance, options) => {
   autoPopulateCreationMethod(sequelize, instance, options);
 };
 
+const beforeUpdate = async (sequelize, instance, options) => {
+  autoPopulateHash(sequelize, instance, options);
+  autoPopulateTemplateTitleModifiedAt(sequelize, instance, options);
+};
+
 const afterUpdate = async (sequelize, instance, options) => {
   await propagateTemplateTitle(sequelize, instance, options);
 };
@@ -77,5 +82,6 @@ export {
   autoPopulateCreationMethod,
   propagateTemplateTitle,
   beforeValidate,
+  beforeUpdate,
   afterUpdate,
 };

--- a/src/models/hooks/objectiveTemplate.js
+++ b/src/models/hooks/objectiveTemplate.js
@@ -8,7 +8,7 @@ const autoPopulateHash = (sequelize, instance, options) => {
     && instance.templateTitle !== null
     && instance.templateTitle !== undefined) {
     instance.set('hash', sequelize.fn('md5', sequelize.fn('TRIM', instance.templateTitle)));
-    if (!options.fields.contains('hash')) {
+    if (!options.fields.includes('hash')) {
       options.fields.push('hash');
     }
   }
@@ -21,7 +21,7 @@ const autoPopulateTemplateTitleModifiedAt = (sequelize, instance, options) => {
     && instance.templateTitle !== null
     && instance.templateTitle !== undefined) {
     instance.set('templateTitleModifiedAt', new Date());
-    if (!options.fields.contains('templateTitleModifiedAt')) {
+    if (!options.fields.includes('templateTitleModifiedAt')) {
       options.fields.push('templateTitleModifiedAt');
     }
   }
@@ -34,7 +34,7 @@ const autoPopulateCreationMethod = (sequelize, instance, options) => {
         || instance.creationMethod === null
         || instance.creationMethod === undefined)) {
     instance.set('creationMethod', AUTOMATIC_CREATION);
-    if (!options.fields.contains('creationMethod')) {
+    if (!options.fields.includes('creationMethod')) {
       options.fields.push('creationMethod');
     }
   }

--- a/src/models/hooks/objectiveTemplate.js
+++ b/src/models/hooks/objectiveTemplate.js
@@ -1,33 +1,42 @@
 import { Op } from 'sequelize';
 import { AUTOMATIC_CREATION } from '../../constants';
 
-const autoPopulateHash = (sequelize, instance) => {
+const autoPopulateHash = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed)
     && changed.includes('templateTitle')
     && instance.templateTitle !== null
     && instance.templateTitle !== undefined) {
     instance.set('hash', sequelize.fn('md5', sequelize.fn('TRIM', instance.templateTitle)));
+    if (!options.fields.contains('hash')) {
+      options.fields.push('hash');
+    }
   }
 };
 
-const autoPopulateTemplateTitleModifiedAt = (sequelize, instance) => {
+const autoPopulateTemplateTitleModifiedAt = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed)
     && changed.includes('templateTitle')
     && instance.templateTitle !== null
     && instance.templateTitle !== undefined) {
     instance.set('templateTitleModifiedAt', new Date());
+    if (!options.fields.contains('templateTitleModifiedAt')) {
+      options.fields.push('templateTitleModifiedAt');
+    }
   }
 };
 
-const autoPopulateCreationMethod = (sequelize, instance) => {
+const autoPopulateCreationMethod = (sequelize, instance, options) => {
   const changed = instance.changed();
   if (Array.isArray(changed)
         && (!changed.includes('creationMethod')
         || instance.creationMethod === null
         || instance.creationMethod === undefined)) {
     instance.set('creationMethod', AUTOMATIC_CREATION);
+    if (!options.fields.contains('creationMethod')) {
+      options.fields.push('creationMethod');
+    }
   }
 };
 
@@ -53,10 +62,10 @@ const propagateTemplateTitle = async (sequelize, instance, options) => {
   }
 };
 
-const beforeValidate = (sequelize, instance) => {
-  autoPopulateHash(sequelize, instance);
-  autoPopulateTemplateTitleModifiedAt(sequelize, instance);
-  autoPopulateCreationMethod(sequelize, instance);
+const beforeValidate = (sequelize, instance, options) => {
+  autoPopulateHash(sequelize, instance, options);
+  autoPopulateTemplateTitleModifiedAt(sequelize, instance, options);
+  autoPopulateCreationMethod(sequelize, instance, options);
 };
 
 const afterUpdate = async (sequelize, instance, options) => {

--- a/src/models/objective.js
+++ b/src/models/objective.js
@@ -1,7 +1,12 @@
 const {
   Model,
 } = require('sequelize');
-const { beforeValidate, afterUpdate, afterCreate } = require('./hooks/objective');
+const {
+  beforeValidate,
+  beforeUpdate,
+  afterUpdate,
+  afterCreate,
+} = require('./hooks/objective');
 
 /**
  * Objective table. Stores objectives for goals.
@@ -103,6 +108,7 @@ module.exports = (sequelize, DataTypes) => {
     hooks: {
       beforeValidate: async (instance, options) => beforeValidate(sequelize, instance, options),
       afterCreate: async (instance, options) => afterCreate(sequelize, instance, options),
+      beforeUpdate: async (instance, options) => beforeUpdate(sequelize, instance, options),
       afterUpdate: async (instance, options) => afterUpdate(sequelize, instance, options),
     },
   });

--- a/src/models/objectiveTemplate.js
+++ b/src/models/objectiveTemplate.js
@@ -1,6 +1,6 @@
 const { Model } = require('sequelize');
 const { CREATION_METHOD } = require('../constants');
-const { beforeValidate, afterUpdate } = require('./hooks/objectiveTemplate');
+const { beforeValidate, beforeUpdate, afterUpdate } = require('./hooks/objectiveTemplate');
 // const { auditLogger } = require('../logger');
 
 module.exports = (sequelize, DataTypes) => {
@@ -64,6 +64,7 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'ObjectiveTemplate',
     hooks: {
       beforeValidate: async (instance, options) => beforeValidate(sequelize, instance, options),
+      beforeUpdate: async (instance, options) => beforeUpdate(sequelize, instance, options),
       afterUpdate: async (instance, options) => afterUpdate(sequelize, instance, options),
     },
   });

--- a/src/models/tests/goals.test.js
+++ b/src/models/tests/goals.test.js
@@ -119,11 +119,11 @@ describe('Goals', () => {
     autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
-    expect(instance.firstSuspendedAt).toEqual(undefined);
+    expect(instance.firstCeasedSuspendedAt).toEqual(undefined);
     expect(instance.firstClosedAt).toEqual(undefined);
     expect(instance.lastNotStartedAt).toEqual(undefined);
     expect(instance.lastInProgressAt).toEqual(undefined);
-    expect(instance.lastSuspendedAt).toEqual(undefined);
+    expect(instance.lastCeasedSuspendedAt).toEqual(undefined);
     expect(instance.lastClosedAt).toEqual(undefined);
 
     instance = {
@@ -134,11 +134,11 @@ describe('Goals', () => {
     autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
-    expect(instance.firstSuspendedAt).toEqual(undefined);
+    expect(instance.firstCeasedSuspendedAt).toEqual(undefined);
     expect(instance.firstClosedAt).toEqual(undefined);
     expect(instance.lastNotStartedAt).toEqual(undefined);
     expect(instance.lastInProgressAt).toEqual(undefined);
-    expect(instance.lastSuspendedAt).toEqual(undefined);
+    expect(instance.lastCeasedSuspendedAt).toEqual(undefined);
     expect(instance.lastClosedAt).toEqual(undefined);
 
     instance = {
@@ -150,11 +150,11 @@ describe('Goals', () => {
     autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
-    expect(instance.firstSuspendedAt).toEqual(undefined);
+    expect(instance.firstCeasedSuspendedAt).toEqual(undefined);
     expect(instance.firstClosedAt).toEqual(undefined);
     expect(instance.lastNotStartedAt).toEqual(undefined);
     expect(instance.lastInProgressAt).toEqual(undefined);
-    expect(instance.lastSuspendedAt).toEqual(undefined);
+    expect(instance.lastCeasedSuspendedAt).toEqual(undefined);
     expect(instance.lastClosedAt).toEqual(undefined);
 
     instance = {
@@ -166,11 +166,11 @@ describe('Goals', () => {
     autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
-    expect(instance.firstSuspendedAt).toEqual(undefined);
+    expect(instance.firstCeasedSuspendedAt).toEqual(undefined);
     expect(instance.firstClosedAt).toEqual(undefined);
     expect(instance.lastNotStartedAt).toEqual(undefined);
     expect(instance.lastInProgressAt).toEqual(undefined);
-    expect(instance.lastSuspendedAt).toEqual(undefined);
+    expect(instance.lastCeasedSuspendedAt).toEqual(undefined);
     expect(instance.lastClosedAt).toEqual(undefined);
 
     instance = {
@@ -182,11 +182,11 @@ describe('Goals', () => {
     autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
-    expect(instance.firstSuspendedAt).toEqual(undefined);
+    expect(instance.firstCeasedSuspendedAt).toEqual(undefined);
     expect(instance.firstClosedAt).toEqual(undefined);
     expect(instance.lastNotStartedAt).toEqual(undefined);
     expect(instance.lastInProgressAt).toEqual(undefined);
-    expect(instance.lastSuspendedAt).toEqual(undefined);
+    expect(instance.lastCeasedSuspendedAt).toEqual(undefined);
     expect(instance.lastClosedAt).toEqual(undefined);
 
     instance = {
@@ -200,12 +200,12 @@ describe('Goals', () => {
     expect((Date.parse(instance.firstNotStartedAt)))
       .toBeLessThan(ts);
     expect(instance.firstInProgressAt).toEqual(undefined);
-    expect(instance.firstSuspendedAt).toEqual(undefined);
+    expect(instance.firstCeasedSuspendedAt).toEqual(undefined);
     expect(instance.firstClosedAt).toEqual(undefined);
     expect((Date.parse(instance.lastNotStartedAt)))
       .toBeLessThan(ts);
     expect(instance.lastInProgressAt).toEqual(undefined);
-    expect(instance.lastSuspendedAt).toEqual(undefined);
+    expect(instance.lastCeasedCeasedSuspendedAt).toEqual(undefined);
     expect(instance.lastClosedAt).toEqual(undefined);
     expect(instance.lastNotStartedAt).toEqual(instance.firstNotStartedAt);
 
@@ -237,17 +237,17 @@ describe('Goals', () => {
     instance.status = GOAL_STATUS.SUSPENDED;
     options = { fields: [] };
     autoPopulateStatusChangeDates(null, instance, options);
-    expect((Date.parse(instance.firstSuspendedAt)))
+    expect((Date.parse(instance.firstCeasedSuspendedAt)))
       .toBeGreaterThan((Date.parse(instance.lastInProgressAt)));
-    expect((Date.parse(instance.lastSuspendedAt)))
+    expect((Date.parse(instance.lastCeasedSuspendedAt)))
       .toBeGreaterThan((Date.parse(instance.lastInProgressAt)));
-    expect(instance.lastSuspendedAt).toEqual(instance.firstSuspendedAt);
+    expect(instance.lastCeasedSuspendedAt).toEqual(instance.firstCeasedSuspendedAt);
 
     await sleep(1000);
     options = { fields: [] };
     autoPopulateStatusChangeDates(null, instance, options);
-    expect((Date.parse(instance.lastSuspendedAt)))
-      .toBeGreaterThan((Date.parse(instance.firstSuspendedAt)));
+    expect((Date.parse(instance.lastCeasedSuspendedAt)))
+      .toBeGreaterThan((Date.parse(instance.firstCeasedSuspendedAt)));
 
     await sleep(1000);
 
@@ -255,9 +255,9 @@ describe('Goals', () => {
     options = { fields: [] };
     autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.firstClosedAt)))
-      .toBeGreaterThan((Date.parse(instance.lastSuspendedAt)));
+      .toBeGreaterThan((Date.parse(instance.lastCeasedSuspendedAt)));
     expect((Date.parse(instance.lastClosedAt)))
-      .toBeGreaterThan((Date.parse(instance.lastSuspendedAt)));
+      .toBeGreaterThan((Date.parse(instance.lastCeasedSuspendedAt)));
     expect(instance.lastClosedAt).toEqual(instance.firstClosedAt);
 
     await sleep(1000);

--- a/src/models/tests/goals.test.js
+++ b/src/models/tests/goals.test.js
@@ -49,21 +49,24 @@ describe('Goals', () => {
     let instance = {
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateOnApprovedAR(null, instance);
+    let options = { fields: [] };
+    autoPopulateOnApprovedAR(null, instance, options);
     expect(instance.onApprovedAR).toEqual(false);
 
     instance = {
       onApprovedAR: false,
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateOnApprovedAR(null, instance);
+    options = { fields: [] };
+    autoPopulateOnApprovedAR(null, instance, options);
     expect(instance.onApprovedAR).toEqual(false);
 
     instance = {
       onApprovedAR: true,
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateOnApprovedAR(null, instance);
+    options = { fields: [] };
+    autoPopulateOnApprovedAR(null, instance, options);
     expect(instance.onApprovedAR).toEqual(true);
   });
   it('preventNamChangeWhenOnApprovedAR', async () => {
@@ -112,7 +115,8 @@ describe('Goals', () => {
       changed: () => [],
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateStatusChangeDates(null, instance);
+    let options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
     expect(instance.firstSuspendedAt).toEqual(undefined);
@@ -126,7 +130,8 @@ describe('Goals', () => {
       changed: () => ['status'],
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
     expect(instance.firstSuspendedAt).toEqual(undefined);
@@ -141,7 +146,8 @@ describe('Goals', () => {
       changed: () => ['status'],
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
     expect(instance.firstSuspendedAt).toEqual(undefined);
@@ -156,7 +162,8 @@ describe('Goals', () => {
       changed: () => ['status'],
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
     expect(instance.firstSuspendedAt).toEqual(undefined);
@@ -171,7 +178,8 @@ describe('Goals', () => {
       changed: () => ['status'],
     };
     instance.set = (name, value) => { instance[name] = value; };
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect(instance.firstNotStartedAt).toEqual(undefined);
     expect(instance.firstInProgressAt).toEqual(undefined);
     expect(instance.firstSuspendedAt).toEqual(undefined);
@@ -186,8 +194,9 @@ describe('Goals', () => {
       changed: () => ['status'],
     };
     instance.set = (name, value) => { instance[name] = value; };
+    options = { fields: [] };
     const ts = (new Date()).getTime();
-    autoPopulateStatusChangeDates(null, instance);
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.firstNotStartedAt)))
       .toBeLessThan(ts);
     expect(instance.firstInProgressAt).toEqual(undefined);
@@ -201,15 +210,16 @@ describe('Goals', () => {
     expect(instance.lastNotStartedAt).toEqual(instance.firstNotStartedAt);
 
     await sleep(1000);
-
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.firstNotStartedAt)))
       .toBeLessThan((Date.parse(instance.lastNotStartedAt)));
 
     await sleep(1000);
 
     instance.status = GOAL_STATUS.IN_PROGRESS;
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.firstInProgressAt)))
       .toBeGreaterThan((Date.parse(instance.lastNotStartedAt)));
     expect((Date.parse(instance.lastInProgressAt)))
@@ -217,15 +227,16 @@ describe('Goals', () => {
     expect(instance.lastInProgressAt).toEqual(instance.firstInProgressAt);
 
     await sleep(1000);
-
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.lastInProgressAt)))
       .toBeGreaterThan((Date.parse(instance.firstInProgressAt)));
 
     await sleep(1000);
 
     instance.status = GOAL_STATUS.SUSPENDED;
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.firstSuspendedAt)))
       .toBeGreaterThan((Date.parse(instance.lastInProgressAt)));
     expect((Date.parse(instance.lastSuspendedAt)))
@@ -233,15 +244,16 @@ describe('Goals', () => {
     expect(instance.lastSuspendedAt).toEqual(instance.firstSuspendedAt);
 
     await sleep(1000);
-
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.lastSuspendedAt)))
       .toBeGreaterThan((Date.parse(instance.firstSuspendedAt)));
 
     await sleep(1000);
 
     instance.status = GOAL_STATUS.CLOSED;
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.firstClosedAt)))
       .toBeGreaterThan((Date.parse(instance.lastSuspendedAt)));
     expect((Date.parse(instance.lastClosedAt)))
@@ -249,8 +261,8 @@ describe('Goals', () => {
     expect(instance.lastClosedAt).toEqual(instance.firstClosedAt);
 
     await sleep(1000);
-
-    autoPopulateStatusChangeDates(null, instance);
+    options = { fields: [] };
+    autoPopulateStatusChangeDates(null, instance, options);
     expect((Date.parse(instance.lastClosedAt)))
       .toBeGreaterThan((Date.parse(instance.firstClosedAt)));
   });


### PR DESCRIPTION
## Description of change
Sequelize beforeValidate and other before hooks to not detect added attributes automatically, 


## How to test
Goals - On the RTR page, change the status of the goal repeatedly and monitor the time stamps for each status.
Objectives - Edit a goal with objectives, change objective status repeatedly and monitor the time stamps for each status.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-983


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
