### PR TITLE
Goal end date is no longer a required field

### DIFF
--- a/frontend/src/components/ActivityReportsTable/__tests__/ReportRow.js
+++ b/frontend/src/components/ActivityReportsTable/__tests__/ReportRow.js
@@ -64,4 +64,189 @@ describe('ReportRow', () => {
     userEvent.keyboard('{enter}');
     expect(exportSelected).toHaveBeenCalled();
   });
+
+  it('shows the correct URL for a legacy report', () => {
+    const legacyReport = {
+      startDate: '02/08/2021',
+      lastSaved: '02/05/2021',
+      id: 1,
+      displayId: 'R14-AR-1',
+      regionId: 14,
+      legacyId: 123456,
+      topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+      sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+      calculatedStatus: 'approved',
+      activityRecipients: [
+        {
+          activityRecipientId: 5,
+          name: 'Johnston-Romaguera - 14CH00003',
+          id: 1,
+          grant: {
+            id: 5,
+            number: '14CH00003',
+            recipient: {
+              name: 'Johnston-Romaguera',
+            },
+          },
+          otherEntity: null,
+        },
+        {
+          activityRecipientId: 4,
+          name: 'Johnston-Romaguera - 14CH00002',
+          id: 2,
+          grant: {
+            id: 4,
+            number: '14CH00002',
+            recipient: {
+              name: 'Johnston-Romaguera',
+            },
+          },
+          otherEntity: null,
+        },
+        {
+          activityRecipientId: 1,
+          name: 'Grantee Name - 14CH1234',
+          id: 3,
+          grant: {
+            id: 1,
+            number: '14CH1234',
+            recipient: {
+              name: 'Grantee Name',
+            },
+          },
+          otherEntity: null,
+        },
+      ],
+      author: {
+        fullName: 'Kiwi, GS',
+        name: 'Kiwi',
+        role: 'Grants Specialist',
+        homeRegionId: 14,
+      },
+      activityReportCollaborators: [
+        {
+          fullName: 'Orange, GS',
+          user: {
+            fullName: 'Orange, GS',
+            name: 'Orange',
+            role: 'Grants Specialist',
+          },
+        },
+        {
+          fullName: 'Hermione Granger, SS',
+          user: {
+            fullName: 'Hermione Granger, SS',
+            name: 'Hermione Granger',
+            role: 'System Specialist',
+          },
+        },
+      ],
+    };
+    render(
+      <Router history={history}>
+        <ReportRow
+          report={legacyReport}
+          openMenuUp={false}
+          handleReportSelect={jest.fn()}
+          isChecked={false}
+          numberOfSelectedReports={0}
+          exportSelected={jest.fn()}
+        />
+      </Router>,
+    );
+
+    expect(screen.getByText('R14-AR-1')).toHaveAttribute('href', '/activity-reports/legacy/123456');
+  });
+
+  it('shows the correct URL for an approved report', () => {
+    const legacyReport = {
+      startDate: '02/08/2021',
+      lastSaved: '02/05/2021',
+      id: 1,
+      displayId: 'R14-AR-1',
+      regionId: 14,
+      topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+      sortedTopics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+      calculatedStatus: 'approved',
+      activityRecipients: [
+        {
+          activityRecipientId: 5,
+          name: 'Johnston-Romaguera - 14CH00003',
+          id: 1,
+          grant: {
+            id: 5,
+            number: '14CH00003',
+            recipient: {
+              name: 'Johnston-Romaguera',
+            },
+          },
+          otherEntity: null,
+        },
+        {
+          activityRecipientId: 4,
+          name: 'Johnston-Romaguera - 14CH00002',
+          id: 2,
+          grant: {
+            id: 4,
+            number: '14CH00002',
+            recipient: {
+              name: 'Johnston-Romaguera',
+            },
+          },
+          otherEntity: null,
+        },
+        {
+          activityRecipientId: 1,
+          name: 'Grantee Name - 14CH1234',
+          id: 3,
+          grant: {
+            id: 1,
+            number: '14CH1234',
+            recipient: {
+              name: 'Grantee Name',
+            },
+          },
+          otherEntity: null,
+        },
+      ],
+      author: {
+        fullName: 'Kiwi, GS',
+        name: 'Kiwi',
+        role: 'Grants Specialist',
+        homeRegionId: 14,
+      },
+      activityReportCollaborators: [
+        {
+          fullName: 'Orange, GS',
+          user: {
+            fullName: 'Orange, GS',
+            name: 'Orange',
+            role: 'Grants Specialist',
+          },
+        },
+        {
+          fullName: 'Hermione Granger, SS',
+          user: {
+            fullName: 'Hermione Granger, SS',
+            name: 'Hermione Granger',
+            role: 'System Specialist',
+          },
+        },
+      ],
+    };
+    render(
+      <Router history={history}>
+        <ReportRow
+          report={legacyReport}
+          openMenuUp={false}
+          handleReportSelect={jest.fn()}
+          isChecked={false}
+          numberOfSelectedReports={0}
+          exportSelected={jest.fn()}
+        />
+      </Router>,
+    );
+
+    expect(screen.getByText('R14-AR-1')).toHaveAttribute('href', '/activity-reports/view/1');
+  });
 });

