### PR TITLE
[TTAHUB-1191] Auto save triggers fetch of goal objectives

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -2,6 +2,7 @@ import React, {
   useEffect, useState, useMemo, useContext, useRef,
 } from 'react';
 import PropTypes from 'prop-types';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import moment from 'moment';
 import { useController, useFormContext } from 'react-hook-form/dist/index.ie11';
 import GoalText from '../../../../components/GoalForm/GoalText';
@@ -124,7 +125,7 @@ export default function GoalForm({
    * this use effect fetches
    * associated goal data
    */
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     async function fetchData() {
       try {
         setIsAppLoading(true);
@@ -136,22 +137,12 @@ export default function GoalForm({
       }
     }
 
-    const shouldIFetchData = (
-      goal.goalIds
-      && (
-        !goal.isNew || (
-          goal.isNew
-          && goal.oldGrantIds.filter((g) => g).length
-        )
-      )
-    );
-
-    if (shouldIFetchData) {
+    if (goal.goalIds.length) {
       fetchData();
     } else {
       setObjectives([]);
     }
-  }, [goal.goalIds, goal.isNew, goal.oldGrantIds, reportId, setAppLoadingText, setIsAppLoading]);
+  }, [goal.goalIds, reportId, setAppLoadingText, setIsAppLoading]);
 
   return (
     <>

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/GoalPicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/GoalPicker.js
@@ -8,6 +8,7 @@ import React from 'react';
 import fetchMock from 'fetch-mock';
 import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
 import selectEvent from 'react-select-event';
+import AppLoadingContext from '../../../../../AppLoadingContext';
 
 import GoalPicker, { newGoal } from '../GoalPicker';
 
@@ -33,13 +34,21 @@ const GP = ({ availableGoals, selectedGoals }) => {
   });
 
   return (
-    <FormProvider {...hookForm}>
-      <GoalPicker
-        availableGoals={availableGoals}
-        roles={['central office']}
-        grantIds={[]}
-      />
-    </FormProvider>
+    <AppLoadingContext.Provider value={{
+      setIsAppLoading: jest.fn(),
+      setAppLoadingText: jest.fn(),
+      isAppLoading: false,
+    }}
+    >
+      <FormProvider {...hookForm}>
+        <GoalPicker
+          availableGoals={availableGoals}
+          roles={['central office']}
+          grantIds={[]}
+          reportId={1}
+        />
+      </FormProvider>
+    </AppLoadingContext.Provider>
   );
 };
 
@@ -58,6 +67,7 @@ const renderGoalPicker = (
 describe('GoalPicker', () => {
   beforeAll(async () => {
     fetchMock.get('/api/topic', []);
+    fetchMock.get('/api/goals?reportId=1&goalIds=1', [{ objectives: [] }]);
   });
 
   it('you can select a goal', async () => {


### PR DESCRIPTION
## Description of change

This issue came up in the demo when an auto load triggered the app loader. The core issue here is that the auto save is triggering a useEffect that calls the objective retrieve (which does show the app loader).

## How to test

- Set you auto save interval to 10 seconds
- Create a new recipient report 
- Select an existing goal 
- You should see the initial app loader when the objectives are retrieved
- The next auto save should NOT trigger the auto loader
- Subsequent changes to the goal SHOULD trigger the loader


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1191


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
