### PR TITLE
[TTAHUB-1049] - Resources

### DIFF
--- a/src/migrations/20221209000000-resources-phase-0.js
+++ b/src/migrations/20221209000000-resources-phase-0.js
@@ -1,0 +1,214 @@
+/* eslint-disable max-len */
+// Resources Phase 0: Clean current "ObjectiveResources" and "ActivityReportObjectiveResources" to have each record contain a single value url.
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
+    const loggedUser = '0';
+    const sessionSig = __filename;
+    const auditDescriptor = 'RUN MIGRATIONS';
+    await queryInterface.sequelize.query(
+      `SELECT
+          set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+          set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+          set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+          set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+      { transaction },
+    );
+
+    // clean "ObjectiveResources"
+    // Some the the issues can be solved with known lookup and replace, this will repopulate valid urls over invalid data.
+    // This will allow them to keep the data they would otherwise have lost by manually looking up the url based on the supplied page title.
+    const fixListObjectiveResources = [
+      { id: 166, data: 'https://eclkc.ohs.acf.hhs.gov/program-planning/home-visitor-supervisors-handbook/home-visitor-supervisors-handbook https://eclkc.ohs.acf.hhs.gov/human-resources/home-visitor-supervisors-handbook/home-based-staff-qualifications-knowledge-skills' },
+      { id: 168, data: 'https://eclkc.ohs.acf.hhs.gov/policy/head-start-act/sec-648a-staff-qualifications-development' },
+      { id: 252, data: 'https://eclkc.ohs.acf.hhs.gov/about-us/article/head-start-work-heart-work-ohs-priorities' },
+      { id: 555, data: 'https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-subpart-eligibility-recruitment-selection-enrollment-attendance' },
+      { id: 680, data: 'https://eclkc.ohs.acf.hhs.gov/publication/guiding-questions-active-supervision-safety' },
+      { id: 774, data: 'http://www.teachstone.com' },
+      { id: 775, data: 'http://www.teachstone.com' },
+      { id: 776, data: 'http://www.teachstone.com' },
+      { id: 779, data: 'https://eclkc.ohs.acf.hhs.gov/professional-development/article/practice-based-coaching-pbc https://eclkc.ohs.acf.hhs.gov/publication/practice-based-coaching-pbc-coach-competencies' },
+      { id: 782, data: 'https://eclkc.ohs.acf.hhs.gov/publication/practice-based-coaching-pbc-coach-competencies' },
+      { id: 789, data: 'https://eclkc.ohs.acf.hhs.gov/mental-health/article/understanding-trauma-healing-adults' },
+      { id: 934, data: 'https://eclkc.ohs.acf.hhs.gov/family-support-well-being/article/taking-care-ourselves-stress-relaxation' },
+      { id: 1799, data: 'https://eclkc.ohs.acf.hhs.gov/program-planning/foundations-excellence/foundations-excellence' },
+      { id: 1800, data: 'https://eclkc.ohs.acf.hhs.gov/program-planning/foundations-excellence/foundations-excellence' },
+      { id: 2085, data: 'https://eclkc.ohs.acf.hhs.gov/fiscal-management/article/comparability-wages' },
+      { id: 2087, data: 'https://youtu.be/u4ZoJKF_VuA' },
+      { id: 2594, data: 'https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-subpart-eligibility-recruitment-selection-enrollment-attendance' },
+      { id: 2595, data: 'https://eclkc.ohs.acf.hhs.gov/school-readiness/article/parent-family-community-engagement-pfce-framework' },
+      { id: 2596, data: 'https://eclkc.ohs.acf.hhs.gov/family-engagement/article/journeys-hope-courage' },
+      { id: 2598, data: 'https://eclkc.ohs.acf.hhs.gov/policy/45-cfr-chap-xiii/1302-subpart-eligibility-recruitment-selection-enrollment-attendance' },
+      { id: 2599, data: 'https://eclkc.ohs.acf.hhs.gov/school-readiness/article/parent-family-community-engagement-pfce-framework' },
+      { id: 2600, data: 'https://eclkc.ohs.acf.hhs.gov/family-engagement/article/journeys-hope-courage' },
+      { id: 2729, data: 'https://eclkc.ohs.acf.hhs.gov/professional-development/article/coaching-corner-series https://cultivatelearning.uw.edu/circle-time-magazine/' },
+      { id: 9265, data: 'http://www.federalregister.gov/documents/2019/11/26/2019-25634/head-start-program' },
+      { id: 9328, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+      { id: 9329, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+      { id: 9330, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+      { id: 9331, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+      { id: 9332, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+      { id: 9333, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+      { id: 9334, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+      { id: 9335, data: 'https://mypeers.mangoapps.com/ce/pulse/user/teams/project_teams/uploaded_files?project_id=1360260&folder=6182710' },
+    ];
+
+    await Promise.all(fixListObjectiveResources.map(async (fi) => queryInterface.sequelize.query(`
+    UPDATE "ObjectiveResources"
+    SET "userProvidedUrl" = '${fi.data}'
+    WHERE id = ${fi.id};
+    `, { transaction })));
+
+    // clean "ActivityReportObjectiveResources"
+    const fixListActivityReportObjectiveResources = [
+    // TODO
+    ];
+
+    await Promise.all(fixListActivityReportObjectiveResources.map(async (fi) => queryInterface.sequelize.query(`
+    UPDATE "ActivityReportObjectiveResources"
+    SET "userProvidedUrl" = '${fi.data}'
+    WHERE id = ${fi.id};
+    `, { transaction })));
+
+    const urlRegex = '(?:(?:http|ftp|https|file):\\/\\/)(?:www\\.)?(?:[\\w%_-]+(?:(?:\\.[\\w%_-]+)+)|(?:\\/[\\w][:]))(?:[\\w\\\\\'\'.,@?^=%&:\\/~+#()-]*[\\w@?^=%&\\/~+#-])';
+
+    // clean "ObjectiveResources"
+    // Now that the table has had the correctable values fixed, corrections need to be applied to return the table to its expected structure.
+    // 1. Find all urls in the current data using regex
+    // 2. Generate a list of records with distinct urls where the current value has some data other then just the url found.
+    // 3. Generate a list of counts urls per record id.
+    // 4. Update records that only contain one url to be only the url.
+    // 5. Insert new records into the table for all records that have multiple urls per record.
+    // 6. Delete the original record that contained multiple urls used in step five.
+    // 7. Generate a list of all malformed data that does not contain a url.
+    // 8. Delete all malformed records identified in step seven.
+    // 9. Collect all records that have been affected.
+    // 10. Return statistics form operation.
+    await queryInterface.sequelize.query(`
+    WITH
+        "ObjectiveResourcesURLs" AS (
+            SELECT
+                id,
+                (regexp_matches("userProvidedUrl",'${urlRegex}','g')) urls,
+                "userProvidedUrl",
+                "objectiveId",
+                "createdAt",
+                "updatedAt",
+                "onAR",
+                "onApprovedAR"
+            FROM "ObjectiveResources"
+        ),
+        "ObjectiveResourcesSource" AS (
+            SELECT
+                ru.id,
+                u.url,
+                ru."userProvidedUrl",
+                ru."objectiveId",
+                ru."createdAt",
+                ru."updatedAt",
+                ru."onAR",
+                ru."onApprovedAR"
+            FROM "ObjectiveResources" r
+            JOIN "ObjectiveResourcesURLs" ru
+            ON r.id = ru.id
+            CROSS JOIN UNNEST(ru.urls) u(url)
+            WHERE r."userProvidedUrl" like '%' || u.url || '%'
+            AND trim(r."userProvidedUrl") != u.url
+            ORDER BY r.id
+        ),
+        "ObjectiveResourcesCounts" AS (
+            SELECT
+                id,
+                count(url) cnt
+            FROM "ObjectiveResourcesSource"
+            GROUP BY id
+        ),
+        "UpdateObjectiveResources" AS (
+            UPDATE "ObjectiveResources" "or"
+            SET
+                "userProvidedUrl" = ors.url
+            FROM "ObjectiveResourcesSource" ors
+            JOIN "ObjectiveResourcesCounts" orc
+            ON ors.id = orc.id
+            WHERE "or".id = ors.id
+            AND orc.cnt = 1
+            RETURNING
+                id "objectiveResourceId"
+        ),
+        "NewObjectiveResources" AS (
+            INSERT INTO "ObjectiveResources" (
+                "userProvidedUrl",
+                "objectiveId",
+                "createdAt",
+                "updatedAt",
+                "onAR",
+                "onApprovedAR"
+            )
+            SELECT
+                ors.url "userProvidedUrl",
+                ors."objectiveId",
+                ors."createdAt",
+                ors."updatedAt",
+                ors."onAR",
+                ors."onApprovedAR"
+            FROM "ObjectiveResourcesSource" ors
+            JOIN "ObjectiveResourcesCounts" orc
+            ON ors.id = orc.id
+            WHERE orc.cnt != 1
+            RETURNING
+                id "objectiveResourceId"
+        ),
+        "DeleteObjectiveResources" AS (
+            DELETE FROM "ObjectiveResources" "or"
+            USING "ObjectiveResourcesCounts" orc
+            WHERE "or".id = "orc".id
+            AND orc.cnt != 1
+            RETURNING
+                id "objectiveResourceId"
+        ),
+        "MalformedObjectiveResources" AS (
+            SELECT
+                r.id
+            FROM "ObjectiveResources" r
+            LEFT JOIN "ObjectiveResourcesURLs" ru
+            ON r.id = ru.id
+            WHERE ru.id IS NULL
+        ),
+        "DeleteMalformedObjectiveResources" AS (
+            DELETE FROM "ObjectiveResources" "or"
+            USING "MalformedObjectiveResources" mor
+            WHERE "or".id = "mor".id
+            RETURNING
+                id "objectiveResourceId"
+        ),
+        "AffectedObjectiveResources" AS (
+          SELECT
+            "objectiveResourceId",
+            'updated' "action"
+          FROM "UpdateObjectiveResources"
+          UNION
+          SELECT
+            "objectiveResourceId",
+            'created' "action"
+          FROM "NewObjectiveResources"
+          UNION
+          SELECT
+            "objectiveResourceId",
+            'replaced' "action"
+          FROM "DeleteObjectiveResources"
+          UNION
+          SELECT
+            "objectiveResourceId",
+            'removed' "action"
+          FROM "DeleteMalformedObjectiveResources"
+        )
+        SELECT
+          "action",
+          count("objectiveResourceId")
+        FROM "AffectedObjectiveResources"
+        GROUP BY "action";
+    `, { transaction });
+
+    // clean "ActivityReportObjectiveResources"
+    // TODO
+  }),
+};

--- a/src/migrations/20221209000000-resources-phase-1.js
+++ b/src/migrations/20221209000000-resources-phase-1.js
@@ -1,0 +1,762 @@
+/* eslint-disable max-len */
+module.exports = {
+  up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction(async (transaction) => {
+    const SOURCE_FIELD = {
+      REPORT: {
+        NONECLKC: 'nonECLKCResourcesUsed',
+        ECLKC: 'ECLKCResourcesUsed',
+        CONTEXT: 'context',
+        NOTES: 'additionalNotes',
+      },
+      OBJECTIVE: {
+        TITLE: 'title',
+        TTAPROVIDED: 'ttaProvided',
+      },
+    };
+
+    const loggedUser = '0';
+    const sessionSig = __filename;
+    const auditDescriptor = 'RUN MIGRATIONS';
+    await queryInterface.sequelize.query(
+      `SELECT
+          set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+          set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+          set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+          set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+      { transaction },
+    );
+
+    // make table to hold resource data
+    await queryInterface.createTable('Resources', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      domain: {
+        allowNull: false,
+        type: Sequelize.TEXT,
+      },
+      url: {
+        allowNull: false,
+        type: Sequelize.TEXT,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    }, { transaction });
+
+    // make table to link resources to activity reports
+    await queryInterface.createTable('ActivityReportResources', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      activityReportId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: {
+            tableName: 'ActivityReports',
+          },
+          key: 'id',
+        },
+      },
+      resourceId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: {
+            tableName: 'Resources',
+          },
+          key: 'id',
+        },
+      },
+      sourceField: {
+        allowNull: true,
+        default: null,
+        type: Sequelize.DataTypes.ENUM(Object.values(SOURCE_FIELD.REPORT)),
+      },
+      isAutoDetected: {
+        type: Sequelize.BOOLEAN,
+        default: false,
+        allowNull: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    }, { transaction });
+
+    // make table to link resources to activity reports
+    await queryInterface.createTable('NextStepsResources', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      nextStepId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: {
+            tableName: 'NextSteps',
+          },
+          key: 'id',
+        },
+      },
+      resourceId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: {
+            tableName: 'Resources',
+          },
+          key: 'id',
+        },
+      },
+      isAutoDetected: {
+        type: Sequelize.BOOLEAN,
+        default: false,
+        allowNull: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    }, { transaction });
+
+    // add columns to objective resources to link to resources and identify its source
+    await queryInterface.addColumn(
+      'ObjectiveResources',
+      'resourceId',
+      {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: {
+            tableName: 'Resources',
+          },
+          key: 'id',
+        },
+      },
+      { transaction },
+    );
+
+    await queryInterface.addColumn(
+      'ObjectiveResources',
+      'isAutoDetected',
+      {
+        type: Sequelize.BOOLEAN,
+        default: false,
+        allowNull: false,
+      },
+      { transaction },
+    );
+
+    await queryInterface.addColumn(
+      'ActivityReportObjectiveResources',
+      'sourceField',
+      {
+        allowNull: true,
+        default: null,
+        type: Sequelize.DataTypes.ENUM(Object.values(SOURCE_FIELD.OBJECTIVE)),
+      },
+      { transaction },
+    );
+
+    // add columns to objective resources to link to resources and identify its source
+    await queryInterface.addColumn(
+      'ActivityReportObjectiveResources',
+      'resourceId',
+      {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: {
+            tableName: 'Resources',
+          },
+          key: 'id',
+        },
+      },
+      { transaction },
+    );
+
+    await queryInterface.addColumn(
+      'ActivityReportObjectiveResources',
+      'isAutoDetected',
+      {
+        type: Sequelize.BOOLEAN,
+        default: false,
+        allowNull: false,
+      },
+      { transaction },
+    );
+
+    await queryInterface.addColumn(
+      'ActivityReportObjectiveResources',
+      'sourceField',
+      {
+        allowNull: true,
+        default: null,
+        type: Sequelize.DataTypes.ENUM(Object.values(SOURCE_FIELD.OBJECTIVE)),
+      },
+      { transaction },
+    );
+
+    const urlRegex = '(?:(?:http|ftp|https|file):\\/\\/)(?:www\\.)?(?:[\\w%_-]+(?:(?:\\.[\\w%_-]+)+)|(?:\\/[\\w][:]))(?:[\\w\\\\\'\'.,@?^=%&:\\/~+#()-]*[\\w@?^=%&\\/~+#-])';
+    const domainRegex = '^(?:(?:http|ftp|https|file):\\/\\/)?(?:www\\.)?((?:[\\w%_-]+(?:(?:\\.[\\w%_-]+)+)|(?:\\/[\\w][:])))';
+
+    // populate "Resources" and "ActivityReportResources" from current data from reports via nonECLKCResourcesUsed, ECLKCResourcesUsed, context, & additionalNotes
+    // 1. Generate a list of all reports where either nonECLKCResourcesUsed or ECLKCResourcesUsed is populated.
+    // 2. Collect all urls from nonECLKCResourcesUsed.
+    // 3. Collect all urls from ECLKCResourcesUsed.
+    // 4. Collect all urls from context.
+    // 5. Collect all urls from additionalNotes.
+    // 6. Collect all urls found in steps two through five.
+    // 7. Extract domain from urls and apply requirement that the url must contain at least one alpha char.
+    // 8. Insert distinct domains and urls into "Resources" table and apply requirements that domains to have at least one alpha char and have a valid tld.
+    // 9. Insert all records into "ActivityReportResources" linking the reports to their corresponding records in "Resources".
+    await queryInterface.sequelize.query(`
+    WITH
+      "ARResources" AS (
+        SELECT
+            id "activityReportId",
+            "nonECLKCResourcesUsed",
+            "ECLKCResourcesUsed",
+            "createdAt",
+            "updatedAt"
+        FROM "ActivityReports" a
+        WHERE ( a."nonECLKCResourcesUsed" is not null
+               AND  ARRAY_LENGTH(a."nonECLKCResourcesUsed",1) > 0
+               AND nullIf(a."nonECLKCResourcesUsed"[1],'') IS NOT null)
+        OR (a."ECLKCResourcesUsed" is not null
+            AND  ARRAY_LENGTH(a."ECLKCResourcesUsed",1) > 0
+            AND nullIf(a."ECLKCResourcesUsed"[1],'') IS NOT null)
+        order by ID
+      ),
+      "ARNResources" AS (
+        SELECT
+            arr."activityReportId",
+            (regexp_matches(ne.resource,'${urlRegex}','g')) urls,
+            'nonECLKCResourcesUsed' "SourceField",
+            arr."createdAt",
+            arr."updatedAt"
+        FROM "ARResources" arr
+        CROSS JOIN UNNEST(arr."nonECLKCResourcesUsed") AS ne(resource)
+      ),
+      "AREResources" AS (
+        SELECT
+            arr."activityReportId",
+            (regexp_matches(ne.resource,'${urlRegex}','g')) urls,
+            'ECLKCResourcesUsed' "SourceField",
+            arr."createdAt",
+            arr."updatedAt"
+        FROM "ARResources" arr
+        CROSS JOIN UNNEST(arr."ECLKCResourcesUsed") AS ne(resource)
+      ),
+      "ARCResources" AS (
+        SELECT
+          a.id "activityReportId",
+          (regexp_matches(a.context,'${urlRegex}','g')) urls,
+          'context' "SourceField",
+          a."createdAt",
+          a."updatedAt"
+        FROM "ActivityReports" a
+      ),
+      "ARAResources" AS (
+        SELECT
+          a.id "activityReportId",
+          (regexp_matches(a."additionalNotes",'${urlRegex}','g')) urls,
+          'additionalNotes' "SourceField",
+          a."createdAt",
+          a."updatedAt"
+        FROM "ActivityReports" a
+      ),
+      "ClusteredARResources" AS (
+        SELECT *
+        FROM "ARNResources"
+        UNION
+        SELECT *
+        FROM "AREResources"
+        UNION
+        SELECT *
+        FROM "ARCResources"
+        UNION
+        SELECT *
+        FROM "ARAResources"
+      ),
+      "AllARResources" AS (
+        SELECT
+          carr."activityReportId",
+          carr."SourceField",
+          (regexp_match(url,'${domainRegex}'))[1] "domain",
+          u.url,
+          carr."createdAt" "createdAt",
+          carr."updatedAt" "updatedAt"
+        FROM "ClusteredARResources" carr
+        CROSS JOIN UNNEST(carr.urls) u(url)
+        WHERE u.url ~ '[a-zA-Z]' -- URLS need to have at least one alpha char
+      ),
+      "NewResources" AS (
+        INSERT INTO "Resources" (
+          "domain",
+          "url",
+          "createdAt",
+          "updatedAt"
+        )
+        SELECT
+          aarr."domain",
+          aarr.url,
+          MIN(aarr."createdAt") "createdAt",
+          MAX(aarr."updatedAt") "updatedAt"
+        FROM "AllARResources" aarr
+        WHERE aarr."domain" ~ '[a-zA-Z]' -- Domains need to have at least one alpha char
+        AND aarr."domain" ~ '.*[.][^.0-9][a-zA-Z0-9]' -- Domains need to have a valid tld
+        GROUP BY
+          aarr."domain",
+          aarr.url
+        ORDER BY
+          MIN(aarr."createdAt")
+        RETURNING
+          id "resourceId",
+          "domain",
+          url
+      )
+      INSERT INTO "ActivityReportResources" (
+        "activityReportId",
+        "resourceId",
+        "sourceField",
+        "isAutoDetected",
+        "createdAt",
+        "updatedAt"
+      )
+      SELECT
+        aarr."activityReportId",
+        nr."resourceId",
+        aarr."sourceField",
+        (aarr."sourceField" IN ('${SOURCE_FIELD.REPORT.CONTEXT}', '${SOURCE_FIELD.REPORT.NOTES}')) "isAutoDetected",
+        aarr."createdAt",
+        aarr."updatedAt"
+      FROM "AllARResources" aarr
+      JOIN "NewResources" nr
+      ON aarr."domain" = nr."domain"
+      AND aarr.url = nr.url
+      ORDER BY
+        aarr."activityReportId",
+        nr."resourceId",
+        aarr."createdAt",
+        aarr."updatedAt";
+    `, { transaction });
+
+    // populate "Resources" and "NextStepsResources" from current data from "NextSteps" via note
+    // 1. Collect all urls from note column in "NextSteps".
+    // 2. Extract domain from urls and apply requirement that the url must contain at least one alpha char.
+    // 3. Generate a distinct list of collected urls and apply requirements that domains to have at least one alpha char and have a valid tld.
+    // 4. Update "Resources" for all existing urls.
+    // 5. Insert distinct domains and urls into "Resources" table.
+    // 6. Collect all affected "Resources" records.
+    // 7. Insert all records into "NextStepsResources" linking the "NextSteps" records to their corresponding records in "Resources".
+    await queryInterface.sequelize.query(`
+    WITH
+      "NextStepsUrls" AS (
+        SELECT
+          ns.id "nextStepId",
+          (regexp_matches(ns.note,'${urlRegex}','g')) urls,
+          ns."createdAt",
+          ns."updatedAt"
+        FROM "NextSteps" ns
+        where ns.note like '%http%'
+        OR ns.note like '%HTTP%'
+      ),
+      "NextStepsUrlDomain" AS (
+        SELECT
+          nsu."nextStepId",
+          (regexp_match(u.url, '${domainRegex}'))[1] "domain",
+          u.url,
+          nsu."createdAt",
+          nsu."updatedAt"
+        FROM "NextStepsUrls" nsu
+        CROSS JOIN UNNEST(nsu.urls) u(url)
+        WHERE u.url ~ '[a-zA-Z]' -- URLS need to have atleast one alpha char
+      ),
+      "NextStepResources" AS (
+        SELECT
+          nsud."domain",
+          nsud.url,
+          MIN(nsud."createdAt") "createdAt",
+          MAX(nsud."updatedAt") "updatedAt"
+        FROM "NextStepsUrlDomain" nsud
+        WHERE nsud."domain" ~ '[a-zA-Z]' -- Domains need to have at least one alpha char
+        AND nsud."domain" ~ '.*[.][^.0-9][a-zA-Z0-9]' -- Domains need to have a valid tld
+        GROUP BY
+          nsud."domain",
+          nsud.url
+        ORDER BY
+          MIN(nsud."createdAt")
+      ),
+      "UpdateResources" AS (
+        UPDATE "Resources" r
+        SET
+          "createdAt" = LEAST(r."createdAt", nsr."createdAt"),
+          "updatedAt" = GREATEST(r."updatedAt", nsr."updatedAt")
+        FROM "NextStepResources" nsr
+        JOIN "Resources" r2
+        ON nsr."domain" = r2."domain"
+        AND nsr.url = r2.url
+        WHERE nsr."domain" = r."domain"
+        AND nsr.url = r.url
+        RETURNING
+          id "resourceId",
+          "domain",
+          url
+      ),
+      "NewResources" AS (
+        INSERT INTO "Resources" (
+          "domain",
+          "url",
+          "createdAt",
+          "updatedAt"
+        )
+        SELECT
+          nsr."domain",
+          nsr.url,
+          nsr."createdAt",
+          nsr."updatedAt"
+        FROM "NextStepResources" nsr
+        LEFT JOIN "Resources" r
+        ON nsr."domain" = r."domain"
+        AND nsr.url = r.url
+        WHERE r.id IS NULL
+        ORDER BY
+          nsr."createdAt"
+        RETURNING
+          id "resourceId",
+          "domain",
+          url
+      ),
+      "AffectedResources" AS (
+        SELECT *
+        FROM "UpdateResources"
+        UNION
+        SELECT *
+        FROM "NewResources"
+      )
+      INSERT INTO "NextStepsResources" (
+        "nextStepId",
+        "resourceId",
+        "isAutoDetected",
+        "createdAt",
+        "updatedAt"
+      )
+      SELECT
+        nsud."nextStepId",
+        ar."resourceId",
+        true,
+        nsud."createdAt",
+        nsud."updatedAt"
+      FROM "NextStepsUrlDomain" nsud
+      JOIN "AffectedResources" ar
+      ON nsud."domain" = r."domain"
+      AND nsud.url = r.url
+      ORDER BY
+        nsud."nextStepId",
+        ar."resourceId",
+        nsud."createdAt",
+        nsud."updatedAt";
+    `, { transaction });
+
+    // populate "Resources" from current data from "ObjectiveResources" via userProvidedUrl
+    // 1. Collect all urls from userProvidedUrl column in "ObjectiveResources".
+    // 2. Extract domain from urls and apply requirement that the url must contain at least one alpha char.
+    // 3. Generate a distinct list of collected urls and apply requirements that domains to have at least one alpha char and have a valid tld.
+    // 4. Update "Resources" for all existing urls.
+    // 5. Insert distinct domains and urls into "Resources" table.
+    // 6. Collect all affected "Resources" records.
+    // 7. Update "ObjectiveResources" records to their corresponding records in "Resources".
+    await queryInterface.sequelize.query(`
+    WITH
+      "ObjectiveResourcesURLs" AS (
+        SELECT
+          id "objectiveResourceId",
+          (regexp_matches("userProvidedUrl",'${urlRegex}','g')) urls,
+          "createdAt",
+          "updatedAt",
+        FROM "ObjectiveResources"
+      ),
+      "ObjectiveResourcesUrlDomain" AS (
+        SELECT
+          oru."objectiveResourceId",
+          (regexp_match(u.url, '${domainRegex}'))[1] "domain",
+          u.url,
+          oru."createdAt",
+          oru."updatedAt"
+        FROM "ObjectiveResourcesURLs" oru
+        CROSS JOIN UNNEST(oru.urls) u(url)
+        WHERE u.url ~ '[a-zA-Z]' -- URLS need to have at least one alpha char
+      ),
+      "ObjectiveResourcesResources" AS (
+        SELECT
+          orud."domain",
+          orud.url,
+          MIN(orud."createdAt") "createdAt",
+          MAX(orud."updatedAt") "updatedAt"
+        FROM "ObjectiveResourcesUrlDomain" orud
+        WHERE orud."domain" ~ '[a-zA-Z]' -- Domains need to have at least one alpha char
+        AND orud."domain" ~ '.*[.][^.0-9][a-zA-Z0-9]' -- Domains need to have a valid tld
+        GROUP BY
+          orud."domain",
+          orud.url
+        ORDER BY
+          MIN(orud."createdAt")
+      ),
+      "UpdateResources" AS (
+        UPDATE "Resources" r
+        SET
+          "createdAt" = LEAST(r."createdAt", orr."createdAt"),
+          "updatedAt" = GREATEST(r."updatedAt", orr."updatedAt")
+        FROM "ObjectiveResourcesResources" orr
+        JOIN "Resources" r2
+        ON orr."domain" = r2."domain"
+        AND orr.url = r2.url
+        WHERE orr."domain" = r."domain"
+        AND orr.url = r.url
+        RETURNING
+          id "resourceId",
+          "domain",
+          url
+      ),
+      "NewResources" AS (
+        INSERT INTO "Resources" (
+          "domain",
+          "url",
+          "createdAt",
+          "updatedAt"
+        )
+        SELECT
+          orr."domain",
+          orr.url,
+          orr."createdAt",
+          orr."updatedAt"
+        FROM "ObjectiveResourcesResources" orr
+        LEFT JOIN "Resources" r
+        ON orr."domain" = r."domain"
+        AND orr.url = r.url
+        WHERE r.id IS NULL
+        ORDER BY
+          orr."createdAt"
+        RETURNING
+          id "resourceId",
+          "domain",
+          url
+      ),
+      "AffectedResources" AS (
+        SELECT *
+        FROM "UpdateResources"
+        UNION
+        SELECT *
+        FROM "NewResources"
+      )
+      UPDATE "ObjectiveResources" "or"
+      SET
+        "resourceId" = ar."resourceId"
+      FROM "ObjectiveResourcesUrlDomain" orud
+      JOIN "AffectedResources" ar
+      ON orud."domain" = ar."domain"
+      AND orud.url = ar.url
+      WHERE "or".id = orud."objectiveResourceId";
+    `, { transaction });
+
+    // populate "Resources" and "ObjectiveResources" from current data from "Objectives" via title
+    // 1. Collect all urls from title column in "Objectives".
+    // 2. Extract domain from urls and apply requirement that the url must contain at least one alpha char.
+    // 3. Generate a distinct list of collected urls and apply requirements that domains to have at least one alpha char and have a valid tld.
+    // 4. Update "Resources" for all existing urls.
+    // 5. Insert distinct domains and urls into "Resources" table.
+    // 6. Collect all affected "Resources" records.
+    // 7. Update "ObjectiveResources" for all exiting urls.
+    // 8. Insert "ObjectiveResources" for newly found urls.
+    // 9. Collect all records that have been affected.
+    // 10. Return statistics form operation.
+    await queryInterface.sequelize.query(`
+    WITH
+      "ObjectiveUrls" AS (
+        SELECT
+          o.id "objectiveId",
+          (regexp_matches(o.title,'${urlRegex}','g')) urls,
+          o."createdAt",
+          o."updatedAt",
+          o."onAR",
+          o."onApprovedAR"
+        FROM "Objectives" o
+      ),
+      "ObjectiveUrlDomain" AS (
+        SELECT
+          ou."objectiveId",
+          (regexp_match(u.url, '${domainRegex}'))[1] "domain",
+          u.url,
+          ou."createdAt",
+          ou."updatedAt",
+          ou."onAR",
+          ou."onApprovedAR"
+        FROM "ObjectiveUrls" ou
+        CROSS JOIN UNNEST(ou.urls) u(url)
+        WHERE u.url ~ '[a-zA-Z]' -- URLS need to have atleast one alpha char
+      ),
+      "ObjectiveDetectedResources" AS (
+        SELECT
+          oud."domain",
+          oud.url,
+          MIN(oud."createdAt") "createdAt",
+          MAX(oud."updatedAt") "updatedAt"
+        FROM "ObjectiveUrlDomain" oud
+        WHERE oud."domain" ~ '[a-zA-Z]' -- Domains need to have at least one alpha char
+        AND oud."domain" ~ '.*[.][^.0-9][a-zA-Z0-9]' -- Domains need to have a valid tld
+        GROUP BY
+          oud."domain",
+          oud.url
+        ORDER BY
+          MIN(oud."createdAt")
+      ),
+      ,
+      "UpdateResources" AS (
+        UPDATE "Resources" r
+        SET
+          "createdAt" = LEAST(r."createdAt", odr."createdAt"),
+          "updatedAt" = GREATEST(r."updatedAt", odr."updatedAt")
+        FROM "ObjectiveDetectedResources" odr
+        WHERE odr."domain" = r."domain"
+        AND odr.url = r.url
+        RETURNING
+          id "resourceId",
+          "domain",
+          url
+      ),
+      "NewResources" AS (
+        INSERT INTO "Resources" (
+          "domain",
+          "url",
+          "createdAt",
+          "updatedAt"
+        )
+        SELECT
+          odr."domain",
+          odr.url,
+          odr."createdAt",
+          odr."updatedAt"
+        FROM "ObjectiveDetectedResources" odr
+        LEFT JOIN "Resources" r
+        ON odr."domain" = r."domain"
+        AND odr.url = r.url
+        WHERE r.id IS NULL
+        ORDER BY
+          odr."createdAt"
+        RETURNING
+          id "resourceId",
+          "domain",
+          url
+      ),
+      "AffectedResources" AS (
+        SELECT *
+        FROM "UpdateResources"
+        UNION
+        SELECT *
+        FROM "NewResources"
+      ),
+      "UpdateObjectiveResources" AS (
+        UPDATE "ObjectiveResources" r
+        SET
+          "resourceId" = ar."resourceId",
+          "isAutoDetected" = (r.isAutoDetected AND "isAutoDetected"),
+          "createdAt" = LEAST(r."createdAt", oud."createdAt"),
+          "updatedAt" = GREATEST(r."updatedAt", oud."updatedAt")
+        FROM "ObjectiveUrlDomain" oud
+        JOIN "AffectedResources" ar
+        ON oud."domain" = ar."domain"
+        AND oud.url = ar.url
+        WHERE oud."objectiveId" = r."objectiveId"
+        AND oud.url = r."userProvidedUrl"
+        RETURNING
+          id "objectiveResourceId"
+      ),
+      "NewObjectiveResources" AS (
+        INSERT INTO "ObjectiveResources" (
+          "userProvidedUrl",
+          "objectiveId",
+          "createdAt",
+          "updatedAt",
+          "onAR",
+          "onApprovedAR",
+          "resourceId",
+          "isAutoDetected",
+          "sourceField"
+        )
+        SELECT
+          oud.usr "userProvidedUrl",
+          oud."objectiveId",
+          oud."createdAt",
+          oud."updatedAt",
+          oud."onAR",
+          oud."onApprovedAR",
+          ar."resourceId",
+          true "isAutoDetected",
+          '${SOURCE_FIELD.OBJECTIVE.TITLE}' "sourceField"
+        FROM "ObjectiveUrlDomain" oud
+        JOIN "AffectedResources" ar
+        ON oud."domain" = ar."domain"
+        AND oud.url = ar.url
+        LEFT JOIN "ObjectiveResources" r
+        ON oud."objectiveId" = r."objectiveId"
+        AND oud.url = r."userProvidedUrl"
+        WHERE r.id IS NULL
+        ORDER BY
+          oud."createdAt",
+          ar."resourceId"
+        RETURNING
+          id "objectiveResourceId"
+      ),
+      "AffectedObjectiveResources" AS (
+        SELECT
+          "objectiveResourceId",
+          'updated' "action"
+        FROM "UpdateObjectiveResources"
+        UNION
+        SELECT
+          "objectiveResourceId",
+          'created' "action"
+        FROM "NewObjectiveResources"
+      )
+      SELECT
+        "action",
+        count("objectiveResourceId")
+      FROM "AffectedObjectiveResources"
+      GROUP BY "action";
+    `, { transaction });
+
+    // update "ActivityReportObjectiveResources" to set resourceId
+    // TODO
+
+    // populate "Resources", "ActivityReportObjectiveResources", & "ObjectiveResources" from current data from "ActivityReportObjectives" via ttaProvided
+    // TODO
+  }),
+  down: async (queryInterface) => queryInterface.sequelize.transaction(async (transaction) => {
+
+  }),
+};

