### PR TITLE
[TTAHUB-1076] Show correct buttons on form when editing existing goals

### DIFF
--- a/frontend/src/components/ActivityReportsTable/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/ReportRow.js
@@ -119,7 +119,7 @@ function ReportRow({
         </Link>
       </th>
       <td>
-        <TooltipWithCollection collection={recipients} collectionTitle={`recipients for ${displayId}`} />
+        <TooltipWithCollection collection={recipients} collectionTitle={`recipients for ${displayId}`} position={openMenuUp ? 'top' : 'bottom'} />
       </td>
       <td>{startDate}</td>
       <td>

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -288,7 +288,7 @@ function ActivityReportsTable({
                   report={report}
                   handleReportSelect={handleReportSelect}
                   isChecked={reportCheckboxes[report.id] || false}
-                  openMenuUp={index > displayReports.length - 1}
+                  openMenuUp={index > displayReports.length - 5}
                   numberOfSelectedReports={numberOfSelectedReports}
                   exportSelected={handleDownloadClick}
                 />

--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -78,7 +78,7 @@ function GoalCard({
   const showContextMenu = true;
   const menuItems = [
     {
-      label: 'Edit',
+      label: goalStatus === 'Closed' ? 'View' : 'Edit',
       onClick: () => {
         history.push(`/recipient-tta-records/${recipientId}/region/${regionId}/goals?id[]=${ids.join(',')}`);
       },

--- a/frontend/src/components/GoalForm/GoalDate.js
+++ b/frontend/src/components/GoalForm/GoalDate.js
@@ -16,14 +16,18 @@ export default function GoalDate({
   goalStatus,
 }) {
   if (goalStatus === 'Closed') {
-    return (
-      <>
-        <p className="usa-prose text-bold margin-bottom-0">
-          Anticipated close date (mm/dd/yyyy)
-        </p>
-        <p className="usa-prose margin-0">{endDate}</p>
-      </>
-    );
+    if (endDate && endDate !== 'Invalid date') {
+      return (
+        <>
+          <p className="usa-prose text-bold margin-bottom-0">
+            Anticipated close date (mm/dd/yyyy)
+          </p>
+          <p className="usa-prose margin-0">{endDate}</p>
+        </>
+      );
+    }
+
+    return null;
   }
 
   return (

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -21,6 +21,7 @@ export default function ObjectiveFiles({
   inputName,
   onBlur,
   reportId,
+  label,
 }) {
   const objectiveId = objective.id;
   const hasFiles = useMemo(() => files && files.length > 0, [files]);
@@ -77,7 +78,7 @@ export default function ObjectiveFiles({
             { hideFileToggle ? null : (
               <>
                 <legend>
-                  Do you plan to use any TTA resources that aren&apos;t available as a link?
+                  {label}
                   {' '}
                   <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
                   <QuestionTooltip
@@ -148,6 +149,7 @@ export default function ObjectiveFiles({
 }
 
 ObjectiveFiles.propTypes = {
+  label: PropTypes.string,
   objective: PropTypes.shape({
     isNew: PropTypes.bool,
     id: PropTypes.oneOfType([
@@ -200,4 +202,5 @@ ObjectiveFiles.defaultProps = {
   inputName: '',
   onBlur: () => {},
   reportId: 0,
+  label: "Do you plan to use any TTA resources that aren't available as a link?",
 };

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -32,7 +32,7 @@ export default function ObjectiveFiles({
     () => (hasFiles && files.some((file) => file.onAnyReport)), [hasFiles, files],
   );
 
-  const readOnly = useMemo(() => status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status]);
+  const readOnly = useMemo(() => status === 'Suspended' || status === 'Complete' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status]);
 
   useEffect(() => {
     if (!useFiles && hasFiles) {

--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -22,9 +22,9 @@ export default function ObjectiveTopics({
 }) {
   const initialSelection = useRef(topics.length);
 
-  const readOnly = useMemo(() => status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status]);
+  const readOnly = useMemo(() => status === 'Suspended' || status === 'Complete' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status]);
 
-  if (goalStatus === 'Closed' && !initialSelection.current) {
+  if (readOnly && !initialSelection.current) {
     return null;
   }
 

--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -24,6 +24,10 @@ export default function ObjectiveTopics({
 
   const readOnly = useMemo(() => status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status]);
 
+  if (goalStatus === 'Closed' && !initialSelection.current) {
+    return null;
+  }
+
   if (readOnly && initialSelection.current) {
     return (
       <>

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -25,7 +25,7 @@ export default function ResourceRepeater({
 }) {
   const resourcesWrapper = useRef();
 
-  const readOnly = status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed';
+  const readOnly = status === 'Suspended' || status === 'Complete' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed';
 
   if (readOnly) {
     const onlyResourcesWithValues = resources.filter((resource) => resource.value);

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -291,7 +291,7 @@ export default function GoalForm({
     let isValid = true;
 
     const newObjectiveErrors = objectives.map((objective) => {
-      if (objective.status === 'Complete') {
+      if (objective.status === 'Complete' || (objective.activityReports && objective.activityReports.length)) {
         return [
           <></>,
           <></>,

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -607,8 +607,6 @@ export default function GoalForm({
         ...newGoals,
       ];
 
-      console.log(goals);
-
       const newCreatedGoals = await createOrUpdateGoals(goals);
 
       setCreatedGoals(newCreatedGoals.map((goal) => ({

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -711,6 +711,7 @@ export default function GoalForm({
         {recipient.name}
         {' '}
         - Region
+        {' '}
         {regionId}
       </h1>
 

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -291,6 +291,16 @@ export default function GoalForm({
     let isValid = true;
 
     const newObjectiveErrors = objectives.map((objective) => {
+      if (objective.status === 'Complete') {
+        return [
+          <></>,
+          <></>,
+          <></>,
+          <></>,
+          <></>,
+        ];
+      }
+
       if (!objective.title) {
         isValid = false;
         return [

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -770,7 +770,7 @@ export default function GoalForm({
             { (isNew || status === 'Draft') && status !== 'Closed' && (
               <div className="margin-top-4">
                 { !showForm ? <Button type="submit">Submit goal</Button> : null }
-                { showForm ? <Button type="button" onClick={onSaveAndContinue}>Save and continue</Button> : null }
+                { showForm ? <Button type="button" onClick={() => onSaveAndContinue(false)}>Save and continue</Button> : null }
                 <Button type="button" outline onClick={onSaveDraft}>Save draft</Button>
                 { showForm && !createdGoals.length ? (
                   <Link

--- a/frontend/src/components/Tooltip.js
+++ b/frontend/src/components/Tooltip.js
@@ -11,6 +11,7 @@ export default function Tooltip({
   hideUnderline,
   svgLineTo,
   className,
+  position,
 }) {
   const [showTooltip, setShowTooltip] = useState(false);
 
@@ -22,7 +23,7 @@ export default function Tooltip({
 
   return (
     <span className={cssClasses} data-testid="tooltip">
-      <div aria-hidden="true" className="usa-tooltip__body usa-tooltip__body--top maxw-card-lg">{tooltipText}</div>
+      <div aria-hidden="true" className={`usa-tooltip__body usa-tooltip__body--${position} maxw-card-lg`}>{tooltipText}</div>
       <button type="button" className="usa-button usa-button--unstyled" onClick={onClick}>
         <span className="smart-hub--ellipsis">
           <span aria-hidden={!screenReadDisplayText}>
@@ -71,6 +72,7 @@ Tooltip.propTypes = {
   hideUnderline: PropTypes.bool,
   svgLineTo: PropTypes.number,
   className: PropTypes.string,
+  position: PropTypes.string,
 };
 
 Tooltip.defaultProps = {
@@ -78,4 +80,5 @@ Tooltip.defaultProps = {
   hideUnderline: false,
   svgLineTo: 190,
   className: '',
+  position: 'top',
 };

--- a/frontend/src/components/Tooltip.scss
+++ b/frontend/src/components/Tooltip.scss
@@ -50,12 +50,22 @@
     animation-duration: 500ms;
     animation-fill-mode: forwards;
     animation-iteration-count: 1;
-    bottom: 1.5rem;
     display: inline-block;
     left: -25%;
     line-height: 1; 
     position: absolute;
     white-space: normal;
+
+    &.usa-tooltip__body--top {  
+        bottom: 1.5rem;
+        top: auto;
+    }
+
+    &.usa-tooltip__body--bottom {
+        top: 100%;
+        bottom: auto;
+    }
+
 }
 
 @keyframes fadein {

--- a/frontend/src/components/TooltipWithCollection.js
+++ b/frontend/src/components/TooltipWithCollection.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import Tooltip from './Tooltip';
 
-export default function TooltipWithCollection({ collection, collectionTitle }) {
+export default function TooltipWithCollection({ collection, collectionTitle, position }) {
   if (!collection || collection.length === 0) {
     return null;
   }
@@ -34,6 +34,7 @@ export default function TooltipWithCollection({ collection, collectionTitle }) {
         displayText={tooltip}
         tooltipText={tooltip}
         buttonLabel={`click to visually reveal the ${collectionTitle}`}
+        position={position}
       />
     );
   }
@@ -43,6 +44,7 @@ export default function TooltipWithCollection({ collection, collectionTitle }) {
       displayText={tags}
       tooltipText={tooltip}
       buttonLabel={`click to visually reveal the ${collectionTitle}`}
+      position={position}
     />
   );
 }
@@ -50,4 +52,9 @@ export default function TooltipWithCollection({ collection, collectionTitle }) {
 TooltipWithCollection.propTypes = {
   collection: PropTypes.arrayOf(PropTypes.string).isRequired,
   collectionTitle: PropTypes.string.isRequired,
+  position: PropTypes.string,
+};
+
+TooltipWithCollection.defaultProps = {
+  position: 'top',
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -266,6 +266,7 @@ export default function Objective({
         inputName={objectiveFilesInputName}
         reportId={reportId}
         goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
+        label="Did you use any TTA resources that aren't available as link?"
       />
       <ObjectiveTta
         ttaProvided={objectiveTta}

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -386,6 +386,7 @@ export async function activityReportAndRecipientsById(activityReportId) {
         as: 'grant',
       },
     ],
+    order: ['name'],
   });
 
   // Get all grant programs at once to reduce DB calls.

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -386,7 +386,6 @@ export async function activityReportAndRecipientsById(activityReportId) {
         as: 'grant',
       },
     ],
-    order: ['name'],
   });
 
   // Get all grant programs at once to reduce DB calls.

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -699,12 +699,13 @@ async function cleanupObjectivesForGoal(goalId, currentObjectives) {
       {
         model: ActivityReport,
         as: 'activityReports',
+        required: false,
       },
     ],
   });
 
   const orphanedObjectiveIds = orphanedObjectives
-    .filter((objective) => objective.activityReports.length === 0)
+    .filter((objective) => !objective.activityReports || !objective.activityReports.length)
     .map((objective) => objective.id);
 
   await ObjectiveResource.destroy({


### PR DESCRIPTION
## Description of change
- Editing an existing goal on the RTR now shows different buttons (save and cancel). Save simply saves and returns the user to the RTR, cancel does the same without saving first. 
- The tooltips on the Activity Reports table now open down if they are in the first five rows, the bottom five rows open in the top direction. This prevents tall tooltips being cut off at the top/bottom

## How to test
- Ensure the above works as expected

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1076


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
