### PR TITLE
[TTAHUB-1317] Only find matching objectives based on trim

### DIFF
--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -230,7 +230,7 @@ const determineObjectiveStatus = async (activityReportId, sequelize, isUnlocked)
       // Get latest report by end date.
       const latestAR = relevantARs.reduce((r, a) => {
         if (r && r.endDate) {
-          return r.endDate > a.endDate ? r : a;
+          return new Date(r.endDate) > new Date(a.endDate) ? r : a;
         }
         return a;
       }, {

--- a/src/models/tests/objectiveStatus.test.js
+++ b/src/models/tests/objectiveStatus.test.js
@@ -169,12 +169,12 @@ describe('Objective status update hook', () => {
       grantFour = await Grant.findOne({ where: { id: 476470 } });
 
       // Reports.
-      reportOne = await ActivityReport.create({ ...sampleReport, endDate: '2022-09-30T12:00:00Z' });
+      reportOne = await ActivityReport.create({ ...sampleReport, endDate: '2023-01-01T12:00:00Z' });
       reportTwo = await ActivityReport.create({
         ...sampleReport,
         submissionStatus: REPORT_STATUSES.SUBMITTED,
         calculatedStatus: REPORT_STATUSES.APPROVED,
-        endDate: '2022-09-29T12:00:00Z',
+        endDate: '2022-09-30T12:00:00Z',
       });
       reportThree = await ActivityReport.create({ ...sampleReport });
 

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -363,7 +363,7 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
 
     return [...objectives, {
       ...objective.dataValues,
-      title: objective.title.trim(),
+      title: objective.title,
       value: id,
       ids: [id],
       // Make sure we pass back a list of recipient ids for subsequent saves.
@@ -448,7 +448,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
 
     return [...objectives, {
       ...objective.dataValues,
-      title: objective.title.trim(),
+      title: objective.title,
       value: id,
       ids: [id],
       ttaProvided,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -344,7 +344,7 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
   // we pass in the existing objectives as the accumulator
   const objectivesToSort = newObjectives.reduce((objectives, objective) => {
     const exists = objectives.find((o) => (
-      o.title === objective.title.trim() && o.status === objective.status
+      o.title.trim() === objective.title.trim() && o.status === objective.status
     ));
 
     if (exists) {
@@ -393,7 +393,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
     // objectives represent the accumulator in the find below
     // objective is the objective as it is returned from the API
     const exists = objectives.find((o) => (
-      o.title === objective.title.trim() && o.status === objectiveStatus
+      o.title.trim() === objective.title.trim() && o.status === objectiveStatus
     ));
 
     if (exists) {

--- a/src/services/goals.test.js
+++ b/src/services/goals.test.js
@@ -1,0 +1,167 @@
+import faker from '@faker-js/faker';
+import db, {
+  Recipient,
+  Grant,
+  Goal,
+  Objective,
+} from '../models';
+import {
+  reduceObjectives,
+  reduceObjectivesForActivityReport,
+} from './goals';
+import { OBJECTIVE_STATUS } from '../constants';
+
+const objectivesToReduce = [
+  {
+    id: 1,
+    title: ' This has leading and trailing spaces. ',
+    status: OBJECTIVE_STATUS.IN_PROGRESS,
+  },
+  {
+    id: 2,
+    title: 'This has leading and trailing spaces. ',
+    status: OBJECTIVE_STATUS.IN_PROGRESS,
+  },
+  {
+    id: 3,
+    title: ' This has leading and trailing spaces.',
+    status: OBJECTIVE_STATUS.IN_PROGRESS,
+  },
+  {
+    id: 4,
+    title: 'This doesn\'t leading and trailing spaces.',
+    status: OBJECTIVE_STATUS.COMPLETE,
+  },
+];
+
+describe('Goals DB service', () => {
+  afterAll(async () => {
+    await db.sequelize.close();
+  });
+
+  describe('reduce objectives', () => {
+    let recipient;
+    let grant;
+    let goal;
+    let objectiveOne;
+    let objectiveTwo;
+    let objectiveThree;
+    let objectiveFour;
+
+    beforeAll(async () => {
+      // Recipient.
+      recipient = await Recipient.create({
+        id: faker.datatype.number(),
+        name: faker.name.firstName(),
+      });
+
+      // Grant.
+      grant = await Grant.create({
+        id: faker.datatype.number(),
+        number: faker.datatype.string(),
+        recipientId: recipient.id,
+        regionId: 1,
+      });
+
+      // Goal.
+      goal = await Goal.create({
+        name: 'Goal for Objectives with leading and trailing values',
+        status: 'Draft',
+        endDate: null,
+        isFromSmartsheetTtaPlan: false,
+        onApprovedAR: false,
+        grantId: grant.id,
+        createdVia: 'rtr',
+      });
+
+      // Objectives.
+      objectiveOne = await Objective.create({
+        ...objectivesToReduce[0],
+        goalId: goal.id,
+      });
+      objectiveTwo = await Objective.create({
+        ...objectivesToReduce[1],
+        goalId: goal.id,
+      });
+      objectiveThree = await Objective.create({
+        ...objectivesToReduce[2],
+        goalId: goal.id,
+      });
+      objectiveFour = await Objective.create({
+        ...objectivesToReduce[3],
+        goalId: goal.id,
+      });
+    });
+
+    afterAll(async () => {
+    // Objectives.
+      await Objective.destroy({
+        where: {
+          id: objectiveOne.id,
+        },
+      });
+      await Objective.destroy({
+        where: {
+          id: objectiveTwo.id,
+        },
+      });
+      await Objective.destroy({
+        where: {
+          id: objectiveThree.id,
+        },
+      });
+      await Objective.destroy({
+        where: {
+          id: objectiveFour.id,
+        },
+      });
+
+      // Goal.
+      await Goal.destroy({
+        where: {
+          id: goal.id,
+        },
+      });
+
+      // Grant.
+      await Grant.destroy({
+        where: {
+          id: grant.id,
+        },
+      });
+
+      // Recipient.
+      await Recipient.destroy({
+        where: {
+          id: recipient.id,
+        },
+      });
+    });
+
+    it('objective reduce returns the correct number of objectives with spaces', async () => {
+      const reducedObjectives = await reduceObjectives(
+        [objectiveOne,
+          objectiveTwo,
+          objectiveThree,
+          objectiveFour,
+        ],
+      );
+      expect(reducedObjectives.length).toBe(2);
+      expect(reducedObjectives[0].title.trim()).toBe('This has leading and trailing spaces.');
+      expect(reducedObjectives[1].title).toBe('This doesn\'t leading and trailing spaces.');
+    });
+
+    it('ar reduce returns the correct number of objectives with spaces', async () => {
+      const reducedObjectives = await reduceObjectivesForActivityReport(
+        [objectiveOne,
+          objectiveTwo,
+          objectiveThree,
+          objectiveFour,
+        ],
+      );
+      expect(reducedObjectives.length).toBe(2);
+      expect(reducedObjectives[0].title.trim()).toBe('This has leading and trailing spaces.');
+      expect(reducedObjectives[1].title).toBe('This doesn\'t leading and trailing spaces.');
+    });
+  });
+});

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -201,7 +201,7 @@ function reduceObjectivesForRecipientRecord(currentModel, goal, grantNumbers) {
       const { t, r, endDate } = (objective.activityReports || []).reduce((a, report) => ({
         t: [...a.t, ...report.topics],
         r: [...a.r, ...report.reason],
-        endDate: report.endDate > a.endDate ? report.endDate : a.endDate,
+        endDate: new Date(report.endDate) > new Date(a.endDate) ? report.endDate : a.endDate,
       }), { t: [], r: [], endDate: '' });
 
       // previous added objectives have a regularly accessible attribute, the others
@@ -251,7 +251,7 @@ function reduceObjectivesForRecipientRecord(currentModel, goal, grantNumbers) {
 
   return objectives.sort((a, b) => ((
     a.endDate === b.endDate ? a.id < b.id
-      : a.endDate < b.endDate) ? 1 : -1));
+      : new Date(a.endDate) < new Date(b.endDate)) ? 1 : -1));
 }
 
 function calculatePreviousStatus(goal) {

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -201,7 +201,7 @@ function reduceObjectivesForRecipientRecord(currentModel, goal, grantNumbers) {
       const { t, r, endDate } = (objective.activityReports || []).reduce((a, report) => ({
         t: [...a.t, ...report.topics],
         r: [...a.r, ...report.reason],
-        endDate: new Date(report.endDate) > new Date(a.endDate) ? report.endDate : a.endDate,
+        endDate: new Date(report.endDate) < new Date(a.endDate) ? a.endDate : report.endDate,
       }), { t: [], r: [], endDate: '' });
 
       // previous added objectives have a regularly accessible attribute, the others


### PR DESCRIPTION
## Description of change

This solves a bug that I introduced as part of the fix for [TTAHUB-1240](https://github.com/HHS/Head-Start-TTADP/pull/1204/files).

In attempt to prevent showing duplicate objectives with leading or trailing spaces we perform a trim on the returned objective title. We cannot do this as it flags the title as changed in the Sequelize instance. This causes a validation error to be thrown if the goal is on an approved report (user case).

For now we will see if a non-trailing version of the objective title exists. Else we will return the title as is with spaces.

## How to test

You can edit recipient 'Blueprints' for G-20778, G-12658 and attempt to change all statuses to complete and save.

OR

Create a goal with a few objectives on an approved report. Make sure one of the Objective titles has trailing spaces. You should still be able to edit the goal and make certain changes to the Objective and save without error.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1317


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
