### PR TITLE
[TTAHUB-1183] Prevent read only view on AR objectives also align all objective fields

### DIFF
--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -188,7 +188,7 @@ export default function Form({
         />
       ))}
 
-      { (status !== 'Closed' || userCanEdit) && (
+      { (status !== 'Closed') && (
         <div className="margin-top-4">
           {errors[FORM_FIELD_INDEXES.OBJECTIVES_EMPTY]}
           <PlusButton onClick={onAddNewObjectiveClick} text="Add new objective" />

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -14,7 +14,6 @@ export default function ObjectiveFiles({
   files,
   onChangeFiles,
   goalStatus,
-  status,
   isOnReport,
   onUploadFiles,
   index,
@@ -25,17 +24,19 @@ export default function ObjectiveFiles({
   userCanEdit,
   forceObjectiveSave,
   selectedObjectiveId,
+  editingFromActivityReport,
 }) {
   const objectiveId = objective.id;
   const hasFiles = useMemo(() => files && files.length > 0, [files]);
   const [useFiles, setUseFiles] = useState(hasFiles);
   const [fileError, setFileError] = useState();
-
   const hideFileToggle = useMemo(
     () => (hasFiles && files.some((file) => file.onAnyReport)), [hasFiles, files],
   );
 
-  const readOnly = useMemo(() => !userCanEdit || status === 'Suspended' || status === 'Complete' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed', [goalStatus, isOnReport, status, userCanEdit]);
+  const readOnly = useMemo(() => !editingFromActivityReport
+  && ((goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit),
+  [goalStatus, isOnReport, userCanEdit, editingFromActivityReport]);
 
   useEffect(() => {
     if (!useFiles && hasFiles) {
@@ -55,7 +56,7 @@ export default function ObjectiveFiles({
         </p>
         <ul className="usa-list usa-list--unstyled">
           {files.map((file) => (
-            !(status === 'Complete' && goalStatus === 'Closed') || file.onAnyReport ? (
+            file.onAnyReport ? (
               <li key={uuid()}>
                 {file.originalFileName}
               </li>
@@ -195,7 +196,6 @@ ObjectiveFiles.propTypes = {
   onChangeFiles: PropTypes.func.isRequired,
   goalStatus: PropTypes.string.isRequired,
   isOnReport: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]).isRequired,
-  status: PropTypes.string.isRequired,
   onUploadFiles: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,
   inputName: PropTypes.string,
@@ -204,6 +204,7 @@ ObjectiveFiles.propTypes = {
   userCanEdit: PropTypes.bool.isRequired,
   forceObjectiveSave: PropTypes.bool,
   selectedObjectiveId: PropTypes.number,
+  editingFromActivityReport: PropTypes.bool,
 };
 
 ObjectiveFiles.defaultProps = {
@@ -214,4 +215,5 @@ ObjectiveFiles.defaultProps = {
   forceObjectiveSave: true,
   selectedObjectiveId: undefined,
   label: "Do you plan to use any TTA resources that aren't available as a link?",
+  editingFromActivityReport: false,
 };

--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -120,7 +120,6 @@ export default function ObjectiveForm({
         validateObjectiveTopics={validateObjectiveTopics}
         topics={topics}
         onChangeTopics={onChangeTopics}
-        status={status}
         goalStatus={goalStatus}
         isOnReport={isOnReport || false}
         isLoading={isLoading}
@@ -133,7 +132,6 @@ export default function ObjectiveForm({
         validateResources={validateResources}
         error={errors[OBJECTIVE_FORM_FIELD_INDEXES.RESOURCES]}
         isOnReport={isOnReport || false}
-        status={status}
         goalStatus={goalStatus}
         isLoading={isLoading}
         userCanEdit={userCanEdit}
@@ -144,7 +142,6 @@ export default function ObjectiveForm({
         onChangeFiles={onChangeFiles}
         objective={objective}
         isOnReport={isOnReport || false}
-        status={status}
         isLoading={isLoading}
         onUploadFiles={onUploadFiles}
         index={index}

--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -14,14 +14,17 @@ export default function ObjectiveTopics({
   validateObjectiveTopics,
   topics,
   onChangeTopics,
-  status,
   goalStatus,
   inputName,
   isLoading,
   isOnReport,
   userCanEdit,
+  editingFromActivityReport,
 }) {
-  const readOnly = useMemo(() => status === 'Suspended' || status === 'Complete' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit, [goalStatus, isOnReport, status, userCanEdit]);
+  const readOnly = useMemo(() => !editingFromActivityReport
+  && ((goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit),
+  [goalStatus, isOnReport, userCanEdit, editingFromActivityReport]);
+
   if (readOnly && !topics.length) {
     return null;
   }
@@ -33,7 +36,7 @@ export default function ObjectiveTopics({
         </p>
         <ul className="usa-list usa-list--unstyled">
           {topics.map((topic) => (
-            !(status === 'Complete' && goalStatus === 'Closed') || topic.onAnyReport ? (
+            topic.onAnyReport ? (
               <li key={uuid()}>
                 {topic.name}
               </li>
@@ -45,7 +48,7 @@ export default function ObjectiveTopics({
   }
 
   const { editableTopics, fixedTopics } = topics.reduce((acc, topic) => {
-    if (topic.isOnApprovedReport) {
+    if (!userCanEdit || topic.onAnyReport) {
       acc.fixedTopics.push(topic);
     } else {
       acc.editableTopics.push(topic);
@@ -119,7 +122,6 @@ ObjectiveTopics.propTypes = {
     value: PropTypes.number,
   })).isRequired,
   onChangeTopics: PropTypes.func.isRequired,
-  status: PropTypes.string.isRequired,
   inputName: PropTypes.string,
   isLoading: PropTypes.bool,
   goalStatus: PropTypes.string.isRequired,
@@ -128,9 +130,11 @@ ObjectiveTopics.propTypes = {
     PropTypes.number,
   ]).isRequired,
   userCanEdit: PropTypes.bool.isRequired,
+  editingFromActivityReport: PropTypes.bool,
 };
 
 ObjectiveTopics.defaultProps = {
   inputName: 'topics',
   isLoading: false,
+  editingFromActivityReport: false,
 };

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -18,15 +18,16 @@ export default function ResourceRepeater({
   setResources,
   error,
   validateResources,
-  status,
   isOnReport,
   isLoading,
   goalStatus,
   userCanEdit,
+  editingFromActivityReport,
 }) {
   const resourcesWrapper = useRef();
 
-  const readOnly = status === 'Suspended' || status === 'Complete' || (goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed';
+  const readOnly = !editingFromActivityReport
+  && ((goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit);
 
   if (readOnly) {
     const onlyResourcesWithValues = resources.filter((resource) => resource.value);
@@ -39,7 +40,7 @@ export default function ResourceRepeater({
         <p className="usa-prose text-bold margin-bottom-0">Resource links</p>
         <ul className="usa-list usa-list--unstyled">
           {onlyResourcesWithValues.map((resource) => (
-            !(status === 'Complete' || goalStatus === 'Closed') || resource.onAnyReport ? (
+            resource.onAnyReport ? (
               <li key={uuidv4()}>
                 <a href={resource.value}>{resource.value}</a>
               </li>
@@ -148,7 +149,6 @@ ResourceRepeater.propTypes = {
   setResources: PropTypes.func.isRequired,
   error: PropTypes.node.isRequired,
   validateResources: PropTypes.func.isRequired,
-  status: PropTypes.string.isRequired,
   isOnReport: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.number,
@@ -156,8 +156,10 @@ ResourceRepeater.propTypes = {
   isLoading: PropTypes.bool,
   goalStatus: PropTypes.string.isRequired,
   userCanEdit: PropTypes.bool.isRequired,
+  editingFromActivityReport: PropTypes.bool,
 };
 
 ResourceRepeater.defaultProps = {
   isLoading: false,
+  editingFromActivityReport: false,
 };

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -234,9 +234,9 @@ export default function Objective({
         isOnApprovedReport={isOnApprovedReport || false}
         onChangeTopics={onChangeTopics}
         inputName={objectiveTopicsInputName}
-        status={objectiveStatus}
         goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
         userCanEdit
+        editingFromActivityReport
       />
       <ResourceRepeater
         resources={isOnApprovedReport ? [] : resourcesForRepeater}
@@ -247,16 +247,15 @@ export default function Objective({
           : NO_ERROR}
         validateResources={onBlurResources}
         savedResources={savedResources}
-        status={objective.status || 'Not Started'}
         inputName={objectiveResourcesInputName}
         goalStatus={parentGoal ? parentGoal.status : 'Not Started'}
         userCanEdit
+        editingFromActivityReport
       />
       <ObjectiveFiles
         objective={objective}
         files={objectiveFiles}
         onChangeFiles={onChangeFiles}
-        status={objective.status || 'Not Started'}
         isOnReport={isOnReport || false}
         onUploadFiles={onUploadFile}
         index={index}
@@ -267,6 +266,7 @@ export default function Objective({
         label="Did you use any TTA resources that aren't available as link?"
         selectedObjectiveId={selectedObjective.id}
         userCanEdit
+        editingFromActivityReport
       />
       <ObjectiveTta
         ttaProvided={objectiveTta}


### PR DESCRIPTION
## Description of change

This change aims to prevent ever entering a read only view while entering an objective from the AR. It also cleans up and aligns the topics, resources, and files for the various views.

## How to test

1. Create a Goal with and Objective from the RTR
2. On the objective add 3 topics, 3 resources, and 3 files
3. Create a AR using the goal you created
4. Switching the objective status on the AR should NOT go into a read only view
5. Set the objective to 'In Progress' on the AR and remove 1 topic, 1 resource, and 1 file
6. View the goal on the RTR you should see that only the removed items can be removed (leave them)
7. Approve your report and view the Goal from the RTR it should be in the same state as the goal is NOT complete
8. Complete the goal from the main RTR goals and objectives page
9. You should see that its in a read only view and the topics, resources, and objectives you did NOT use have a icon next to them

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1183


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
