### PR TITLE
[TTAHUB-1107] Add Missing Fields to AR Review (Recipient and OE)

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/__tests__/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/goalsObjectives.js
@@ -323,22 +323,29 @@ describe('goals objectives', () => {
             title: 'title one',
             ttaProvided: 'ttaProvided one',
             status: 'Not Started',
-            topics: ['Hello'],
-            resources: [],
+            topics: [{ name: 'Topic 1' }, { name: 'Topic 2' }, { name: 'Topic 3' }],
+            resources: [{ userProvidedUrl: 'http://test1.gov' }, { userProvidedUrl: 'http://test2.gov' }, { userProvidedUrl: 'http://test3.gov' }],
             roles: ['Chief Inspector'],
+            files: [{ originalFileName: 'test1.txt', url: { url: 'test1.txt' } }],
           },
           {
             id: 2,
             title: 'title two',
             ttaProvided: 'ttaProvided two',
             status: 'Not Started',
-            topics: ['Hello'],
+            topics: [],
             resources: [],
             roles: ['Chief Inspector'],
+            files: [],
           },
         ]}
       />);
       const objective = await screen.findByText('title one');
+      expect(await screen.findByText(/topic 1, topic 2, topic 3/i)).toBeVisible();
+      expect(await screen.findByRole('link', { name: /test1\.txt \(opens in new tab\)/i })).toBeVisible();
+      expect(await screen.findByRole('link', { name: /http:\/\/test1\.gov/i })).toBeVisible();
+      expect(await screen.findByRole('link', { name: /http:\/\/test2\.gov/i })).toBeVisible();
+      expect(await screen.findByRole('link', { name: /http:\/\/test3\.gov/i })).toBeVisible();
       expect(objective).toBeVisible();
     });
 
@@ -351,14 +358,20 @@ describe('goals objectives', () => {
           title: 'title',
           ttaProvided: 'ttaProvided',
           status: 'Not Started',
-          topics: ['Hello'],
-          resources: [],
+          topics: [{ name: 'Topic 1' }, { name: 'Topic 2' }, { name: 'Topic 3' }],
+          resources: [{ value: 'http://test1.gov' }, { value: 'http://test2.gov' }, { value: 'http://test3.gov' }],
           roles: ['Chief Inspector'],
+          files: [{ originalFileName: 'test1.txt', url: { url: 'test1.txt' } }],
         }],
       }]}
       />);
       const objective = await screen.findByText('title');
       expect(objective).toBeVisible();
