### PR TITLE
Show correct condition text for 'My reports' filter

### DIFF
--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -7,9 +7,12 @@ export const AFTER = 'is on or after';
 export const WITHIN = 'is within';
 export const IS = 'is';
 export const IS_NOT = 'is not';
+export const WHERE_IM_THE = 'where I\'m the';
+export const WHERE_IM_NOT_THE = 'where I\'m not the';
 
 export const SELECT_CONDITIONS = [CONTAINS, NOT_CONTAINS];
 export const FILTER_CONDITIONS = [IS, IS_NOT];
+export const MY_REPORTS_FILTER_CONDITIONS = [WHERE_IM_THE, WHERE_IM_NOT_THE];
 export const REGION_CONDITIONS = [IS];
 
 export const QUERY_CONDITIONS = {
@@ -20,6 +23,8 @@ export const QUERY_CONDITIONS = {
   [WITHIN]: 'win',
   [IS]: 'in[]',
   [IS_NOT]: 'nin[]',
+  [WHERE_IM_THE]: 'in[]',
+  [WHERE_IM_NOT_THE]: 'nin[]',
 };
 
 export const DATE_CONDITIONS = [

--- a/frontend/src/components/filter/FilterPills.js
+++ b/frontend/src/components/filter/FilterPills.js
@@ -53,6 +53,16 @@ export function Pill({
   const ariaButtonText = `This button removes the filter: ${filterName} ${condition} ${queryValue}`;
   const queryShortValue = determineQuery(false);
 
+  const determineConditionText = () => {
+    if (!condition) {
+      return null;
+    }
+    if (topic === 'myReports') {
+      return condition;
+    }
+    return condition.toLowerCase();
+  };
+
   return (
     <span className="filter-pill text-middle margin-right-05 padding-top-1 margin-bottom-105">
       {isFirst ? null : <strong> AND </strong>}
@@ -61,7 +71,7 @@ export function Pill({
           {filterName}
         </strong>
         {' '}
-        {condition ? condition.toLowerCase() : null}
+        {determineConditionText()}
       </span>
       <span className="filter-pill-container smart-hub-border-blue-primary border-2px margin-right-1 radius-pill padding-right-1 padding-left-2 padding-y-05">
         <span aria-label={queryValue}>

--- a/frontend/src/components/filter/__tests__/FilterMenu.js
+++ b/frontend/src/components/filter/__tests__/FilterMenu.js
@@ -393,7 +393,7 @@ describe('Filter Menu', () => {
 
     userEvent.selectOptions(topics, 'My reports');
     [conditions] = await screen.findAllByRole('combobox', { name: /condition/i });
-    userEvent.selectOptions(conditions, 'is');
+    userEvent.selectOptions(conditions, 'where I\'m the');
 
     userEvent.selectOptions(topics, 'Topics');
     [conditions] = await screen.findAllByRole('combobox', { name: /condition/i });
@@ -429,7 +429,7 @@ describe('Filter Menu', () => {
 
     userEvent.selectOptions(topics, 'My reports');
     [conditions] = await screen.findAllByRole('combobox', { name: /condition/i });
-    userEvent.selectOptions(conditions, 'is');
+    userEvent.selectOptions(conditions, 'where I\'m the');
 
     userEvent.selectOptions(topics, 'Topics');
     [conditions] = await screen.findAllByRole('combobox', { name: /condition/i });

--- a/frontend/src/components/filter/__tests__/FilterPills.js
+++ b/frontend/src/components/filter/__tests__/FilterPills.js
@@ -95,5 +95,21 @@ describe('Filter Pills', () => {
       renderFilterMenu(filters);
       expect((await screen.findAllByText(/specialist 1, specialist 2, specialist 3\.\.\./i)).length).toBe(2);
     });
+
+    it('shows correct condition text for my reports filter', async () => {
+      const filters = [{
+        id: '1',
+        topic: 'myReports',
+        condition: 'where I\'m the',
+        query: ['Creator'],
+        displayQuery: (q) => q.join(', '),
+        display: 'My reports',
+      },
+      ];
+
+      renderFilterMenu(filters);
+      // Check we keep the correct case for I'm.
+      expect(await screen.findByText('where I\'m the')).toBeVisible();
+    });
   });
 });

--- a/frontend/src/components/filter/activityReportFilters.js
+++ b/frontend/src/components/filter/activityReportFilters.js
@@ -7,6 +7,7 @@ import {
   SELECT_CONDITIONS,
   FILTER_CONDITIONS,
   REGION_CONDITIONS,
+  MY_REPORTS_FILTER_CONDITIONS,
 } from '../../Constants';
 import FilterDateRange from './FilterDateRange';
 import FilterInput from './FilterInput';
@@ -24,6 +25,11 @@ import MyReportsSelect from './MyReportsSelect';
 const EMPTY_MULTI_SELECT = {
   is: [],
   'is not': [],
+};
+
+const EMPTY_MY_REPORTS_MULTI_SELECT = {
+  'where I\'m the': [],
+  'where I\'m not the': [],
 };
 
 const EMPTY_SINGLE_SELECT = {
@@ -287,12 +293,12 @@ export const targetPopulationsFilter = {
 export const myReportsFilter = {
   id: 'myReports',
   display: 'My reports',
-  conditions: FILTER_CONDITIONS,
-  defaultValues: EMPTY_MULTI_SELECT,
+  conditions: MY_REPORTS_FILTER_CONDITIONS,
+  defaultValues: EMPTY_MY_REPORTS_MULTI_SELECT,
   displayQuery: handleArrayQuery,
   renderInput: (id, condition, query, onApplyQuery) => (
     <MyReportsSelect
-      inputId={`my-reports-${condition}-${id}`}
+      inputId={`my-reports-${id}`}
       onApply={onApplyQuery}
       query={query}
     />


### PR DESCRIPTION
## Description of change

We want to show two different conditions for the 'My reports' filter.
- 'where I'm the'
- 'where I'm not the'

## How to test

Create a new filter using the 'My reports' filter. The condition choices should be updated and when applied we should show the correct case for "I'm" in the filter pills.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
