### PR TITLE
[TTAHUB-1129] Display only one message if neither recipient or entity report

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -212,7 +212,7 @@ const GoalsObjectives = ({
       {/**
         * on non-recipient reports, only objectives are shown
       */}
-      {!isRecipientReport && !isObjectivesFormClosed
+      {!isRecipientReport && isOtherEntityReport && !isObjectivesFormClosed
       && (
       <OtherEntity
         recipientIds={activityRecipientIds}


### PR DESCRIPTION
## Description of change

A bug was found that if you don't select recipient or other entity. The Goals and Objectives tab merges two messages.
We should only be displaying the message that tells the user to select one or the other form the summary screen.

## How to test

Create an AR don't select an report type (Recipient vs Entity)
Go to the Goals and Objectives page we should only display the message:

"To add goals and objectives, indicate who the activity was for in Activity Summary."

You should still be able to create Goals and Objectives on a Recipient and Entity report.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1129


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
