### PR TITLE
[TTAHUB-1203] Fix issues with saving multiple goals/save draft on the RTR

### DIFF
--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -69,7 +69,7 @@ describe('ResourceRepeater', () => {
       userCanEdit={false}
     />);
 
-    expect(await screen.findByText('Link to TTA resource used')).toBeVisible();
+    expect(await screen.findByText('Resource links')).toBeVisible();
     const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
     expect(resources1).toBeNull();
     const resources2 = await screen.findByText('http://www.resources2.com');

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -480,6 +480,8 @@ describe('create goal', () => {
     resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });
     userEvent.type(resourceOne, 'https://search.marginalia.nu/');
 
+    await userEvent.click((await screen.findByRole('button', { name: /save draft/i })));
+
     save = await screen.findByRole('button', { name: /save and continue/i });
     userEvent.click(save);
 

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -587,9 +587,10 @@ export default function GoalForm({
 
       const updatedGoals = await createOrUpdateGoals(goals);
 
-      // goalForEditing will only be ever be an array with a length of 1
-      // as only one goal can be edited at a time, and even multi grant goals
-      // are deduplicated on the backend
+      // this filter on updatedGoals will only ever return an array with a length of 1
+      // representing the goal being edited
+      // (only one goal can be edited at a time, and even multi grant goals
+      // are deduplicated on the backend)
       const [goalForEditing] = updatedGoals.filter((goal) => {
         const existingGoal = createdGoals.find((g) => g.id === goal.id);
         return !existingGoal;

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -587,7 +587,7 @@ export default function GoalForm({
 
       const updatedGoals = await createOrUpdateGoals(goals);
 
-      // this will only be ever be an array with a length of 1
+      // goalForEditing will only be ever be an array with a length of 1
       // as only one goal can be edited at a time, and even multi grant goals
       // are deduplicated on the backend
       const [goalForEditing] = updatedGoals.filter((goal) => {

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -587,10 +587,23 @@ export default function GoalForm({
 
       const updatedGoals = await createOrUpdateGoals(goals);
 
-      const updatedObjectives = updatedGoals && updatedGoals.length > 0
-        && updatedGoals[0] && updatedGoals[0].objectives && updatedGoals[0].objectives.length > 0
-        ? [...updatedGoals[0].objectives]
-        : [];
+      const newCreatedGoals = updatedGoals.filter((goal) => {
+        const existingGoal = createdGoals.find((g) => g.id === goal.id);
+        return existingGoal;
+      });
+
+      // this will only be ever be an array with a length of 1
+      // as only one goal can be edited at a time, and even multi grant goals
+      // are deduplicated on the backend
+      const [goalForEditing] = updatedGoals.filter((goal) => {
+        const existingGoal = createdGoals.find((g) => g.id === goal.id);
+        return !existingGoal;
+      });
+
+      setCreatedGoals(newCreatedGoals);
+
+      const updatedObjectives = goalForEditing
+        && goalForEditing.objectives ? goalForEditing.objectives : [];
 
       updateObjectives(updatedObjectives);
 
@@ -599,8 +612,13 @@ export default function GoalForm({
         type: 'success',
       });
 
-      const newIds = updatedGoals.flatMap((g) => g.goalIds);
-      setIds(newIds);
+      // if we are not creating a new goal, we want to update the goal ids
+      // for the case of adding a grant to an existing goal. If we are creating a new goal,
+      // we don't keep track of the ids, so we don't need to update them
+      if (!isNew) {
+        const newIds = updatedGoals.flatMap((g) => g.goalIds);
+        setIds(newIds);
+      }
     } catch (error) {
       setAlert({
         message: 'There was an error saving your goal',

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -587,11 +587,6 @@ export default function GoalForm({
 
       const updatedGoals = await createOrUpdateGoals(goals);
 
-      const newCreatedGoals = updatedGoals.filter((goal) => {
-        const existingGoal = createdGoals.find((g) => g.id === goal.id);
-        return existingGoal;
-      });
-
       // this will only be ever be an array with a length of 1
       // as only one goal can be edited at a time, and even multi grant goals
       // are deduplicated on the backend
@@ -599,8 +594,6 @@ export default function GoalForm({
         const existingGoal = createdGoals.find((g) => g.id === goal.id);
         return !existingGoal;
       });
-
-      setCreatedGoals(newCreatedGoals);
 
       const updatedObjectives = goalForEditing
         && goalForEditing.objectives ? goalForEditing.objectives : [];

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -587,13 +587,14 @@ export default function GoalForm({
 
       const updatedGoals = await createOrUpdateGoals(goals);
 
-      // this filter on updatedGoals will only ever return an array with a length of 1
+      // this find owill only ever 1 goal
       // representing the goal being edited
       // (only one goal can be edited at a time, and even multi grant goals
       // are deduplicated on the backend)
-      const [goalForEditing] = updatedGoals.filter((goal) => {
-        const existingGoal = createdGoals.find((g) => g.id === goal.id);
-        return !existingGoal;
+      const existingIds = createdGoals.map((g) => g.id);
+      const goalForEditing = updatedGoals.find((goal) => {
+        const { id } = goal;
+        return !existingIds.includes(id);
       });
 
       const updatedObjectives = goalForEditing

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -667,6 +667,7 @@ export default function GoalForm({
             regionId: parseInt(regionId, DECIMAL_BASE),
             recipientId: recipient.id,
             objectives: goal.objectives,
+            isRttapa: goal.isRttapa,
           }));
           return [...acc, ...g];
         }, []),
@@ -724,7 +725,6 @@ export default function GoalForm({
     // date pickers, as they are uncontrolled inputs
     // PS - endDate can be null
     setDatePickerKey(goal.endDate ? `DPK-${goal.endDate}` : '00');
-
     setObjectives(goal.objectives);
 
     setShowForm(true);

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -587,8 +587,9 @@ export default function GoalForm({
 
       const updatedGoals = await createOrUpdateGoals(goals);
 
-      // this find owill only ever 1 goal
+      // this find will only ever 1 goal
       // representing the goal being edited
+      // we search the new goals and get the one that wasn't in the existing created goals
       // (only one goal can be edited at a time, and even multi grant goals
       // are deduplicated on the backend)
       const existingIds = createdGoals.map((g) => g.id);


### PR DESCRIPTION
## Description of change
This change fixes the bugs described in 
- https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1203 (ids were being tracked and used to overwrite the first goal when adding multiple goals on the RTR)
- https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1204 (save draft when editing multiple goals automatically uses first goal's objectives)

## How to test
Add a new goal to the RTR, 2 objectives with topics, resources, attachments. Save draft then save and continue.
Add another goal with distinct data, then save draft. All should be well (second goal's info all visible)
Save and continue, review info, then submit. 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1203
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1204


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
