### PR TITLE
[TTAHUB-1188] Fix issue where objectives with some data weren't being saved

### DIFF
--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -311,10 +311,19 @@ function Navigator({
     setValue('goalName', '');
     setValue('goalEndDate', '');
     setValue('goalIsRttapa', '');
+    setValue('goalForEditing.objectives', []);
 
     // the form value is updated but the react state is not
     // so here we go (todo - why are there two sources of truth?)
-    updateFormData({ ...formData, goals: newGoals });
+    updateFormData({
+      ...formData,
+      goals: newGoals,
+      goalForEditing: null,
+      goalName: '',
+      goalEndDate: '',
+      goalIsRttapa: '',
+      'goalForEditing.objectives': [],
+    });
   };
 
   const onObjectiveFormNavigate = async () => {

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -161,7 +161,13 @@ export default function Objective({
     setSelectedObjective(newObjective);
     onChangeResources(newObjective.resources);
     onChangeTitle(newObjective.title);
-    onChangeTta(newObjective.ttaProvided || '');
+
+    // we only want to set the tta provided if it already exists, otherwise
+    // we don't want to clear the value in the field
+    if (newObjective.ttaProvided && newObjective.ttaProvided !== '<p></p>') {
+      onChangeTta(newObjective.ttaProvided);
+    }
+
     onChangeStatus(newObjective.status);
     onChangeTopics(newObjective.topics);
     onChangeFiles(newObjective.files || []);

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import {
   render, screen, within, act, fireEvent, waitFor,
 } from '@testing-library/react';
+import selectEvent from 'react-select-event';
 import React from 'react';
 import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
@@ -44,6 +45,8 @@ const flushPromises = async (rerender, ui) => {
   await act(() => waitFor(() => rerender(ui)));
 };
 
+let getValues;
+
 const RenderObjective = ({
   // eslint-disable-next-line react/prop-types
   objective = defaultObjective, onRemove = () => {},
@@ -62,6 +65,8 @@ const RenderObjective = ({
   hookForm.register('goals');
   hookForm.register('objectives');
 
+  getValues = hookForm.getValues;
+
   const onUpdate = (obj) => {
     hookForm.setValue('objectives', [obj]);
   };
@@ -72,7 +77,16 @@ const RenderObjective = ({
       <Objective
         objective={defaultObjective}
         topicOptions={[]}
-        options={[]}
+        options={[
+          {
+            label: 'Create a new objective',
+            value: 'Create a new objective',
+            topics: [],
+            resources: [],
+            files: [],
+            status: 'Not Started',
+            title: '',
+          }]}
         index={1}
         remove={onRemove}
         fieldArrayName="objectives"
@@ -136,5 +150,17 @@ describe('Objective', () => {
     expect(fetchMock.called()).toBe(true);
     await screen.findByText(/error uploading your file/i);
     fetchMock.restore();
+  });
+
+  it('does not clear TTA provided between objective changes', async () => {
+    render(<RenderObjective />);
+    await screen.findByText('What');
+    await act(async () => selectEvent.select(screen.getByLabelText(/Select TTA objective/i), ['Create a new objective']));
+    expect(await screen.findByText('What')).toBeVisible();
+
+    const values = getValues();
+    const { objectives } = values;
+    const ttas = objectives.map((o) => o.ttaProvided);
+    expect(ttas).toEqual(['<p><ul><li>What</li></ul></p>', '<p><ul><li>What</li></ul></p>']);
   });
 });

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -934,13 +934,7 @@ describe('saveGoalsForReport (more tests)', () => {
             status: 'Not Started',
             goalId: rtrGoal.id,
             files: [],
-            topics: [
-              {
-                name: topic.name,
-                id: topic.id,
-              },
-
-            ],
+            topics: [],
             resources: [],
           },
           {
@@ -998,6 +992,8 @@ describe('saveGoalsForReport (more tests)', () => {
 
     expect(afterActivityReportObjectives.length).toBe(2);
     expect(afterActivityReportObjectives.map((o) => o.objectiveId)).toContain(rtrObjective.id);
+    // eslint-disable-next-line max-len
+    const existingObjectiveARO = afterActivityReportObjectives.find((o) => o.objectiveId === rtrObjective.id);
 
     const afterObjectiveTopics = await ObjectiveTopic.findAll({
       where: {
@@ -1014,7 +1010,7 @@ describe('saveGoalsForReport (more tests)', () => {
     // and that both are associated with the activity report
     const afterActivityReportObjectiveTopics = await ActivityReportObjectiveTopic.findAll({
       where: {
-        activityReportObjectiveId: afterActivityReportObjectives[0].id,
+        activityReportObjectiveId: existingObjectiveARO.id,
       },
     });
 
@@ -1039,7 +1035,7 @@ describe('saveGoalsForReport (more tests)', () => {
 
     const afterActivityReportObjectiveResources = await ActivityReportObjectiveResource.findAll({
       where: {
-        activityReportObjectiveId: afterActivityReportObjectives[0].id,
+        activityReportObjectiveId: existingObjectiveARO.id,
       },
     });
 

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -928,8 +928,7 @@ describe('saveGoalsForReport (more tests)', () => {
         name: rtrGoal.name,
         objectives: [
           {
-            id: rtrObjective.id,
-            isNew: false,
+            isNew: true,
             ttaProvided: 'This is some TTA for this guy',
             title: '',
             status: 'Not Started',

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -926,32 +926,50 @@ describe('saveGoalsForReport (more tests)', () => {
         goalIds: [rtrGoal.id],
         id: rtrGoal.id,
         name: rtrGoal.name,
-        objectives: [{
-          id: rtrObjective.id,
-          isNew: false,
-          ttaProvided: 'This is some TTA for this guy',
-          title: rtrObjective.title,
-          status: 'In Progress',
-          goalId: rtrGoal.id,
-          files: [],
-          topics: [
-            {
-              name: topic.name,
-              id: topic.id,
-            },
-            {
-              name: secondTopic.name,
-              id: secondTopic.id,
-            },
-          ],
+        objectives: [
+          {
+            id: rtrObjective.id,
+            isNew: false,
+            ttaProvided: 'This is some TTA for this guy',
+            title: '',
+            status: 'Not Started',
+            goalId: rtrGoal.id,
+            files: [],
+            topics: [
+              {
+                name: topic.name,
+                id: topic.id,
+              },
 
-          resources: [
-            {
-              key: 'gibberish-i-THINK-thats-obvious',
-              value: 'https://www.google.com', // a fine resource
-            },
-          ],
-        }],
+            ],
+            resources: [],
+          },
+          {
+            id: rtrObjective.id,
+            isNew: false,
+            ttaProvided: 'This is some TTA for this guy',
+            title: rtrObjective.title,
+            status: 'In Progress',
+            goalId: rtrGoal.id,
+            files: [],
+            topics: [
+              {
+                name: topic.name,
+                id: topic.id,
+              },
+              {
+                name: secondTopic.name,
+                id: secondTopic.id,
+              },
+            ],
+
+            resources: [
+              {
+                key: 'gibberish-i-THINK-thats-obvious',
+                value: 'https://www.google.com', // a fine resource
+              },
+            ],
+          }],
         grantIds: [grantOne.id],
         status: 'In Progress',
       },
@@ -979,8 +997,8 @@ describe('saveGoalsForReport (more tests)', () => {
       },
     });
 
-    expect(afterActivityReportObjectives.length).toBe(1);
-    expect(afterActivityReportObjectives[0].objectiveId).toBe(rtrObjective.id);
+    expect(afterActivityReportObjectives.length).toBe(2);
+    expect(afterActivityReportObjectives.map((o) => o.objectiveId)).toContain(rtrObjective.id);
 
     const afterObjectiveTopics = await ObjectiveTopic.findAll({
       where: {

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1281,7 +1281,11 @@ async function createObjectivesForGoal(goal, objectives, report) {
   }
 
   // we don't want to create objectives with blank titles
-  return Promise.all(objectives.filter((o) => o.title).map(async (objective) => {
+  return Promise.all(objectives.filter((o) => o.title
+    || o.ttaProvided
+    || o.topics.length
+    || o.resources
+    || o.files).map(async (objective) => {
     const {
       id,
       isNew,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1284,8 +1284,8 @@ async function createObjectivesForGoal(goal, objectives, report) {
   return Promise.all(objectives.filter((o) => o.title
     || o.ttaProvided
     || o.topics.length
-    || o.resources
-    || o.files).map(async (objective) => {
+    || o.resources.length
+    || o.files.length).map(async (objective) => {
     const {
       id,
       isNew,


### PR DESCRIPTION
## Description of change

Previously, an objective would need to have a title in order to be saved. With this change, if any part of the form is filled out, an objective will be saved.

## How to test
To reproduce bug on main ar redesign:

- create an AR with one recipient
- use an existing goal with an objective
- select the objective, but don't save
- click "Yes" under file upload
- change your mind and select "Create a new objective"
-  note uploading message appears which is correct
- enter TTa provided and "Save draft"
- note the TTA provided is saved leading someone to believe that they saved their TTA provided.
- click "Save draft" again
- the TTA provided is gone


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1188
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1197

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
