### PR TITLE
[Ttahub-1128] Can view RTR page with URL when don't have permission

### DIFF
--- a/src/policies/recipient.js
+++ b/src/policies/recipient.js
@@ -1,30 +1,23 @@
-import { find, isUndefined } from 'lodash';
 import SCOPES from '../middleware/scopeConstants';
 
 export default class Recipient {
-  constructor(user, recipient, regionId) {
+  constructor(user, recipient) {
     this.user = user;
     this.recipient = recipient;
-    this.regionId = regionId;
+    this.regionIds = this.recipient.grants.map((grant) => grant.regionId);
   }
 
   canReadInRegion(region) {
     // a goal can have multiple regions
-    const permissions = find(
-      this.user.permissions,
-      (permission) => (
-        (
-          permission.scopeId === SCOPES.READ_WRITE_REPORTS
-          || permission.scopeId === SCOPES.APPROVE_REPORTS
-          || permission.scopeId === SCOPES.READ_REPORTS
-        )
-        && permission.regionId === region),
-    );
-    return !isUndefined(permissions);
+    return this.user.permissions.some((permission) => (
+      permission.scopeId === SCOPES.READ_WRITE_REPORTS
+      || permission.scopeId === SCOPES.APPROVE_REPORTS
+      || permission.scopeId === SCOPES.READ_REPORTS
+    )
+    && permission.regionId === region);
   }
 
   canView() {
-    const region = this.regionId;
-    return this.canReadInRegion(region);
+    return this.regionIds.some((regionId) => this.canReadInRegion(regionId));
   }
 }

--- a/src/policies/recipient.js
+++ b/src/policies/recipient.js
@@ -1,0 +1,30 @@
+import { find, isUndefined } from 'lodash';
+import SCOPES from '../middleware/scopeConstants';
+
+export default class Recipient {
+  constructor(user, recipient, regionId) {
+    this.user = user;
+    this.recipient = recipient;
+    this.regionId = regionId;
+  }
+
+  canReadInRegion(region) {
+    // a goal can have multiple regions
+    const permissions = find(
+      this.user.permissions,
+      (permission) => (
+        (
+          permission.scopeId === SCOPES.READ_WRITE_REPORTS
+          || permission.scopeId === SCOPES.APPROVE_REPORTS
+          || permission.scopeId === SCOPES.READ_REPORTS
+        )
+        && permission.regionId === region),
+    );
+    return !isUndefined(permissions);
+  }
+
+  canView() {
+    const region = this.regionId;
+    return this.canReadInRegion(region);
+  }
+}

--- a/src/routes/recipient/handlers.js
+++ b/src/routes/recipient/handlers.js
@@ -34,26 +34,17 @@ export async function getGoalsByIdandRecipient(req, res) {
 export async function getRecipient(req, res) {
   try {
     const { recipientId } = req.params;
-
     const { grant: scopes } = filtersToScopes(req.query);
     const recipient = await recipientById(recipientId, scopes);
-    const { regionId } = recipient.grants[0];
-
-    const user = await userById(req.session.userId);
-
-    let canView = true;
-    const policy = new Recipient(user, recipient, regionId);
-    if (!policy.canView()) {
-      canView = false;
-    }
-
-    if (!canView) {
-      res.sendStatus(401);
+    if (!recipient) {
+      res.sendStatus(404);
       return;
     }
 
-    if (!recipient) {
-      res.sendStatus(404);
+    const user = await userById(req.session.userId);
+    const policy = new Recipient(user, recipient);
+    if (!policy.canView()) {
+      res.sendStatus(401);
       return;
     }
 

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -6,6 +6,7 @@ import {
 import {
   getGoalsByActivityRecipient, recipientById, recipientsByName,
 } from '../../services/recipient';
+import SCOPES from '../../middleware/scopeConstants';
 
 jest.mock('../../services/recipient', () => ({
   recipientById: jest.fn(),
@@ -17,12 +18,20 @@ jest.mock('../../services/recipient', () => ({
 
 jest.mock('../../services/accessValidation');
 
+const mockUserById = {
+  permissions: [{ scopeId: SCOPES.READ_REPORTS, regionId: 1 }],
+};
+
+jest.mock('../../services/users', () => ({
+  userById: jest.fn(() => mockUserById),
+}));
+
 describe('getRecipient', () => {
-  const recipientWhere = { name: 'Mr Thaddeus Q Recipient' };
+  const recipientWhere = { name: 'Mr Thaddeus Q Recipient', grants: [{ regionId: 1 }] };
 
   const mockResponse = {
     attachment: jest.fn(),
-    json: jest.fn(),
+    json: jest.fn((x) => console.log(x)),
     send: jest.fn(),
     sendStatus: jest.fn(),
     status: jest.fn(() => ({
@@ -38,6 +47,9 @@ describe('getRecipient', () => {
         'region.in': 1,
         modelType: 'grant',
       },
+      session: {
+        userId: 1,
+      },
     };
     recipientById.mockResolvedValue(recipientWhere);
     await getRecipient(req, mockResponse);
@@ -52,6 +64,9 @@ describe('getRecipient', () => {
       query: {
         'region.in': 1,
         modelType: 'grant',
+      },
+      session: {
+        userId: 1,
       },
     };
     recipientById.mockResolvedValue(null);

--- a/src/seeders/20201124160449-users.js
+++ b/src/seeders/20201124160449-users.js
@@ -15,6 +15,11 @@ const staticUserPermissions = [
   },
   {
     userId: 1,
+    scopeId: READ_REPORTS,
+    regionId: 14,
+  },
+  {
+    userId: 1,
     scopeId: ADMIN,
     regionId: 14,
   },


### PR DESCRIPTION
## Description of change
added policy for recipients based on region


## How to test

1. view recipient profile page
2. edit users permissions to not have access to region of recipient
3. go back to recipients profile page
4. should get a 401 response 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1128


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
