### PR TITLE
Set objectives

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -26,7 +26,7 @@ export default function GoalForm({
   datePickerKey,
 }) {
   // pull the errors out of the form context
-  const { errors, watch } = useFormContext();
+  const { errors, watch, setValue } = useFormContext();
 
   // App Loading Context.
   const { isAppLoading, setAppLoadingText, setIsAppLoading } = useContext(AppLoadingContext);
@@ -131,7 +131,7 @@ export default function GoalForm({
         setIsAppLoading(true);
         setAppLoadingText('Loading');
         const data = await goalsByIdsAndActivityReport(goal.goalIds, reportId);
-        setObjectives(data[0].objectives);
+        setValue('goalForEditing.objectives', data[0].objectives);
       } finally {
         setIsAppLoading(false);
       }

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useState, useMemo, useContext, useRef,
+  useEffect, useMemo, useContext, useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
@@ -120,7 +120,8 @@ export default function GoalForm({
     onUpdateDate(goal.endDate ? goal.endDate : defaultEndDate);
   }, [defaultEndDate, goal.endDate, onUpdateDate]);
 
-  const [objectives, setObjectives] = useState([]);
+  const objectives = watch('goalForEditing.objectives');
+
   /*
    * this use effect fetches
    * associated goal data
@@ -142,7 +143,6 @@ export default function GoalForm({
         //
         // For this reason, both the `objectives` state and the `objectives` field
         // array are updated.
-        setObjectives(data[0].objectives);
         setValue('goalForEditing.objectives', data[0].objectives);
       } finally {
         setIsAppLoading(false);
@@ -152,7 +152,6 @@ export default function GoalForm({
     if (goal.goalIds.length) {
       fetchData();
     } else {
-      setObjectives([]);
       setValue('goalForEditing.objectives', []);
     }
   }, [goal.goalIds, reportId, setAppLoadingText, setIsAppLoading]);

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -132,17 +132,6 @@ export default function GoalForm({
         setIsAppLoading(true);
         setAppLoadingText('Loading');
         const data = await goalsByIdsAndActivityReport(goal.goalIds, reportId);
-
-        // The `objectives` state is provided to the `Objectives` component,
-        // but only is used to render the `options` which are passed
-        // to the `Select` component.
-        //
-        // The objective which is ultimately provided to the `Objective` component
-        // is actually pulled from react-hook-form by making
-        // a call to `useFieldArray('goalForEditing.objectives')`.
-        //
-        // For this reason, both the `objectives` state and the `objectives` field
-        // array are updated.
         setValue('goalForEditing.objectives', data[0].objectives);
       } finally {
         setIsAppLoading(false);

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useMemo, useContext, useRef,
+  useEffect, useMemo, useContext, useRef, useState,
 } from 'react';
 import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
@@ -120,7 +120,7 @@ export default function GoalForm({
     onUpdateDate(goal.endDate ? goal.endDate : defaultEndDate);
   }, [defaultEndDate, goal.endDate, onUpdateDate]);
 
-  const objectives = watch('goalForEditing.objectives');
+  const [objectives, setObjectives] = useState([]);
 
   /*
    * this use effect fetches
@@ -133,6 +133,7 @@ export default function GoalForm({
         setAppLoadingText('Loading');
         const data = await goalsByIdsAndActivityReport(goal.goalIds, reportId);
         setValue('goalForEditing.objectives', data[0].objectives);
+        setObjectives(data[0].objectives);
       } finally {
         setIsAppLoading(false);
       }
@@ -142,6 +143,7 @@ export default function GoalForm({
       fetchData();
     } else {
       setValue('goalForEditing.objectives', []);
+      setObjectives([]);
     }
   }, [goal.goalIds, reportId, setAppLoadingText, setIsAppLoading]);
 

--- a/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalForm.js
@@ -131,6 +131,18 @@ export default function GoalForm({
         setIsAppLoading(true);
         setAppLoadingText('Loading');
         const data = await goalsByIdsAndActivityReport(goal.goalIds, reportId);
+
+        // The `objectives` state is provided to the `Objectives` component,
+        // but only is used to render the `options` which are passed
+        // to the `Select` component.
+        //
+        // The objective which is ultimately provided to the `Objective` component
+        // is actually pulled from react-hook-form by making
+        // a call to `useFieldArray('goalForEditing.objectives')`.
+        //
+        // For this reason, both the `objectives` state and the `objectives` field
+        // array are updated.
+        setObjectives(data[0].objectives);
         setValue('goalForEditing.objectives', data[0].objectives);
       } finally {
         setIsAppLoading(false);
@@ -141,6 +153,7 @@ export default function GoalForm({
       fetchData();
     } else {
       setObjectives([]);
+      setValue('goalForEditing.objectives', []);
     }
   }, [goal.goalIds, reportId, setAppLoadingText, setIsAppLoading]);
 

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -75,14 +75,6 @@ export default function Objective({
   });
 
   const {
-    field: { onChange: onChangeId },
-  } = useController({
-    name: `${fieldArrayName}[${index}].id`,
-    rules: {},
-    defaultValue: objective.id || objective.value || null,
-  });
-
-  const {
     field: {
       onChange: onChangeTopics,
       onBlur: onBlurTopics,
@@ -182,7 +174,6 @@ export default function Objective({
     onChangeTopics(newObjective.topics);
     onChangeFiles(newObjective.files || []);
     onObjectiveChange(newObjective, index); // Call parent on objective change.
-    onChangeId(newObjective.id || newObjective.value);
   };
 
   const onUploadFile = async (files, _objective, setError) => {

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/GoalPicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/GoalPicker.js
@@ -26,6 +26,7 @@ const GP = ({ availableGoals, selectedGoals }) => {
     mode: 'onChange',
     defaultValues: {
       goals: selectedGoals,
+      goalForEditing: { objectives: [], goalIds: [] },
       author: {
         role: 'central office',
       },


### PR DESCRIPTION
## Description of change


this fixes the following bug on main-ar-redesign:

1. create recipient form
2. create new goal, fill it out
3. create new objective, fill it out
4. click save draft and notice you are still not able to upload attachments


## How to test

do the above steps on this branch, notice that after you save draft, you are able to add attachments

ensure that the `Objective` component is receiving a valid `id` for its `objective` prop:

![Screen Shot 2022-11-17 at 4 56 30 PM](https://user-images.githubusercontent.com/17074357/202585262-dd085153-3a17-40ba-9066-cd16319b7558.png)

previously, after saving draft:

![Screen Shot 2022-11-17 at 5 00 06 PM](https://user-images.githubusercontent.com/17074357/202585562-347a7367-f34b-45d9-be3a-581709acaa98.png)


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
