### PR TITLE
[TTAHUB-1085] Update form state when saving draft on goals and objectives page

### DIFF
--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -291,7 +291,7 @@ export default function GoalForm({
     let isValid = true;
 
     const newObjectiveErrors = objectives.map((objective) => {
-      if (objective.status === 'Complete') {
+      if (objective.status === 'Complete' || (objective.activityReports && objective.activityReports.length)) {
         return [
           <></>,
           <></>,

--- a/frontend/src/components/Navigator/__tests__/index.js
+++ b/frontend/src/components/Navigator/__tests__/index.js
@@ -167,7 +167,7 @@ describe('Navigator', () => {
     userEvent.click(await screen.findByRole('button', { name: 'first page Not Started' }));
     await waitFor(() => expect(
       updateForm,
-    ).toHaveBeenCalledWith({ ...initialData, second: null }, true));
+    ).toHaveBeenCalledWith({ ...initialData, second: null }));
     await waitFor(() => expect(updatePage).toHaveBeenCalledWith(1));
   });
 

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -131,7 +131,7 @@ function Navigator({
     const { status, ...values } = getValues();
     const data = { ...formData, ...values, pageState: newNavigatorState() };
 
-    updateFormData(data, true);
+    updateFormData(data);
     try {
       // Always clear the previous error message before a save.
       updateErrorMessage();
@@ -175,6 +175,7 @@ function Navigator({
     };
 
     let allGoals = [...selectedGoals, goal];
+
     // save goal to api, come back with new ids for goal and objectives
     try {
       // we only need save goal if we have a goal name
@@ -195,7 +196,7 @@ function Navigator({
       // update form data
       const { status, ...values } = getValues();
       const data = { ...formData, ...values, pageState: newNavigatorState() };
-      updateFormData(data, true);
+      updateFormData(data);
 
       updateErrorMessage('');
       updateLastSaveTime(moment());
@@ -288,7 +289,7 @@ function Navigator({
 
     // the form value is updated but the react state is not
     // so here we go (todo - why are there two sources of truth?)
-    updateFormData({ ...formData, goals: newGoals }, true);
+    updateFormData({ ...formData, goals: newGoals });
   };
 
   const onObjectiveFormNavigate = async () => {
@@ -326,7 +327,7 @@ function Navigator({
     toggleObjectiveForm(true);
 
     // Update form data (formData has otherEntityIds).
-    updateFormData({ ...formData, objectivesWithoutGoals: newObjectives }, true);
+    updateFormData({ ...formData, objectivesWithoutGoals: newObjectives });
   };
 
   const onGoalFormNavigate = async () => {

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -191,6 +191,12 @@ function Navigator({
         const goalBeingEdited = allGoals.find((g) => g.name === goal.name);
         setValue('goalForEditing', goalBeingEdited);
       }
+
+      // update form data
+      const { status, ...values } = getValues();
+      const data = { ...formData, ...values, pageState: newNavigatorState() };
+      updateFormData(data, true);
+
       updateErrorMessage('');
       updateLastSaveTime(moment());
     } catch (error) {
@@ -332,20 +338,7 @@ function Navigator({
       await saveGoalsNavigate();
     }
   };
-
-  const onUpdatePage = async (index) => {
-    await onSaveForm();
-    if (index !== page.position) {
-      updatePage(index);
-      updateShowSavedDraft(false);
-    }
-  };
-
-  const onContinue = () => {
-    onUpdatePage(page.position + 1);
-  };
-
-  useInterval(async () => {
+  const draftSaver = async () => {
     // Determine if we should save draft on auto save.
     const saveGoalsDraft = isGoalsObjectivesPage && !isGoalFormClosed;
     const saveObjectivesDraft = isGoalsObjectivesPage && !isObjectivesFormClosed;
@@ -359,6 +352,22 @@ function Navigator({
       // Save regular.
       await onSaveForm();
     }
+  };
+
+  const onUpdatePage = async (index) => {
+    await draftSaver();
+    if (index !== page.position) {
+      updatePage(index);
+      updateShowSavedDraft(false);
+    }
+  };
+
+  const onContinue = () => {
+    onUpdatePage(page.position + 1);
+  };
+
+  useInterval(async () => {
+    await draftSaver();
   }, autoSaveInterval);
 
   // A new form page is being shown so we need to reset `react-hook-form` so validations are

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -391,7 +391,7 @@ function ActivityReport({
 
         // Update form data.
         if (shouldUpdateFromNetwork && activityReportId !== 'new') {
-          updateFormData({ ...formData, ...report }, true);
+          updateFormData({ ...formData, goalForEditing: null, ...report }, true);
         } else {
           updateFormData({ ...report, ...formData }, true);
         }

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -999,7 +999,10 @@ export async function goalsForGrants(grantIds) {
     where: {
       '$grant.id$': ids,
       status: {
-        [Op.notIn]: ['Closed', 'Suspended'],
+        [Op.or]: [
+          { [Op.notIn]: ['Closed', 'Suspended'] },
+          { [Op.is]: null },
+        ],
       },
     },
     include: [

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -769,16 +769,11 @@ export async function createOrUpdateGoals(goals) {
       createdVia,
       endDate,
       status,
-      ...fields
+      ...options
     } = goalData;
 
     // there can only be one on the goal form (multiple grants maybe, but one recipient)
     recipient = recipientId;
-
-    const options = {
-      ...fields,
-      isFromSmartsheetTtaPlan: false,
-    };
 
     // we first need to see if the goal exists given what ids we have
     // for new goals, the id will be an empty array

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -798,6 +798,7 @@ export async function createOrUpdateGoals(goals) {
         },
         defaults: {
           status: 'Draft', // if we are creating a goal for the first time, it should be set to 'Draft'
+          isFromSmartsheetTtaPlan: false,
         },
       });
     }

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -809,7 +809,10 @@ export async function createOrUpdateGoals(goals) {
         {
           ...options,
           status,
-          createdVia: createdVia || 'rtr',
+          // if the createdVia column is populated, keep what's there
+          // otherwise, if the goal is imported, we say so
+          // otherwise, we've got ourselves an rtr goal, baby
+          createdVia: createdVia || (newGoal.isFromSmartsheetTtaPlan ? 'imported' : 'rtr'),
           endDate: endDate || null,
         },
         { individualHooks: true },
@@ -995,20 +998,9 @@ export async function goalsForGrants(grantIds) {
     group: ['"Goal"."name"', '"Goal"."status"', '"Goal"."endDate"', '"Goal"."onApprovedAR"'],
     where: {
       '$grant.id$': ids,
-      [Op.or]: [
-        {
-          status: 'Not Started',
-        },
-        {
-          status: 'In Progress',
-        },
-        {
-          status: null,
-        },
-        {
-          status: 'Draft',
-        },
-      ],
+      status: {
+        [Op.notIn]: ['Closed', 'Suspended'],
+      },
     },
     include: [
       {


### PR DESCRIPTION
## Description of change
This PR fixes the bugs below.

## How to test

**Data lingers in the local storage. Some data stays in the local storage and gives the users an incorrect view of what is in the database (Krys)**

Steps to see one case:

    create a new AR (I tried with 2 recipients)

    select an existing goal and click "Save Draft"
    navigate away from the page through the navigator
    come back and remove the goal
    select a different existing goal and use "Save Draft"
    reload the page
    observe that the old removed goal shows instead of the new one.

**Newly refreshed goal disappears when a page is refreshed. (Krys - this might be related to the above)**

Steps:

    create an AR (I used 2 different recipients)
    select an existing goal and click "Save Draft"
    refresh the page to see the goal disappear

**Navigating away from the "Goals and Objectives" section on an AR doesn't save data. (Krys)**

Steps:

    create a goal on a new AR
    without pressing "Save Draft", navigate away by selecting a different section, e.g. "Next Steps"
    come back to the "Goals & Objectives". 
    note no goals show

**Editing a newly imported goal on the RTR page changes the "createdVia"**

To simulate this scenario:

    find a goal that was imported from the RTTAPA that doesn't have an end date (if unable to find, change the "createdVia" and "isFromSmartsheetTtaPlan" in the db for any goal without the end date to simulate an imported goal)

    add an end date to the goal on the RTR page
    in the db, the "createdVia" will now be "rtr" and the "isFromSmartsheetTtaPlan" flag false

**Imported goals that don't have status are missing from the goal selection dropdown on an AR**

Steps:

    find a goal that was imported from the RTTAPA with a blank status
    create an activity report and try adding that goal to it
    the goal will not appear on the dropdown
    change the goal's status to "In Progress"
    the goal is now present in the dropdown on the AR dropdown.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1085


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
