### PR TITLE
[TTAHUB-1104] Fix issue when setting new status if previous status was null

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -109,7 +109,7 @@ function GoalCard({
             goalId={id}
             status={goalStatus}
             onUpdateGoalStatus={onUpdateGoalStatus}
-            previousStatus={previousStatus}
+            previousStatus={previousStatus || 'Not Started'} // Open the escape hatch!
             regionId={regionId}
           />
         </div>

--- a/frontend/src/components/GoalCards/GoalCards.js
+++ b/frontend/src/components/GoalCards/GoalCards.js
@@ -66,7 +66,11 @@ function GoalCards({
     const updatedGoalIds = updatedGoal.map(({ id }) => id);
 
     const newGoals = goals.map(
-      (g) => (updatedGoalIds.includes(g.id) ? { ...g, goalStatus: newGoalStatus } : g),
+      (g) => (updatedGoalIds.includes(g.id) ? {
+        ...g,
+        goalStatus: newGoalStatus,
+        previousStatus: oldGoalStatus,
+      } : g),
     );
     setGoals(newGoals);
   };

--- a/frontend/src/components/GoalCards/GoalCards.js
+++ b/frontend/src/components/GoalCards/GoalCards.js
@@ -69,7 +69,7 @@ function GoalCards({
       (g) => (updatedGoalIds.includes(g.id) ? {
         ...g,
         goalStatus: newGoalStatus,
-        previousStatus: oldGoalStatus,
+        previousStatus: oldGoalStatus || 'Not Started',
       } : g),
     );
     setGoals(newGoals);


### PR DESCRIPTION
## Description of change

There was a bug that if a goal didn't have a previous status and the new status was set to 'Suspended'. We weren't setting the new previous status and it locked the goal status to only be 'Closed'.

## How to test

Find a goal that has a NULL previousStatus in the DB. Set the status of the goal to 'Suspended'. You should be able to set the goal to one of two options 1. the previous status or 2. closed.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1104


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
