### PR TITLE
[TTAHUB-1116] AR content wording changes

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -118,7 +118,7 @@ export default function ObjectiveFiles({
                     <>
                       <FormGroup className="ttahub-objective-files-dropzone margin-top-2 margin-bottom-0" error={fileError}>
                         <Label htmlFor="files">Attach any non-link resources</Label>
-                        <span className="usa-hint display-block margin-top-0 margin-bottom-2">Example file types: .docx, .pdf, .ppt (max size 30 MB)</span>
+                        <span className="usa-hint display-block">Example file types: .docx, .pdf, .ppt (max size 30 MB)</span>
                         {fileError
                       && (
                         <ErrorMessage className="margin-bottom-1">

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -117,7 +117,7 @@ export default function ObjectiveFiles({
                   ? (
                     <>
                       <FormGroup className="ttahub-objective-files-dropzone margin-top-2 margin-bottom-0" error={fileError}>
-                        <Label htmlFor="files">Attach any available non-link resources</Label>
+                        <Label htmlFor="files">Attach any non-link resources</Label>
                         <span className="usa-hint display-block margin-top-0 margin-bottom-2">Example file types: .docx, .pdf, .ppt (max size 30 MB)</span>
                         {fileError
                       && (

--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -76,15 +76,11 @@ export default function ObjectiveTopics({
 
       <FormGroup error={error.props.children}>
         <Label htmlFor={inputName}>
-          { topics && topics.length
-            ? <>Add more topics</>
-            : (
-              <>
-                Topics
-                {' '}
-                <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
-              </>
-            )}
+          <>
+            Topics
+            {' '}
+            <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
+          </>
         </Label>
         {error}
         <Select

--- a/frontend/src/components/GoalForm/ReadOnlyGoal.js
+++ b/frontend/src/components/GoalForm/ReadOnlyGoal.js
@@ -52,7 +52,7 @@ export default function ReadOnlyGoal({
           )
           : null }
         <div className="margin-bottom-2">
-          <h4 className="margin-0">Goal</h4>
+          <h4 className="margin-0">Recipient&apos;s goal</h4>
           <p className="usa-prose margin-0">{goal.name}</p>
         </div>
         <div className="margin-bottom-2">

--- a/frontend/src/components/GoalForm/ReadOnlyObjective.js
+++ b/frontend/src/components/GoalForm/ReadOnlyObjective.js
@@ -28,7 +28,7 @@ export default function ReadOnlyObjective({ objective }) {
     <div className="ttahub-goal-form-objective-summary">
       <h3 className="margin-top-0 margin-bottom-2">Objective summary</h3>
       <div className="margin-bottom-2">
-        <h4 className="margin-0">Objective</h4>
+        <h4 className="margin-0">TTA objective</h4>
         <p className="usa-prose margin-0">{objective.title}</p>
       </div>
 
@@ -56,7 +56,7 @@ export default function ReadOnlyObjective({ objective }) {
       {objective.files && objective.files.length
         ? (
           <div className="margin-bottom-2">
-            <h4 className="margin-0">Resources</h4>
+            <h4 className="margin-0">Resource attachments</h4>
             <ul className="usa-list usa-list--unstyled">
               { objective.files.map((f) => {
                 const fileName = f.originalFileName || f.path;
@@ -85,7 +85,7 @@ export default function ReadOnlyObjective({ objective }) {
       {objective.status
         ? (
           <div className="margin-bottom-2">
-            <h4 className="margin-0">Status</h4>
+            <h4 className="margin-0">Objective status</h4>
             <p className="usa-prose margin-0">{objective.status}</p>
           </div>
         )

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -82,7 +82,7 @@ export default function ResourceRepeater({
     <>
       { fixedResources.length ? (
         <>
-          <p className="usa-prose text-bold margin-bottom-0">Links to TTA resource used</p>
+          <p className="usa-prose text-bold margin-bottom-0">Link to TTA resource used</p>
           <ul className="usa-list usa-list--unstyled">
             {fixedResources.map((resource) => (
               <li key={resource.key}><a href={resource.value}>{resource.value}</a></li>
@@ -95,7 +95,7 @@ export default function ResourceRepeater({
         <FormGroup error={error.props.children}>
           <div ref={resourcesWrapper}>
             <Label htmlFor="resources" className={fixedResources.length ? 'text-bold' : ''}>
-              {!fixedResources.length ? 'Links to TTA resource used' : 'Add resource link'}
+              {!fixedResources.length ? 'Link to TTA resource used' : 'Add resource link'}
               <QuestionTooltip
                 text="Copy and paste addresses of web pages describing resources used for this objective. Usually this is an ECLKC page."
               />

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -82,7 +82,7 @@ export default function ResourceRepeater({
     <>
       { fixedResources.length ? (
         <>
-          <p className="usa-prose text-bold margin-bottom-0">Resource links</p>
+          <p className="usa-prose text-bold margin-bottom-0">Links to TTA resource used</p>
           <ul className="usa-list usa-list--unstyled">
             {fixedResources.map((resource) => (
               <li key={resource.key}><a href={resource.value}>{resource.value}</a></li>
@@ -95,7 +95,7 @@ export default function ResourceRepeater({
         <FormGroup error={error.props.children}>
           <div ref={resourcesWrapper}>
             <Label htmlFor="resources" className={fixedResources.length ? 'text-bold' : ''}>
-              {!fixedResources.length ? 'Resource links' : 'Add resource link'}
+              {!fixedResources.length ? 'Links to TTA resource used' : 'Add resource link'}
               <QuestionTooltip
                 text="Copy and paste addresses of web pages describing resources used for this objective. Usually this is an ECLKC page."
               />

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveFiles.js
@@ -110,7 +110,7 @@ describe('ObjectiveFiles', () => {
     />);
     let radio = screen.getByRole('radio', { name: /yes/i });
     userEvent.click(radio);
-    const attachResources = await screen.findByText('Attach any available non-link resources');
+    const attachResources = await screen.findByText('Attach any non-link resources');
     expect(attachResources).toBeVisible();
     const uploadBtn = screen.getByRole('button', { name: /select and upload/i });
     expect(uploadBtn).toBeVisible();

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -138,7 +138,7 @@ describe('ObjectiveForm', () => {
       setObjective,
     );
 
-    const label = await screen.findByText('Links to TTA resource used');
+    const label = await screen.findByText('Link to TTA resource used');
     expect(label).toBeVisible();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -138,7 +138,7 @@ describe('ObjectiveForm', () => {
       setObjective,
     );
 
-    const label = await screen.findByText('Resource links');
+    const label = await screen.findByText('Links to TTA resource used');
     expect(label).toBeVisible();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
@@ -43,7 +43,7 @@ describe('ObjectiveTopics', () => {
 
   it('displays the correct label', async () => {
     renderObjectiveTopics();
-    const label = await screen.queryAllByText(/topics/i);
+    const label = screen.queryAllByText(/topics/i);
     expect(label).toHaveLength(2);
     const fastDancing = await screen.findByRole('listitem');
     expect(fastDancing).toHaveTextContent('Dancing but too fast');

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveTopics.js
@@ -43,9 +43,8 @@ describe('ObjectiveTopics', () => {
 
   it('displays the correct label', async () => {
     renderObjectiveTopics();
-    const label = await screen.findByText('Topics');
-    expect(label).toBeVisible();
-    expect(screen.getByText(/add more topics/i)).toBeVisible();
+    const label = await screen.queryAllByText(/topics/i);
+    expect(label).toHaveLength(2);
     const fastDancing = await screen.findByRole('listitem');
     expect(fastDancing).toHaveTextContent('Dancing but too fast');
     expect(screen.getByText(/dancing but too slow/i)).toBeVisible();

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -22,7 +22,7 @@ describe('ResourceRepeater', () => {
       userCanEdit
     />);
 
-    expect(await screen.findByText('Links to TTA resource used')).toBeVisible();
+    expect(await screen.findByText('Link to TTA resource used')).toBeVisible();
     const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
     expect(resources1).not.toBeNull();
     const resources2 = await screen.findByText('http://www.resources2.com');
@@ -69,7 +69,7 @@ describe('ResourceRepeater', () => {
       userCanEdit={false}
     />);
 
-    expect(await screen.findByText('Links to TTA resource used')).toBeVisible();
+    expect(await screen.findByText('Link to TTA resource used')).toBeVisible();
     const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
     expect(resources1).toBeNull();
     const resources2 = await screen.findByText('http://www.resources2.com');

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -22,7 +22,7 @@ describe('ResourceRepeater', () => {
       userCanEdit
     />);
 
-    expect(await screen.findByText('Resource links')).toBeVisible();
+    expect(await screen.findByText('Links to TTA resource used')).toBeVisible();
     const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
     expect(resources1).not.toBeNull();
     const resources2 = await screen.findByText('http://www.resources2.com');
@@ -69,7 +69,7 @@ describe('ResourceRepeater', () => {
       userCanEdit={false}
     />);
 
-    expect(await screen.findByText('Resource links')).toBeVisible();
+    expect(await screen.findByText('Links to TTA resource used')).toBeVisible();
     const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
     expect(resources1).toBeNull();
     const resources2 = await screen.findByText('http://www.resources2.com');

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -737,7 +737,7 @@ describe('create goal', () => {
     act(() => userEvent.click(yes));
     expect(yes.checked).toBe(true);
 
-    await screen.findByText('Attach any available non-link resources');
+    await screen.findByText('Attach any non-link resources');
 
     const dispatchEvt = (node, type, data) => {
       const event = new Event(type, { bubbles: true });

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -101,7 +101,7 @@ export default function NextStepsRepeater({
 
   const dateLabel = (index) => (stepType === 'recipient'
     ? `When does the ${recipientLabel} anticipate completing step ${index + 1}?`
-    : `When do you anticipate completing step ${index + 1}?`);
+    : 'When do you anticipate completing this step?');
 
   return (
     <>

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -101,7 +101,7 @@ export default function NextStepsRepeater({
 
   const dateLabel = (index) => (stepType === 'recipient'
     ? `When does the ${recipientLabel} anticipate completing step ${index + 1}?`
-    : 'When do you anticipate completing this step?');
+    : `When do you anticipate completing step ${index + 1}?`);
 
   return (
     <>

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -17,7 +17,6 @@ import RecipientReviewSection from './components/RecipientReviewSection';
 import OtherEntityReviewSection from './components/OtherEntityReviewSection';
 import { validateObjectives } from './components/objectiveValidator';
 import ConnectionError from './components/ConnectionError';
-import Req from '../../../components/Req';
 import ReadOnly from '../../../components/GoalForm/ReadOnly';
 import PlusButton from '../../../components/GoalForm/PlusButton';
 import OtherEntity from './components/OtherEntity';

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -196,10 +196,7 @@ const GoalsObjectives = ({
       <Helmet>
         <title>Goals and objectives</title>
       </Helmet>
-      <p className="usa-prose">
-        <Req className="margin-right-1" />
-        indicates required field
-      </p>
+
       {(!isOtherEntityReport && !isRecipientReport) && (
         <Alert noIcon type="info">
           To add goals and objectives, indicate who the activity was for in

--- a/frontend/src/pages/ActivityReport/Pages/supportingAttachments.js
+++ b/frontend/src/pages/ActivityReport/Pages/supportingAttachments.js
@@ -35,9 +35,7 @@ const SupportingAttachments = ({
             </ul>
           </Label>
 
-          <span className="usa-hint font-sans-3xs">File types accepted:</span>
-          <br />
-          <span className="usa-hint font-sans-3xs">images, .pdf, .docx, .xlsx, .pptx, .doc, .xls, .ppt, .zip, .txt, .csv (max size 30 MB)</span>
+          <span className="usa-hint font-sans-3xs">Example: .doc, .pdf, .txt, .csv (max size 30 MB)</span>
           { fileError && (<ErrorMessage>{fileError}</ErrorMessage>)}
           <Controller
             name="files"


### PR DESCRIPTION
## Description of change

from https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1116:

### Goals and Objectives

- The field label for "Topics" should always be "Topics" - please remove the label that is changing to "Add more topics"
- "Resource links" should be "Link to TTA resource used" when in edit mode 
- "Attach any available non-link resources" should be "Attach any non-link resources"
This label should be closer to the "Select and upload" button than to the radio button above

### G&O Summary View

- remove *indicates required field from below Goals and Objectives
- "Goal" should be Recipient's goal
- "Objective" should be "TTA objective"
- "Resources" should be "Resource links" (links)
- "Resources" should be "Resource attachments" (attachments)
- "Status" should be "Objective status"


## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1116


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
