### PR TITLE
[TTAHUB-1103] Remove bold objective name

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
@@ -16,10 +16,6 @@
   padding: 0;
 }
 
-.ttahub-approved-report-section div[id^="rdw-wrapper-tta-objective"]{
-  font-weight: bold;
-}
-
 @media screen {
   .ttahub-approved-report-section__striped {
     background-color: $gray-two;


### PR DESCRIPTION
## Description of change

Per Lauren and Patrice we want to remove the bold status on Objective name in Approved and Approved Print screens.

## How to test

View an approved report the Objective name should NOT be bold.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1103


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
