### PR TITLE
[TTAHUB-1245] Fix the x axis labels on the total hrs/tta graph

### DIFF
--- a/frontend/src/widgets/TotalHrsAndRecipientGraph.js
+++ b/frontend/src/widgets/TotalHrsAndRecipientGraph.js
@@ -8,6 +8,7 @@ import AccessibleWidgetData from './AccessibleWidgetData';
 import Container from '../components/Container';
 import colors from '../colors';
 import './TotalHrsAndRecipientGraph.scss';
+import { DECIMAL_BASE } from '../Constants';
 
 export function TotalHrsAndRecipientGraph({ data, loading }) {
   // the state for which lines to show
@@ -101,6 +102,8 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
         },
       }];
 
+    const ticklabelstep = parseInt(data[0].x.length / 12, DECIMAL_BASE);
+
     // Specify Chart Layout.
     const layout = {
       height: 320,
@@ -126,6 +129,7 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
         automargin: false,
         tickangle: 0,
         showgrid: false,
+        ticklabelstep,
         b: 0,
         t: 0,
         autotypenumbers: 'strict',
@@ -233,9 +237,6 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
 }
 
 TotalHrsAndRecipientGraph.propTypes = {
-  dateTime: PropTypes.shape({
-    timestamp: PropTypes.string, label: PropTypes.string,
-  }),
   data: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.shape({
@@ -249,7 +250,6 @@ TotalHrsAndRecipientGraph.propTypes = {
 };
 
 TotalHrsAndRecipientGraph.defaultProps = {
-  dateTime: { timestamp: '', label: '' },
   data: [
     {
       name: 'Hours of Training', x: [], y: [], month: '',


### PR DESCRIPTION
## Description of change
Currently, the X-axis on the Total Hours/TTA graph is unreadable if you remove all filters. This change dynamically computes the number of labels on the x-axis to show using 12 as the maximum.

## How to test
Go to the regional dashboard and remove all filters. You should see a readable amount of labels there.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1245


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [n/a] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
