### PR TITLE
Update ARO status from 'Completed' to 'Complete'

### DIFF
--- a/src/migrations/20221122125923-update-aro-completed-status.js
+++ b/src/migrations/20221122125923-update-aro-completed-status.js
@@ -1,0 +1,20 @@
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      const loggedUser = '0';
+      const sessionSig = __filename;
+      const auditDescriptor = 'RUN MIGRATIONS';
+      await queryInterface.sequelize.query(
+        `SELECT
+                set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+                set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+                set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+                set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+        { transaction },
+      );
+      await queryInterface.sequelize.query('UPDATE "ActivityReportObjectives" SET "status" = \'Complete\' WHERE "status" = \'Completed\'', { transaction });
+    },
+  ),
+  down: async () => {
+  },
+};

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -48,6 +48,7 @@ const preventTitleChangeWhenOnApprovedAR = (sequelize, instance) => {
 
 const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
   const changed = instance.changed();
+  console.log('\n\n\n----------Instance: ', instance);
   if (Array.isArray(changed) && changed.includes('status')) {
     const now = new Date();
     switch (instance.status) {

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -48,7 +48,6 @@ const preventTitleChangeWhenOnApprovedAR = (sequelize, instance) => {
 
 const autoPopulateStatusChangeDates = (sequelize, instance, options) => {
   const changed = instance.changed();
-  console.log('\n\n\n----------Instance: ', instance);
   if (Array.isArray(changed) && changed.includes('status')) {
     const now = new Date();
     switch (instance.status) {


### PR DESCRIPTION
## Description of change

If a report was submitted before the update. But was approved after the update. The ARO status will still have 'completed' status. This is causing an issue in an objective hook.

## How to test

Using main restore the latest DB from **11/17** and use the **user 195** to approve report **25040**. Notice that the approve fails with a server error in the hook. Pull this branch and run migrations. Now attempt to approve the report again you shouldn't get any errors.

In addition the ARO table should have all 'Completed' statues update to 'Complete'.

As a final test create a new report and approve it.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
