### PR TITLE
[TTAHUB-1074] fix delete button functionality from edit goals page

### DIFF
--- a/frontend/src/components/GoalForm/ReadOnlyGoal.js
+++ b/frontend/src/components/GoalForm/ReadOnlyGoal.js
@@ -18,7 +18,7 @@ export default function ReadOnlyGoal({
     },
     {
       label: 'Remove',
-      onClick: () => onRemove(goal.id),
+      onClick: () => onRemove(goal),
     },
   ];
 
@@ -26,7 +26,7 @@ export default function ReadOnlyGoal({
     menuItems = [
       {
         label: 'Remove',
-        onClick: () => onRemove(goal.id),
+        onClick: () => onRemove(goal),
       },
     ];
   }
@@ -84,7 +84,10 @@ ReadOnlyGoal.propTypes = {
     objectives: PropTypes.arrayOf(
       PropTypes.shape({
         ttaProvided: PropTypes.string,
-        resources: PropTypes.arrayOf(PropTypes.string),
+        resources: PropTypes.arrayOf(PropTypes.shape({
+          key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+          value: PropTypes.string,
+        })),
         topics: PropTypes.arrayOf(PropTypes.shape({
           label: PropTypes.string,
         })),

--- a/frontend/src/components/GoalForm/__tests__/ReadOnlyGoal.js
+++ b/frontend/src/components/GoalForm/__tests__/ReadOnlyGoal.js
@@ -55,6 +55,9 @@ describe('ReadOnlyGoal', () => {
     const menu = await screen.findByTestId('menu');
     const removeButton = within(menu).getByText('Remove');
     userEvent.click(removeButton);
-    expect(onRemove).toHaveBeenCalledWith(1);
+
+    expect(onRemove).toHaveBeenCalledWith({
+      endDate: null, grant: {}, id: 1, name: 'Sample goal', objectives: [],
+    });
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -365,7 +365,7 @@ describe('create goal', () => {
     userEvent.click(goalActions);
 
     fetchMock.restore();
-    fetchMock.delete('/api/goals/64175', JSON.stringify(1));
+    fetchMock.delete('/api/goals?goalIds=64175', JSON.stringify(1));
     expect(fetchMock.called()).toBe(false);
 
     const deleteButton = within(await screen.findByTestId('menu')).getByRole('button', { name: /remove/i });
@@ -451,7 +451,7 @@ describe('create goal', () => {
     save = await screen.findByRole('button', { name: /save and continue/i });
     userEvent.click(save);
 
-    fetchMock.delete('/api/goals/64175', JSON.stringify(1));
+    fetchMock.delete('/api/goals?goalIds=64175', JSON.stringify(1));
 
     const goalActions = await screen.findByRole('button', { name: /actions for goal/i });
     userEvent.click(goalActions);

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -670,10 +670,10 @@ export default function GoalForm({
   const onRemove = async (g) => {
     setIsLoading(true);
     try {
-      const success = await deleteGoal(g, regionId);
+      const success = await deleteGoal(g.goalIds, regionId);
 
       if (success) {
-        const newGoals = createdGoals.filter((goal) => goal.id !== g);
+        const newGoals = createdGoals.filter((goal) => goal.id !== g.id);
         setCreatedGoals(newGoals);
         if (!newGoals.length) {
           setShowForm(true);

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -238,7 +238,7 @@ export default function GoalForm({
   const validateGoalName = (message = GOAL_NAME_ERROR) => {
     let error = <></>;
 
-    if (!goalName) {
+    if (!goalName || !goalName.trim()) {
       error = <span className="usa-error-message">{message}</span>;
     }
 

--- a/frontend/src/fetchers/goals.js
+++ b/frontend/src/fetchers/goals.js
@@ -42,8 +42,8 @@ export async function updateGoalStatus(
   return updatedGoal.json();
 }
 
-export async function deleteGoal(id, regionId) {
-  const url = join(goalsUrl, id.toString());
+export async function deleteGoal(goalIds, regionId) {
+  const url = join(goalsUrl, `?${goalIds.map((id) => `goalIds=${id}`).join('&')}`);
   const deleted = await destroy(url, { regionId });
   return deleted.json();
 }

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -109,9 +109,10 @@ const GoalsObjectives = ({
     setValue('goalForEditing', newGoal(grantIds));
   };
 
-  const onRemove = (goalId) => {
-    const copyOfSelectedGoals = selectedGoals.map((goal) => ({ ...goal }));
-    const index = copyOfSelectedGoals.findIndex((goal) => goal.id === goalId);
+  const onRemove = (goal) => {
+    const goalId = goal.id;
+    const copyOfSelectedGoals = selectedGoals.map((g) => ({ ...g }));
+    const index = copyOfSelectedGoals.findIndex((g) => g.id === goalId);
 
     if (index !== -1) {
       copyOfSelectedGoals.splice(index, 1);

--- a/src/routes/goals/handlers.js
+++ b/src/routes/goals/handlers.js
@@ -114,7 +114,7 @@ export async function changeGoalStatus(req, res) {
 export async function deleteGoal(req, res) {
   try {
     const { goalIds } = req.query;
-    const ids = goalIds.map((id) => parseInt(id, DECIMAL_BASE));
+    const ids = [goalIds].flat().map((id) => parseInt(id, DECIMAL_BASE));
 
     const user = await userById(req.session.userId);
 

--- a/src/routes/goals/handlers.js
+++ b/src/routes/goals/handlers.js
@@ -114,7 +114,7 @@ export async function changeGoalStatus(req, res) {
 export async function deleteGoal(req, res) {
   try {
     const { goalIds } = req.query;
-    const ids = [goalIds].flat().map((id) => parseInt(id, DECIMAL_BASE));
+    const ids = [goalIds].flatMap((id) => parseInt(id, DECIMAL_BASE));
 
     const user = await userById(req.session.userId);
 

--- a/src/routes/goals/handlers.test.js
+++ b/src/routes/goals/handlers.test.js
@@ -376,8 +376,8 @@ describe('deleteGoal', () => {
 
   it('checks permissions', async () => {
     const req = {
-      params: {
-        goalId: 1,
+      query: {
+        goalIds: [1],
       },
       session: {
         userId: 1,
@@ -405,8 +405,8 @@ describe('deleteGoal', () => {
 
   it('handles success', async () => {
     const req = {
-      params: {
-        goalId: 1,
+      query: {
+        goalIds: [1],
       },
       session: {
         userId: 1,
@@ -435,8 +435,8 @@ describe('deleteGoal', () => {
 
   it('handles failures', async () => {
     const req = {
-      params: {
-        goalId: 1,
+      query: {
+        goalIds: [1],
       },
       session: {
         userId: 1,

--- a/src/routes/goals/index.js
+++ b/src/routes/goals/index.js
@@ -13,6 +13,6 @@ router.post('/', transactionWrapper(createGoals));
 router.get('/', transactionWrapper(retrieveGoalsByIds));
 router.get('/:goalId/recipient/:recipientId', transactionWrapper(retrieveGoalByIdAndRecipient));
 router.put('/changeStatus', transactionWrapper(changeGoalStatus));
-router.delete('/:goalId', transactionWrapper(deleteGoal));
+router.delete('/', transactionWrapper(deleteGoal));
 
 export default router;

--- a/src/services/goalServices/destroyGoal.test.js
+++ b/src/services/goalServices/destroyGoal.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import faker from '@faker-js/faker';
 import { destroyGoal } from '../goals';
 import db, {
@@ -11,7 +10,7 @@ import db, {
 } from '../../models';
 import { auditLogger } from '../../logger';
 
-describe.skip('destroyGoal handler', () => {
+describe('destroyGoal handler', () => {
   const oldFindAll = ActivityReport.findAll;
 
   let goal;
@@ -32,24 +31,19 @@ describe.skip('destroyGoal handler', () => {
     goal = await Goal.create({
       name: 'This is some serious goal text',
       status: 'Draft',
+      grantId: grant.id,
     });
 
     goalTwo = await Goal.create({
       name: 'This is another goal',
       status: 'Not Started',
+      grantId: grant.id,
     });
-
-    // await GrantGoal.create({
-    //   recipientId: recipient.id,
-    //   grantId: grant.id,
-    //   goalId: goal.id,
-    // });
 
     objective = await Objective.create({
       goalId: goal.id,
       status: 'Not Started',
       title: 'Make everything ok',
-      // ttaProvided: 'No',
     });
 
     await ObjectiveResource.create({
@@ -70,12 +64,6 @@ describe.skip('destroyGoal handler', () => {
         goalId: goal.id,
       },
     });
-
-    // await GrantGoal.destroy({
-    //   where: {
-    //     goalId: goal.id,
-    //   },
-    // });
 
     await Goal.destroy({
       where: {
@@ -106,12 +94,6 @@ describe.skip('destroyGoal handler', () => {
         id: goal.id,
       },
     });
-
-    // let foundGrantGoal = await GrantGoal.findAll({
-    //   where: {
-    //     goalId: goal.id,
-    //   },
-    // });
 
     let foundObjective = await Objective.findAll({
       where: {
@@ -156,7 +138,6 @@ describe.skip('destroyGoal handler', () => {
     });
 
     expect(foundGoal.length).toBe(0);
-    // expect(foundGrantGoal.length).toBe(0);
     expect(foundObjective.length).toBe(0);
     expect(foundObjectiveResource.length).toBe(0);
   });

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -776,7 +776,7 @@ export async function createOrUpdateGoals(goals) {
       where: {
         grantId,
         status: { [Op.not]: 'Closed' },
-        id: ids,
+        id: ids || [],
       },
     });
 


### PR DESCRIPTION
## Description of change
In the distant past, when the manage goals page was constructed, I was asked to disable deleting of goals from the manage goals page so that things couldn't get too wild while we were testing.

It was just a few nights ago that I awoke with the realization that I had never rewired things. I mopped the sweat from my brow, dusted off this code and discovered it was largely still functional, except for needing a few small tweaks. I removed references to the GrantGoals table. I refactored it to remove two goals at once where appropriate. I believe it now functions as intended. 

## How to test
The only way to access it is by creating a goal from the RTR and then immediately deleting it. There is no "read only" screen for editing goals any longer. This change also effects (mildly) the delete goals function from the AR, although only on the frontend.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1074


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
