### PR TITLE
fix nodemon ignores

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
       "./tests/",
       "./playwright-report/",
       "./test-results/",
-      "./playwright-config.js"
+      "./playwright.config.js"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "start:ci": "cross-env POSTGRES_USERNAME=postgres POSTGRES_DB=ttasmarthub TTA_SMART_HUB_URI=http://localhost:3000 concurrently \"yarn start:web\" \"yarn client\" \"yarn start:worker\"",
     "start:web": "node ./build/server/index.js",
     "start:worker": "node ./build/server/worker.js",
-    "server": "nodemon src/index.js --exec babel-node --ignore ./tests/ --ignore ./playwright-report/ --ignore ./test-results/",
-    "worker": "nodemon src/worker.js --exec babel-node --ignore ./tests/ --ignore ./playwright-report/ --ignore ./test-results/",
-    "server:debug": "nodemon --inspect=0.0.0.0:9229 src/index.js --exec babel-node --ignore ./tests/ --ignore ./playwright-report/ --ignore ./test-results/",
+    "server": "nodemon src/index.js --exec babel-node",
+    "worker": "nodemon src/worker.js --exec babel-node",
+    "server:debug": "nodemon --inspect=0.0.0.0:9229 src/index.js --exec babel-node",
     "client": "yarn --cwd frontend start",
     "test": "jest src --runInBand", 
     "test:ci": "./bin/test-backend-ci",    
@@ -178,7 +178,11 @@
     "ignore": [
       "./reports/",
       "./cucumber/",
-      "./frontend/"
+      "./frontend/",
+      "./tests/",
+      "./playwright-report/",
+      "./test-results/",
+      "./playwright-config.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of change

see: https://github.com/HHS/Head-Start-TTADP/pull/1209#discussion_r1040050147

## How to test

changes to frontend files should not trigger nodemon

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
