### PR TITLE
[TTAHUB-1105] Fix bug with Recipient and OE attachments

### DIFF
--- a/frontend/src/components/FileUploader/ObjectiveFileUploader.js
+++ b/frontend/src/components/FileUploader/ObjectiveFileUploader.js
@@ -30,7 +30,6 @@ const ObjectiveFileUploader = ({
     const fileHasObjectiveFile = file.ObjectiveFile && file.ObjectiveFile.objectiveId;
     const objectiveHasBeenSaved = objective.ids && objective.ids.length && objective.ids.length > 0;
     const uploaderIsOnReport = reportId > 0 && objectiveHasBeenSaved;
-    console.log('\n\n\n\n----------------------------Objective:', objective);
     try {
       if (uploaderIsOnReport) {
         // remove from activity report objective file only

--- a/frontend/src/components/FileUploader/ObjectiveFileUploader.js
+++ b/frontend/src/components/FileUploader/ObjectiveFileUploader.js
@@ -29,8 +29,8 @@ const ObjectiveFileUploader = ({
     const file = files[removedFileIndex];
     const fileHasObjectiveFile = file.ObjectiveFile && file.ObjectiveFile.objectiveId;
     const objectiveHasBeenSaved = objective.ids && objective.ids.length && objective.ids.length > 0;
-    const uploaderIsOnReport = reportId > 0;
-
+    const uploaderIsOnReport = reportId > 0 && objectiveHasBeenSaved;
+    console.log('\n\n\n\n----------------------------Objective:', objective);
     try {
       if (uploaderIsOnReport) {
         // remove from activity report objective file only

--- a/frontend/src/components/FileUploader/__tests__/ObjectiveFileUploader.js
+++ b/frontend/src/components/FileUploader/__tests__/ObjectiveFileUploader.js
@@ -27,12 +27,12 @@ describe('ObjectiveFileUploader', () => {
   };
 
   const RenderFileUploader = ({
-    onChange, files, upload = jest.fn(), reportId = 0,
+    onChange, files, upload = jest.fn(), reportId = 0, objIds = [],
   }) => (
     <ObjectiveFileUploader
       onChange={onChange}
       files={files}
-      objective={{ id: 1 }}
+      objective={{ id: 1, ids: objIds }}
       id="id"
       upload={upload}
       index={0}
@@ -113,10 +113,11 @@ describe('ObjectiveFileUploader', () => {
 
   it('files are properly removed when on a report', async () => {
     const mockOnChange = jest.fn();
-    render(<RenderFileUploader reportId={1} onChange={mockOnChange} files={[file('fileOne', 1, null), { ...file('fileTwo', 2), ObjectiveFile: { objectiveId: 1 } }]} />);
+    render(<RenderFileUploader reportId={1} objIds={[1]} onChange={mockOnChange} files={[file('fileOne', 1, null), { ...file('fileTwo', 2), ObjectiveFile: { objectiveId: 1 } }]} />);
     expect(screen.getByText('fileOne')).toBeVisible();
     expect(screen.getByText('fileTwo')).toBeVisible();
     expect(screen.getByText('Pending')).toBeVisible();
+
     fetchMock.delete('/api/files/report/1/file/2', { status: 204 });
     const fileTwo = screen.getByText('fileTwo');
     fireEvent.click(fileTwo.parentNode.lastChild.firstChild);

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -182,7 +182,7 @@ export default function Objective({
     // handle file upload
     try {
       const data = new FormData();
-      data.append('objectiveIds', JSON.stringify(objectiveToAttach.ids));
+      data.append('objectiveIds', JSON.stringify(!objectiveToAttach.ids ? [0] : objectiveToAttach.ids));
       files.forEach((file) => {
         data.append('file', file);
       });

--- a/src/policies/objective.js
+++ b/src/policies/objective.js
@@ -20,7 +20,9 @@ export default class Objective {
   canUpdate() {
     if (!this.objective.onApprovedAR
         && (this.objective.otherEntityId
-          || this.canWriteInRegion(this.objective.goal.grant.regionId))) {
+          || (this.objective.goal
+              && this.objective.goal.grant
+              && this.canWriteInRegion(this.objective.goal.grant.regionId)))) {
       return true;
     }
     return false;

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -375,7 +375,7 @@ const uploadObjectivesFile = async (req, res) => {
       const data = await createObjectivesFileMetaData(
         originalFilename,
         fileName,
-        objectiveIds,
+        objectiveIds.filter((i) => i !== 0), // Exclude unsaved objectives.
         size,
       );
       try {

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -336,7 +336,7 @@ const uploadObjectivesFile = async (req, res) => {
   const user = await userById(req.session.userId);
 
   objectiveIds = JSON.parse(objectiveIds);
-  const metadata = [];
+  const scanQueue = [];
 
   if (!objectiveIds || !objectiveIds.length) {
     return res.status(400).send({ error: 'objective ids are required' });
@@ -381,32 +381,32 @@ const uploadObjectivesFile = async (req, res) => {
       try {
         const uploadedFile = await uploadFile(buffer, fileName, fileTypeToUse);
         const url = getPresignedURL(uploadedFile.key);
-        await updateStatus(metadata.id, UPLOADED);
-        metadata.push({ ...data, url });
+        await updateStatus(data.id, UPLOADED);
+        scanQueue.push({ ...data, url });
 
         return data;
       } catch (err) {
         if (data) {
-          await updateStatus(metadata.id, UPLOAD_FAILED);
+          await updateStatus(data.id, UPLOAD_FAILED);
         }
         return handleErrors(req, res, err, logContext);
       }
     }));
-    res.status(200).send(metadata);
+    res.status(200).send(scanQueue);
   } catch (err) {
     return handleErrors(req, res, err, logContext);
   }
 
-  return Promise.all(metadata.map(async (m) => {
+  return Promise.all(scanQueue.map(async (queueItem) => {
     try {
-      if (!m.key || !m.id) {
+      if (!queueItem.key || !queueItem.id) {
         throw new Error('Missing key or id for file status update');
       }
-      await addToScanQueue({ key: m.key });
-      return updateStatus(multiparty.id, QUEUED);
+      await addToScanQueue({ key: queueItem.key });
+      return updateStatus(queueItem.id, QUEUED);
     } catch (err) {
-      auditLogger.error(`${logContext} Failed to queue ${m.originalFileName}. Error: ${err}`);
-      return updateStatus(m.id, QUEUEING_FAILED);
+      auditLogger.error(`${logContext} Failed to queue ${queueItem.originalFileName}. Error: ${err}`);
+      return updateStatus(queueItem.id, QUEUEING_FAILED);
     }
   }));
 };

--- a/src/services/files.js
+++ b/src/services/files.js
@@ -116,6 +116,7 @@ const getObjectiveTemplateFilesById = async (objectiveTemplateId) => ObjectiveTe
 });
 
 const updateStatus = async (fileId, fileStatus) => {
+  /* TODO: If an error occurs make sure it bubbles up. */
   let file;
   try {
     file = await File.update({ status: fileStatus }, {


### PR DESCRIPTION
## Description of change

When investigating a bug for Other Entity attachments. I also found another bug that would crash the server if we attempted to add attachments on a recipient AR if the Goal wasn't saved.

**NOTE:** Right now if you attempt to save attachments on a AR were the goal IS NOT saved. It wont save the files unless you are an admin. I'm assuming this is by design. I have another change if we want to check region before we throw a 400.

## How to test

- Create a Multi Recipient AR and add/remove file attachments on multiple objectives **without** saving the goal 
- Create an Other Entity AR and add/remove file attachments on multiple objectives

Verify database data is correct. Approve both reports (saving goals) and assert data again.

- Create a goal from RTR with multiple objectives add/remove file attachments.

Verify database data.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1105

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
