### PR TITLE
[TTAHUB-1101] Fix Other-Entity ID Not Saving

### DIFF
--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -215,8 +215,7 @@ function Navigator({
 
     const fieldArrayName = 'objectivesWithoutGoals';
     const currentObjectives = getValues(fieldArrayName);
-    const otherEntityIds = recipients.map(({ id }) => id);
-
+    const otherEntityIds = recipients.map((otherEntity) => otherEntity.activityRecipientId);
     // Save objectives.
     try {
       const newObjectives = await saveObjectivesForReport(
@@ -308,8 +307,7 @@ function Navigator({
       return;
     }
 
-    const otherEntityIds = recipients.map(({ id }) => id);
-
+    const otherEntityIds = recipients.map((otherEntity) => otherEntity.activityRecipientId);
     // Save objectives.
     let newObjectives;
     try {


### PR DESCRIPTION
## Description of change

When creating an 'Other-Entity' report we were not correctly setting the 'otherEntityId' this problem existed for both the 'Save objective' and 'Save draft' buttons.

## How to test

Create an 'Other-Entity' report add an objective (of multi) click Save draft. The Objective 'otherEntityId' column should be populated. Repeat the same steps but this time click 'Save objective' the entity id should be populated.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1101


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
