### PR TITLE
TTAHUB-1106 Goal status sorting fixes

### DIFF
--- a/frontend/src/components/GoalCards/GoalsCardsHeader.js
+++ b/frontend/src/components/GoalCards/GoalsCardsHeader.js
@@ -89,7 +89,7 @@ export default function GoalCardsHeader({
             <option value="createdOn-desc">creation date (newest to oldest) </option>
             <option value="createdOn-asc">creation date (oldest to newest) </option>
             <option value="goalStatus-asc">goal status (drafts first)</option>
-            <option value="goalStatus-desc">goal status (completed first) </option>
+            <option value="goalStatus-desc">goal status (closed first) </option>
           </Dropdown>
         </div>
         {!hidePagination && (

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -395,20 +395,24 @@ export async function getGoalsByActivityRecipient(
     order: orderGoalsBy(sortBy, sortDir),
   });
 
-  // status sorting order provided by TTAHUB-1106
-  const ascOrder = ['draft', 'not started', 'in progress', 'suspended', 'closed'];
-  const descOrder = Array.from(ascOrder).reverse();
+  let sorted = rows;
 
-  const sorted = rows.sort((a, b) => {
-    const aStatus = a.status.toLowerCase();
-    const bStatus = b.status.toLowerCase();
-    // if we found some weird status that for some reason isn't in ascOrder, sort it last
-    if (!ascOrder.includes(aStatus) || !ascOrder.includes(bStatus)) return 1;
+  if (sortBy === 'goalStatus') {
+    // status sorting order provided by TTAHUB-1106
+    const ascOrder = ['draft', 'not started', 'in progress', 'suspended', 'closed'];
+    const descOrder = Array.from(ascOrder).reverse();
 
-    return sortDir.toLowerCase() === 'asc'
-      ? ascOrder.indexOf(aStatus) - ascOrder.indexOf(bStatus)
-      : descOrder.indexOf(aStatus) - descOrder.indexOf(bStatus);
-  });
+    sorted = rows.sort((a, b) => {
+      const aStatus = a.status.toLowerCase();
+      const bStatus = b.status.toLowerCase();
+      // if we found some weird status that for some reason isn't in ascOrder, sort it last
+      if (!ascOrder.includes(aStatus) || !ascOrder.includes(bStatus)) return 1;
+
+      return sortDir.toLowerCase() === 'asc'
+        ? ascOrder.indexOf(aStatus) - ascOrder.indexOf(bStatus)
+        : descOrder.indexOf(aStatus) - descOrder.indexOf(bStatus);
+    });
+  }
 
   const allGoalIds = [];
 

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -398,8 +398,8 @@ export async function getGoalsByActivityRecipient(
   let sorted = rows;
 
   if (sortBy === 'goalStatus') {
-    // status sorting order provided by TTAHUB-1106
-    const ascOrder = ['draft', 'not started', 'in progress', 'suspended', 'closed'];
+    // order determined by the statuses in the GOAL_STATUS constant
+    const ascOrder = Object.values(GOAL_STATUS).map((s) => s.toLowerCase());
     const descOrder = Array.from(ascOrder).reverse();
 
     sorted = rows.sort((a, b) => {

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -13,7 +13,12 @@ import {
   Topic,
 } from '../models';
 import orderRecipientsBy from '../lib/orderRecipientsBy';
-import { RECIPIENTS_PER_PAGE, GOALS_PER_PAGE, REPORT_STATUSES } from '../constants';
+import {
+  RECIPIENTS_PER_PAGE,
+  GOALS_PER_PAGE,
+  REPORT_STATUSES,
+  GOAL_STATUS,
+} from '../constants';
 import filtersToScopes from '../scopes';
 import orderGoalsBy from '../lib/orderGoalsBy';
 import goalStatusGraph from '../widgets/goalStatusGraph';

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -395,9 +395,24 @@ export async function getGoalsByActivityRecipient(
     order: orderGoalsBy(sortBy, sortDir),
   });
 
+  // status sorting order provided by TTAHUB-1106
+  const ascOrder = ['draft', 'not started', 'in progress', 'suspended', 'closed'];
+  const descOrder = Array.from(ascOrder).reverse();
+
+  const sorted = rows.sort((a, b) => {
+    const aStatus = a.status.toLowerCase();
+    const bStatus = b.status.toLowerCase();
+    // if we found some weird status that for some reason isn't in ascOrder, sort it last
+    if (!ascOrder.includes(aStatus) || !ascOrder.includes(bStatus)) return 1;
+
+    return sortDir.toLowerCase() === 'asc'
+      ? ascOrder.indexOf(aStatus) - ascOrder.indexOf(bStatus)
+      : descOrder.indexOf(aStatus) - descOrder.indexOf(bStatus);
+  });
+
   const allGoalIds = [];
 
-  const r = rows.reduce((previous, current) => {
+  const r = sorted.reduce((previous, current) => {
     const existingGoal = previous.goalRows.find(
       (g) => g.goalStatus === current.status
         && g.goalText.trim() === current.name.trim()


### PR DESCRIPTION
## Description of change

Sort description for descending goal status should read "Goal status - closed first" instead of "Goals status - completed first".

Goal sort ascending (drafts first) should be:

1. Draft
2. Not started
3. In progress
4. Suspended
5. Closed

Goal sort descending (closed first) should be:

1. Closed
2. Suspended
3. In progress
4. Not started
5. Draft


## How to test

Go to RTR -> G&O and sort by goal status desc and asc. Confirm the order aligns with the above spec.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1106


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
