### PR TITLE
[TTAHUB-1162] Prevent adding files until objective saved

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuid } from 'uuid';
 import {
-  Label, Radio, Fieldset, FormGroup, ErrorMessage,
+  Label, Radio, Fieldset, FormGroup, ErrorMessage, Alert,
 } from '@trussworks/react-uswds';
 import QuestionTooltip from './QuestionTooltip';
 import UnusedData from './UnusedData';
@@ -23,6 +23,7 @@ export default function ObjectiveFiles({
   reportId,
   label,
   userCanEdit,
+  forceObjectiveSave,
 }) {
   const objectiveId = objective.id;
   const hasFiles = useMemo(() => files && files.length > 0, [files]);
@@ -64,6 +65,8 @@ export default function ObjectiveFiles({
     );
   }
 
+  const showSaveDraftInfo = forceObjectiveSave && !objectiveId;
+
   return (
     <>
       {
@@ -96,20 +99,31 @@ export default function ObjectiveFiles({
                 )}
                   />
                 </legend>
-                <Radio
-                  label="Yes"
-                  id={`add-objective-files-yes-${objectiveId}-${index}`}
-                  name={`add-objective-files-${objectiveId}-${index}`}
-                  checked={useFiles}
-                  onChange={() => setUseFiles(true)}
-                />
-                <Radio
-                  label="No"
-                  id={`add-objective-files-no-${objectiveId}-${index}`}
-                  name={`add-objective-files-${objectiveId}-${index}`}
-                  checked={!useFiles}
-                  onChange={() => setUseFiles(false)}
-                />
+                { showSaveDraftInfo
+                  ? (
+                    <Alert type="info" headingLevel="h4" slim>
+                      Save draft before uploading resources.
+                    </Alert>
+                  )
+                  : (
+                    <>
+                      <Radio
+                        label="Yes"
+                        id={`add-objective-files-yes-${objectiveId}-${index}`}
+                        name={`add-objective-files-${objectiveId}-${index}`}
+                        checked={useFiles}
+                        onChange={() => setUseFiles(true)}
+                      />
+                      <Radio
+                        label="No"
+                        id={`add-objective-files-no-${objectiveId}-${index}`}
+                        name={`add-objective-files-${objectiveId}-${index}`}
+                        checked={!useFiles}
+                        onChange={() => setUseFiles(false)}
+                      />
+                    </>
+                  )}
+
               </>
             ) }
             {
@@ -198,6 +212,7 @@ ObjectiveFiles.propTypes = {
   onBlur: PropTypes.func,
   reportId: PropTypes.number,
   userCanEdit: PropTypes.bool.isRequired,
+  forceObjectiveSave: PropTypes.bool,
 };
 
 ObjectiveFiles.defaultProps = {
@@ -205,5 +220,6 @@ ObjectiveFiles.defaultProps = {
   inputName: '',
   onBlur: () => {},
   reportId: 0,
+  forceObjectiveSave: true,
   label: "Do you plan to use any TTA resources that aren't available as a link?",
 };

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveFiles.js
@@ -140,4 +140,21 @@ describe('ObjectiveFiles', () => {
     />);
     expect(screen.queryByRole('radio', { name: /yes/i })).not.toBeInTheDocument();
   });
+
+  it('shows message if objective is not saved', async () => {
+    render(<ObjectiveFiles
+      files={[]}
+      onChangeFiles={jest.fn()}
+      objective={{ id: undefined }}
+      isOnReport
+      onUploadFiles={jest.fn()}
+      index={0}
+      inputName="objectiveFiles"
+      onBlur={jest.fn()}
+      status="Draft"
+      goalStatus="In Progress"
+      userCanEdit
+    />);
+    expect(await screen.findByText('Save draft before uploading resources.')).toBeVisible();
+  });
 });

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -152,7 +152,7 @@ export default function GoalForm({
     } else {
       setObjectives([]);
     }
-  }, [goal.goalIds, goal.isNew, goal.oldGrantIds, reportId, setAppLoadingText]);
+  }, [goal.goalIds, goal.isNew, goal.oldGrantIds, reportId, setAppLoadingText, setIsAppLoading]);
 
   return (
     <>


### PR DESCRIPTION
## Description of change

In an attempt to prevent some of the weird errors we are getting on the AR goal creation we will force the user to save the objective before adding files.

## How to test

Make sure user is forced to save objectives before uploading files.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1162


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
