### PR TITLE
[TTAHUB-1213] Fix unable to delete goal from the RTR

### DIFF
--- a/src/routes/goals/handlers.js
+++ b/src/routes/goals/handlers.js
@@ -129,7 +129,7 @@ export async function deleteGoal(req, res) {
       return;
     }
 
-    const deletedGoal = await destroyGoal(goalIds);
+    const deletedGoal = await destroyGoal(ids);
 
     if (!deletedGoal) {
       res.sendStatus(404);


### PR DESCRIPTION
## Description of change
An incorrect parameter was making it way to the SQL for destroy goals, and so the handler was never getting called

## How to test
Create a goal on the RTR. Delete it. You should be able to do so without error.

## Issue(s)
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1213

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
