### PR TITLE
[TTAHUB-1192] Fix TTA Provided to keep auto grow height

### DIFF
--- a/frontend/src/components/RichEditor.js
+++ b/frontend/src/components/RichEditor.js
@@ -10,7 +10,7 @@
  * threshold as well.
 */
 
-import React, { useState, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Editor } from 'react-draft-wysiwyg';
 import draftToHtml from 'draftjs-to-html';
@@ -31,34 +31,18 @@ const BASE_EDITOR_HEIGHT = '10rem';
 const RichEditor = ({
   ariaLabel, value, onChange, onBlur,
 }) => {
-  const [height, setHeight] = useState(BASE_EDITOR_HEIGHT);
-
-  const editorRef = useRef();
-
   let defaultEditorState;
   if (value) {
     defaultEditorState = getEditorState(value);
   }
 
   const onInternalChange = (currentContentState) => {
-    // an improvement would be converting to rems to match the initial height but
-    // it might not matter since we're deriving the scroll height directly from the client here
-    setHeight(editorRef.current && editorRef.current.scrollHeight ? `${editorRef.current.scrollHeight}px` : BASE_EDITOR_HEIGHT);
-
     const html = draftToHtml(currentContentState);
     onChange(html);
   };
 
   return (
     <Editor
-      // I wish I could link to a reason/some documentation why I had to do this
-      // but honestly I just reverse engineered the errors I was getting in the console
-      // until it worked (not setting a value to ref said something to the effect of
-      // 'editorRef is not a function' and we went from there)
-      editorRef={(ref) => {
-        editorRef.current = ref;
-        return ref;
-      }}
       onBlur={onBlur}
       spellCheck
       defaultEditorState={defaultEditorState}
@@ -66,7 +50,7 @@ const RichEditor = ({
       ariaLabel={ariaLabel}
       handlePastedText={() => false}
       tabIndex="0"
-      editorStyle={{ border: '1px solid #565c65', height }}
+      editorStyle={{ border: '1px solid #565c65', minHeight: BASE_EDITOR_HEIGHT }}
       toolbar={{
         options: ['inline', 'blockType', 'list'],
         inline: {


### PR DESCRIPTION
## Description of change

If the user enters TTA Provided that's larger than the default height of the text box we need to maintain the new height.

## How to test

Create an RTR add a goal with several objectives who's TTA Provided is larger than the default text box height.

- Save draft should maintain the heights
- Save goal and editing the goal should still maintain the heights
- Leaving the page and coming back should maintain heights
- Reducing the text height should still auto adjust

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1192


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