--- a/frontend/src/components/GoalForm/GoalDate.js
+++ b/frontend/src/components/GoalForm/GoalDate.js
@@ -31,7 +31,6 @@ export default function GoalDate({
       <Label htmlFor={inputName}>
         Anticipated close date (mm/dd/yyyy)
         {' '}
-        <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
         <QuestionTooltip text="When do you expect to end TTA work and mark this goal as closed?" />
       </Label>
       {error}

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -84,6 +84,7 @@ export default function ObjectiveFiles({
                     text={(
                       <div>
                         Examples include:
+                        {' '}
                         <ul className="usa-list">
                           <li>Presentation slides from PD events</li>
                           <li>PDF&apos;s you created from multiple tta resources</li>

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -38,7 +38,7 @@ export default function ResourceRepeater({
         <p className="usa-prose text-bold margin-bottom-0">Resource links</p>
         <ul className="usa-list usa-list--unstyled">
           {onlyResourcesWithValues.map((resource) => (
-            !(status === 'Complete' && goalStatus === 'Closed') || resource.onAnyReport ? (
+            !(status === 'Complete' || goalStatus === 'Closed') || resource.onAnyReport ? (
               <li key={uuidv4()}>
                 <a href={resource.value}>{resource.value}</a>
               </li>

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -106,7 +106,7 @@ describe('ObjectiveForm', () => {
     expect(setObjectiveError).toHaveBeenCalledWith(index, [<span className="usa-error-message">{objectiveTextError}</span>, <></>, <></>]);
   });
 
-  it('you can change role and status', async () => {
+  it('you can change status', async () => {
     const removeObjective = jest.fn();
     const setObjectiveError = jest.fn();
     const setObjective = jest.fn();

--- a/frontend/src/components/GoalForm/__tests__/ReadOnlyGoal.js
+++ b/frontend/src/components/GoalForm/__tests__/ReadOnlyGoal.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import {
-  render, screen,
+  render, screen, within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ReadOnlyGoal from '../ReadOnlyGoal';
@@ -15,11 +15,11 @@ describe('ReadOnlyGoal', () => {
     id: 1,
   };
 
-  const renderReadOnlyGoal = (hideEdit = false) => {
+  const renderReadOnlyGoal = (hideEdit = false, onRemove = jest.fn()) => {
     render((
       <ReadOnlyGoal
         onEdit={jest.fn()}
-        onRemove={jest.fn()}
+        onRemove={onRemove}
         hideEdit={hideEdit}
         goal={createdGoal}
         index={0}
@@ -44,5 +44,17 @@ describe('ReadOnlyGoal', () => {
     userEvent.click(contextButton);
     const menu = await screen.findByTestId('menu');
     expect(menu.querySelectorAll('li').length).toBe(1);
+  });
+
+  it('calls on remove', async () => {
+    const onRemove = jest.fn();
+    renderReadOnlyGoal(false, onRemove);
+
+    const contextButton = await screen.findByRole('button');
+    userEvent.click(contextButton);
+    const menu = await screen.findByTestId('menu');
+    const removeButton = within(menu).getByText('Remove');
+    userEvent.click(removeButton);
+    expect(onRemove).toHaveBeenCalledWith(1);
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/UnusedData.js
+++ b/frontend/src/components/GoalForm/__tests__/UnusedData.js
@@ -14,5 +14,18 @@ describe('UnusedData', () => {
 
     expect(await screen.findByText('value')).toBeVisible();
     expect(document.querySelector('svg')).toBeTruthy();
+    expect(document.querySelector('a')).toBe(null);
+  });
+
+  it('shows a link when it is supposed to', async () => {
+    render(<UnusedData
+      key="key"
+      value="value"
+      isLink
+    />);
+
+    expect(await screen.findByText('value')).toBeVisible();
+    expect(document.querySelector('svg')).toBeTruthy();
+    expect(document.querySelector('a')).toBeTruthy();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -150,7 +150,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     const save = await screen.findByRole('button', { name: /save and continue/i });
@@ -160,9 +160,7 @@ describe('create goal', () => {
     await screen.findByText('Select at least one recipient grant number');
 
     const combo = await screen.findByLabelText(/Recipient grant numbers/i);
-    await selectEvent.select(combo, ['Turtle 1']);
-
-    const cancel = await screen.findByRole('link', { name: 'Cancel' });
+    await selectEvent.select(combo, ['Turtle 2']);
 
     const newObjective = await screen.findByRole('button', { name: 'Add new objective' });
     userEvent.click(newObjective);
@@ -173,7 +171,7 @@ describe('create goal', () => {
     const topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['CLASS: Instructional Support']);
 
-    const resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });
+    const resourceOne = document.querySelector('#resource-1');
     userEvent.type(resourceOne, 'https://search.marginalia.nu/');
 
     userEvent.click(save);
@@ -186,8 +184,6 @@ describe('create goal', () => {
     fetchMock.post('/api/goals', postResponse);
 
     await screen.findByText(`Your goal was last saved at ${moment().format('MM/DD/YYYY [at] h:mm a')}`);
-
-    expect(cancel).not.toBeVisible();
 
     const submit = await screen.findByRole('button', { name: /submit goal/i });
     userEvent.click(submit);
@@ -215,7 +211,7 @@ describe('create goal', () => {
     // saving drafts works
     const saveDraft = await screen.findByRole('button', { name: /save draft/i });
     userEvent.click(saveDraft);
-    expect(fetchMock.called()).toBe(true);
+    expect(fetchMock.called()).toBe(false);
 
     // reset fetch mock state
     fetchMock.restore();
@@ -231,10 +227,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    userEvent.click(save);
-    await screen.findByText('Enter a valid date');
-
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, 'apple season');
 
     userEvent.click(save);
@@ -278,7 +271,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     const save = await screen.findByRole('button', { name: /save and continue/i });
@@ -341,7 +334,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     const newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -396,7 +389,7 @@ describe('create goal', () => {
     let goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    let ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    let ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     let newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -433,7 +426,7 @@ describe('create goal', () => {
     goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is more goal text');
 
-    ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -481,7 +474,7 @@ describe('create goal', () => {
     let goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     const newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -537,7 +530,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     const cancel = await screen.findByRole('link', { name: 'Cancel' });
@@ -592,7 +585,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     let newObjective = await screen.findByRole('button', { name: 'Add new objective' });
@@ -673,7 +666,7 @@ describe('create goal', () => {
     const goalText = await screen.findByRole('textbox', { name: 'Recipient\'s goal *' });
     userEvent.type(goalText, 'This is goal text');
 
-    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\) \*/i });
+    const ed = await screen.findByRole('textbox', { name: /anticipated close date \(mm\/dd\/yyyy\)/i });
     userEvent.type(ed, '08/15/2023');
 
     const newObjective = await screen.findByRole('button', { name: 'Add new objective' });

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -256,7 +256,7 @@ export default function GoalForm({
   const validateEndDate = () => {
     let error = <></>;
 
-    if (!endDate || !moment(endDate, 'MM/DD/YYYY').isValid()) {
+    if (endDate && !moment(endDate, 'MM/DD/YYYY').isValid()) {
       error = <span className="usa-error-message">{GOAL_DATE_ERROR}</span>;
     }
 
@@ -365,7 +365,7 @@ export default function GoalForm({
     && validateEndDate()
     && validateObjectives()
   );
-  const isValidDraft = () => validateGrantNumbers() || validateGoalName() || validateEndDate();
+  const isValidDraft = () => validateGrantNumbers() && validateGoalName();
 
   const updateObjectives = (updatedObjectives) => {
     // when we set a new set of objectives

--- a/frontend/src/components/__tests__/AutomaticResizingTextarea.js
+++ b/frontend/src/components/__tests__/AutomaticResizingTextarea.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AutomaticResizingTextarea from '../AutomaticResizingTextarea';
+
+describe('AutomaticResizingTextarea', () => {
+  const poem = `When the flush of a newborn sun fell first on Eden's green and gold,   
+    Our father Adam sat under the Tree and scratched with a stick in the mold;   
+    And the first rude sketch that the world had seen was joy to his mighty heart,   
+    Till the Devil whispered behind the leaves: "It's pretty, but is it Art?"   
+       
+    Wherefore he called to his wife and fled to fashion his work anew— 
+    The first of his race who cared a fig for the first, most dread review;   
+    And he left his lore to the use of his sons—and that was a glorious gain   
+    When the Devil chuckled: "Is it Art?" in the ear of the branded Cain.   
+       
+    They builded a tower to shiver the sky and wrench the stars apart,   
+    Till the Devil grunted behind the bricks: "It's striking, but is it Art?" 
+    The stone was dropped by the quarry-side, and the idle derrick swung,   
+    While each man talked of the aims of art, and each in an alien tongue.   
+       
+    They fought and they talked in the north and the south, they talked and they fought in the west,
+    Till the waters rose on the jabbering land, and the poor Red Clay had rest—   
+    Had rest till the dank blank-canvas dawn when the dove was preened to start,  
+    And the Devil bubbled below the keel: "It's human, but is it Art?"   
+       
+    The tale is old as the Eden Tree—as new as the new-cut tooth—   
+    For each man knows ere his lip-thatch grows he is master of Art and Truth;   
+    And each man hears as the twilight nears, to the beat of his dying heart,   
+    The Devil drum on the darkened pane: "You did it, but was it Art?"  
+       
+    We have learned to whittle the Eden Tree to the shape of a surplice-peg,   
+    We have learned to bottle our parents twain in the yolk of an addled egg,   
+    We know that the tail must wag the dog, as the horse is drawn by the cart;   
+    But the Devil whoops, as he whooped of old: "It's clever, but is it Art?"   
+       
+    When the flicker of London's sun falls faint on the club-room's green and gold,  
+    The sons of Adam sit them down and scratch with their pens in the mold—   
+    They scratch with their pens in the mold of their graves, and the ink and the anguish start   
+    When the Devil mutters behind the leaves: "It's pretty, but is it art?"   
+       
+    Now, if we could win to the Eden Tree where the four great rivers flow,   
+    And the wreath of Eve is red on the turf as she left it long ago, 
+    And if we could come when the sentry slept, and softly scurry through,   
+    By the favor of God we might know as much—as our father Adam knew`;
+
+  const TextArea = () => {
+    const [value, setValue] = React.useState('test');
+    const onChange = (e) => setValue(e.target.value);
+    return (
+      <AutomaticResizingTextarea onUpdateText={onChange} onBlur={jest.fn()} inputName="test" value={value} />
+    );
+  };
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, value: 500 });
+  });
+
+  it('resizes', async () => {
+    render(<TextArea />);
+
+    const textarea = document.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+
+    expect(textarea.style.height).toBe('160px');
+    userEvent.clear(textarea);
+    userEvent.paste(textarea, poem);
+    expect(textarea).toHaveValue(poem);
+    expect(textarea.style.height).toBe('500px');
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -55,7 +55,7 @@ export default function GoalForm({
     rules: {
       validate: {
         isValidDate: (value) => activityRecipientType === 'other-entity' || (
-          (value && moment(value, 'MM/DD/YYYY').isValid())
+          (value && moment(value, 'MM/DD/YYYY').isValid()) || value === ''
         ) || GOAL_DATE_ERROR,
       },
     },

--- a/frontend/src/pages/ActivityReport/Pages/components/goalValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/goalValidator.js
@@ -1,7 +1,6 @@
 import {
   validateListOfResources,
   GOAL_NAME_ERROR,
-  GOAL_DATE_ERROR,
 } from '../../../../components/GoalForm/constants';
 
 export const UNFINISHED_OBJECTIVES = 'All objective fields must be completed';
@@ -50,10 +49,6 @@ export const unfinishedGoals = (goals, setError = () => {}) => {
 
     if (!goal.name) {
       setError('goalName', { message: GOAL_NAME_ERROR });
-    }
-
-    if (!goal.endDate) {
-      setError('goalEndDate', { message: GOAL_DATE_ERROR });
     }
 
     // Every goal must have an objective or the `goals` field has unfinished goals

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -751,6 +751,7 @@ export async function createOrUpdateGoals(goals) {
       regionId,
       objectives,
       createdVia,
+      endDate,
       status,
       ...fields
     } = goalData;
@@ -793,13 +794,18 @@ export async function createOrUpdateGoals(goals) {
     // we can't update this stuff if the goal is on an approved AR
     if (newGoal && !newGoal.onApprovedAR) {
       await newGoal.update(
-        { ...options, status, createdVia: createdVia || 'rtr' },
+        {
+          ...options,
+          status,
+          createdVia: createdVia || 'rtr',
+          endDate: endDate || null,
+        },
         { individualHooks: true },
       );
     // except for the end date, which is always editable
     } else if (newGoal) {
       await newGoal.update(
-        { endDate: options.endDate },
+        { endDate: endDate || null },
         { individualHooks: true },
       );
     }


### PR DESCRIPTION
## Description of change

Make a goal's end date an optional field. Also added some tests for front end test coverage.
In addition, fixed a bug that made it unreasonably hard to get read only resources

## How to test
Add an end date to the create goals form, or not. Try it both ways, then do the same on the Activity Report.
Confirm that resources on the RTR are now read only if a goal is closed OR and objective is completed

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1072


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
