### PR TITLE
Fix goals created sort

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -982,7 +982,13 @@ export async function goalsForGrants(grantIds) {
         attributes: [],
       },
     ],
-    order: [['created', 'desc']],
+    order: [[sequelize.fn(
+      'MAX',
+      sequelize.fn(
+        'DISTINCT',
+        sequelize.col('"Goal"."createdAt"'),
+      ),
+    ), 'desc']],
   });
 }
 


### PR DESCRIPTION
## Description of change

Ever since the sort for the goal retrieve has been implemented I have been getting the  following error: 

**SequelizeDatabaseError: column Goal.created does not exist**

## How to test

Goal retrieve and order should work as it did before.

Core Issue: 
For some reason I'm the only one on the team getting this error but the below query is what's causing the error for me.

SELECT 
	ARRAY_AGG(DISTINCT("grant"."id")) AS "_0",
	ARRAY_AGG(DISTINCT("Goal"."id")) AS "_1",
	ARRAY_AGG(DISTINCT("grant"."oldGrantId")) AS "_2",
	MAX(DISTINCT("Goal"."createdAt")) AS "_3",
	"Goal"."name",
	"Goal"."status",
	"Goal"."onApprovedAR",
	"Goal"."endDate"
FROM "Goals" AS "Goal"
LEFT OUTER JOIN "Grants" AS "grant" ON "Goal"."grantId" = "grant"."id"
WHERE ("Goal"."status" = 'Not Started'
							OR "Goal"."status" = 'In Progress'
							OR "Goal"."status" IS NULL
							OR "Goal"."status" = 'Draft')
	AND "grant"."id" IN (10431,7764)
GROUP BY "Goal"."name",
	"Goal"."status",
	"Goal"."endDate",
	"Goal"."onApprovedAR"
ORDER BY "Goal"."createdAt" DESC;

The code changes the order by to be the following:

ORDER BY MAX(DISTINCT("Goal"."createdAt")) DESC;

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
