### PR TITLE
[TTAHUB-857] Add new paging to goals and update select

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -89,8 +89,10 @@ function GoalCard({
   ];
 
   return (
-    <article className="ttahub-goal-card usa-card margin-x-3 margin-y-2 padding-3 radius-lg border smart-hub-border-base-lighter ">
-
+    <article
+      className="ttahub-goal-card usa-card margin-x-3 margin-y-2 padding-3 radius-lg border smart-hub-border-base-lighter"
+      data-testid="goalCard"
+    >
       <div className="display-flex flex-justify">
         <div className="display-flex flex-align-start flex-row">
           <Checkbox

--- a/frontend/src/components/GoalCards/GoalCards.js
+++ b/frontend/src/components/GoalCards/GoalCards.js
@@ -5,8 +5,6 @@ import { Grid, Alert } from '@trussworks/react-uswds';
 import GoalsCardsHeader from './GoalsCardsHeader';
 import Container from '../Container';
 import GoalCard from './GoalCard';
-import { GOALS_PER_PAGE } from '../../Constants';
-
 import CloseSuspendReasonModal from '../CloseSuspendReasonModal';
 import { updateGoalStatus } from '../../fetchers/goals';
 
@@ -23,6 +21,8 @@ function GoalCards({
   sortConfig,
   setGoals,
   allGoalIds,
+  perPage,
+  perPageChange,
 }) {
   // Goal select check boxes.
   const [selectedGoalCheckBoxes, setSelectedGoalCheckBoxes] = useState({});
@@ -144,7 +144,7 @@ function GoalCards({
           count={goalsCount || 0}
           activePage={sortConfig.activePage}
           offset={sortConfig.offset}
-          perPage={GOALS_PER_PAGE}
+          perPage={perPage}
           handlePageChange={handlePageChange}
           recipientId={recipientId}
           regionId={regionId}
@@ -156,6 +156,7 @@ function GoalCards({
           selectAllGoalCheckboxSelect={selectAllGoalCheckboxSelect}
           selectAllGoals={checkAllGoals}
           selectedGoalIds={selectedCheckBoxes}
+          perPageChange={perPageChange}
         />
         <div>
 
@@ -200,9 +201,12 @@ GoalCards.propTypes = {
   }).isRequired,
   setGoals: PropTypes.func.isRequired,
   allGoalIds: PropTypes.arrayOf(PropTypes.number),
+  perPage: PropTypes.number,
+  perPageChange: PropTypes.func.isRequired,
 };
 
 GoalCards.defaultProps = {
   allGoalIds: [],
+  perPage: 10,
 };
 export default GoalCards;

--- a/frontend/src/components/GoalCards/GoalCards.js
+++ b/frontend/src/components/GoalCards/GoalCards.js
@@ -81,13 +81,8 @@ function GoalCards({
       && (checkValues.length === goals.length || checkValues.length === goalsCount)
       && checkValues.every((v) => v === true)) {
       setAllGoalsChecked(true);
-    } else {
-      if (allGoalsChecked === true) {
-        setAllGoalsChecked(false);
-      }
-      if (printAllGoals === true) {
-        setPrintAllGoals(false);
-      }
+    } else if (printAllGoals === true) {
+      setPrintAllGoals(false);
     }
   }, [selectedGoalCheckBoxes, allGoalsChecked, printAllGoals, goalsCount, goals.length]);
 

--- a/frontend/src/components/GoalCards/GoalCards.js
+++ b/frontend/src/components/GoalCards/GoalCards.js
@@ -157,6 +157,7 @@ function GoalCards({
           selectAllGoals={checkAllGoals}
           selectedGoalIds={selectedCheckBoxes}
           perPageChange={perPageChange}
+          pageGoalIds={goals.map((g) => g.id)}
         />
         <div>
 

--- a/frontend/src/components/GoalCards/GoalDataController.js
+++ b/frontend/src/components/GoalCards/GoalDataController.js
@@ -11,7 +11,7 @@ import { Grid } from '@trussworks/react-uswds';
 import { filtersToQueryString } from '../../utils';
 import GoalsTable from './GoalCards';
 import { GoalStatusChart } from '../../widgets/GoalStatusGraph';
-import { GOALS_PER_PAGE } from '../../Constants';
+import { GOALS_PER_PAGE, DECIMAL_BASE } from '../../Constants';
 import './GoalTable.scss';
 import { getRecipientGoals } from '../../fetchers/recipient';
 
@@ -47,6 +47,7 @@ function GoalDataController({
   // Page Behavior.
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [goalsPerPage, setGoalsPerPage] = useState(GOALS_PER_PAGE);
 
   const defaultSort = showNewGoals
     ? {
@@ -75,7 +76,7 @@ function GoalDataController({
           sortConfig.sortBy,
           sortConfig.direction,
           sortConfig.offset,
-          GOALS_PER_PAGE,
+          goalsPerPage,
           query,
         );
         setData(response);
@@ -93,11 +94,11 @@ function GoalDataController({
       return;
     }
     fetchGoals(filterQuery);
-  }, [sortConfig, filters, recipientId, regionId, showNewGoals, setSortConfig]);
+  }, [sortConfig, filters, recipientId, regionId, showNewGoals, setSortConfig, goalsPerPage]);
 
   const handlePageChange = (pageNumber) => {
     setSortConfig({
-      ...sortConfig, activePage: pageNumber, offset: (pageNumber - 1) * GOALS_PER_PAGE,
+      ...sortConfig, activePage: pageNumber, offset: (pageNumber - 1) * goalsPerPage,
     });
   };
 
@@ -105,6 +106,16 @@ function GoalDataController({
     setSortConfig({
       ...sortConfig, sortBy, direction, activePage: 1, offset: 0,
     });
+  };
+
+  const perPageChange = (e) => {
+    const perPageValue = parseInt(e.target.value, DECIMAL_BASE);
+    setSortConfig({
+      ...sortConfig,
+      activePage: 1,
+      offset: 0,
+    });
+    setGoalsPerPage(perPageValue);
   };
 
   const displayGoals = useMemo(() => (
@@ -136,6 +147,8 @@ function GoalDataController({
           sortConfig={sortConfig}
           setGoals={setGoals}
           loading={loading}
+          perPage={goalsPerPage}
+          perPageChange={perPageChange}
         />
       </FilterContext.Provider>
     </div>

--- a/frontend/src/components/GoalCards/GoalsCardsHeader.js
+++ b/frontend/src/components/GoalCards/GoalsCardsHeader.js
@@ -10,7 +10,7 @@ import UserContext from '../../UserContext';
 import { canEditOrCreateGoals } from '../../permissions';
 import { DECIMAL_BASE } from '../../Constants';
 import colors from '../../colors';
-import { SelectPagination } from '../SelectPagination';
+import SelectPagination from '../SelectPagination';
 
 export default function GoalCardsHeader({
   title,

--- a/frontend/src/components/GoalCards/GoalsCardsHeader.js
+++ b/frontend/src/components/GoalCards/GoalsCardsHeader.js
@@ -5,24 +5,12 @@ import {
 } from '@trussworks/react-uswds';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
-import Pagination from 'react-js-pagination';
 import { Link, useHistory } from 'react-router-dom';
 import UserContext from '../../UserContext';
 import { canEditOrCreateGoals } from '../../permissions';
 import { DECIMAL_BASE } from '../../Constants';
 import colors from '../../colors';
-
-export function renderTotal(offset, perPage, activePage, count) {
-  const from = offset >= count ? 0 : offset + 1;
-  const offsetTo = perPage * activePage;
-  let to;
-  if (offsetTo > count) {
-    to = count;
-  } else {
-    to = offsetTo;
-  }
-  return `${from}-${to} of ${count}`;
-}
+import { SelectPagination } from '../SelectPagination';
 
 export default function GoalCardsHeader({
   title,
@@ -97,33 +85,14 @@ export default function GoalCardsHeader({
         </div>
         {!hidePagination && (
         <div className="smart-hub--table-nav">
-          <span aria-label="Pagination for goals">
-            <span
-              className="smart-hub--total-count display-flex flex-align-center height-full margin-2 desktop:margin-0 padding-right-1"
-              aria-label={`Page ${activePage}, displaying goals ${renderTotal(
-                offset,
-                perPage,
-                activePage,
-                count,
-              )}`}
-            >
-              <span>{renderTotal(offset, perPage, activePage, count)}</span>
-              <Pagination
-                innerClass="pagination desktop:margin-x-0 margin-top-0 margin-x-2"
-                hideFirstLastPages
-                prevPageText="<Prev"
-                nextPageText="Next>"
-                activePage={activePage}
-                itemsCountPerPage={perPage}
-                totalItemsCount={count}
-                pageRangeDisplayed={4}
-                onChange={handlePageChange}
-                linkClassPrev="smart-hub--link-prev"
-                linkClassNext="smart-hub--link-next"
-                tabIndex={0}
-              />
-            </span>
-          </span>
+          <SelectPagination
+            title="Goals"
+            offset={offset}
+            perPage={perPage}
+            activePage={activePage}
+            count={count}
+            handlePageChange={handlePageChange}
+          />
         </div>
         )}
 
@@ -135,7 +104,7 @@ export default function GoalCardsHeader({
           id="select-all-goal-checkboxes"
           aria-label="deselect all goals"
           checked={allGoalsChecked}
-          onClick={selectAllGoalCheckboxSelect}
+          onChange={selectAllGoalCheckboxSelect}
         />
         {numberOfSelectedGoals > 0
             && (

--- a/frontend/src/components/GoalCards/GoalsCardsHeader.js
+++ b/frontend/src/components/GoalCards/GoalsCardsHeader.js
@@ -31,6 +31,7 @@ export default function GoalCardsHeader({
   selectAllGoals,
   selectedGoalIds,
   perPageChange,
+  pageGoalIds,
 }) {
   const history = useHistory();
   const { user } = useContext(UserContext);
@@ -39,7 +40,7 @@ export default function GoalCardsHeader({
   const showAddNewButton = hasActiveGrants && hasButtonPermissions;
   const onPrint = () => {
     history.push(`/recipient-tta-records/${recipientId}/region/${regionId}/goals-objectives/print${window.location.search}`, {
-      sortConfig, selectedGoalIds,
+      sortConfig, selectedGoalIds: !selectedGoalIds.length ? pageGoalIds : selectedGoalIds,
     });
   };
 
@@ -70,7 +71,7 @@ export default function GoalCardsHeader({
           className="display-flex flex-align-center usa-button usa-button--unstyled margin-x-3 margin-y-3"
           onClick={onPrint}
         >
-          Preview and print selected
+          {`Preview and print ${selectedGoalIds.length > 0 ? 'selected' : ''}`}
         </Button>
       </div>
       <div className="desktop:display-flex flex-justify ">
@@ -184,6 +185,7 @@ GoalCardsHeader.propTypes = {
   selectAllGoals: PropTypes.func,
   selectedGoalIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   perPageChange: PropTypes.func.isRequired,
+  pageGoalIds: PropTypes.number.isRequired,
 };
 
 GoalCardsHeader.defaultProps = {

--- a/frontend/src/components/GoalCards/GoalsCardsHeader.js
+++ b/frontend/src/components/GoalCards/GoalsCardsHeader.js
@@ -30,6 +30,7 @@ export default function GoalCardsHeader({
   selectAllGoalCheckboxSelect,
   selectAllGoals,
   selectedGoalIds,
+  perPageChange,
 }) {
   const history = useHistory();
   const { user } = useContext(UserContext);
@@ -76,7 +77,14 @@ export default function GoalCardsHeader({
         <div className="desktop:display-flex flex-align-center">
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label className="display-block margin-right-1" style={{ minWidth: 'max-content' }} htmlFor="sortBy">Sort by</label>
-          <Dropdown onChange={setSortBy} value={`${sortConfig.sortBy}-${sortConfig.direction}`} className="margin-top-0" id="sortBy" name="sortBy">
+          <Dropdown
+            onChange={setSortBy}
+            value={`${sortConfig.sortBy}-${sortConfig.direction}`}
+            className="margin-top-0"
+            id="sortBy"
+            name="sortBy"
+            data-testid="sortGoalsBy"
+          >
             <option value="createdOn-desc">creation date (newest to oldest) </option>
             <option value="createdOn-asc">creation date (oldest to newest) </option>
             <option value="goalStatus-asc">goal status (drafts first)</option>
@@ -92,6 +100,7 @@ export default function GoalCardsHeader({
             activePage={activePage}
             count={count}
             handlePageChange={handlePageChange}
+            perPageChange={perPageChange}
           />
         </div>
         )}
@@ -174,6 +183,7 @@ GoalCardsHeader.propTypes = {
   numberOfSelectedGoals: PropTypes.number,
   selectAllGoals: PropTypes.func,
   selectedGoalIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  perPageChange: PropTypes.func.isRequired,
 };
 
 GoalCardsHeader.defaultProps = {

--- a/frontend/src/components/GoalCards/GoalsCardsHeader.js
+++ b/frontend/src/components/GoalCards/GoalsCardsHeader.js
@@ -134,7 +134,7 @@ export default function GoalCardsHeader({
           label="Select all"
           id="select-all-goal-checkboxes"
           aria-label="deselect all goals"
-          defaultChecked={allGoalsChecked}
+          checked={allGoalsChecked}
           onClick={selectAllGoalCheckboxSelect}
         />
         {numberOfSelectedGoals > 0

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -393,13 +393,13 @@ describe('Goals Table', () => {
     });
 
     it('sorts by created on', async () => {
-      const sortCreated = await screen.findByRole('combobox');
+      const sortCreated = await screen.findByTestId('sortGoalsBy');
       userEvent.selectOptions(sortCreated, 'createdOn-desc');
       expect(requestSort).toHaveBeenCalled();
     });
 
     it('sorts by goal status', async () => {
-      const sortCreated = await screen.findByRole('combobox');
+      const sortCreated = await screen.findByTestId('sortGoalsBy');
       userEvent.selectOptions(sortCreated, 'goalStatus-asc');
       await screen.findByText('TTA goals and objectives');
       expect(requestSort).toHaveBeenCalled();

--- a/frontend/src/components/SelectPagination.js
+++ b/frontend/src/components/SelectPagination.js
@@ -3,19 +3,7 @@ import PropTypes from 'prop-types';
 import Pagination from 'react-js-pagination';
 import { Dropdown } from '@trussworks/react-uswds';
 
-export function renderTotal(title, offset, perPage, activePage, count) {
-  const from = offset >= count ? 0 : offset + 1;
-  const offsetTo = perPage * activePage;
-  let to;
-  if (offsetTo > count) {
-    to = count;
-  } else {
-    to = offsetTo;
-  }
-  return `Showing ${from}-${to} of ${count} ${title.toLowerCase()}`;
-}
-
-export const SelectPagination = ({
+function SelectPagination({
   title,
   offset,
   activePage,
@@ -23,52 +11,63 @@ export const SelectPagination = ({
   handlePageChange,
   perPage,
   perPageChange,
-}) => (
-  <span aria-label={`Pagination for ${title}`}>
-    <span
-      className="smart-hub--total-count display-flex flex-align-center height-full margin-2 desktop:margin-0 padding-right-1"
-      aria-label={`Page ${activePage}, displaying ${title} ${renderTotal(
-        title,
-        offset,
-        perPage,
-        activePage,
-        count,
-      )}`}
-    >
-      <Dropdown
-        className="margin-top-0 margin-right-1 width-auto"
-        id="perPage"
-        name="perPage"
-        data-testid="perPage"
-        onChange={perPageChange}
-        aria-label={`Select ${title.toLowerCase()} per page`}
+}) {
+  const renderTotal = () => {
+    const from = offset >= count ? 0 : offset + 1;
+    const offsetTo = perPage * activePage;
+    let to;
+    if (offsetTo > count) {
+      to = count;
+    } else {
+      to = offsetTo;
+    }
+    return `Showing ${from}-${to} of ${count} ${title.toLowerCase()}`;
+  };
+
+  return (
+    <span aria-label={`Pagination for ${title}`}>
+      <span
+        className="smart-hub--total-count display-flex flex-align-center height-full margin-2 desktop:margin-0 padding-right-1"
+        aria-label={`Page ${activePage}, displaying ${title} ${renderTotal(
+          title,
+          offset,
+          perPage,
+          activePage,
+          count,
+        )}`}
       >
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50">50</option>
-        <option value={count}>all</option>
-      </Dropdown>
-      <span>{renderTotal(title, offset, perPage, activePage, count)}</span>
-      <Pagination
-        innerClass="pagination desktop:margin-x-0 margin-top-0 margin-x-2"
-        hideFirstLastPages
-        prevPageText="<Prev"
-        nextPageText="Next>"
-        activePage={activePage}
-        itemsCountPerPage={perPage}
-        totalItemsCount={count}
-        pageRangeDisplayed={4}
-        onChange={handlePageChange}
-        linkClassPrev="smart-hub--link-prev"
-        linkClassNext="smart-hub--link-next"
-        tabIndex={0}
-      />
+        <Dropdown
+          className="margin-top-0 margin-right-1 width-auto"
+          id="perPage"
+          name="perPage"
+          data-testid="perPage"
+          onChange={perPageChange}
+          aria-label={`Select ${title.toLowerCase()} per page`}
+        >
+          <option value="10">10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+          <option value={count}>all</option>
+        </Dropdown>
+        <span>{renderTotal(title, offset, perPage, activePage, count)}</span>
+        <Pagination
+          innerClass="pagination desktop:margin-x-0 margin-top-0 margin-x-2"
+          hideFirstLastPages
+          prevPageText="<Prev"
+          nextPageText="Next>"
+          activePage={activePage}
+          itemsCountPerPage={perPage}
+          totalItemsCount={count}
+          pageRangeDisplayed={4}
+          onChange={handlePageChange}
+          linkClassPrev="smart-hub--link-prev"
+          linkClassNext="smart-hub--link-next"
+          tabIndex={0}
+        />
+      </span>
     </span>
-  </span>
-);
-
-export default SelectPagination;
-
+  );
+}
 SelectPagination.propTypes = {
   offset: PropTypes.number,
   activePage: PropTypes.number,
@@ -85,3 +84,4 @@ SelectPagination.defaultProps = {
   offset: 0,
   perPage: 10,
 };
+export default SelectPagination;

--- a/frontend/src/components/SelectPagination.js
+++ b/frontend/src/components/SelectPagination.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Pagination from 'react-js-pagination';
+
+export function renderTotal(offset, perPage, activePage, count) {
+  const from = offset >= count ? 0 : offset + 1;
+  const offsetTo = perPage * activePage;
+  let to;
+  if (offsetTo > count) {
+    to = count;
+  } else {
+    to = offsetTo;
+  }
+  return `${from}-${to} of ${count}`;
+}
+
+export const SelectPagination = ({
+  title,
+  offset,
+  perPage,
+  activePage,
+  count,
+  handlePageChange,
+}) => (
+  <span aria-label={`Pagination for ${title}`}>
+    <span
+      className="smart-hub--total-count display-flex flex-align-center height-full margin-2 desktop:margin-0 padding-right-1"
+      aria-label={`Page ${activePage}, displaying ${title} ${renderTotal(
+        offset,
+        perPage,
+        activePage,
+        count,
+      )}`}
+    >
+      <span>{renderTotal(offset, perPage, activePage, count)}</span>
+      <Pagination
+        innerClass="pagination desktop:margin-x-0 margin-top-0 margin-x-2"
+        hideFirstLastPages
+        prevPageText="<Prev"
+        nextPageText="Next>"
+        activePage={activePage}
+        itemsCountPerPage={perPage}
+        totalItemsCount={count}
+        pageRangeDisplayed={4}
+        onChange={handlePageChange}
+        linkClassPrev="smart-hub--link-prev"
+        linkClassNext="smart-hub--link-next"
+        tabIndex={0}
+      />
+    </span>
+  </span>
+);
+
+export default SelectPagination;
+
+SelectPagination.propTypes = {
+  offset: PropTypes.number,
+  perPage: PropTypes.number,
+  activePage: PropTypes.number,
+  count: PropTypes.number,
+  handlePageChange: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+SelectPagination.defaultProps = {
+  count: 0,
+  activePage: 0,
+  offset: 0,
+  perPage: 10,
+};

--- a/frontend/src/components/SelectPagination.js
+++ b/frontend/src/components/SelectPagination.js
@@ -41,6 +41,7 @@ export const SelectPagination = ({
         name="perPage"
         data-testid="perPage"
         onChange={perPageChange}
+        aria-label={`Select ${title.toLowerCase()} per page`}
       >
         <option value="10">10</option>
         <option value="25">25</option>

--- a/frontend/src/components/SelectPagination.js
+++ b/frontend/src/components/SelectPagination.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Pagination from 'react-js-pagination';
+import { Dropdown } from '@trussworks/react-uswds';
 
-export function renderTotal(offset, perPage, activePage, count) {
+export function renderTotal(title, offset, perPage, activePage, count) {
   const from = offset >= count ? 0 : offset + 1;
   const offsetTo = perPage * activePage;
   let to;
@@ -11,28 +12,42 @@ export function renderTotal(offset, perPage, activePage, count) {
   } else {
     to = offsetTo;
   }
-  return `${from}-${to} of ${count}`;
+  return `Showing ${from}-${to} of ${count} ${title.toLowerCase()}`;
 }
 
 export const SelectPagination = ({
   title,
   offset,
-  perPage,
   activePage,
   count,
   handlePageChange,
+  perPage,
+  perPageChange,
 }) => (
   <span aria-label={`Pagination for ${title}`}>
     <span
       className="smart-hub--total-count display-flex flex-align-center height-full margin-2 desktop:margin-0 padding-right-1"
       aria-label={`Page ${activePage}, displaying ${title} ${renderTotal(
+        title,
         offset,
         perPage,
         activePage,
         count,
       )}`}
     >
-      <span>{renderTotal(offset, perPage, activePage, count)}</span>
+      <Dropdown
+        className="margin-top-0 margin-right-1 width-auto"
+        id="perPage"
+        name="perPage"
+        data-testid="perPage"
+        onChange={perPageChange}
+      >
+        <option value="10">10</option>
+        <option value="25">25</option>
+        <option value="50">50</option>
+        <option value={count}>all</option>
+      </Dropdown>
+      <span>{renderTotal(title, offset, perPage, activePage, count)}</span>
       <Pagination
         innerClass="pagination desktop:margin-x-0 margin-top-0 margin-x-2"
         hideFirstLastPages
@@ -55,11 +70,12 @@ export default SelectPagination;
 
 SelectPagination.propTypes = {
   offset: PropTypes.number,
-  perPage: PropTypes.number,
   activePage: PropTypes.number,
   count: PropTypes.number,
   handlePageChange: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
+  perPage: PropTypes.number,
+  perPageChange: PropTypes.func.isRequired,
 };
 
 SelectPagination.defaultProps = {

--- a/frontend/src/components/__tests__/SelectPagination.js
+++ b/frontend/src/components/__tests__/SelectPagination.js
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import { screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SelectPagination } from '../SelectPagination';
+import SelectPagination from '../SelectPagination';
 
 describe('SelectPagination', () => {
   const renderSelectPagination = (handlePageChange = () => {}, perPageChange = () => {}) => {

--- a/frontend/src/components/__tests__/SelectPagination.js
+++ b/frontend/src/components/__tests__/SelectPagination.js
@@ -1,0 +1,39 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SelectPagination } from '../SelectPagination';
+
+describe('SelectPagination', () => {
+  const renderSelectPagination = (handlePageChange = () => {}) => {
+    render(<SelectPagination
+      title="Testing"
+      offset={0}
+      perPage={10}
+      activePage={1}
+      count={20}
+      handlePageChange={handlePageChange}
+    />);
+  };
+
+  it('renders correctly', async () => {
+    renderSelectPagination();
+    expect(await screen.findByText(/1-10 of 20/i)).toBeVisible();
+    expect(await screen.findByLabelText(/pagination for testing/i)).toBeVisible();
+    expect(await screen.findByRole('link', { name: /go to previous page/i })).toBeVisible();
+    expect(await screen.findByRole('link', { name: /go to next page/i })).toBeVisible();
+  });
+
+  it('handles page change', async () => {
+    const nextPage = jest.fn();
+    renderSelectPagination(nextPage);
+
+    const nextPageBtn = await screen.findByRole('link', { name: /go to next page/i });
+    userEvent.click(nextPageBtn);
+    await waitFor(() => expect(nextPage).toHaveBeenCalled());
+
+    const firstPageBtn = await screen.findByRole('link', { name: /go to page number 1/i });
+    userEvent.click(firstPageBtn);
+    await waitFor(() => expect(nextPage).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/__tests__/SelectPagination.js
+++ b/frontend/src/components/__tests__/SelectPagination.js
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SelectPagination } from '../SelectPagination';
 
 describe('SelectPagination', () => {
-  const renderSelectPagination = (handlePageChange = () => {}) => {
+  const renderSelectPagination = (handlePageChange = () => {}, perPageChange = () => {}) => {
     render(<SelectPagination
       title="Testing"
       offset={0}
@@ -13,6 +13,7 @@ describe('SelectPagination', () => {
       activePage={1}
       count={20}
       handlePageChange={handlePageChange}
+      perPageChange={perPageChange}
     />);
   };
 
@@ -36,5 +37,13 @@ describe('SelectPagination', () => {
     const firstPageBtn = await screen.findByRole('link', { name: /go to page number 1/i });
     userEvent.click(firstPageBtn);
     await waitFor(() => expect(nextPage).toHaveBeenCalled());
+  });
+
+  it('handles per page change', async () => {
+    const perPage = jest.fn();
+    renderSelectPagination(() => {}, perPage);
+    const perPageDropDown = await screen.findByTestId('perPage');
+    userEvent.selectOptions(perPageDropDown, '25');
+    await waitFor(() => expect(perPage).toHaveBeenCalled());
   });
 });

--- a/frontend/src/components/__tests__/SelectPagination.js
+++ b/frontend/src/components/__tests__/SelectPagination.js
@@ -22,6 +22,7 @@ describe('SelectPagination', () => {
     expect(await screen.findByLabelText(/pagination for testing/i)).toBeVisible();
     expect(await screen.findByRole('link', { name: /go to previous page/i })).toBeVisible();
     expect(await screen.findByRole('link', { name: /go to next page/i })).toBeVisible();
+    expect(await screen.findByText(/showing 1-10 of 20 testing/i)).toBeVisible();
   });
 
   it('handles page change', async () => {

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -224,7 +224,7 @@ describe('Goals and Objectives', () => {
 
     fetchMock.restore();
     fetchMock.get('/api/recipient/401/region/1/goals?sortBy=createdOn&sortDir=asc&offset=0&limit=10', { count: 1, goalRows: goals, statuses: defaultStatuses });
-    const sortCreated = await screen.findByRole('combobox');
+    const sortCreated = await screen.findByTestId('sortGoalsBy');
     userEvent.selectOptions(sortCreated, 'createdOn-asc');
 
     await waitFor(() => expect(fetchMock.called()).toBeTruthy());

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -256,4 +256,58 @@ describe('Goals and Objectives', () => {
 
     expect(await screen.findByText(/Unable to fetch goals/i)).toBeVisible();
   });
+
+  it('adjusts items per page', async () => {
+    fetchMock.restore();
+
+    const goalToUse = {
+      id: 0,
+      goalStatus: 'Not Started',
+      createdOn: '2021-06-15',
+      goalText: '',
+      goalTopics: ['Human Resources', 'Safety Practices', 'Program Planning and Services'],
+      objectiveCount: 5,
+      goalNumbers: ['G-4598'],
+      reasons: ['Monitoring | Deficiency', 'Monitoring | Noncompliance'],
+      objectives: [],
+    };
+    const goalCount = 60;
+    const goalsToDisplay = [];
+    // eslint-disable-next-line no-plusplus
+    for (let i = 1; i <= goalCount; i++) {
+      const goalText = `This is goal text ${i}.`;
+      goalsToDisplay.push({ ...goalToUse, id: i, goalText });
+    }
+    const noFilterUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=10';
+    fetchMock.get(noFilterUrl,
+      {
+        count: goalCount,
+        goalRows: goalsToDisplay.slice(0, 10),
+        statuses: defaultStatuses,
+      });
+
+    // Render.
+    act(() => renderGoalsAndObjectives());
+
+    // Assert initial.
+    expect(await screen.findByText(/1-10 of 60/i)).toBeVisible();
+    let goalsPerPage = screen.queryAllByTestId('goalCard');
+    expect(goalsPerPage.length).toBe(10);
+
+    // Change per page.
+    const noFilterUrlMore = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=25';
+    fetchMock.get(noFilterUrlMore,
+      {
+        count: goalCount,
+        goalRows: goalsToDisplay.slice(0, 25),
+        statuses: defaultStatuses,
+      });
+    const perPageDropDown = await screen.findByRole('combobox', { name: /select goals per page/i });
+    userEvent.selectOptions(perPageDropDown, '25');
+
+    // Assert per page change.
+    expect(await screen.findByText(/1-25 of 60/i)).toBeVisible();
+    goalsPerPage = screen.queryAllByTestId('goalCard');
+    expect(goalsPerPage.length).toBe(25);
+  });
 });


### PR DESCRIPTION
## Description of change

- Persist 'select all' check box until they unselect it. 
- Always show select all pages alert if 'select all' is checked and all pages aren't selected.
- Paging now has 'per page' selector in 10, 25, 50, and all.
- Changing the rows per page brings you back to the first page.

## How to test

Make sure the design is matched and the above are working as expected.

https://www.figma.com/proto/WoAULVDXnKuVx5t1y9jgzW/RTTAPA-Goals-Plan?node-id=367%3A38184&scaling=min-zoom&page-id=210%3A18964&starting-point-node-id=367%3A36637&show-proto-sidebar=1

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-857

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
