### PR TITLE
[TTAHUB-1277] PD type events are unusable

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1692,7 +1692,7 @@ export async function getGoalsForReport(reportId) {
         as: 'objectives',
         include: [
           {
-            separate: true,
+            required: true,
             model: ActivityReportObjective,
             as: 'activityReportObjectives',
             where: {
@@ -1700,7 +1700,7 @@ export async function getGoalsForReport(reportId) {
             },
             include: [
               {
-
+                separate: true,
                 model: ActivityReportObjectiveTopic,
                 as: 'activityReportObjectiveTopics',
                 required: false,
@@ -1712,6 +1712,7 @@ export async function getGoalsForReport(reportId) {
                 ],
               },
               {
+                separate: true,
                 model: ActivityReportObjectiveFile,
                 as: 'activityReportObjectiveFiles',
                 required: false,
@@ -1723,6 +1724,7 @@ export async function getGoalsForReport(reportId) {
                 ],
               },
               {
+                separate: true,
                 model: ActivityReportObjectiveResource,
                 as: 'activityReportObjectiveResources',
                 required: false,
@@ -1735,6 +1737,7 @@ export async function getGoalsForReport(reportId) {
             as: 'topics',
           },
           {
+            separate: true,
             model: ObjectiveResource,
             as: 'resources',
             attributes: [['userProvidedUrl', 'value']],

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -403,23 +403,29 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
       // we can dedupe these using lodash
       exists.resources = uniqBy([
         ...exists.resources,
-        ...objective.activityReportObjectives[0].activityReportObjectiveResources.map(
-          (r) => r.dataValues,
-        ),
+        ...(objective.activityReportObjectives
+          && objective.activityReportObjectives.length > 0
+          ? objective.activityReportObjectives[0].activityReportObjectiveResources
+            .map((r) => r.dataValues)
+          : []),
       ], 'value');
 
       exists.topics = uniqBy([
         ...exists.topics,
-        ...objective.activityReportObjectives[0].activityReportObjectiveTopics.map(
-          (t) => t.topic.dataValues,
-        ),
+        ...(objective.activityReportObjectives
+          && objective.activityReportObjectives.length > 0
+          ? objective.activityReportObjectives[0].activityReportObjectiveTopics
+            .map((t) => t.topic.dataValues)
+          : []),
       ], 'id');
 
       exists.files = uniqBy([
         ...exists.files,
-        ...objective.activityReportObjectives[0].activityReportObjectiveFiles.map(
-          (f) => ({ ...f.file.dataValues, url: f.file.url }),
-        ),
+        ...(objective.activityReportObjectives
+          && objective.activityReportObjectives.length > 0
+          ? objective.activityReportObjectives[0].activityReportObjectiveFiles
+            .map((f) => ({ ...f.file.dataValues, url: f.file.url }))
+          : []),
       ], 'key');
 
       return objectives;
@@ -455,15 +461,21 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
       // of the activity report not the state of the objective, which is what
       // we are getting at with this method (getGoalsForReport)
 
-      topics: objective.activityReportObjectives[0].activityReportObjectiveTopics.map(
-        (t) => t.topic.dataValues,
-      ),
-      resources: objective.activityReportObjectives[0].activityReportObjectiveResources.map(
-        (r) => r.dataValues,
-      ),
-      files: objective.activityReportObjectives[0].activityReportObjectiveFiles.map(
-        (f) => ({ ...f.file.dataValues, url: f.file.url }),
-      ),
+      topics: objective.activityReportObjectives
+        && objective.activityReportObjectives.length > 0
+        ? objective.activityReportObjectives[0].activityReportObjectiveTopics
+          .map((t) => t.topic.dataValues)
+        : [],
+      resources: objective.activityReportObjectives
+        && objective.activityReportObjectives.length > 0
+        ? objective.activityReportObjectives[0].activityReportObjectiveResources
+          .map((r) => r.dataValues)
+        : [],
+      files: objective.activityReportObjectives
+        && objective.activityReportObjectives.length > 0
+        ? objective.activityReportObjectives[0].activityReportObjectiveFiles
+          .map((f) => ({ ...f.file.dataValues, url: f.file.url }))
+        : [],
     }];
   }, currentObjectives);
 
@@ -1675,10 +1687,12 @@ export async function getGoalsForReport(reportId) {
         required: true,
       },
       {
+        separate: true,
         model: Objective,
         as: 'objectives',
         include: [
           {
+            separate: true,
             model: ActivityReportObjective,
             as: 'activityReportObjectives',
             where: {


### PR DESCRIPTION
## Description of change
Force slow query to run in parts to reduce intermediate data set. Users report had an intermediate data set with 59,535 rows.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1277


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
