### PR TITLE
[TTAHUB-1254] Fix bug with other entity reports

### DIFF
--- a/frontend/src/components/Navigator/__tests__/index.js
+++ b/frontend/src/components/Navigator/__tests__/index.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import React from 'react';
+import React, { useContext } from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   render, screen, waitFor, within, act,
@@ -7,9 +7,16 @@ import {
 import fetchMock from 'fetch-mock';
 import { useFormContext } from 'react-hook-form/dist/index.ie11';
 import Navigator from '../index';
+import UserContext from '../../../UserContext';
 import { NOT_STARTED, IN_PROGRESS } from '../constants';
 import NetworkContext from '../../../NetworkContext';
 import AppLoadingContext from '../../../AppLoadingContext';
+import GoalFormContext from '../../../GoalFormContext';
+
+// user mock
+const user = {
+  name: 'test@test.com',
+};
 
 // eslint-disable-next-line react/prop-types
 const Input = ({ name, required }) => {
@@ -21,6 +28,26 @@ const Input = ({ name, required }) => {
       name={name}
       ref={register({ required })}
     />
+  );
+};
+
+const OETest = () => {
+  const { isObjectivesFormClosed } = useContext(GoalFormContext);
+  const { register } = useFormContext();
+  return (
+    <>
+      <h1>
+        { isObjectivesFormClosed ? 'Objective form closed' : 'Objective form open' }
+
+      </h1>
+      <div className="usa-error-message">
+        <div className="ttahub-resource-repeater">
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="goalName">Name</label>
+          <input type="text" id="goalName" name="goalName" ref={register()} />
+        </div>
+      </div>
+    </>
   );
 };
 
@@ -107,40 +134,46 @@ describe('Navigator', () => {
     onUpdateError = jest.fn(),
   ) => {
     render(
-      <NetworkContext.Provider value={{
-        connectionActive: true,
-        localStorageAvailable: true,
-      }}
-      >
-        <AppLoadingContext.Provider value={{
-          setIsAppLoading: jest.fn(),
-          setAppLoadingText: jest.fn(),
-          isAppLoading: false,
+      <UserContext.Provider value={{ user }}>
+        <NetworkContext.Provider value={{
+          connectionActive: true,
+          localStorageAvailable: true,
         }}
         >
-          <Navigator
-            editable
-            reportId={1}
-            submitted={false}
-            formData={formData}
-            updateFormData={updateForm}
-            onReview={() => {}}
-            isApprover={false}
-            defaultValues={{ first: '', second: '' }}
-            pages={pages}
-            currentPage={currentPage}
-            onFormSubmit={onSubmit}
-            updatePage={updatePage}
-            onSave={onSave}
-            updateErrorMessage={onUpdateError}
-            onResetToDraft={() => {}}
-            updateLastSaveTime={() => {}}
-            isPendingApprover={false}
-          />
-        </AppLoadingContext.Provider>
-      </NetworkContext.Provider>,
+          <AppLoadingContext.Provider value={{
+            setIsAppLoading: jest.fn(),
+            setAppLoadingText: jest.fn(),
+            isAppLoading: false,
+          }}
+          >
+            <Navigator
+              editable
+              reportId={1}
+              submitted={false}
+              formData={formData}
+              updateFormData={updateForm}
+              onReview={() => {}}
+              isApprover={false}
+              defaultValues={{ first: '', second: '' }}
+              pages={pages}
+              currentPage={currentPage}
+              onFormSubmit={onSubmit}
+              updatePage={updatePage}
+              onSave={onSave}
+              updateErrorMessage={onUpdateError}
+              onResetToDraft={() => {}}
+              updateLastSaveTime={() => {}}
+              isPendingApprover={false}
+            />
+          </AppLoadingContext.Provider>
+        </NetworkContext.Provider>
+      </UserContext.Provider>,
     );
   };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
 
   it('sets dirty forms as "in progress"', async () => {
     renderNavigator();
@@ -266,7 +299,7 @@ describe('Navigator', () => {
     const saveGoal = await screen.findByRole('button', { name: 'Save goal' });
     expect(saveGoal.textContent).toBe('Save goal');
     expect(saveGoal).toBeVisible();
-    fetchMock.post('/api/activityReports/goals', 200);
+    fetchMock.post('/api/activity-reports/goals', 200);
     await act(async () => userEvent.click(saveGoal));
     expect(saveGoal.textContent).toBe('Save and continue');
   });
@@ -436,5 +469,200 @@ describe('Navigator', () => {
     jest.advanceTimersByTime(1000 * 60 * 2);
     fetchMock.post('api/activity-reports/objectives', []);
     expect(fetchMock.called('api/activity-reports/objectives')).toBe(false);
+  });
+
+  it('opens the objectives form if the objectives are invalid', async () => {
+    const onSubmit = jest.fn();
+    const onSave = jest.fn();
+    const updatePage = jest.fn();
+    const updateForm = jest.fn();
+    const pages = [{
+      position: 1,
+      path: 'goals-objectives',
+      label: 'first page',
+      review: false,
+      render: () => (
+        <OETest />
+      ),
+    }];
+
+    const oeData = {
+      ...initialData,
+      activityRecipientType: 'other-entity',
+      objectives: [
+        {
+          taste: 'kind of bitter',
+        },
+      ],
+    };
+
+    act(() => renderNavigator('goals-objectives', onSubmit, onSave, updatePage, updateForm, pages, oeData));
+
+    expect(await screen.findByText('Objective form open')).toBeVisible();
+  });
+
+  it('opens the objectives form if there are no objectives', async () => {
+    const onSubmit = jest.fn();
+    const onSave = jest.fn();
+    const updatePage = jest.fn();
+    const updateForm = jest.fn();
+    const pages = [{
+      position: 1,
+      path: 'goals-objectives',
+      label: 'first page',
+      review: false,
+      render: () => (
+        <OETest />
+      ),
+    }];
+
+    const oeData = {
+      ...initialData,
+      activityRecipientType: 'other-entity',
+      objectives: [],
+    };
+
+    act(() => renderNavigator('goals-objectives', onSubmit, onSave, updatePage, updateForm, pages, oeData));
+
+    expect(await screen.findByText('Objective form open')).toBeVisible();
+  });
+
+  it('handles invalid OE resources in the auto save', async () => {
+    const onSubmit = jest.fn();
+    const onSave = jest.fn();
+    const updatePage = jest.fn();
+    const updateForm = jest.fn();
+    const pages = [{
+      position: 1,
+      path: 'goals-objectives',
+      label: 'first page',
+      review: false,
+      render: () => (
+        <OETest />
+      ),
+    }];
+
+    const oeData = {
+      ...initialData,
+      activityRecipientType: 'other-entity',
+      objectives: [
+        {
+          title: 'objective',
+          topics: ['test'],
+          ttaProvided: 'tta provided',
+          resources: [{
+            value: 'WHAT THE DEVIL IS THIS',
+          }],
+        },
+      ],
+    };
+
+    act(() => renderNavigator('goals-objectives', onSubmit, onSave, updatePage, updateForm, pages, oeData));
+
+    expect(await screen.findByText('Objective form open')).toBeVisible();
+    fetchMock.restore();
+    fetchMock.post('/api/activity-reports/objectives', [{
+      title: 'objective',
+      topics: ['test'],
+      ttaProvided: 'tta provided',
+      resources: [{
+        value: 'https://test.com',
+      }],
+    }]);
+    jest.advanceTimersByTime(1000 * 60 * 2);
+    await waitFor(() => expect(fetchMock.called()).toBe(false));
+  });
+
+  it('OE auto save with valid resources', async () => {
+    const onSubmit = jest.fn();
+    const onSave = jest.fn();
+    const updatePage = jest.fn();
+    const updateForm = jest.fn();
+    const pages = [{
+      position: 1,
+      path: 'goals-objectives',
+      label: 'first page',
+      review: false,
+      render: () => (
+        <OETest />
+      ),
+    }];
+
+    const oeData = {
+      ...initialData,
+      activityRecipientType: 'other-entity',
+      objectives: [
+        {
+          title: 'objective',
+          topics: ['test'],
+          ttaProvided: 'tta provided',
+          resources: [{
+            value: 'https://test.com',
+          }],
+        },
+      ],
+    };
+
+    act(() => renderNavigator('goals-objectives', onSubmit, onSave, updatePage, updateForm, pages, oeData));
+
+    expect(await screen.findByText('Objective form open')).toBeVisible();
+    fetchMock.restore();
+    fetchMock.post('/api/activity-reports/objectives', [{
+      title: 'objective',
+      topics: ['test'],
+      ttaProvided: 'tta provided',
+      resources: [{
+        value: 'https://test.com',
+      }],
+    }]);
+    jest.advanceTimersByTime(1000 * 60 * 2);
+    await waitFor(() => expect(fetchMock.called()).toBe(false));
+  });
+
+  it('saves draft for an other entity report', async () => {
+    const onSubmit = jest.fn();
+    const onSave = jest.fn();
+    const updatePage = jest.fn();
+    const updateForm = jest.fn();
+    const pages = [{
+      position: 1,
+      path: 'goals-objectives',
+      label: 'first page',
+      review: false,
+      render: () => (
+        <OETest />
+      ),
+    }];
+
+    const formData = {
+      ...initialData,
+      activityRecipientType: 'other-entity',
+      activityRecipients: [{ activityRecipientId: 1 }],
+      goalForEditing: null,
+      goals: [],
+      objectivesWithoutGoals: [{
+        title: 'objective',
+        topics: ['test'],
+        ttaProvided: 'tta provided',
+        resources: [{
+          value: 'https://test.com',
+        }],
+      }],
+    };
+
+    renderNavigator('goals-objectives', onSubmit, onSave, updatePage, updateForm, pages, formData);
+    const saveDraft = await screen.findByRole('button', { name: 'Save draft' });
+    expect(saveDraft).toBeVisible();
+    fetchMock.restore();
+    fetchMock.post('/api/activity-reports/objectives', [{
+      title: 'objective',
+      topics: ['test'],
+      ttaProvided: 'tta provided',
+      resources: [{
+        value: 'https://test.com',
+      }],
+    }]);
+    act(() => userEvent.click(saveDraft));
+    await waitFor(() => expect(fetchMock.called()).toBe(true));
   });
 });

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -276,8 +276,6 @@ function Navigator({
     const currentObjectives = getValues(fieldArrayName);
     const otherEntityIds = recipients.map((otherEntity) => otherEntity.activityRecipientId);
 
-    console.log({ currentObjectives });
-
     let invalidResources = false;
     const invalidResourceIndices = [];
 
@@ -290,8 +288,6 @@ function Navigator({
         }
       });
     }
-
-    console.log({ invalidResources, invalidResourceIndices, isAutoSave });
 
     if (!isAutoSave && invalidResources) {
       // make an attempt to focus on the first invalid resource
@@ -309,8 +305,6 @@ function Navigator({
 
     // Save objectives.
     try {
-      console.log('we made it to the try');
-
       let newObjectives = await saveObjectivesForReport(
         {
           objectivesWithoutGoals: objectivesWithValidResourcesOnly(
@@ -322,8 +316,6 @@ function Navigator({
           region: formData.regionId,
         },
       );
-
-      console.log(newObjectives);
 
       // if we are autosaving, we want to preserve the resources that were added in the UI
       // whether or not they are valid (although nothing is saved to the database)
@@ -346,7 +338,7 @@ function Navigator({
       updateErrorMessage('');
 
       // we have to do this here, after the form data has been updated
-      if (isAutoSave && goalForEditing) {
+      if (isAutoSave) {
         invalidResourceIndices.forEach((index) => {
           setError(`${fieldArrayName}[${index}].resources`, { message: OBJECTIVE_RESOURCES });
         });

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -317,6 +317,8 @@ function Navigator({
         },
       );
 
+      console.log(newObjectives);
+
       // if we are autosaving, we want to preserve the resources that were added in the UI
       // whether or not they are valid (although nothing is saved to the database)
       // this is a convenience so that a work in progress isn't erased

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -134,7 +134,6 @@ function Navigator({
     }
     return newPageState;
   };
-
   const onSaveForm = async (isAutoSave = false) => {
     setSavingLoadScreen(isAutoSave);
     if (!editable) {
@@ -143,7 +142,6 @@ function Navigator({
     }
     const { status, ...values } = getValues();
     const data = { ...formData, ...values, pageState: newNavigatorState() };
-
     updateFormData(data);
     try {
       // Always clear the previous error message before a save.
@@ -278,7 +276,20 @@ function Navigator({
     const currentObjectives = getValues(fieldArrayName);
     const otherEntityIds = recipients.map((otherEntity) => otherEntity.activityRecipientId);
 
-    if (!isAutoSave && !validateListOfResources(currentObjectives.map((o) => o.resources).flat())) {
+    let invalidResources = false;
+    const invalidResourceIndices = [];
+
+    if (currentObjectives) {
+    // refire the objective resource validation
+      currentObjectives.forEach((objective, index) => {
+        if (!validateListOfResources(objective.resources)) {
+          invalidResources = true;
+          invalidResourceIndices.push(index);
+        }
+      });
+    }
+
+    if (!isAutoSave && invalidResources) {
       // make an attempt to focus on the first invalid resource
       // having a sticky header complicates this enough to make me not want to do this perfectly
       // right out of the gate
@@ -316,10 +327,22 @@ function Navigator({
         }));
       }
 
+      // update form data
+      const { status, ...values } = getValues();
+      const data = { ...formData, ...values, pageState: newNavigatorState() };
+      updateFormData(data);
+
       // Set updated objectives.
       setValue('objectivesWithoutGoals', newObjectives);
       updateLastSaveTime(moment());
       updateErrorMessage('');
+
+      // we have to do this here, after the form data has been updated
+      if (isAutoSave && goalForEditing) {
+        invalidResourceIndices.forEach((index) => {
+          setError(`${fieldArrayName}[${index}].resources`, { message: OBJECTIVE_RESOURCES });
+        });
+      }
     } catch (error) {
       updateErrorMessage('A network error has prevented us from saving your activity report to our database. Your work is safely saved to your web browser in the meantime.');
     } finally {

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -276,6 +276,8 @@ function Navigator({
     const currentObjectives = getValues(fieldArrayName);
     const otherEntityIds = recipients.map((otherEntity) => otherEntity.activityRecipientId);
 
+    console.log({ currentObjectives });
+
     let invalidResources = false;
     const invalidResourceIndices = [];
 
@@ -288,6 +290,8 @@ function Navigator({
         }
       });
     }
+
+    console.log({ invalidResources, invalidResourceIndices, isAutoSave });
 
     if (!isAutoSave && invalidResources) {
       // make an attempt to focus on the first invalid resource
@@ -305,6 +309,8 @@ function Navigator({
 
     // Save objectives.
     try {
+      console.log('we made it to the try');
+
       let newObjectives = await saveObjectivesForReport(
         {
           objectivesWithoutGoals: objectivesWithValidResourcesOnly(

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -7,7 +7,7 @@ import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
 
 import { mockWindowProperty, withText } from '../../../testHelpers';
-import { unflattenResourcesUsed, findWhatsChanged, updateGoals } from '../index';
+import { unflattenResourcesUsed, findWhatsChanged } from '../index';
 import {
   REPORT_STATUSES,
 } from '../../../Constants';
@@ -92,37 +92,6 @@ describe('ActivityReport', () => {
 
       const startDate = await screen.findByRole('textbox', { name: /start date/i });
       expect(startDate).toBeVisible();
-    });
-  });
-
-  describe('updateGoals', () => {
-    it('sets new goals as such', () => {
-      const report = {
-        goals: [{
-          id: 123,
-          name: 'name',
-        }],
-      };
-      const updateFn = updateGoals(report);
-      const { goals } = updateFn({ goals: [{ id: 'id', name: 'name', new: true }] });
-
-      expect(goals.length).toBe(1);
-      expect(goals[0].id).toBe(123);
-      expect(goals[0].new).toBeTruthy();
-    });
-
-    it('sets old goals as such', () => {
-      const report = {
-        goals: [{
-          id: 123,
-          name: 'name',
-        }],
-      };
-      const updateFn = updateGoals(report);
-      const { goals } = updateFn({ goals: [{ id: 'id', name: 'name' }] });
-      expect(goals.length).toBe(1);
-      expect(goals[0].id).toBe(123);
-      expect(goals[0].new).toBeFalsy();
     });
   });
 

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -178,36 +178,6 @@ export const unflattenResourcesUsed = (array) => {
   return array.map((value) => ({ value }));
 };
 
-/**
- * Goals created are editable until the report is loaded again. The report used to
- * not update freshly created goals with their DB id once saved, but this caused
- * any additional updates to create a brand new goal instead of updating the old goal.
- * We now use the goal created in the DB. However this means we no longer know if the
- * goal should be editable or not, since it was loaded from the DB. This method takes
- * the list of newly created goals and grabs their names, placed in the `editableGoals`
- * variable. Then all goals returned form the API (the report object passed into this
- * method) have their name compared against the list of fresh goals. The UI then uses
- * the `new` property to determine if a goal should be editable or not.
- * @param {*} report the freshly updated report
- * @returns {function} function that can be used by `setState` to update
- * formData
- */
-export const updateGoals = (report) => (oldFormData) => {
-  const oldGoals = oldFormData.goals || [];
-  const newGoals = report.goals || [];
-
-  const goalsThatUsedToBeNew = oldGoals.filter((goal) => goal.new);
-  const goalsFreshlySavedInDB = goalsThatUsedToBeNew.map((goal) => goal.name);
-  const goals = newGoals.map((goal) => {
-    const goalEditable = goalsFreshlySavedInDB.includes(goal.name);
-    return {
-      ...goal,
-      new: goalEditable,
-    };
-  });
-  return { ...oldFormData, goals, objectivesWithoutGoals: report.objectivesWithoutGoals };
-};
-
 function ActivityReport({
   match, location, region,
 }) {

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -564,7 +564,13 @@ function ActivityReport({
           : data.creatorRole;
         const updatedFields = findWhatsChanged({ ...data, creatorRole }, formData);
         const updatedReport = await saveReport(
-          reportId.current, { ...updatedFields, version: 2, approverUserIds: approverIds }, {},
+          reportId.current, {
+            ...updatedFields,
+            version: 2,
+            approverUserIds:
+            approverIds,
+            pageState: data.pageState,
+          }, {},
         );
 
         updateFormData({

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -27,10 +27,8 @@ export default function GoalsObjectives({
   const onRemoveFilter = (id) => {
     const newFilters = [...filters];
     const index = newFilters.findIndex((item) => item.id === id);
-    if (index !== -1) {
-      newFilters.splice(index, 1);
-      setFilters(newFilters);
-    }
+    newFilters.splice(index, 1);
+    setFilters(newFilters);
   };
 
   const filtersToApply = expandFilters(filters);

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -60,10 +60,8 @@ export default function TTAHistory({
   const onRemoveFilter = (id) => {
     const newFilters = [...filters];
     const index = newFilters.findIndex((item) => item.id === id);
-    if (index !== -1) {
-      newFilters.splice(index, 1);
-      setFilters(newFilters);
-    }
+    newFilters.splice(index, 1);
+    setFilters(newFilters);
   };
 
   const onApply = (newFilters) => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,6 +4,7 @@ import { devices } from '@playwright/test';
 // see https://playwright.dev/docs/api/class-testconfig
 export default {
   testDir: './tests',
+  workers: 2, // changing because of possible data collisions
   expect: {
     /** max time expect() should wait for conditions to be met. */
     timeout: 8000,

--- a/tests/other-entity-report.spec.ts
+++ b/tests/other-entity-report.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import { describe } from 'node:test';
+
+async function blur(page) {
+  await page.getByText('Office of Head Start TTA Hub').click();
+}
+
+describe('other entity report', () => {
+  test('create a report with two other entities and one objective', async ({ page }) => {
+    await page.goto('http://localhost:3000/');
+
+    // create a new report
+    await page.getByRole('link', { name: 'Activity Reports' }).click();
+    await page.getByRole('button', { name: '+ New Activity Report' }).click();
+      
+    const heading = await page.getByRole('heading', { name: /activity report for region \d/i });
+    const regionNumber = await heading.textContent().then((text) => text!.match(/\d/)![0]);
+   
+    // select two recipiients
+    await page.locator('label').filter({ hasText: 'Other entity' }).click();
+    await page.locator('#activityRecipients div').filter({ hasText: '- Select -' }).nth(1).click();
+    await page.locator('#react-select-3-option-0').click();
+    await page.locator('#react-select-3-option-1').click();
+
+    // cycle through the side nav
+    await page.getByRole('button', { name: 'Goals and objectives Not started' }).click();
+    await page.getByRole('button', { name: 'Supporting attachments Not started' }).click();
+    await page.getByRole('button', { name: 'Next steps Not started' }).click();
+    await page.getByRole('button', { name: 'Review and submit' }).click();
+    
+    // fill out the activity summary
+    await page.getByRole('button', { name: 'Activity summary In Progress' }).click();
+    await page.locator('#targetPopulations div').filter({ hasText: '- Select -' }).nth(1).click();
+    await page.locator('#react-select-19-option-0').click();
+    await page.locator('.smart-hub-activity-report > div:nth-child(2) > div:nth-child(2)').click();
+    await page.getByRole('group', { name: 'Who requested this activity? Use "Regional Office" for TTA not requested by recipient. *' }).locator('label').filter({ hasText: 'Recipient' }).click();
+    await page.getByRole('group', { name: 'Reason for activity' }).getByTestId('label').locator('div').filter({ hasText: '- Select -' }).nth(2).click();
+    await page.locator('#react-select-21-option-0').click();
+    await page.getByLabel(/Start date/i).fill('04/05/2021');
+    await page.getByLabel('End date *mm/dd/yyyy').fill('05/07/2021');
+    await page.getByLabel('Duration in hours (round to the nearest half hour) *').fill('2');
+    await page.getByRole('group', { name: 'What TTA was provided *' }).getByText('Training').click();
+    await page.getByText('Virtual').click();
+    await page.getByText('Video').click();
+    await page.locator('#participants div').filter({ hasText: '- Select -' }).nth(1).click();
+    await page.locator('#react-select-23-option-1').click();
+    await page.locator('#react-select-23-option-3').click();
+    await page.locator('.smart-hub-activity-report > div:nth-child(2) > div').first().click();
+    await page.getByLabel('Number of participants involved *').click();
+    await page.getByLabel('Number of participants involved *').fill('3');   
+    await page.getByRole('button', { name: 'Save and continue' }).click();
+
+    // fill out the objectives form
+    await page.getByRole('button', { name: 'Add new objective' }).click();
+
+    await page.getByTestId('textarea').fill('test');
+
+    // fill in an invalid resource
+    await page.getByTestId('textInput').fill('asdfasdf');
+
+    // select a topic
+    await page.locator('.css-125guah-control').click();
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    // clear out the invalid resource
+    await page.getByTestId('textInput').fill('');
+
+    // add tta provided
+    await page.getByRole('textbox', { name: 'TTA provided for objective' }).locator('div').nth(2).click();
+    await page.keyboard.type('hello');
+
+    await page.getByRole('button', { name: 'Save objectives' }).click();
+    await page.getByRole('button', { name: 'Save and continue' }).click();
+
+    // skip supporting attachments
+    await page.getByRole('button', { name: 'Save and continue' }).click();
+
+    // fill out next steps
+    await page.getByTestId('specialistNextSteps-input').click();
+    await page.getByTestId('specialistNextSteps-input').fill('1');
+    await page.getByLabel('When do you anticipate completing step 1? *').click();
+    await page.getByLabel('When do you anticipate completing step 1? *').fill('12/01/2050');
+    await page.getByTestId('recipientNextSteps-input').click();
+    await page.getByTestId('recipientNextSteps-input').fill('2');
+    await page.getByLabel('When does the other entity anticipate completing step 1? *').click();
+    await page.getByLabel('When does the other entity anticipate completing step 1? *').fill('12/01/2050');
+    await page.getByRole('button', { name: 'Save and continue' }).click();
+
+    // select an approver
+    await page.locator('.css-g1d714-ValueContainer').click();
+    await page.locator('#react-select-33-option-0').click();
+    
+    // extract the AR number from the URL:
+    const url = page.url();
+    const arNumber = url.split('/').find((part) => /^\d+$/.test(part));
+
+    await blur(page);
+
+    // submit for approval
+    await page.getByRole('button', { name: 'Submit for approval' }).click();
+
+    // verify draft report in table
+    page.getByRole('heading', { name: `TTA activity report R0${regionNumber}-AR-${arNumber}` });
+  });
+})


### PR DESCRIPTION
## Description of change
Fixes two bugs with other entity reports, one of which was introduced by #1209, the other I'm not sure. Add an e2e test to validate the fix. 

## How to test
You can see these bugs on main
- First bug: Start an other entity report. On the activity summary, select only the other entities, then proceed to cycle through the links in the activity report side navigation. You should find yourself stuck by a syntax error.
- Second bug: Complete an other entity report. You'll find that you cannot get the "goals and objectives" side nav label to show complete if you proceed through the report in order (it shows complete when you save and continue onto "supporting attachments," but if you proceed to next steps it reverts to "Not started")

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1254


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
