### PR TITLE
fix for loading on objectives

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -29,7 +29,7 @@ export default function GoalForm({
   const { errors, watch } = useFormContext();
 
   // App Loading Context.
-  const { isAppLoading, setAppLoadingText } = useContext(AppLoadingContext);
+  const { isAppLoading, setAppLoadingText, setIsAppLoading } = useContext(AppLoadingContext);
 
   /**
    * add controllers for all the controlled fields
@@ -121,7 +121,6 @@ export default function GoalForm({
   }, [defaultEndDate, goal.endDate, onUpdateDate]);
 
   const [objectives, setObjectives] = useState([]);
-  const [loadingObjectives, setLoadingObjectives] = useState(false);
   /*
    * this use effect fetches
    * associated goal data
@@ -129,12 +128,12 @@ export default function GoalForm({
   useEffect(() => {
     async function fetchData() {
       try {
-        setLoadingObjectives(true);
+        setIsAppLoading(true);
         setAppLoadingText('Loading');
         const data = await goalsByIdsAndActivityReport(goal.goalIds, reportId);
         setObjectives(data[0].objectives);
       } finally {
-        setLoadingObjectives(false);
+        setIsAppLoading(false);
       }
     }
 
@@ -166,7 +165,7 @@ export default function GoalForm({
         inputName={goalTextInputName}
         isOnReport={goal.onApprovedAR || false}
         goalStatus={status}
-        isLoading={isAppLoading || loadingObjectives}
+        isLoading={isAppLoading}
         userCanEdit
       />
 
@@ -189,7 +188,7 @@ export default function GoalForm({
         key={datePickerKey} // force a re-render when the a new goal is picked
         inputName={goalEndDateInputName}
         goalStatus={status}
-        isLoading={isAppLoading || loadingObjectives}
+        isLoading={isAppLoading}
         userCanEdit
       />
 


### PR DESCRIPTION
## Description of change

We need to show a loading screen when we are retrieving objectives for a goal.

## How to test

Create an Recipient AR select different goals. When we are retrieving the goals we should show a loader to prevent them from selecting an objecitve not associated with the goal.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
