### PR TITLE
[TTAHUB-1223] Users unable to delete objectives

### DIFF
--- a/src/migrations/20221122125923-update-aro-completed-status.js
+++ b/src/migrations/20221122125923-update-aro-completed-status.js
@@ -1,0 +1,20 @@
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      const loggedUser = '0';
+      const sessionSig = __filename;
+      const auditDescriptor = 'RUN MIGRATIONS';
+      await queryInterface.sequelize.query(
+        `SELECT
+                set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+                set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+                set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+                set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+        { transaction },
+      );
+      await queryInterface.sequelize.query('UPDATE "ActivityReportObjectives" SET "status" = \'Complete\' WHERE "status" = \'Completed\'', { transaction });
+    },
+  ),
+  down: async () => {
+  },
+};

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1074,7 +1074,7 @@ export async function goalsForGrants(grantIds) {
 
 async function removeActivityReportObjectivesFromReport(reportId, objectiveIdsToRemove) {
   const activityReportObjectivesToDestroy = Array.isArray(objectiveIdsToRemove)
-  && objectiveIdsToRemove > 0
+  && objectiveIdsToRemove.length > 0
     ? await ActivityReportObjective.findAll({
       attributes: ['id'],
       where: {


### PR DESCRIPTION
## Description of change

Bug was found were users are unable to delete objectives.

## How to test

You should be able to delete an objective (aro) from a report then revisit and see it still deleted.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1223

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
