### PR TITLE
[TTAHUB-1082] Sort goals on the Activity Report by the linking ARGoal table

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1522,6 +1522,14 @@ export async function getGoalsForReport(reportId) {
     },
     include: [
       {
+        attributes: ['activityReportId', 'createdAt'],
+        model: ActivityReportGoal,
+        as: 'activityReportGoals',
+        where: {
+          activityReportId: reportId,
+        },
+      },
+      {
         model: Grant,
         as: 'grant',
         required: true,
@@ -1583,6 +1591,9 @@ export async function getGoalsForReport(reportId) {
           },
         ],
       },
+    ],
+    order: [
+      [[sequelize.col('activityReportGoals.createdAt'), 'asc']],
     ],
   });
 


### PR DESCRIPTION
## Description of change
The results from "getGoalsForReport" now sorted by the creation date of the ActivityReportGoal. The deduplication function that is called after the SQL query will handle any weirdness around adding and removing recipients, so that the end result is that the matching sets of goals will be ordered by the earliest ActivityReportGoal.

## How to test
Validate in the UI that adding, editing and removing goals to an activity report preserves this order.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1082


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
