### PR TITLE
[TTAHUB-1202] Sort RTR goals by the correct column

### DIFF
--- a/src/services/createOrUpdateGoals.test.js
+++ b/src/services/createOrUpdateGoals.test.js
@@ -218,6 +218,10 @@ describe('createOrUpdateGoals', () => {
     expect(titles).toContain('This is an objective');
     expect(titles).not.toContain('This objective will be deleted');
 
+    // should always be in the same order, by rtr order
+    const order = objectivesOnUpdatedGoal.map((obj) => obj.rtrOrder);
+    expect(order).toStrictEqual([1, 2]);
+
     const objectiveOnUpdatedGoal = await Objective.findByPk(objective.id, { raw: true });
     expect(objectiveOnUpdatedGoal.id).toBe(objective.id);
     expect(objectiveOnUpdatedGoal.title).toBe('This is an objective');

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -360,11 +360,6 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
 
     const id = objective.getDataValue('id') ? objective.getDataValue('id') : objective.getDataValue('value');
 
-    const arOrder = objective.activityReportObjectives
-      && objective.activityReportObjectives[0]
-      && objective.activityReportObjectives[0].arOrder
-      ? objective.activityReportObjectives[0].arOrder : null;
-
     return [...objectives, {
       ...objective.dataValues,
       title: objective.title.trim(),
@@ -373,17 +368,16 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
       // Make sure we pass back a list of recipient ids for subsequent saves.
       recipientIds: [objective.getDataValue('otherEntityId')],
       isNew: false,
-      arOrder,
     }];
   }, currentObjectives);
 
-  // Sort by AR Order in place.
   objectivesToSort.sort((o1, o2) => {
-    if (o1.arOrder < o2.arOrder) {
+    if (o1.rtrOrder < o2.rtrOrder) {
       return -1;
     }
     return 1;
   });
+
   return objectivesToSort;
 }
 


### PR DESCRIPTION
## Description of change
It looks like we erroneously started sorting the RTR goals by the AR column when we merged the AR order PR. 

## How to test
RTR objectives maintain their order

## Issue(s)
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1202

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
