### PR TITLE
Fix AR supporting attachments

### DIFF
--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -106,7 +106,9 @@ const deleteHandler = async (req, res) => {
         res.sendStatus(403);
         return;
       }
-      const rf = file.reportFiles.find((r) => r.reportId === reportId);
+      const rf = file.reportFiles.find(
+        (r) => r.activityReportId === parseInt(reportId, DECIMAL_BASE),
+      );
       if (rf) {
         await deleteActivityReportFile(rf.id);
       }


### PR DESCRIPTION
## Description of change

Right now users are unable to delete file attachments on the AR 'Supporting attachments' page.

## How to test

You should now be able to delete files from the AR 'Supporting attachments' page.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
