### PR TITLE
[TTAHUB-1076] Use permissions on front end of create goals

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -78,7 +78,6 @@ function GoalCard({
   };
 
   const contextMenuLabel = `Actions for goal ${id}`;
-  const showContextMenu = true;
   const menuItems = [
     {
       label: goalStatus === 'Closed' ? 'View' : 'Edit',
@@ -111,14 +110,10 @@ function GoalCard({
             regionId={regionId}
           />
         </div>
-        {showContextMenu
-          ? (
-            <ContextMenu
-              label={contextMenuLabel}
-              menuItems={menuItems}
-            />
-          )
-          : null}
+        <ContextMenu
+          label={contextMenuLabel}
+          menuItems={menuItems}
+        />
       </div>
       <div className="display-flex flex-wrap margin-y-2 margin-left-5">
         <div className="ttahub-goal-card__goal-column ttahub-goal-card__goal-column__goal-text padding-right-3">

--- a/frontend/src/components/GoalCards/__tests__/ObjectiveCard.js
+++ b/frontend/src/components/GoalCards/__tests__/ObjectiveCard.js
@@ -1,0 +1,41 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
+import ObjectiveCard from '../ObjectiveCard';
+
+describe('ObjectiveCard', () => {
+  const history = createMemoryHistory();
+
+  it('renders legacy reports', async () => {
+    const objective = {
+      id: 123,
+      title: 'This is an objective',
+      endDate: '2020-01-01',
+      reasons: ['reason1', 'reason2'],
+      status: 'In Progress',
+      grantNumbers: ['grant1', 'grant2'],
+      activityReports: [
+        {
+          displayId: 'r-123',
+          legacyId: '123',
+          number: '678',
+          id: 678,
+          endDate: '2020-01-01',
+        },
+      ],
+    };
+    render(
+      <Router history={history}>
+        <ObjectiveCard objective={objective} objectivesExpanded />
+      </Router>,
+    );
+    expect(screen.getByText('This is an objective')).toBeInTheDocument();
+    expect(screen.getByText('2020-01-01')).toBeInTheDocument();
+    expect(screen.getByText('reason1')).toBeInTheDocument();
+    expect(screen.getByText('reason2')).toBeInTheDocument();
+    const link = screen.getByText('r-123');
+    expect(link).toHaveAttribute('href', '/activity-reports/legacy/123');
+  });
+});

--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -46,6 +46,7 @@ export default function Form({
   goalNumbers,
   clearEmptyObjectiveError,
   onUploadFiles,
+  userCanEdit,
 }) {
   const { isLoading } = useContext(GoalFormLoadingContext);
 
@@ -135,6 +136,7 @@ export default function Form({
         validateGrantNumbers={validateGrantNumbers}
         error={errors[FORM_FIELD_INDEXES.GRANTS]}
         isLoading={isLoading}
+        userCanEdit={userCanEdit}
       />
 
       <GoalText
@@ -145,6 +147,7 @@ export default function Form({
         onUpdateText={onUpdateText}
         isLoading={isLoading}
         goalStatus={status}
+        userCanEdit={userCanEdit}
       />
 
       <GoalDate
@@ -156,6 +159,7 @@ export default function Form({
         key={datePickerKey}
         isLoading={isLoading}
         goalStatus={status}
+        userCanEdit={userCanEdit}
       />
 
       { objectives.map((objective, i) => (
@@ -173,10 +177,11 @@ export default function Form({
           topicOptions={topicOptions}
           onUploadFiles={onUploadFiles}
           goalStatus={status}
+          userCanEdit={userCanEdit}
         />
       ))}
 
-      { status !== 'Closed' && (
+      { (status !== 'Closed' || userCanEdit) && (
         <div className="margin-top-4">
           {errors[FORM_FIELD_INDEXES.OBJECTIVES_EMPTY]}
           <PlusButton onClick={onAddNewObjectiveClick} text="Add new objective" />
@@ -245,8 +250,10 @@ Form.propTypes = {
   clearEmptyObjectiveError: PropTypes.func.isRequired,
   onUploadFiles: PropTypes.func.isRequired,
   validateGoalNameAndRecipients: PropTypes.func.isRequired,
+  userCanEdit: PropTypes.bool,
 };
 
 Form.defaultProps = {
   endDate: null,
+  userCanEdit: false,
 };

--- a/frontend/src/components/GoalForm/GoalDate.js
+++ b/frontend/src/components/GoalForm/GoalDate.js
@@ -14,8 +14,9 @@ export default function GoalDate({
   inputName,
   isLoading,
   goalStatus,
+  userCanEdit,
 }) {
-  if (goalStatus === 'Closed') {
+  if (goalStatus === 'Closed' || !userCanEdit) {
     if (endDate && endDate !== 'Invalid date') {
       return (
         <>
@@ -60,6 +61,7 @@ GoalDate.propTypes = {
   inputName: PropTypes.string,
   isLoading: PropTypes.bool,
   goalStatus: PropTypes.string.isRequired,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 GoalDate.defaultProps = {

--- a/frontend/src/components/GoalForm/GoalText.js
+++ b/frontend/src/components/GoalForm/GoalText.js
@@ -14,6 +14,7 @@ export default function GoalText({
   inputName,
   isLoading,
   goalStatus,
+  userCanEdit,
 }) {
   return (
     <FormGroup error={error.props.children}>
@@ -22,7 +23,7 @@ export default function GoalText({
         {' '}
         {!isOnReport ? <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span> : null }
       </Label>
-      { isOnReport || goalStatus === 'Closed' ? (
+      { isOnReport || goalStatus === 'Closed' || !userCanEdit ? (
         <p className="usa-prose margin-top-0">{goalName}</p>
       ) : (
         <>
@@ -51,6 +52,7 @@ GoalText.propTypes = {
   inputName: PropTypes.string,
   isLoading: PropTypes.bool,
   goalStatus: PropTypes.string.isRequired,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 GoalText.defaultProps = {

--- a/frontend/src/components/GoalForm/GrantSelect.js
+++ b/frontend/src/components/GoalForm/GrantSelect.js
@@ -20,6 +20,7 @@ export default function GrantSelect({
   inputName,
   label,
   isLoading,
+  userCanEdit,
 }) {
   return (
     <FormGroup error={error.props.children}>
@@ -28,7 +29,7 @@ export default function GrantSelect({
         {' '}
         {!isOnReport ? <Req /> : null }
       </Label>
-      {possibleGrants.length === 1 || isOnReport ? (
+      {possibleGrants.length === 1 || isOnReport || !userCanEdit ? (
         <p className="margin-top-0 usa-prose">{selectedGrants.map((grant) => grant.label).join(', ')}</p>
       ) : (
         <>
@@ -71,6 +72,7 @@ GrantSelect.propTypes = {
   inputName: PropTypes.string,
   label: PropTypes.string,
   isLoading: PropTypes.bool,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 GrantSelect.defaultProps = {

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -22,6 +22,7 @@ export default function ObjectiveFiles({
   onBlur,
   reportId,
   label,
+  userCanEdit,
 }) {
   const objectiveId = objective.id;
   const hasFiles = useMemo(() => files && files.length > 0, [files]);
@@ -32,7 +33,7 @@ export default function ObjectiveFiles({
     () => (hasFiles && files.some((file) => file.onAnyReport)), [hasFiles, files],
   );
 
-  const readOnly = useMemo(() => status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status]);
+  const readOnly = useMemo(() => !userCanEdit || status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status, userCanEdit]);
 
   useEffect(() => {
     if (!useFiles && hasFiles) {
@@ -195,6 +196,7 @@ ObjectiveFiles.propTypes = {
   inputName: PropTypes.string,
   onBlur: PropTypes.func,
   reportId: PropTypes.number,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 ObjectiveFiles.defaultProps = {

--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -28,6 +28,7 @@ export default function ObjectiveForm({
   topicOptions,
   onUploadFiles,
   goalStatus,
+  userCanEdit,
 }) {
   // the parent objective data from props
   const {
@@ -110,6 +111,7 @@ export default function ObjectiveForm({
         validateObjectiveTitle={validateObjectiveTitle}
         status={status}
         isLoading={isLoading}
+        userCanEdit={userCanEdit}
       />
 
       <ObjectiveTopics
@@ -122,6 +124,7 @@ export default function ObjectiveForm({
         goalStatus={goalStatus}
         isOnReport={isOnReport || false}
         isLoading={isLoading}
+        userCanEdit={userCanEdit}
       />
 
       <ResourceRepeater
@@ -133,6 +136,7 @@ export default function ObjectiveForm({
         status={status}
         goalStatus={goalStatus}
         isLoading={isLoading}
+        userCanEdit={userCanEdit}
       />
       { title && (
       <ObjectiveFiles
@@ -145,6 +149,7 @@ export default function ObjectiveForm({
         onUploadFiles={onUploadFiles}
         index={index}
         goalStatus={goalStatus}
+        userCanEdit={userCanEdit}
       />
       )}
 
@@ -154,6 +159,7 @@ export default function ObjectiveForm({
         onChangeStatus={onChangeStatus}
         inputName={`objective-status-${index}`}
         isLoading={isLoading}
+        userCanEdit={userCanEdit}
       />
 
     </div>
@@ -204,6 +210,7 @@ ObjectiveForm.propTypes = {
     value: PropTypes.number,
   })).isRequired,
   onUploadFiles: PropTypes.func.isRequired,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 ObjectiveForm.defaultProps = {

--- a/frontend/src/components/GoalForm/ObjectiveStatus.js
+++ b/frontend/src/components/GoalForm/ObjectiveStatus.js
@@ -8,18 +8,19 @@ export default function ObjectiveStatus({
   onChangeStatus,
   inputName,
   isLoading,
+  userCanEdit,
 }) {
   // capture the initial status so updates to the status don't cause the dropdown to disappear
   const initialStatus = useRef(status);
 
   // if the goal is closed, the objective status should be read-only
   const hideDropdown = useMemo(() => {
-    if (goalStatus === 'Closed') {
+    if (goalStatus === 'Closed' || !userCanEdit) {
       return true;
     }
 
     return false;
-  }, [goalStatus]);
+  }, [goalStatus, userCanEdit]);
 
   const options = useMemo(() => {
     // if the objective is complete, it can only go back to in progress
@@ -86,6 +87,7 @@ ObjectiveStatus.propTypes = {
   inputName: PropTypes.string.isRequired,
   onChangeStatus: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 ObjectiveStatus.defaultProps = {

--- a/frontend/src/components/GoalForm/ObjectiveTitle.js
+++ b/frontend/src/components/GoalForm/ObjectiveTitle.js
@@ -15,14 +15,16 @@ export default function ObjectiveTitle({
   status,
   inputName,
   isLoading,
+  userCanEdit,
 }) {
   const readOnly = useMemo(() => (
     isOnApprovedReport
     || status === 'Complete'
     || status === 'Suspended'
     || (status === 'Not Started' && isOnReport)
-    || (status === 'In Progress' && isOnReport)),
-  [isOnApprovedReport, isOnReport, status]);
+    || (status === 'In Progress' && isOnReport)
+    || !userCanEdit),
+  [isOnApprovedReport, isOnReport, status, userCanEdit]);
 
   return (
     <FormGroup error={error.props.children}>
@@ -59,6 +61,7 @@ ObjectiveTitle.propTypes = {
   status: PropTypes.string.isRequired,
   inputName: PropTypes.string,
   isLoading: PropTypes.bool,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 ObjectiveTitle.defaultProps = {

--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -19,10 +19,11 @@ export default function ObjectiveTopics({
   inputName,
   isLoading,
   isOnReport,
+  userCanEdit,
 }) {
   const initialSelection = useRef(topics.length);
 
-  const readOnly = useMemo(() => status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status]);
+  const readOnly = useMemo(() => status === 'Suspended' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit, [goalStatus, isOnReport, status, userCanEdit]);
 
   if (goalStatus === 'Closed' && !initialSelection.current) {
     return null;
@@ -130,6 +131,7 @@ ObjectiveTopics.propTypes = {
     PropTypes.bool,
     PropTypes.number,
   ]).isRequired,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 ObjectiveTopics.defaultProps = {

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -22,6 +22,7 @@ export default function ResourceRepeater({
   isOnReport,
   isLoading,
   goalStatus,
+  userCanEdit,
 }) {
   const resourcesWrapper = useRef();
 
@@ -50,7 +51,7 @@ export default function ResourceRepeater({
   }
 
   const { editableResources, fixedResources } = resources.reduce((acc, resource) => {
-    if (resource.onAnyReport) {
+    if (resource.onAnyReport || !userCanEdit) {
       acc.fixedResources.push(resource);
     } else {
       acc.editableResources.push(resource);
@@ -90,49 +91,51 @@ export default function ResourceRepeater({
         </>
       ) : null }
 
-      <FormGroup error={error.props.children}>
-        <div ref={resourcesWrapper}>
-          <Label htmlFor="resources" className={fixedResources.length ? 'text-bold' : ''}>
-            {!fixedResources.length ? 'Resource links' : 'Add resource link'}
-            <QuestionTooltip
-              text="Copy and paste addresses of web pages describing resources used for this objective. Usually this is an ECLKC page."
-            />
-          </Label>
-          {error}
-          <div className="ttahub-resource-repeater">
-            { editableResources.map((r, i) => (
-              <div key={r.key} className="display-flex" id="resources">
-                <Label htmlFor={`resource-${i + 1}`} className="sr-only">
-                  Resource
-                  {' '}
-                  { i + 1 }
-                </Label>
-                <URLInput
-                  id={`resource-${i + 1}`}
-                  onBlur={validateResources}
-                  onChange={({ target: { value } }) => updateResource(value, i)}
-                  value={r.value}
-                  disabled={isLoading}
-                />
-                { resources.length > 1 ? (
-                  <Button unstyled type="button" onClick={() => removeResource(i)}>
-                    <FontAwesomeIcon className="margin-x-1" color={colors.ttahubMediumBlue} icon={faTrash} />
-                    <span className="sr-only">
-                      remove resource
-                      {' '}
-                      { i + 1 }
-                    </span>
-                  </Button>
-                ) : null}
-              </div>
-            ))}
-          </div>
+      { userCanEdit ? (
+        <FormGroup error={error.props.children}>
+          <div ref={resourcesWrapper}>
+            <Label htmlFor="resources" className={fixedResources.length ? 'text-bold' : ''}>
+              {!fixedResources.length ? 'Resource links' : 'Add resource link'}
+              <QuestionTooltip
+                text="Copy and paste addresses of web pages describing resources used for this objective. Usually this is an ECLKC page."
+              />
+            </Label>
+            {error}
+            <div className="ttahub-resource-repeater">
+              { editableResources.map((r, i) => (
+                <div key={r.key} className="display-flex" id="resources">
+                  <Label htmlFor={`resource-${i + 1}`} className="sr-only">
+                    Resource
+                    {' '}
+                    { i + 1 }
+                  </Label>
+                  <URLInput
+                    id={`resource-${i + 1}`}
+                    onBlur={validateResources}
+                    onChange={({ target: { value } }) => updateResource(value, i)}
+                    value={r.value}
+                    disabled={isLoading}
+                  />
+                  { resources.length > 1 ? (
+                    <Button unstyled type="button" onClick={() => removeResource(i)}>
+                      <FontAwesomeIcon className="margin-x-1" color={colors.ttahubMediumBlue} icon={faTrash} />
+                      <span className="sr-only">
+                        remove resource
+                        {' '}
+                        { i + 1 }
+                      </span>
+                    </Button>
+                  ) : null}
+                </div>
+              ))}
+            </div>
 
-          <div className="ttahub-resource-repeater--add-new margin-top-1 margin-bottom-3">
-            <PlusButton text="Add new resource" onClick={addResource} />
+            <div className="ttahub-resource-repeater--add-new margin-top-1 margin-bottom-3">
+              <PlusButton text="Add new resource" onClick={addResource} />
+            </div>
           </div>
-        </div>
-      </FormGroup>
+        </FormGroup>
+      ) : null }
     </>
   );
 }
@@ -152,6 +155,7 @@ ResourceRepeater.propTypes = {
   ]).isRequired,
   isLoading: PropTypes.bool,
   goalStatus: PropTypes.string.isRequired,
+  userCanEdit: PropTypes.bool.isRequired,
 };
 
 ResourceRepeater.defaultProps = {

--- a/frontend/src/components/GoalForm/__tests__/GrantSelect.js
+++ b/frontend/src/components/GoalForm/__tests__/GrantSelect.js
@@ -7,18 +7,21 @@ import userEvent from '@testing-library/user-event';
 import GrantSelect from '../GrantSelect';
 
 describe('GrantSelect', () => {
-  const renderGrantSelect = (validateGrantNumbers = jest.fn()) => {
+  const renderGrantSelect = (
+    validateGrantNumbers = jest.fn(), userCanEdit = true, selectedGrants = [],
+  ) => {
     render((
       <div>
         <GrantSelect
           error={<></>}
           setSelectedGrants={jest.fn()}
-          selectedGrants={[]}
+          selectedGrants={selectedGrants}
           validateGrantNumbers={validateGrantNumbers}
           label="Select grants"
           inputName="grantSelect"
           isLoading={false}
           isOnReport={false}
+          userCanEdit={userCanEdit}
           possibleGrants={[
             {
               value: 1,
@@ -34,7 +37,7 @@ describe('GrantSelect', () => {
       </div>));
   };
 
-  it('shows the read only view', async () => {
+  it('calls the on change handler', async () => {
     const validateGrantNumbers = jest.fn();
     renderGrantSelect(validateGrantNumbers);
     const select = await screen.findByLabelText(/select grants/i);
@@ -43,5 +46,16 @@ describe('GrantSelect', () => {
     userEvent.click(await screen.findByText('Blur me'));
 
     expect(validateGrantNumbers).toHaveBeenCalled();
+  });
+
+  it('shows the read only view', async () => {
+    const validateGrantNumbers = jest.fn();
+    const userCanEdit = false;
+    renderGrantSelect(validateGrantNumbers, userCanEdit, [{
+      value: 1,
+      label: 'Grant 1',
+    }]);
+    await screen.findByText(/select grants/i);
+    expect(await screen.findByText('Grant 1')).toBeVisible();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveFiles.js
@@ -23,6 +23,7 @@ describe('ObjectiveFiles', () => {
       onBlur={jest.fn()}
       goalStatus="Closed"
       onUploadFiles={jest.fn()}
+      userCanEdit
     />);
     expect(await screen.findByText('Resource files')).toBeVisible();
     expect(screen.getByText(/testfile1\.txt/i)).toBeVisible();
@@ -44,6 +45,28 @@ describe('ObjectiveFiles', () => {
       onBlur={jest.fn()}
       goalStatus="Not Started"
       onUploadFiles={jest.fn()}
+      userCanEdit
+    />);
+    expect(await screen.findByText('Resource files')).toBeVisible();
+    expect(screen.getByText(/testfile1\.txt/i)).toBeVisible();
+    expect(screen.getByText(/testfile2\.txt/i)).toBeVisible();
+  });
+
+  it('shows the read only when a user can\'t edit', async () => {
+    render(<ObjectiveFiles
+      files={[
+        { originalFileName: 'TestFile1.txt', id: 1 },
+        { originalFileName: 'TestFile2.txt', id: 2 },
+      ]}
+      onChangeFiles={jest.fn()}
+      objective={{ id: 1 }}
+      status="In Progress"
+      index={0}
+      inputName="objectiveFiles"
+      onBlur={jest.fn()}
+      goalStatus="Not Started"
+      onUploadFiles={jest.fn()}
+      userCanEdit={false}
     />);
     expect(await screen.findByText('Resource files')).toBeVisible();
     expect(screen.getByText(/testfile1\.txt/i)).toBeVisible();
@@ -65,6 +88,7 @@ describe('ObjectiveFiles', () => {
       onBlur={jest.fn()}
       onUploadFiles={jest.fn()}
       goalStatus="In Progress"
+      userCanEdit
     />);
     expect(screen.getByText(/testfile1\.txt/i)).toBeVisible();
     expect(screen.getByText(/testfile2\.txt/i)).toBeVisible();
@@ -82,6 +106,7 @@ describe('ObjectiveFiles', () => {
       onBlur={jest.fn()}
       status="Draft"
       goalStatus="In Progress"
+      userCanEdit
     />);
     let radio = screen.getByRole('radio', { name: /yes/i });
     userEvent.click(radio);
@@ -111,6 +136,7 @@ describe('ObjectiveFiles', () => {
       onBlur={jest.fn()}
       status="Draft"
       goalStatus="In Progress"
+      userCanEdit
     />);
     expect(screen.queryByRole('radio', { name: /yes/i })).not.toBeInTheDocument();
   });

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -65,6 +65,7 @@ describe('ObjectiveForm', () => {
           'Curriculum (Instructional or Parenting)',
           'Data and Evaluation',
         ].map((name, id) => ({ id, name }))}
+        userCanEdit
       />
     ));
   };
@@ -106,7 +107,7 @@ describe('ObjectiveForm', () => {
     expect(setObjectiveError).toHaveBeenCalledWith(index, [<span className="usa-error-message">{objectiveTextError}</span>, <></>, <></>]);
   });
 
-  it('you can change role and status', async () => {
+  it('you can change status', async () => {
     const removeObjective = jest.fn();
     const setObjectiveError = jest.fn();
     const setObjective = jest.fn();

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveStatus.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveStatus.js
@@ -16,6 +16,7 @@ describe('ObjectiveStatus', () => {
       onChangeStatus={onChangeStatus}
       inputName="objective-status"
       isOnReport={false}
+      userCanEdit
     />);
 
     const dropdown = await screen.findByLabelText('Objective status');
@@ -37,6 +38,7 @@ describe('ObjectiveStatus', () => {
       onChangeStatus={onChangeStatus}
       inputName="objective-status"
       isOnReport={false}
+      userCanEdit
     />);
 
     const dropdown = await screen.findByLabelText('Objective status');
@@ -55,6 +57,25 @@ describe('ObjectiveStatus', () => {
       onChangeStatus={onChangeStatus}
       inputName="objective-status"
       isOnReport={false}
+      userCanEdit
+    />);
+
+    const label = await screen.findByText('Objective status');
+
+    expect(label).toBeVisible();
+    expect(label.tagName).toEqual('P');
+
+    expect(document.querySelector('select')).toBe(null);
+  });
+
+  it('shows the read only view when the user cannot edit', async () => {
+    render(<ObjectiveStatus
+      status="In Progress"
+      goalStatus="In Progress"
+      onChangeStatus={jest.fn()}
+      inputName="objective-status"
+      isOnReport={false}
+      userCanEdit={false}
     />);
 
     const label = await screen.findByText('Objective status');

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
@@ -26,6 +26,7 @@ describe('ObjectiveTopics', () => {
     topics = defaultTopicSelection,
     objectiveStatus = 'In Progress',
     goalStatus = 'In Progress',
+    userCanEdit = true,
   ) => render((
     <ObjectiveTopics
       error={<></>}
@@ -36,6 +37,7 @@ describe('ObjectiveTopics', () => {
       status={objectiveStatus}
       isOnReport={isOnReport}
       goalStatus={goalStatus}
+      userCanEdit={userCanEdit}
     />
   ));
 
@@ -55,6 +57,20 @@ describe('ObjectiveTopics', () => {
       defaultTopicSelection,
       'Not Started',
       'Not Started',
+    );
+
+    expect(await screen.findByText(/dancing but too slow/i)).toBeVisible();
+    expect(await screen.findByText(/dancing but too fast/i)).toBeVisible();
+    expect(document.querySelector('input')).toBeNull();
+  });
+
+  it('shows the read only view when a user can\'t edit', async () => {
+    renderObjectiveTopics(
+      false,
+      defaultTopicSelection,
+      'Not Started',
+      'Not Started',
+      false,
     );
 
     expect(await screen.findByText(/dancing but too slow/i)).toBeVisible();

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -19,6 +19,7 @@ describe('ResourceRepeater', () => {
       isOnReport={false}
       isLoading={false}
       goalStatus="In Progress"
+      userCanEdit
     />);
 
     expect(await screen.findByText('Resource links')).toBeVisible();
@@ -29,7 +30,7 @@ describe('ResourceRepeater', () => {
     expect(resources2.tagName).toBe('A');
   });
 
-  it('shows the read only view', async () => {
+  it('shows the read only view for used resources', async () => {
     render(<ResourceRepeater
       error={<></>}
       resources={[
@@ -42,6 +43,30 @@ describe('ResourceRepeater', () => {
       isOnReport
       isLoading={false}
       goalStatus="Not Started"
+      userCanEdit
+    />);
+
+    expect(await screen.findByText('Resource links')).toBeVisible();
+    const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
+    expect(resources1).toBeNull();
+    const resources2 = await screen.findByText('http://www.resources2.com');
+    expect(resources2).toBeVisible();
+    expect(resources2.tagName).toBe('A');
+  });
+
+  it('shows the read only view when a user can\'t edit', async () => {
+    render(<ResourceRepeater
+      error={<></>}
+      resources={[
+        { key: 1, value: 'http://www.resources.com', onAnyReport: false },
+        { key: 1, value: 'http://www.resources2.com', onAnyReport: true },
+      ]}
+      setResources={jest.fn()}
+      validateResources={jest.fn()}
+      status="In Progress"
+      isLoading={false}
+      goalStatus="Not Started"
+      userCanEdit={false}
     />);
 
     expect(await screen.findByText('Resource links')).toBeVisible();

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -15,8 +15,9 @@ import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import CreateGoal from '../index';
+import UserContext from '../../../UserContext';
 import { OBJECTIVE_ERROR_MESSAGES } from '../constants';
-import { REPORT_STATUSES } from '../../../Constants';
+import { REPORT_STATUSES, SCOPE_IDS } from '../../../Constants';
 import { BEFORE_OBJECTIVES_CREATE_GOAL, BEFORE_OBJECTIVES_SELECT_RECIPIENTS } from '../Form';
 
 const [
@@ -101,11 +102,18 @@ describe('create goal', () => {
     const history = createMemoryHistory();
     render((
       <Router history={history}>
-        <CreateGoal
-          recipient={recipient}
-          regionId="1"
-          isNew={goalId === 'new'}
-        />
+        <UserContext.Provider value={{
+          user: {
+            permissions: [{ regionId: 1, scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS }],
+          },
+        }}
+        >
+          <CreateGoal
+            recipient={recipient}
+            regionId="1"
+            isNew={goalId === 'new'}
+          />
+        </UserContext.Provider>
       </Router>
     ));
   }

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -2,6 +2,7 @@ import React, {
   useEffect,
   useState,
   useMemo,
+  useContext,
 } from 'react';
 import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
@@ -26,12 +27,13 @@ import {
   SELECT_GRANTS_ERROR,
   OBJECTIVE_DEFAULT_ERRORS,
 } from './constants';
-import { DECIMAL_BASE } from '../../Constants';
+import { DECIMAL_BASE, SCOPE_IDS } from '../../Constants';
 import ReadOnly from './ReadOnly';
 import PlusButton from './PlusButton';
 import colors from '../../colors';
 import GoalFormLoadingContext from '../../GoalFormLoadingContext';
 import useUrlParamState from '../../hooks/useUrlParamState';
+import UserContext from '../../UserContext';
 
 const [
   objectiveTextError,
@@ -98,6 +100,20 @@ export default function GoalForm({
   const [errors, setErrors] = useState(FORM_FIELD_DEFAULT_ERRORS);
 
   const [isLoading, setIsLoading] = useState(false);
+
+  const { user } = useContext(UserContext);
+
+  const canView = useMemo(() => user.permissions.filter(
+    (permission) => permission.regionId === parseInt(regionId, DECIMAL_BASE),
+  ).length > 0, [regionId, user.permissions]);
+
+  const canEdit = useMemo(() => user.permissions.filter(
+    (permission) => permission.regionId === parseInt(regionId, DECIMAL_BASE)
+      && (
+        permission.scopeId === SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS
+        || permission.scopeId === SCOPE_IDS.APPROVE_ACTIVITY_REPORTS
+      ),
+  ).length > 0, [regionId, user.permissions]);
 
   const isOnReport = useMemo(() => objectives.some(
     (objective) => objective.activityReports && objective.activityReports.length > 0,
@@ -694,6 +710,14 @@ export default function GoalForm({
     }
   };
 
+  if (!canView) {
+    return (
+      <Alert role="alert" className="margin-y-2" type="error">
+        You don&apos;t have permission to view this page
+      </Alert>
+    );
+  }
+
   return (
     <>
       { showRTRnavigation ? (
@@ -764,10 +788,11 @@ export default function GoalForm({
               status={status || 'Needs status'}
               goalNumbers={goalNumbers}
               onUploadFiles={onUploadFiles}
+              userCanEdit={canEdit}
             />
             )}
 
-            { (isNew || status === 'Draft') && status !== 'Closed' && (
+            { canEdit && (isNew || status === 'Draft') && status !== 'Closed' && (
               <div className="margin-top-4">
                 { !showForm ? <Button type="submit">Submit goal</Button> : null }
                 { showForm ? <Button type="button" onClick={onSaveAndContinue}>Save and continue</Button> : null }
@@ -786,7 +811,7 @@ export default function GoalForm({
               </div>
             )}
 
-            { (!isNew && status !== 'Draft') && status !== 'Closed' && (
+            { canEdit && (!isNew && status !== 'Draft') && status !== 'Closed' && (
             <div className="margin-top-4">
               <Button
                 type="submit"

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -143,6 +143,7 @@ export default function GoalForm({
         isOnReport={goal.onApprovedAR || false}
         goalStatus={status}
         isLoading={isLoading || loadingObjectives}
+        userCanEdit
       />
 
       <GoalDate
@@ -154,6 +155,7 @@ export default function GoalForm({
         inputName={goalEndDateInputName}
         goalStatus={status}
         isLoading={isLoading || loadingObjectives}
+        userCanEdit
       />
 
       <Objectives

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -240,6 +240,7 @@ export default function Objective({
         inputName={objectiveTopicsInputName}
         status={objectiveStatus}
         goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
+        userCanEdit
       />
       <ResourceRepeater
         resources={isOnApprovedReport ? [] : resourcesForRepeater}
@@ -253,6 +254,7 @@ export default function Objective({
         status={objective.status || 'Not Started'}
         inputName={objectiveResourcesInputName}
         goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
+        userCanEdit
       />
       <ObjectiveFiles
         objective={objective}
@@ -267,6 +269,7 @@ export default function Objective({
         reportId={reportId}
         goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
         label="Did you use any TTA resources that aren't available as link?"
+        userCanEdit
       />
       <ObjectiveTta
         ttaProvided={objectiveTta}
@@ -284,6 +287,7 @@ export default function Objective({
         inputName={objectiveStatusInputName}
         status={objectiveStatus}
         onChangeStatus={onChangeStatus}
+        userCanEdit
       />
     </>
   );


### PR DESCRIPTION
## Description of change
The create goals form is tied to a region. Users with read only permissions will see the create goals form in read only. Users without any regional permissions will see an error message

## How to test
Verify the above is true, verify that the existing permissions/behavior is uninterrupted. 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1076

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
