### PR TITLE
[TTAHUB-1158] readonly duplicate goals

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -156,12 +156,13 @@ const GoalsObjectives = ({
 
     toggleGoalForm(false);
 
-    // remove the goal from the "selected goals"
-    const copyOfSelectedGoals = selectedGoals.map((g) => ({ ...g }));
-    copyOfSelectedGoals.splice(index, 1);
+    let copyOfSelectedGoals = selectedGoals.map((g) => ({ ...g }));
     if (currentlyEditing) {
       copyOfSelectedGoals.push(currentlyEditing);
     }
+
+    // remove the goal from the "selected goals"
+    copyOfSelectedGoals = copyOfSelectedGoals.filter((g) => g.id !== goal.id);
 
     onUpdateGoals(copyOfSelectedGoals);
   };


### PR DESCRIPTION
## Description of change

This PR just ensures the correct goal is removed from the array provided to the `ReadOnly` component using `filter` instead of `splice` and relying on the provided index.


## How to test

1. create an AR with multiple recipients (10)
2. on the Goals and Objectives page create a goal using an exising goal.
3. create an objective and fill in all the fields
4. wait for the auto save
5. right after auto save click save goal
6. select edit
7. note the edit form is shown **and the read only version of the same goal is NOT shown**.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1158


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
