### PR TITLE
[TTAHUB-1307] fix bug with review and actively edited goals

### DIFF
--- a/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
@@ -1,0 +1,228 @@
+import { REPORT_STATUSES } from '../../../Constants';
+import { convertGoalsToFormData } from '../formDataHelpers';
+
+describe('convertGoalsToFormData', () => {
+  it('converts', () => {
+    const { goals, goalForEditing } = convertGoalsToFormData(
+      [
+        {
+          id: 1,
+          activityReportGoals: [
+            {
+              id: 1,
+              isActivelyEdited: true,
+            },
+          ],
+        },
+        {
+          id: 2,
+          activityReportGoals: [
+            {
+              id: 2,
+              isActivelyEdited: false,
+            },
+          ],
+        },
+      ],
+      [1, 2, 3],
+      REPORT_STATUSES.DRAFT,
+    );
+
+    expect(goals).toEqual([
+      {
+        id: 2,
+        grantIds: [1, 2, 3],
+        activityReportGoals: [
+          { id: 2, isActivelyEdited: false },
+        ],
+      },
+    ]);
+
+    expect(goalForEditing).toEqual({
+      id: 1,
+      grantIds: [1, 2, 3],
+      activityReportGoals: [
+        { id: 1, isActivelyEdited: true },
+      ],
+    });
+  });
+  it('only returns one goalForEditing (even if more than one activityreportgoal has isActivelyEditing: true', () => {
+    const { goals, goalForEditing } = convertGoalsToFormData(
+      [
+        {
+          id: 1,
+          activityReportGoals: [
+            {
+              id: 1,
+              isActivelyEdited: true,
+            },
+          ],
+        },
+        {
+          id: 2,
+          activityReportGoals: [
+            {
+              id: 3,
+              isActivelyEdited: true,
+            },
+          ],
+        },
+      ],
+      [1, 2, 3],
+      REPORT_STATUSES.DRAFT,
+    );
+
+    expect(goals).toEqual([
+      {
+        id: 2,
+        grantIds: [1, 2, 3],
+        activityReportGoals: [
+          {
+            id: 3,
+            isActivelyEdited: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(goalForEditing).toEqual({
+      id: 1,
+      grantIds: [1, 2, 3],
+      activityReportGoals: [
+        {
+          id: 1,
+          isActivelyEdited: true,
+        },
+      ],
+    });
+  });
+  it('returns an empty goalForEditing if no activityreportgoal has isActivelyEditing: true', () => {
+    const { goals, goalForEditing } = convertGoalsToFormData(
+      [
+        {
+          id: 1,
+          activityReportGoals: [
+            {
+              id: 1,
+              isActivelyEdited: false,
+            },
+          ],
+        },
+        {
+          id: 2,
+          activityReportGoals: [
+            {
+              id: 3,
+              isActivelyEdited: false,
+            },
+          ],
+        },
+      ],
+      [1, 2, 3],
+      REPORT_STATUSES.DRAFT,
+    );
+
+    expect(goals).toEqual([
+      {
+        id: 1,
+        grantIds: [1, 2, 3],
+        activityReportGoals: [
+          {
+            id: 1,
+            isActivelyEdited: false,
+          },
+        ],
+      },
+      {
+        id: 2,
+        grantIds: [1, 2, 3],
+        activityReportGoals: [
+          {
+            id: 3,
+            isActivelyEdited: false,
+          },
+        ],
+      },
+    ]);
+
+    expect(goalForEditing).toEqual(null);
+  });
+  it('returns an empty goalForEditing if activityreportgoal is not set', () => {
+    const { goals, goalForEditing } = convertGoalsToFormData(
+      [
+        {
+          id: 1,
+        },
+        {
+          id: 2,
+        },
+      ],
+      [1, 2, 3],
+      REPORT_STATUSES.DRAFT,
+    );
+
+    expect(goals).toEqual([
+      {
+        id: 1,
+        grantIds: [1, 2, 3],
+      },
+      {
+        id: 2,
+        grantIds: [1, 2, 3],
+      },
+    ]);
+
+    expect(goalForEditing).toEqual(null);
+  });
+  it('returns an empty goalForEditing if the goal is submitted', () => {
+    const { goals, goalForEditing } = convertGoalsToFormData(
+      [
+        {
+          id: 1,
+          activityReportGoals: [
+            {
+              id: 1,
+              isActivelyEdited: true,
+            },
+          ],
+        },
+        {
+          id: 2,
+          activityReportGoals: [
+            {
+              id: 3,
+              isActivelyEdited: true,
+            },
+          ],
+        },
+      ],
+      [1, 2, 3],
+      REPORT_STATUSES.SUBMITTED,
+    );
+
+    expect(goals).toEqual([
+      {
+        id: 1,
+        grantIds: [1, 2, 3],
+        activityReportGoals: [
+          {
+            id: 1,
+            isActivelyEdited: true,
+          },
+        ],
+      },
+      {
+        id: 2,
+        grantIds: [1, 2, 3],
+        activityReportGoals: [
+          {
+            id: 3,
+            isActivelyEdited: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(goalForEditing).toEqual(null);
+  });
+});

--- a/frontend/src/pages/ActivityReport/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/formDataHelpers.js
@@ -6,6 +6,11 @@ import {
   REPORT_STATUSES,
 } from '../../Constants';
 
+const ALLOWED_STATUSES_FOR_GOAL_EDITING = [
+  REPORT_STATUSES.DRAFT,
+  REPORT_STATUSES.NEEDS_ACTION,
+];
+
 /**
  * compares two objects using lodash "isEqual" and returns the difference
  * @param {*} object
@@ -86,7 +91,7 @@ export const convertGoalsToFormData = (
     // if any of the goals ids are included in the activelyEditedGoals id array
     goal.activityReportGoals
     && goal.activityReportGoals.some((arGoal) => arGoal.isActivelyEdited
-    && [REPORT_STATUSES.DRAFT, REPORT_STATUSES.NEEDS_ACTION].includes(calculatedStatus)
+    && ALLOWED_STATUSES_FOR_GOAL_EDITING.includes(calculatedStatus)
     && !accumulatedData.goalForEditing)
   ) {
     // we set it as the goal for editing

--- a/frontend/src/pages/ActivityReport/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/formDataHelpers.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import {
   DATE_DISPLAY_FORMAT,
   DATEPICKER_VALUE_FORMAT,
+  REPORT_STATUSES,
 } from '../../Constants';
 
 /**
@@ -65,16 +66,28 @@ export const unflattenResourcesUsed = (array) => {
 
 // this function takes goals returned from the API and parses them appropriately,
 // setting the editable goal (or at least doing its best guess)
+/**
+ *
+ * @param {goal[]} goals
+ * @param {number[]} grantIds
+ * @param {string} calculatedStatus
+ * we need the calculated status to determine whether or not to set the goalForEditing
+ * if we aren't editing, we need to make sure goals is populated so the review section
+ * displays properly
+ * @returns { goal[], goalForEditing }
+ */
 export const convertGoalsToFormData = (
-  goals, grantIds,
+  goals, grantIds, calculatedStatus = REPORT_STATUSES.DRAFT,
 ) => goals.reduce((accumulatedData, goal) => {
   // we are relying on the backend to have properly captured the goalForEditing
   // if there is some breakdown happening, and we have two set,
   // we will just fall back to just using the first matching goal
   if (
     // if any of the goals ids are included in the activelyEditedGoals id array
-    goal.activityReportGoals.some((arGoal) => arGoal.isActivelyEdited)
-        && !accumulatedData.goalForEditing
+    goal.activityReportGoals
+    && goal.activityReportGoals.some((arGoal) => arGoal.isActivelyEdited
+    && [REPORT_STATUSES.DRAFT, REPORT_STATUSES.NEEDS_ACTION].includes(calculatedStatus)
+    && !accumulatedData.goalForEditing)
   ) {
     // we set it as the goal for editing
     // eslint-disable-next-line no-param-reassign
@@ -110,7 +123,7 @@ export const convertReportToFormData = (fetchedReport) => {
   }));
 
   const { goals, goalForEditing } = convertGoalsToFormData(
-    fetchedReport.goalsAndObjectives, grantIds,
+    fetchedReport.goalsAndObjectives, grantIds, fetchedReport.calculatedStatus,
   );
   const objectivesWithoutGoals = convertObjectivesWithoutGoalsToFormData(
     fetchedReport.objectivesWithoutGoals, otherEntities,

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -7,6 +7,7 @@ import {
   Role,
   ActivityReportApprover,
   User as UserModel,
+  ActivityReportGoal,
   sequelize,
 } from '../../models';
 import ActivityReport from '../../policies/activityReport';
@@ -605,6 +606,15 @@ export async function submitReport(req, res) {
     // Resubmitting resets any needs_action status to null ("pending" status)
     await ActivityReportApprover.update({ status: null }, {
       where: { status: APPROVER_STATUSES.NEEDS_ACTION, activityReportId },
+      individualHooks: true,
+    });
+
+    // on submit, we should inform the backend that we
+    // are no longer editing any goals (since we are submitting)
+    await ActivityReportGoal.update({
+      isActivelyEdited: false,
+    }, {
+      where: { activityReportId },
       individualHooks: true,
     });
 


### PR DESCRIPTION
## Description of change
This PR fixes a recent bug where the back end was tracking which goals were actively being edited and which were not.
Essentially, a goal would still be marked as being edited even though the report was submitted, and the review section was not being populated. This fix makes two changes. 1) It prevents the goals being sorted by the "activelyEditedGoal" attribute on the frontend if the goal is not draft or needs action and 2) updates all activity report goals associated with a report on submission so that they are all set to isActivelyEdited: false, and so any weird states where a report is somehow submitted without closing the goal form are handled.

## How to test
I am unsure of how to reproduce the bug through the UI - it may be a result of reports created before this improvement was released and submitted afterwards. However, to see the bug in action on the main branch, create a report, submit it. Mark a different user as an approver. Update one of the associated activity report goals to "isActivelyEdited: true" and view the report as the approver. The goals and objectives section will be missing the goal that was marked isActivelyEdited. On this branch, you will see that goal.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1307


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
