### PR TITLE
[TTAHUB-1207] Switch RTR Goal Loader to App Loader

### DIFF
--- a/frontend/src/GoalFormLoadingContext.js
+++ b/frontend/src/GoalFormLoadingContext.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const GoalFormLoadingContext = React.createContext({
-  isLoading: false,
-});
-
-export default GoalFormLoadingContext;

--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -11,13 +11,12 @@ import GrantSelect from './GrantSelect';
 import GoalText from './GoalText';
 import GoalDate from './GoalDate';
 import GoalRttapa from './GoalRttapa';
-import Loader from '../Loader';
 import {
   OBJECTIVE_DEFAULTS,
   OBJECTIVE_DEFAULT_ERRORS,
   FORM_FIELD_INDEXES,
 } from './constants';
-import GoalFormLoadingContext from '../../GoalFormLoadingContext';
+import AppLoadingContext from '../../AppLoadingContext';
 import './Form.scss';
 
 export const BEFORE_OBJECTIVES_CREATE_GOAL = 'Enter a goal before adding an objective';
@@ -53,7 +52,7 @@ export default function Form({
   onUploadFiles,
   userCanEdit,
 }) {
-  const { isLoading } = useContext(GoalFormLoadingContext);
+  const { isAppLoading } = useContext(AppLoadingContext);
 
   const onUpdateText = (e) => setGoalName(e.target.value);
 
@@ -97,7 +96,6 @@ export default function Form({
 
   return (
     <div className="ttahub-create-goals-form">
-      <Loader loading={isLoading} loadingLabel="Loading" text="Loading" />
       { fetchError ? <Alert type="error" role="alert">{ fetchError }</Alert> : null}
       <div className="display-flex flex-align-center margin-top-2 margin-bottom-1">
         <h2 className="margin-0">{formTitle}</h2>
@@ -130,7 +128,7 @@ export default function Form({
         possibleGrants={possibleGrants}
         validateGrantNumbers={validateGrantNumbers}
         error={errors[FORM_FIELD_INDEXES.GRANTS]}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         goalStatus={status}
         userCanEdit={userCanEdit}
       />
@@ -141,7 +139,7 @@ export default function Form({
         isOnReport={isOnReport}
         validateGoalName={validateGoalName}
         onUpdateText={onUpdateText}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         goalStatus={status}
         userCanEdit={userCanEdit}
       />
@@ -151,7 +149,7 @@ export default function Form({
         isRttapa={isRttapa}
         onBlur={validateIsRttapa}
         onChange={setIsRttapa}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         goalStatus={status}
         isOnApprovedReport={isOnApprovedReport || false}
         initial={initialRttapa}
@@ -164,7 +162,7 @@ export default function Form({
         endDate={moment(endDate, 'YYYY-MM-DD').format('MM/DD/YYYY')}
         validateEndDate={validateEndDate}
         key={datePickerKey}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         goalStatus={status}
         userCanEdit={userCanEdit}
       />

--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -10,7 +10,7 @@ import {
 } from './constants';
 import { REPORT_STATUSES } from '../../Constants';
 import ObjectiveStatus from './ObjectiveStatus';
-import GoalFormLoadingContext from '../../GoalFormLoadingContext';
+import AppLoadingContext from '../../AppLoadingContext';
 
 const [
   objectiveTitleError,
@@ -45,7 +45,7 @@ export default function ObjectiveForm({
     )))
   ), [objective.activityReports]);
 
-  const { isLoading } = useContext(GoalFormLoadingContext);
+  const { isAppLoading } = useContext(AppLoadingContext);
 
   // onchange handlers
   const onChangeTitle = (e) => setObjective({ ...objective, title: e.target.value });
@@ -110,7 +110,7 @@ export default function ObjectiveForm({
         onChangeTitle={onChangeTitle}
         validateObjectiveTitle={validateObjectiveTitle}
         status={status}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         userCanEdit={userCanEdit}
       />
 
@@ -122,7 +122,7 @@ export default function ObjectiveForm({
         onChangeTopics={onChangeTopics}
         goalStatus={goalStatus}
         isOnReport={isOnReport || false}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         userCanEdit={userCanEdit}
       />
 
@@ -133,7 +133,7 @@ export default function ObjectiveForm({
         error={errors[OBJECTIVE_FORM_FIELD_INDEXES.RESOURCES]}
         isOnReport={isOnReport || false}
         goalStatus={goalStatus}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         userCanEdit={userCanEdit}
       />
       { title && (
@@ -142,7 +142,7 @@ export default function ObjectiveForm({
         onChangeFiles={onChangeFiles}
         objective={objective}
         isOnReport={isOnReport || false}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         onUploadFiles={onUploadFiles}
         index={index}
         goalStatus={goalStatus}
@@ -156,7 +156,7 @@ export default function ObjectiveForm({
         goalStatus={goalStatus}
         onChangeStatus={onChangeStatus}
         inputName={`objective-status-${index}`}
-        isLoading={isLoading}
+        isLoading={isAppLoading}
         userCanEdit={userCanEdit}
       />
 

--- a/frontend/src/components/GoalForm/ReadOnly.js
+++ b/frontend/src/components/GoalForm/ReadOnly.js
@@ -2,18 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReadOnlyGoal from './ReadOnlyGoal';
 import './ReadOnly.scss';
-import Loader from '../Loader';
 
 export default function ReadOnly({
   onEdit,
   onRemove,
   createdGoals,
   hideEdit,
-  loading,
 }) {
   return (
     <>
-      <Loader loading={loading} loadingLabel="Submitting your goals" />
       { createdGoals.map((goal, index) => (
         <div key={`read-only-goal-${goal.id}`}>
           <ReadOnlyGoal
@@ -42,10 +39,8 @@ ReadOnly.propTypes = {
   onEdit: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   hideEdit: PropTypes.bool,
-  loading: PropTypes.bool,
 };
 
 ReadOnly.defaultProps = {
   hideEdit: false,
-  loading: false,
 };

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -19,6 +19,7 @@ import UserContext from '../../../UserContext';
 import { OBJECTIVE_ERROR_MESSAGES } from '../constants';
 import { REPORT_STATUSES, SCOPE_IDS } from '../../../Constants';
 import { BEFORE_OBJECTIVES_CREATE_GOAL, BEFORE_OBJECTIVES_SELECT_RECIPIENTS } from '../Form';
+import AppLoadingContext from '../../../AppLoadingContext';
 
 const [
   objectiveTitleError, objectiveTopicsError, objectiveResourcesError,
@@ -109,11 +110,20 @@ describe('create goal', () => {
           },
         }}
         >
-          <CreateGoal
-            recipient={recipient}
-            regionId="1"
-            isNew={goalId === 'new'}
-          />
+          <AppLoadingContext.Provider value={
+          {
+            setIsAppLoading: jest.fn(),
+            setAppLoadingText: jest.fn(),
+            isAppLoading: false,
+          }
+        }
+          >
+            <CreateGoal
+              recipient={recipient}
+              regionId="1"
+              isNew={goalId === 'new'}
+            />
+          </AppLoadingContext.Provider>
         </UserContext.Provider>
       </Router>
     ));

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -33,7 +33,7 @@ import { DECIMAL_BASE, SCOPE_IDS } from '../../Constants';
 import ReadOnly from './ReadOnly';
 import PlusButton from './PlusButton';
 import colors from '../../colors';
-import GoalFormLoadingContext from '../../GoalFormLoadingContext';
+import AppLoadingContext from '../../AppLoadingContext';
 import useUrlParamState from '../../hooks/useUrlParamState';
 import UserContext from '../../UserContext';
 
@@ -105,7 +105,7 @@ export default function GoalForm({
 
   const [errors, setErrors] = useState(FORM_FIELD_DEFAULT_ERRORS);
 
-  const [isLoading, setIsLoading] = useState(false);
+  const { isAppLoading, setIsAppLoading, setAppLoadingText } = useContext(AppLoadingContext);
 
   const { user } = useContext(UserContext);
 
@@ -188,19 +188,23 @@ export default function GoalForm({
       } catch (err) {
         setFetchError('There was an error loading your goal');
       } finally {
-        setIsLoading(false);
+        setIsAppLoading(false);
       }
     }
 
-    if (!fetchAttempted && !isNew && !isLoading) {
-      setIsLoading(true);
-    }
-
-    // only fetch once, on load, and only if the id isn't 'new'
-    if (!fetchAttempted && !isNew && isLoading) {
+    if (!fetchAttempted && !isNew && !isAppLoading) {
+      setAppLoadingText('Loading');
+      setIsAppLoading(true);
       fetchGoal();
     }
-  }, [errors, fetchAttempted, recipient.id, isNew, isLoading, ids]);
+  }, [errors,
+    fetchAttempted,
+    recipient.id,
+    isNew,
+    isAppLoading,
+    ids,
+    setAppLoadingText,
+    setIsAppLoading]);
 
   // for fetching topic options from API
   useEffect(() => {
@@ -437,7 +441,8 @@ export default function GoalForm({
   // on form submit
   const onSubmit = async (e) => {
     e.preventDefault();
-    setIsLoading(true);
+    setAppLoadingText('Submitting');
+    setIsAppLoading(true);
     try {
       // if the goal is a draft, submission should move it to "not started"
       const gs = createdGoals.reduce((acc, goal) => {
@@ -469,13 +474,14 @@ export default function GoalForm({
         type: 'error',
       });
     } finally {
-      setIsLoading(false);
+      setIsAppLoading(false);
     }
   };
 
   const onUploadFiles = async (files, objective, setFileUploadErrorMessage, index) => {
     // The first thing we need to know is... does this objective need to be created?
-    setIsLoading(true);
+    setAppLoadingText('Uploading');
+    setIsAppLoading(true);
 
     // there is some weirdness where an objective may or may not have the "ids" property
     let objectiveIds = objective.ids ? objective.ids : [];
@@ -545,7 +551,7 @@ export default function GoalForm({
     } catch (error) {
       setFileUploadErrorMessage('File(s) could not be uploaded');
     } finally {
-      setIsLoading(false);
+      setIsAppLoading(false);
     }
 
     return null;
@@ -555,8 +561,8 @@ export default function GoalForm({
     if (!isValidDraft()) {
       return;
     }
-
-    setIsLoading(true);
+    setAppLoadingText('Saving');
+    setIsAppLoading(true);
 
     try {
       let newGoals = [];
@@ -621,7 +627,7 @@ export default function GoalForm({
         type: 'error',
       });
     } finally {
-      setIsLoading(false);
+      setIsAppLoading(false);
     }
   };
 
@@ -642,8 +648,8 @@ export default function GoalForm({
     if (!isValidNotStarted()) {
       return;
     }
-
-    setIsLoading(true);
+    setAppLoadingText('Saving');
+    setIsAppLoading(true);
     try {
       const newGoals = selectedGrants.map((g) => ({
         grantId: g.value,
@@ -700,7 +706,7 @@ export default function GoalForm({
         type: 'error',
       });
     } finally {
-      setIsLoading(false);
+      setIsAppLoading(false);
     }
   };
 
@@ -736,7 +742,8 @@ export default function GoalForm({
    * @param {Number} g
    */
   const onRemove = async (g) => {
-    setIsLoading(true);
+    setAppLoadingText('Removing goal');
+    setIsAppLoading(true);
     try {
       const success = await deleteGoal(g.goalIds, regionId);
 
@@ -758,7 +765,7 @@ export default function GoalForm({
         type: 'error',
       });
     } finally {
-      setIsLoading(false);
+      setIsAppLoading(false);
     }
   };
 
@@ -792,26 +799,24 @@ export default function GoalForm({
       </h1>
 
       <Container className="margin-y-3 margin-left-2 width-tablet" paddingX={4} paddingY={5}>
-        <GoalFormLoadingContext.Provider value={{ isLoading }}>
-          { createdGoals.length ? (
-            <>
-              <ReadOnly
-                createdGoals={createdGoals}
-                onRemove={onRemove}
-                onEdit={onEdit}
-                loading={isLoading}
-              />
-              <div className="margin-bottom-4">
-                {!showForm && isNew
-                  ? (
-                    <PlusButton onClick={() => setShowForm(true)} text="Add another goal" />
-                  ) : null }
-              </div>
-            </>
-          ) : null }
+        { createdGoals.length ? (
+          <>
+            <ReadOnly
+              createdGoals={createdGoals}
+              onRemove={onRemove}
+              onEdit={onEdit}
+            />
+            <div className="margin-bottom-4">
+              {!showForm && isNew
+                ? (
+                  <PlusButton onClick={() => setShowForm(true)} text="Add another goal" />
+                ) : null }
+            </div>
+          </>
+        ) : null }
 
-          <form onSubmit={onSubmit}>
-            { showForm && (
+        <form onSubmit={onSubmit}>
+          { showForm && (
             <Form
               fetchError={fetchError}
               onSaveDraft={onSaveDraft}
@@ -846,28 +851,28 @@ export default function GoalForm({
               onUploadFiles={onUploadFiles}
               userCanEdit={canEdit}
             />
-            )}
+          )}
 
-            { canEdit && (isNew || status === 'Draft') && status !== 'Closed' && (
-              <div className="margin-top-4">
-                { !showForm ? <Button type="submit">Submit goal</Button> : null }
-                { showForm ? <Button type="button" onClick={() => onSaveAndContinue(false)}>Save and continue</Button> : null }
-                <Button type="button" outline onClick={onSaveDraft}>Save draft</Button>
-                { showForm && !createdGoals.length ? (
-                  <Link
-                    to={`/recipient-tta-records/${recipient.id}/region/${regionId}/goals-objectives/`}
-                    className=" usa-button usa-button--outline"
-                  >
-                    Cancel
-                  </Link>
-                ) : null }
-                { showForm && createdGoals.length ? (
-                  <Button type="button" outline onClick={clearForm} data-testid="create-goal-form-cancel">Cancel</Button>
-                ) : null }
-              </div>
-            )}
+          { canEdit && (isNew || status === 'Draft') && status !== 'Closed' && (
+          <div className="margin-top-4">
+            { !showForm ? <Button type="submit">Submit goal</Button> : null }
+            { showForm ? <Button type="button" onClick={() => onSaveAndContinue(false)}>Save and continue</Button> : null }
+            <Button type="button" outline onClick={onSaveDraft}>Save draft</Button>
+            { showForm && !createdGoals.length ? (
+              <Link
+                to={`/recipient-tta-records/${recipient.id}/region/${regionId}/goals-objectives/`}
+                className=" usa-button usa-button--outline"
+              >
+                Cancel
+              </Link>
+            ) : null }
+            { showForm && createdGoals.length ? (
+              <Button type="button" outline onClick={clearForm} data-testid="create-goal-form-cancel">Cancel</Button>
+            ) : null }
+          </div>
+          )}
 
-            { canEdit && (!isNew && status !== 'Draft') && status !== 'Closed' && (
+          { canEdit && (!isNew && status !== 'Draft') && status !== 'Closed' && (
             <div className="margin-top-4">
               <Button
                 type="submit"
@@ -885,11 +890,10 @@ export default function GoalForm({
                 Cancel
               </Link>
             </div>
-            ) }
+          ) }
 
-            { alert.message ? <Alert role="alert" className="margin-y-2" type={alert.type}>{alert.message}</Alert> : null }
-          </form>
-        </GoalFormLoadingContext.Provider>
+          { alert.message ? <Alert role="alert" className="margin-y-2" type={alert.type}>{alert.message}</Alert> : null }
+        </form>
       </Container>
     </>
   );

--- a/frontend/src/pages/RecipientRecord/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/__tests__/index.js
@@ -10,6 +10,7 @@ import RecipientRecord from '../index';
 import { formatDateRange } from '../../../utils';
 import UserContext from '../../../UserContext';
 import { SCOPE_IDS } from '../../../Constants';
+import AppLoadingContext from '../../../AppLoadingContext';
 
 const { ADMIN } = SCOPE_IDS;
 const yearToDate = encodeURIComponent(formatDateRange({ yearToDate: true, forDateTime: true }));
@@ -96,7 +97,16 @@ describe('recipient record page', () => {
     render(
       <Router history={history}>
         <UserContext.Provider value={{ user }}>
-          <RecipientRecord match={match} />
+          <AppLoadingContext.Provider value={
+          {
+            setIsAppLoading: jest.fn(),
+            setAppLoadingText: jest.fn(),
+            isAppLoading: false,
+          }
+        }
+          >
+            <RecipientRecord match={match} />
+          </AppLoadingContext.Provider>
         </UserContext.Provider>
       </Router>,
     );


### PR DESCRIPTION
## Description of change

When creating goals from the RTR we want to use the same loader (app) as when working with goals from the AR.

## How to test

Creating or updating goals from the RTR should use the App Loader. This includes saving, saving draft, adding attachments, submitting, and removing goals.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1207


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
