### PR TITLE
[TTAHUB-1069] Prevent Clicking Save Goal Multiple Times

### DIFF
--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -150,11 +150,22 @@ function Navigator({
   const isOtherEntityReport = activityRecipientType === 'other-entity';
 
   const onSaveDraft = async () => {
-    await onSaveForm(); // save the form data to the server
-    updateShowSavedDraft(true); // show the saved draft message
+    if (isLoading) {
+      return;
+    }
+    setIsLoading(true);
+    try {
+      await onSaveForm(); // save the form data to the server
+      updateShowSavedDraft(true); // show the saved draft message
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const onSaveDraftGoal = async () => {
+    if (isLoading) {
+      return;
+    }
     // Prevent user from making changes to goal title during auto-save.
     setIsLoading(true);
     // the goal form only allows for one goal to be open at a time
@@ -324,12 +335,20 @@ function Navigator({
   };
 
   const onGoalFormNavigate = async () => {
-    if (isOtherEntityReport) {
+    if (isLoading) {
+      return;
+    }
+    setIsLoading(true);
+    try {
+      if (isOtherEntityReport) {
       // Save objectives for other-entity report.
-      await onObjectiveFormNavigate();
-    } else {
+        await onObjectiveFormNavigate();
+      } else {
       // Save goals for recipient report.
-      await saveGoalsNavigate();
+        await saveGoalsNavigate();
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
 


### PR DESCRIPTION
## Description of change

This prevents a goal bug if the user clicks Save Goal or Save Draft multiple times.

## How to test

Create an AR go to the goals page create a Goal and Objective. Mashing the 'Save Draft' or 'Save Goal' button should only send a single save request. The user should only be able to save again once the initial save completes. 

Goals, Objectives, ARG's, and ARO's are created correctly in the database.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1069

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
