### PR TITLE
[TTAHUB-1195] store ID in form data & add stopgap file upload label

### DIFF
--- a/frontend/src/components/FileUploader/FileTable.js
+++ b/frontend/src/components/FileUploader/FileTable.js
@@ -26,6 +26,8 @@ export const getStatus = (status) => {
       return 'Rejected';
     case 'PENDING':
       return 'Pending';
+    case 'SCANNING_FAILED':
+      return 'Uploaded';
     default:
       break;
   }

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -73,6 +73,14 @@ export default function Objective({
   });
 
   const {
+    field: { onChange: onChangeId },
+  } = useController({
+    name: `${fieldArrayName}[${index}].id`,
+    rules: {},
+    defaultValue: objective.id || objective.value || null,
+  });
+
+  const {
     field: {
       onChange: onChangeTopics,
       onBlur: onBlurTopics,
@@ -166,6 +174,7 @@ export default function Objective({
     onChangeTopics(newObjective.topics);
     onChangeFiles(newObjective.files || []);
     onObjectiveChange(newObjective, index); // Call parent on objective change.
+    onChangeId(newObjective.id || newObjective.value);
   };
 
   const onUploadFile = async (files, _objective, setError) => {


### PR DESCRIPTION
## Description of change
Store the objective ID in the form data so it is findable when using an existing objective
Also add some verbiage, hopefully temporarily, to cover the case when the file is successfully uploaded but not scanned.

## How to test
To recreate bug:
Create a Goal and Objective from RTR. Then while using both on a recipient report, you should be unable to add a file attachment.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
