### PR TITLE
[TTAHUB-1301] Allow adding files to objectives on approved AR

### DIFF
--- a/src/policies/objective.js
+++ b/src/policies/objective.js
@@ -1,5 +1,5 @@
 import { find, isUndefined } from 'lodash';
-import { GOAL_STATUS, OBJECTIVE_STATUS } from '../constants';
+import { OBJECTIVE_STATUS, GOAL_STATUS } from '../constants';
 import SCOPES from '../middleware/scopeConstants';
 
 export default class Objective {
@@ -18,11 +18,22 @@ export default class Objective {
     return !isUndefined(permissions);
   }
 
+  canUpload() {
+    if (this.objective.status !== OBJECTIVE_STATUS.COMPLETE
+          && (this.objective.otherEntityId
+            || (this.objective.goal
+                && this.objective.goal.status !== GOAL_STATUS.CLOSED
+                && this.objective.goal.grant
+                && this.canWriteInRegion(this.objective.goal.grant.regionId)))) {
+      return true;
+    }
+    return false;
+  }
+
   canUpdate() {
-    if (!this.objective.status !== OBJECTIVE_STATUS.COMPLETE
+    if (!this.objective.onApprovedAR
         && (this.objective.otherEntityId
           || (this.objective.goal
-              && this.objective.goal.status !== GOAL_STATUS.CLOSED
               && this.objective.goal.grant
               && this.canWriteInRegion(this.objective.goal.grant.regionId)))) {
       return true;

--- a/src/policies/objective.js
+++ b/src/policies/objective.js
@@ -1,4 +1,5 @@
 import { find, isUndefined } from 'lodash';
+import { GOAL_STATUS, OBJECTIVE_STATUS } from '../constants';
 import SCOPES from '../middleware/scopeConstants';
 
 export default class Objective {
@@ -18,9 +19,10 @@ export default class Objective {
   }
 
   canUpdate() {
-    if (!this.objective.onApprovedAR
+    if (!this.objective.status !== OBJECTIVE_STATUS.COMPLETE
         && (this.objective.otherEntityId
           || (this.objective.goal
+              && this.objective.goal.status !== GOAL_STATUS.CLOSED
               && this.objective.goal.grant
               && this.canWriteInRegion(this.objective.goal.grant.regionId)))) {
       return true;

--- a/src/policies/objective.test.js
+++ b/src/policies/objective.test.js
@@ -1,0 +1,85 @@
+import Objective from './objective';
+import SCOPES from '../middleware/scopeConstants';
+import { GOAL_STATUS, OBJECTIVE_STATUS } from '../constants';
+
+describe('Objective policies', () => {
+  describe('canUpload', () => {
+    const baseObjective = {
+      status: OBJECTIVE_STATUS.NOT_STARTED,
+      goal: {
+        status: GOAL_STATUS.NOT_STARTED,
+        grant: {
+          regionId: 1,
+        },
+      },
+    };
+    const baseUser = {
+      permissions: [
+        {
+          scopeId: SCOPES.READ_WRITE_REPORTS,
+          regionId: 1,
+        },
+      ],
+    };
+
+    it('is false if objective is complete', () => {
+      const objective = {
+        ...baseObjective,
+        status: OBJECTIVE_STATUS.COMPLETE,
+      };
+      const policy = new Objective(objective, baseUser);
+      expect(policy.canUpload()).toBe(false);
+    });
+
+    it('is false if goal is closed', () => {
+      const objective = {
+        ...baseObjective,
+        goal: {
+          ...baseObjective.goal,
+          status: GOAL_STATUS.CLOSED,
+        },
+      };
+      const policy = new Objective(objective, baseUser);
+      expect(policy.canUpload()).toBe(false);
+    });
+
+    it('is false if the goal doesn\'t have a grant', () => {
+      const objective = {
+        ...baseObjective,
+        goal: {
+          ...baseObjective.goal,
+          grant: null,
+        },
+      };
+      const policy = new Objective(objective, baseUser);
+      expect(policy.canUpload()).toBe(false);
+    });
+
+    it('is false if the user doesn\'t have write permissions in the grant\'s region', () => {
+      const objective = {
+        ...baseObjective,
+      };
+      const user = {
+        ...baseUser,
+        permissions: [],
+      };
+      const policy = new Objective(objective, user);
+      expect(policy.canUpload()).toBe(false);
+    });
+
+    it('is true if all the conditions are satisfied', () => {
+      const policy = new Objective(baseObjective, baseUser);
+      expect(policy.canUpload()).toBe(true);
+    });
+
+    it('returns true for other entity objectives that aren\'t complete', () => {
+      const objective = {
+        ...baseObjective,
+        otherEntityId: 1,
+        goal: null,
+      };
+      const policy = new Objective(objective, baseUser);
+      expect(policy.canUpload()).toBe(true);
+    });
+  });
+});

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -115,7 +115,7 @@ const deleteHandler = async (req, res) => {
     } else if (objectiveId) {
       const objective = await getObjectiveById(objectiveId);
       const objectivePolicy = new ObjectivePolicy(objective, user);
-      if (!objectivePolicy.canUpload()) {
+      if (!objectivePolicy.canUpdate()) {
         res.sendStatus(403);
         return;
       }
@@ -431,7 +431,7 @@ const deleteObjectiveFileHandler = async (req, res) => {
       }
       const objective = await getObjectiveById(objectiveId);
       const objectivePolicy = new ObjectivePolicy(objective, user);
-      if (!objectivePolicy.canUpload()) {
+      if (!objectivePolicy.canUpdate()) {
         canUpdate = false;
         res.sendStatus(403);
         return null;

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -289,7 +289,7 @@ const uploadHandler = async (req, res) => {
     } else if (objectiveId) {
       const objective = await getObjectiveById(objectiveId);
       const objectivePolicy = new ObjectivePolicy(objective, user);
-      if (!(objectivePolicy.canUpdate()
+      if (!(objectivePolicy.canUpload()
       || (await validateUserAuthForAdmin(req.session.userId)))) {
         return res.sendStatus(403);
       }

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -115,7 +115,7 @@ const deleteHandler = async (req, res) => {
     } else if (objectiveId) {
       const objective = await getObjectiveById(objectiveId);
       const objectivePolicy = new ObjectivePolicy(objective, user);
-      if (!objectivePolicy.canUpdate()) {
+      if (!objectivePolicy.canUpload()) {
         res.sendStatus(403);
         return;
       }
@@ -361,7 +361,7 @@ const uploadObjectivesFile = async (req, res) => {
       const authorizations = await Promise.all(objectiveIds.map(async (objectiveId) => {
         const objective = await getObjectiveById(objectiveId);
         const objectivePolicy = new ObjectivePolicy(objective, user);
-        if (!objective || !objectivePolicy.canUpdate()) {
+        if (!objective || !objectivePolicy.canUpload()) {
           const admin = await validateUserAuthForAdmin(req.session.userId);
           if (!admin) {
             return false;
@@ -431,7 +431,7 @@ const deleteObjectiveFileHandler = async (req, res) => {
       }
       const objective = await getObjectiveById(objectiveId);
       const objectivePolicy = new ObjectivePolicy(objective, user);
-      if (!objectivePolicy.canUpdate()) {
+      if (!objectivePolicy.canUpload()) {
         canUpdate = false;
         res.sendStatus(403);
         return null;

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -274,7 +274,7 @@ describe('File Upload', () => {
 
     it('tests a objective file upload', async () => {
       ObjectivePolicy.mockImplementation(() => ({
-        canUpdate: () => true,
+        canUpload: () => true,
       }));
       uploadFile.mockResolvedValue({ key: 'key' });
       const response = await request(app)
@@ -302,7 +302,7 @@ describe('File Upload', () => {
 
     it('allows an admin to upload a objective file', async () => {
       ObjectivePolicy.mockImplementation(() => ({
-        canUpdate: () => false,
+        canUpload: () => false,
       }));
       validateUserAuthForAdmin.mockResolvedValue(true);
       uploadFile.mockResolvedValue({ key: 'key' });
@@ -332,7 +332,7 @@ describe('File Upload', () => {
 
     it('deletes a objective file', async () => {
       ObjectivePolicy.mockImplementation(() => ({
-        canUpdate: () => true,
+        canUpload: () => true,
       }));
       const file = await File.create({
         objectiveId: objective.dataValues.id,
@@ -394,6 +394,22 @@ describe('File Upload', () => {
         .expect(403)
         .then(() => expect(uploadFile).not.toHaveBeenCalled());
     });
+
+    it('tests an unauthorized objective file upload', async () => {
+      validateUserAuthForAdmin.mockResolvedValue(false);
+      ObjectivePolicy.mockImplementation(() => ({
+        canUpload: () => false,
+      }));
+      await request(app)
+        .post('/api/files')
+        .field('objectiveId', objective.dataValues.id)
+        .attach('file', `${__dirname}/testfiles/testfile.pdf`)
+        .expect(403)
+        .then(() => {
+          expect(uploadFile).not.toHaveBeenCalled();
+        });
+    });
+
     it('tests an incorrect file type', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -277,11 +277,16 @@ describe('File Upload', () => {
         canUpload: () => true,
       }));
       uploadFile.mockResolvedValue({ key: 'key' });
-      const response = await request(app)
-        .post('/api/files')
-        .field('objectiveId', objective.dataValues.id)
-        .attach('file', `${__dirname}/testfiles/testfile.pdf`)
-        .expect(200);
+      let response;
+      try {
+        response = await request(app)
+          .post('/api/files')
+          .field('objectiveId', objective.dataValues.id)
+          .attach('file', `${__dirname}/testfiles/testfile.pdf`)
+          .expect(200);
+      } catch (e) {
+        console.log(e);
+      }
       fileId = response.body.id;
       expect(uploadFile).toHaveBeenCalled();
       expect(mockAddToScanQueue).toHaveBeenCalled();
@@ -362,7 +367,7 @@ describe('File Upload', () => {
 
   describe('File Upload Handlers error handling', () => {
     // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('tests a file upload without a report id', async () => {
+    it('tests a file upload without a report id', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
       }));

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -332,7 +332,7 @@ describe('File Upload', () => {
 
     it('deletes a objective file', async () => {
       ObjectivePolicy.mockImplementation(() => ({
-        canUpload: () => true,
+        canUpdate: () => true,
       }));
       const file = await File.create({
         objectiveId: objective.dataValues.id,

--- a/tests/activity-report.spec.ts
+++ b/tests/activity-report.spec.ts
@@ -13,6 +13,7 @@ async function getFullName(page) {
 
 test.describe("Activity Report", () => {
   test('can create an AR with multiple goals, submit for review, and review', async ({ page }) => {
+    test.slow();
     const fullName = await getFullName(page);
 
     await page.getByRole('link', { name: 'Activity Reports' }).click();


### PR DESCRIPTION
## Description of change
Based on a user support request, we identified that the logic for checking if an objective allows file uploads to be faulty. This change allows uploads to an objective if the objective is on an approved AR. It also adds a check to see if the objective is complete OR if the goal is closed.

## How to test
Test objective file uploads

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1301


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
