### PR TITLE
Check for null goal status when sorting

### DIFF
--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -408,6 +408,9 @@ export async function getGoalsByActivityRecipient(
     const descOrder = Array.from(ascOrder).reverse();
 
     sorted = rows.sort((a, b) => {
+      // if for some reason status is falsy, we sort last
+      if (!a.status || !b.status) return 1;
+
       const aStatus = a.status.toLowerCase();
       const bStatus = b.status.toLowerCase();
       // if we found some weird status that for some reason isn't in ascOrder, sort it last


### PR DESCRIPTION
## Description of change

goal status might potentially be null, so sorting logic should account for this

## How to test

set goal status to null in the DB

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
