### PR TITLE
[TTAHUB-1029] Remove extra alert from goals form

### DIFF
--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -87,8 +87,7 @@ export default function Form({
 
   const formTitle = goalNumbers && goalNumbers.length ? `Goal ${goalNumbers.join(', ')}` : 'Recipient TTA goal';
 
-  const showApprovedReportAlert = isOnApprovedReport && status !== 'Closed';
-  const showNotStartedAlert = isOnReport && !showApprovedReportAlert && status !== 'Closed';
+  const showAlert = isOnReport && status !== 'Closed';
 
   return (
     <div className="ttahub-create-goals-form">
@@ -108,18 +107,9 @@ export default function Form({
       </div>
 
       {
-        showNotStartedAlert ? (
+        showAlert ? (
           <Alert type="info" noIcon>
             <p className="usa-prose">This goal is used on an activity report, so some fields can&apos;t be edited.</p>
-          </Alert>
-        )
-          : null
-      }
-
-      {
-        showApprovedReportAlert ? (
-          <Alert type="info" noIcon>
-            <p className="usa-prose">Field entries that are used on an activity report can no longer be edited. </p>
           </Alert>
         )
           : null

--- a/frontend/src/components/GoalForm/__tests__/Form.js
+++ b/frontend/src/components/GoalForm/__tests__/Form.js
@@ -63,18 +63,6 @@ describe('Goal Form > Form component', () => {
     expect(document.querySelector('.ttahub-create-goals-form')).not.toBeNull();
   });
 
-  it('shows an error where some objectives are in progress', async () => {
-    const objectives = [{
-      title: 'This is an objective',
-      status: 'In Progress',
-      topics: [],
-      resources: [],
-    }];
-    renderGoalForm({ ...DEFAULT_GOAL, isOnApprovedReport: true }, objectives);
-
-    expect(await screen.findByText(/Field entries that are used on an activity report can no longer be edited/i)).toBeVisible();
-  });
-
   it('shows an error when the fetch has failed', async () => {
     const objectives = [];
     renderGoalForm(DEFAULT_GOAL, objectives, 'There was a fetch error');


### PR DESCRIPTION
## Description of change

Feedback from designers: we had two alerts on the manage goals form, one of which was no longer supposed to be in use. This PR removes the "Field entries that are used on an activity report can no longer be edited" so that any report on an activity report gets this message: "This goal is used on an activity report, so some fields can&apos;t be edited," and there is no other state. 

## How to test
Verify the above

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1029


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
