### PR TITLE
[TTAHUB-1164] nextSteps isPageComplete bug

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/nextSteps.js
@@ -217,7 +217,7 @@ describe('isPageComplete for Next steps', () => {
 
   it('returns false if no next steps are provided', async () => {
     const result = isPageComplete({
-      specialistNextSteps: [], participantNextSteps: [],
+      specialistNextSteps: [], recipientNextSteps: [],
     }, { isValid: false });
     expect(result).toBe(false);
   });
@@ -228,7 +228,7 @@ describe('isPageComplete for Next steps', () => {
         note: '',
         completeDate: '09/17/2017',
       }],
-      participantNextSteps: [
+      recipientNextSteps: [
         {
           note: 'A step sir',
           completeDate: '09/17/2017',
@@ -244,7 +244,7 @@ describe('isPageComplete for Next steps', () => {
         note: 'a step',
         completeDate: '09/17/2017',
       }],
-      participantNextSteps: [
+      recipientNextSteps: [
         {
           note: 'A step sir',
           completeDate: 'a step a step a step',

--- a/frontend/src/pages/ActivityReport/Pages/nextSteps.js
+++ b/frontend/src/pages/ActivityReport/Pages/nextSteps.js
@@ -12,16 +12,16 @@ export const isPageComplete = (formData, formState) => {
     return true;
   }
 
-  const { specialistNextSteps, participantNextSteps } = formData;
-  if (!specialistNextSteps || !participantNextSteps) {
+  const { specialistNextSteps, recipientNextSteps } = formData;
+  if (!specialistNextSteps || !recipientNextSteps) {
     return false;
   }
 
-  if (!specialistNextSteps.length || !participantNextSteps.length) {
+  if (!specialistNextSteps.length || !recipientNextSteps.length) {
     return false;
   }
 
-  if (![...specialistNextSteps, ...participantNextSteps].every((step) => step.note && moment(step.completeDate, 'MM/DD/YYYY').isValid())) {
+  if (![...specialistNextSteps, ...recipientNextSteps].every((step) => step.note && moment(step.completeDate, 'MM/DD/YYYY').isValid())) {
     return false;
   }
 


### PR DESCRIPTION
## Description of change

`isPageComplete` referenced an incorrect variable name: `participantNextSteps`, when it should have been `recipientNextSteps`.

## How to test

1. Create an AR
2. On the next steps page, don't fill out the date
3. Click "Save and continue"
4. Notice next steps on Navigator are still "In progress".
5. Return to next steps, fill out dates and click "Save and continue"
6. Next steps in Navigator should now be "Completed"

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1164


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