--- a/src/migrations/20221209000000-resources-phase-1.js
+++ b/src/migrations/20221209000000-resources-phase-1.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+// Resources Phase 1: Create and Populate Resources table from all explicitly and implicitly included resources from across ActivityReports, NextSteps, & Objectives
 module.exports = {
   up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction(async (transaction) => {
     const SOURCE_FIELD = {

--- a/src/migrations/20221212000000-resources-phase-2.js
+++ b/src/migrations/20221212000000-resources-phase-2.js
@@ -1,0 +1,126 @@
+/* eslint-disable max-len */
+// Resources Phase 2: Create structure to support collecting and maintaining metadata for resources
+module.exports = {
+  up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      const METADATA_PROCESSING_STATES_TYPES = {
+        QUEUEING: 'QUEUEING',
+        QUEUEING_FAILED: 'QUEUEING_FAILED',
+        QUEUED: 'QUEUED',
+        IDENTIFYING_FRAMEWORK: 'IDENTIFYING_FRAMEWORK',
+        CAPTURING: 'CAPTURING',
+        CAPTURING_FAILED: 'CAPTURING_FAILED',
+        PROCESSING: 'PROCESSING',
+        PROCESSING_FAILED: 'PROCESSING_FAILED',
+        PROCESSED: 'PROCESSED',
+        REPROCESSING_REQUESTED: 'REPROCESSING_REQUESTED',
+      };
+
+      const FRAMEWORK_TYPE = {
+        DRUPAL: 'Drupal ',
+        WORDPRESS: 'WordPress',
+        JOOMLA: 'Joomla',
+        WIX: 'Wix',
+        SQUARESPACE: 'Squarespace',
+        BLOGGER: 'Blogger',
+      };
+
+      const SITE_ACCESSOR = {
+        DRUPAL_JSON: '?_format=json',
+        DRUPAL_HAL_JSON: '?_format=hal_json',
+        WORDPRESS_JSON_POSTS: '/wp-json/wp/v2/posts',
+      };
+
+      const loggedUser = '0';
+      const sessionSig = __filename;
+      const auditDescriptor = 'RUN MIGRATIONS';
+      await queryInterface.sequelize.query(
+        `SELECT
+                set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+                set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+                set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+                set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+        { transaction },
+      );
+
+      // make table to hold metadata about resources
+      await queryInterface.createTable('ResourceMetadata', {
+        id: {
+          allowNull: false,
+          autoIncrement: true,
+          primaryKey: true,
+          type: Sequelize.INTEGER,
+        },
+        resourceId: {
+          allowNull: true,
+          type: Sequelize.INTEGER,
+          references: {
+            model: {
+              tableName: 'Resources',
+            },
+            key: 'id',
+          },
+        },
+        metaDataStatus: {
+          allowNull: false,
+          default: null,
+          type: Sequelize.DataTypes.ENUM(Object.values(METADATA_PROCESSING_STATES_TYPES)),
+        },
+        frameworkType: {
+          allowNull: true,
+          default: null,
+          type: Sequelize.DataTypes.ENUM(Object.values(FRAMEWORK_TYPE)),
+        },
+        siteAccesor: {
+          allowNull: true,
+          default: null,
+          type: Sequelize.DataTypes.STRING,
+        },
+        data: {
+          allowNull: false,
+          type: Sequelize.JSON,
+        },
+        created: {
+          allowNull: true,
+          type: Sequelize.DATE,
+        },
+        changed: {
+          allowNull: true,
+          type: Sequelize.DATE,
+        },
+        title: {
+          allowNull: true,
+          type: Sequelize.TEXT,
+        },
+        field_taxonomy_national_centers: {
+          allowNull: true,
+          type: Sequelize.JSON,
+        },
+        field_taxonomy_topic: {
+          allowNull: true,
+          type: Sequelize.JSON,
+        },
+        langcode: {
+          allowNull: true,
+          type: Sequelize.JSON,
+        },
+        field_content: {
+          allowNull: true,
+          type: Sequelize.JSON,
+        },
+        createdAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+        },
+      }, { transaction });
+
+      //await queryInterface.sequelize.query('UPDATE "ActivityReportObjectives" SET "status" = \'Complete\' WHERE "status" = \'Completed\'', { transaction });
+    },
+  ),
+  down: async () => {
+  },
+};


### PR DESCRIPTION
## Description of change
Phase 0: Clean current "ObjectiveResources" and "ActivityReportObjectiveResources" to have each record contain a single value url.
Phase 1: Create and Populate Resources table from all explicitly and implicitly included resources from across ActivityReports, NextSteps, & Objectives
Phase 2: Create structure to support collecting and maintaining metadata for resources

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-162
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-588
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1049


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
