### PR TITLE
[TTAHUB-1146] Topics missing on OE when obj is suspended

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { v4 as uuid } from 'uuid';
 import PropTypes from 'prop-types';
 import {
@@ -21,15 +21,11 @@ export default function ObjectiveTopics({
   isOnReport,
   userCanEdit,
 }) {
-  const initialSelection = useRef(topics.length);
-
   const readOnly = useMemo(() => status === 'Suspended' || status === 'Complete' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit, [goalStatus, isOnReport, status, userCanEdit]);
-
-  if (readOnly && !initialSelection.current) {
+  if (readOnly && !topics.length) {
     return null;
   }
-
-  if (readOnly && initialSelection.current) {
+  if (readOnly && topics.length) {
     return (
       <>
         <p className="usa-prose text-bold margin-bottom-0">


### PR DESCRIPTION
## Description of change

On other entity reports if an objective has topics and is marked 'suspended' the topics are being hidden. They should be shown as read only.

## How to test

- Create a Recipient report with Goal and Objective. If the Objective status is suspended and we have topics they should be shown as read only.
- Create a Other Entity report with Goal and Objective. If the Objective status is suspended and we have topics they should be shown as read only.

Should be able to save and edit objectives on both report types.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1146


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