+      expect(await screen.findByText(/topic 1, topic 2, topic 3/i)).toBeVisible();
+      expect(await screen.findByRole('link', { name: /test1\.txt \(opens in new tab\)/i })).toBeVisible();
+      expect(await screen.findByRole('link', { name: /http:\/\/test1\.gov/i })).toBeVisible();
+      expect(await screen.findByRole('link', { name: /http:\/\/test2\.gov/i })).toBeVisible();
+      expect(await screen.findByRole('link', { name: /http:\/\/test3\.gov/i })).toBeVisible();
     });
 
     it('isPageComplete is true', async () => {

--- a/frontend/src/pages/ActivityReport/Pages/components/OtherEntityReviewSection.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/OtherEntityReviewSection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { useFormContext } from 'react-hook-form/dist/index.ie11';
 import { isUndefined } from 'lodash';
 import { Editor } from 'react-draft-wysiwyg';
@@ -21,19 +22,59 @@ const OtherEntityReviewSection = () => {
       key="Objectives"
       basePath="goals-objectives"
       anchor="goals-and-objectives"
-      title="Objectives"
+      title="Objective summary"
       canEdit={canEdit}
     >
       <>
         {objectivesWithoutGoals.map((objective) => (
           <div key={objective.id} className="desktop:flex-align-end display-flex flex-column flex-justify-center margin-top-1">
             <div>
-              <span className="text-bold">Objective:</span>
+              <span className="text-bold">TTA Objective:</span>
               {' '}
               {objective.title}
             </div>
-            <div>
-              <span className="text-bold">TTA Provided:</span>
+            <div className="margin-top-1">
+              <span className="text-bold">Topics:</span>
+              {' '}
+              {
+                objective.topics.map((t) => t.name).join(', ')
+              }
+            </div>
+            <div className="margin-top-1">
+              <span className="text-bold">Resource links:</span>
+              {' '}
+              <ul className="usa-list usa-list--unstyled">
+                {objective.resources.map((r) => (
+                  <li key={uuidv4()}>
+                    <a href={r.userProvidedUrl}>{r.userProvidedUrl}</a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="margin-top-1">
+              <span className="text-bold">Resource attachments:</span>
+              {' '}
+              {
+                objective.files.map((attachment) => (
+                  <li key={attachment.url.url}>
+                    <a
+                      href={attachment.url.url}
+                      target={attachment.originalFileName.endsWith('.txt') ? '_blank' : '_self'}
+                      rel="noreferrer"
+                    >
+                      {
+                        `${attachment.originalFileName}
+                         ${attachment.originalFileName.endsWith('.txt')
+                          ? ' (opens in new tab)'
+                          : ''}`
+                      }
+                    </a>
+                  </li>
+                ))
+              }
+            </div>
+            <div className="margin-top-1">
+              <span className="text-bold">TTA provided:</span>
               {' '}
               <Editor
                 readOnly
@@ -41,8 +82,8 @@ const OtherEntityReviewSection = () => {
                 defaultEditorState={getEditorState(objective.ttaProvided)}
               />
             </div>
-            <div>
-              <span className="text-bold">Status:</span>
+            <div className="margin-top-1">
+              <span className="text-bold">Objective status:</span>
               {' '}
               {objective.status}
             </div>

--- a/frontend/src/pages/ActivityReport/Pages/components/RecipientReviewSection.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/RecipientReviewSection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { useFormContext } from 'react-hook-form/dist/index.ie11';
 import { isUndefined } from 'lodash';
 import { Editor } from 'react-draft-wysiwyg';
@@ -21,7 +22,7 @@ const RecipientReviewSection = () => {
       key="Goals"
       basePath="goals-objectives"
       anchor="goals-and-objectives"
-      title="Goals"
+      title="Goals summary"
       canEdit={canEdit}
     >
       {goals.map((goal) => {
@@ -44,13 +45,53 @@ const RecipientReviewSection = () => {
                         {' '}
                         {objective.title}
                       </div>
-                      <div>
-                        <span className="text-bold">Status:</span>
+                      <div className="margin-top-1">
+                        <span className="text-bold">Topics:</span>
+                        {' '}
+                        {
+                          objective.topics.map((t) => t.name).join(', ')
+                        }
+                      </div>
+                      <div className="margin-top-1">
+                        <span className="text-bold">Resource links:</span>
+                        {' '}
+                        <ul className="usa-list usa-list--unstyled">
+                          {objective.resources.map((r) => (
+                            <li key={uuidv4()}>
+                              <a href={r.value}>{r.value}</a>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div className="margin-top-1">
+                        <span className="text-bold">Resource attachments:</span>
+                        {' '}
+                        {
+                          objective.files.map((attachment) => (
+                            <li key={attachment.url.url}>
+                              <a
+                                href={attachment.url.url}
+                                target={attachment.originalFileName.endsWith('.txt') ? '_blank' : '_self'}
+                                rel="noreferrer"
+                              >
+                                {
+                                  `${attachment.originalFileName}
+                                   ${attachment.originalFileName.endsWith('.txt')
+                                    ? ' (opens in new tab)'
+                                    : ''}`
+                                }
+                              </a>
+                            </li>
+                          ))
+                        }
+                      </div>
+                      <div className="margin-top-1">
+                        <span className="text-bold">Objective status:</span>
                         {' '}
                         {objective.status}
                       </div>
-                      <div>
-                        <span className="text-bold">TTA Provided:</span>
+                      <div className="margin-top-1">
+                        <span className="text-bold">TTA provided:</span>
                         {' '}
                         <Editor
                           readOnly

--- a/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
@@ -15,7 +15,7 @@ describe('Approved Activity Report V2 component', () => {
         ttaProvided: 'All of it',
       },
       topics: [{ label: 'being fancy' }],
-      resources: [{ value: 'http://www.website.com' }],
+      resources: [{ value: 'http://www.website.com', userProvidedUrl: 'http://www.OtherEntity.com' }],
       status: 'Test status',
       files: [
         {
@@ -100,7 +100,7 @@ describe('Approved Activity Report V2 component', () => {
       ...report, goalsAndObjectives: [], objectivesWithoutGoals: mockObjectives, activityRecipientType: 'other-entity',
     }}
     />);
-    expect(await screen.findByText(/http:\/\/www.website.com/i)).toBeInTheDocument();
+    expect(await screen.findByText(/http:\/\/www.otherentity.com/i)).toBeInTheDocument();
     expect(await screen.findByText(/Objective 1/i)).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -21,24 +21,26 @@ function formatNextSteps(nextSteps, heading, striped) {
   }));
 }
 
-function formatObjectiveLinks(resources) {
+function formatObjectiveLinks(resources, isOtherEntity = false) {
   if (Array.isArray(resources) && resources.length > 0) {
     return (
       <ul>
-        {resources.map((resource) => (
-          <li key={resource.value}>
-            <a
-              href={resource.value}
-              rel="noreferrer"
-            >
-              { resource.value }
-            </a>
-          </li>
-        ))}
+        {resources.map((resource) => {
+          const resourceValue = isOtherEntity ? resource.userProvidedUrl : resource.value;
+          return (
+            <li key={resourceValue}>
+              <a
+                href={resourceValue}
+                rel="noreferrer"
+              >
+                { resourceValue }
+              </a>
+            </li>
+          );
+        })}
       </ul>
     );
   }
-
   return [];
 }
 
@@ -69,7 +71,7 @@ function formatTtaType(ttaType) {
   return ttaType.map((type) => dict[type]).join(', ');
 }
 
-function addObjectiveSectionsToArray(objectives, sections, striped) {
+function addObjectiveSectionsToArray(objectives, sections, striped, isOtherEntity = false) {
   let isStriped = striped;
   objectives.forEach((objective) => {
     isStriped = !isStriped;
@@ -78,7 +80,7 @@ function addObjectiveSectionsToArray(objectives, sections, striped) {
       data: {
         'TTA objective': objective.title,
         Topics: formatSimpleArray(objective.topics.map(({ name }) => name)),
-        'Resource links': formatObjectiveLinks(objective.resources),
+        'Resource links': formatObjectiveLinks(objective.resources, isOtherEntity),
         'Resource attachments': objective.files.length ? mapAttachments(objective.files) : 'None provided',
         'TTA provided': objective.ttaProvided,
         'Objective status': objective.status,
@@ -122,7 +124,7 @@ function calculateGoalsAndObjectives(report) {
       addObjectiveSectionsToArray(goal.objectives, sections, striped);
     });
   } else if (report.activityRecipientType === 'other-entity') {
-    addObjectiveSectionsToArray(report.objectivesWithoutGoals, sections, striped);
+    addObjectiveSectionsToArray(report.objectivesWithoutGoals, sections, striped, true);
   }
 
   return sections;

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -86,7 +86,6 @@ export default function ApprovedActivityReport({ match, user }) {
     async function fetchReport() {
       try {
         const data = await getReport(match.params.activityReportId);
-
         if (!allowedRegions.includes(data.regionId)) {
           setNotAuthorized(true);
           return;


### PR DESCRIPTION
## Description of change

This fixes Topics, Files, and Resources on the review screen for both 'Recipient' and 'Other-Entity' reports.

It also fixes resources for 'Other-Entity' on the approved report screen.

NOTE: When testing this its important to note that there is a bug saving OE file attachments that should be fixed by this PR 
https://github.com/HHS/Head-Start-TTADP/pull/1129.

## How to test

Make sure all items correctly show on the review and approved screens for both 'Recipient' and 'Other-Entity' reports.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1107


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
