### PR TITLE
[TTAHUB-1246] fix controls regardless of scroll on topic freq graph

### DIFF
--- a/frontend/src/components/Container.js
+++ b/frontend/src/components/Container.js
@@ -19,7 +19,7 @@ function Container({
   const skipBottom = skipBottomPadding ? 'padding-bottom-0' : '';
 
   return (
-    <div className={`${classes} ${className} position-relative butter`}>
+    <div className={`${classes} ${className} position-relative`}>
       <Loader loading={loading} loadingLabel={loadingLabel} />
       <div className={`padding-x-${paddingX} padding-y-${paddingY} ${skipTop} ${skipBottom}`}>
         {children}

--- a/frontend/src/widgets/TopicFrequencyGraph.css
+++ b/frontend/src/widgets/TopicFrequencyGraph.css
@@ -1,5 +1,4 @@
 .ttahub--topic-frequency-graph {
-    padding-bottom: 3em; /* to make sure the entire dropdown is visible */
     width: 100%;
 }
 
@@ -37,6 +36,7 @@
     content: 'Topics';
     display: block;
     padding-left: 10em;
+    padding-bottom: 2em;
 }
 
 .grid-gap-1 {

--- a/frontend/src/widgets/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/TopicFrequencyGraph.js
@@ -140,7 +140,7 @@ export function TopicFrequencyGraphWidget({
       yaxis: {
         tickformat: ',.0d',
         title: {
-          standoff: 60,
+          standoff: 80,
           text: 'Number of Activity Reports',
           font: {
             color: colors.textInk,
@@ -172,8 +172,8 @@ export function TopicFrequencyGraphWidget({
   }
 
   return (
-    <Container className="ttahub--topic-frequency-graph overflow-x-scroll" paddingX={3} paddingY={3} loading={loading} loadingLabel="Topic frequency loading">
-      <Grid row className="position-relative margin-bottom-2">
+    <Container className="ttahub--topic-frequency-graph" paddingX={3} paddingY={3} loading={loading} loadingLabel="Topic frequency loading">
+      <Grid row className="margin-bottom-2">
         <Grid className="flex-align-self-center" desktop={{ col: 'auto' }} mobileLg={{ col: 8 }}>
           <h2 className="ttahub--dashboard-widget-heading margin-0">Number of Activity Reports by Topic</h2>
         </Grid>
@@ -217,7 +217,7 @@ export function TopicFrequencyGraphWidget({
       </Grid>
       { showAccessibleData
         ? <AccessibleWidgetData caption="Number of Activity Reports by Topic Table" columnHeadings={columnHeadings} rows={tableRows} />
-        : <div data-testid="bars" className="tta-dashboard--bar-graph-container" ref={bars} /> }
+        : <div data-testid="bars" className="tta-dashboard--bar-graph-container overflow-x-scroll overflow-y-hidden padding-y-1" ref={bars} /> }
 
     </Container>
   );


### PR DESCRIPTION
## Description of change

The controls on the Topic Frequency graph scroll with the graph, which makes it easy to lose the title or the ability to switch to a table.

## How to test

View the Topic/Frequency graph and scroll it. Notice the controls & title stay in place while only the graph scrolls

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1246


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [n/a] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
