### PR TITLE
[TTAHUB-1240] Prevent showing duplicate objectives with trailing spaces

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -341,7 +341,7 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
   // we pass in the existing objectives as the accumulator
   return newObjectives.reduce((objectives, objective) => {
     const exists = objectives.find((o) => (
-      o.title === objective.title && o.status === objective.status
+      o.title === objective.title.trim() && o.status === objective.status
     ));
 
     if (exists) {
@@ -360,6 +360,7 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
 
     return [...objectives, {
       ...objective.dataValues,
+      title: objective.title.trim(),
       value: id,
       ids: [id],
       // Make sure we pass back a list of recipient ids for subsequent saves.
@@ -380,7 +381,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
     // objectives represent the accumulator in the find below
     // objective is the objective as it is returned from the API
     const exists = objectives.find((o) => (
-      o.title === objective.title && o.status === objectiveStatus
+      o.title === objective.title.trim() && o.status === objectiveStatus
     ));
 
     if (exists) {
@@ -424,6 +425,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
 
     return [...objectives, {
       ...objective.dataValues,
+      title: objective.title.trim(),
       value: id,
       ids: [id],
       ttaProvided,


### PR DESCRIPTION
## Description of change

A bug was found that will display two objectives with the same text if one of them ends with a blank space ' '.

Right now when we attempt to check if an objective exists on the BE we trim the title. When we retrieve the Objectives for the FE we should do the same.

**NOTE:** If the objectives have different statuses we will show two of them regardless of text.

## How to test

Find or create a goal that has two objectives with the same text except one of them has a trailing white space. Create a report using this Goal we should only show the objective once in the list. Creating and updating the objective on the report should yield the correct objective id in the ARO table.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1240

## Checklists

### Every PR
<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
