### PR TITLE
[TTAHUB-1168] add loaders to file upload and AR review

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
@@ -15,6 +15,7 @@ import NetworkContext from '../../../../../NetworkContext';
 
 import ReviewSubmit from '../index';
 import { REPORT_STATUSES } from '../../../../../Constants';
+import AppLoadingContext from '../../../../../AppLoadingContext';
 
 const availableApprovers = [
   { id: 1, name: 'approver 1' },
@@ -100,20 +101,23 @@ const renderReview = (
   render(
     <Router history={history}>
       <UserContext.Provider value={{ user }}>
-        <NetworkContext.Provider value={{ connectionActive: true, localStorageAvailable: true }}>
-          <RenderReview
-            allComplete={allComplete}
-            onSubmit={onSubmit}
-            onResetToDraft={onResetToDraft}
-            formData={{
-              ...formData, calculatedStatus, submissionStatus: calculatedStatus, author: { name: 'user' }, approvers, id: 1, displayId: '1',
-            }}
-            isApprover={isApprover}
-            isPendingApprover={isPendingApprover}
-            onReview={onReview}
-            pages={pages}
-          />
-        </NetworkContext.Provider>
+        {/* eslint-disable-next-line max-len */}
+        <AppLoadingContext.Provider value={{ setIsAppLoading: jest.fn(), setAppLoadingText: jest.fn() }}>
+          <NetworkContext.Provider value={{ connectionActive: true, localStorageAvailable: true }}>
+            <RenderReview
+              allComplete={allComplete}
+              onSubmit={onSubmit}
+              onResetToDraft={onResetToDraft}
+              formData={{
+                ...formData, calculatedStatus, submissionStatus: calculatedStatus, author: { name: 'user' }, approvers, id: 1, displayId: '1',
+              }}
+              isApprover={isApprover}
+              isPendingApprover={isPendingApprover}
+              onReview={onReview}
+              pages={pages}
+            />
+          </NetworkContext.Provider>
+        </AppLoadingContext.Provider>
       </UserContext.Provider>
     </Router>,
   );

--- a/frontend/src/pages/ActivityReport/Pages/Review/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
@@ -8,6 +8,7 @@ import PrintSummary from '../PrintSummary';
 import { REPORT_STATUSES } from '../../../../Constants';
 import './index.scss';
 import { Accordion } from '../../../../components/Accordion';
+import AppLoadingContext from '../../../../AppLoadingContext';
 
 const ReviewSubmit = ({
   onSubmit,
@@ -24,7 +25,7 @@ const ReviewSubmit = ({
   lastSaveTime,
 }) => {
   const { additionalNotes, calculatedStatus } = formData;
-
+  const { setIsAppLoading, setAppLoadingText } = useContext(AppLoadingContext);
   const [reviewed, updateReviewed] = useState(false);
   const [error, updateError] = useState();
 
@@ -39,7 +40,8 @@ const ReviewSubmit = ({
 
   const onFormReview = async (data) => {
     // we need to validate as we do on submit
-
+    setIsAppLoading(true);
+    setAppLoadingText('Submitting');
     try {
       await onReview(data);
       updateReviewed(true);
@@ -47,6 +49,8 @@ const ReviewSubmit = ({
     } catch (e) {
       updateReviewed(false);
       updateError('Unable to review report');
+    } finally {
+      setIsAppLoading(false);
     }
   };
 

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -21,6 +21,7 @@ import {
   OBJECTIVE_TOPICS,
 } from './goalValidator';
 import { validateListOfResources } from '../../../../components/GoalForm/constants';
+import AppLoadingContext from '../../../../AppLoadingContext';
 import './Objective.scss';
 
 export default function Objective({
@@ -46,6 +47,7 @@ export default function Objective({
   }))();
   const [selectedObjective, setSelectedObjective] = useState(initialObjective);
   const { getValues } = useFormContext();
+  const { setAppLoadingText, setIsAppLoading } = useContext(AppLoadingContext);
 
   /**
    * add controllers for all the controlled fields
@@ -176,6 +178,8 @@ export default function Objective({
 
     // handle file upload
     try {
+      setIsAppLoading(true);
+      setAppLoadingText('Uploading');
       const data = new FormData();
       data.append('objectiveIds', JSON.stringify(!objectiveToAttach.ids ? [0] : objectiveToAttach.ids));
       files.forEach((file) => {
@@ -187,6 +191,8 @@ export default function Objective({
     } catch (error) {
       setError('There was an error uploading your file(s).');
       return null;
+    } finally {
+      setIsAppLoading(false);
     }
   };
 

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/Objective.js
@@ -7,6 +7,7 @@ import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
 import { FormProvider, useForm } from 'react-hook-form/dist/index.ie11';
 import Objective from '../Objective';
+import AppLoadingContext from '../../../../../AppLoadingContext';
 
 const defaultObjective = {
   id: 1,
@@ -69,27 +70,35 @@ const RenderObjective = ({
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <FormProvider {...hookForm}>
-      <Objective
-        objective={defaultObjective}
-        topicOptions={[]}
-        options={[]}
-        index={1}
-        remove={onRemove}
-        fieldArrayName="objectives"
-        goalId={1}
-        onRemove={onRemove}
-        onUpdate={onUpdate}
-        parentLabel="goals"
-        objectiveAriaLabel="1 on goal 1"
-        goalIndex={0}
-        objectiveIndex={0}
-        errors={{}}
-        onObjectiveChange={jest.fn()}
-        onSaveDraft={jest.fn()}
-        parentGoal={{ status: 'In Progress' }}
-        initialObjectiveStatus="Not Started"
-        reportId={98123}
-      />
+      <AppLoadingContext.Provider value={
+        {
+          setAppLoadingText: jest.fn(),
+          setIsAppLoading: jest.fn(),
+        }
+      }
+      >
+        <Objective
+          objective={defaultObjective}
+          topicOptions={[]}
+          options={[]}
+          index={1}
+          remove={onRemove}
+          fieldArrayName="objectives"
+          goalId={1}
+          onRemove={onRemove}
+          onUpdate={onUpdate}
+          parentLabel="goals"
+          objectiveAriaLabel="1 on goal 1"
+          goalIndex={0}
+          objectiveIndex={0}
+          errors={{}}
+          onObjectiveChange={jest.fn()}
+          onSaveDraft={jest.fn()}
+          parentGoal={{ status: 'In Progress' }}
+          initialObjectiveStatus="Not Started"
+          reportId={98123}
+        />
+      </AppLoadingContext.Provider>
     </FormProvider>
   );
 };


### PR DESCRIPTION
## Description of change
Reviewing a report and uploading a file to the AR Objective are two additional areas of the site where you might have a multi-second wait with no feedback. This change adds the application loading screen to those two areas.

## How to test
Review a submitted AR. Note the loading screen.
Upload a file to an objective on the AR. Note the loading screen.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1168


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
