### PR TITLE
[TTAHUB-1074] Add sort options to the goal cards/RTR

### DIFF
--- a/frontend/src/components/GoalCards/GoalDataController.js
+++ b/frontend/src/components/GoalCards/GoalDataController.js
@@ -101,15 +101,7 @@ function GoalDataController({
     });
   };
 
-  const requestSort = (sortBy) => {
-    let direction = 'asc';
-    if (
-      sortConfig
-      && sortConfig.sortBy === sortBy
-      && sortConfig.direction === 'asc'
-    ) {
-      direction = 'desc';
-    }
+  const requestSort = (sortBy, direction) => {
     setSortConfig({
       ...sortConfig, sortBy, direction, activePage: 1, offset: 0,
     });

--- a/frontend/src/components/GoalCards/GoalsCardsHeader.js
+++ b/frontend/src/components/GoalCards/GoalsCardsHeader.js
@@ -47,7 +47,10 @@ export default function GoalCardsHeader({
     });
   };
 
-  const setSortBy = (e) => requestSort(e.target.value);
+  const setSortBy = (e) => {
+    const [sortBy, direction] = e.target.value.split('-');
+    requestSort(sortBy, direction);
+  };
 
   return (
     <div className="padding-x-3">
@@ -78,9 +81,11 @@ export default function GoalCardsHeader({
         <div className="desktop:display-flex flex-align-center">
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label className="display-block margin-right-1" style={{ minWidth: 'max-content' }} htmlFor="sortBy">Sort by</label>
-          <Dropdown onChange={setSortBy} value={sortConfig.sortBy} className="margin-top-0" id="sortBy" name="sortBy">
-            <option value="goalStatus">Goal status</option>
-            <option value="createdOn">Created on</option>
+          <Dropdown onChange={setSortBy} value={`${sortConfig.sortBy}-${sortConfig.direction}`} className="margin-top-0" id="sortBy" name="sortBy">
+            <option value="createdOn-desc">creation date (newest to oldest) </option>
+            <option value="createdOn-asc">creation date (oldest to newest) </option>
+            <option value="goalStatus-asc">goal status (drafts first)</option>
+            <option value="goalStatus-desc">goal status (completed first) </option>
           </Dropdown>
         </div>
         {!hidePagination && (

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -393,13 +393,13 @@ describe('Goals Table', () => {
 
     it('sorts by created on', async () => {
       const sortCreated = await screen.findByRole('combobox');
-      userEvent.selectOptions(sortCreated, 'createdOn');
+      userEvent.selectOptions(sortCreated, 'createdOn-desc');
       expect(requestSort).toHaveBeenCalled();
     });
 
     it('sorts by goal status', async () => {
       const sortCreated = await screen.findByRole('combobox');
-      userEvent.selectOptions(sortCreated, 'goalStatus');
+      userEvent.selectOptions(sortCreated, 'goalStatus-asc');
       await screen.findByText('TTA goals and objectives');
       expect(requestSort).toHaveBeenCalled();
     });

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -225,7 +225,7 @@ describe('Goals and Objectives', () => {
     fetchMock.restore();
     fetchMock.get('/api/recipient/401/region/1/goals?sortBy=createdOn&sortDir=asc&offset=0&limit=10', { count: 1, goalRows: goals, statuses: defaultStatuses });
     const sortCreated = await screen.findByRole('combobox');
-    userEvent.selectOptions(sortCreated, 'createdOn');
+    userEvent.selectOptions(sortCreated, 'createdOn-asc');
 
     await waitFor(() => expect(fetchMock.called()).toBeTruthy());
   });


### PR DESCRIPTION
## Description of change
Sort options are now:
-creation date (newest to oldest) 
-creation date (oldest to newest)
-goal status (drafts first)
-goal status (completed first) 

## How to test
Ensure that the options appear as above; ensure that they sort as appropriate.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1074

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
