### PR TITLE
[TTAHUB-1320] RTR only updates one Objective status on rolled up Goals

### DIFF
--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -798,14 +798,14 @@ describe('create goal', () => {
       endDate: '2021-10-08',
       goalNumbers: ['G-12389'],
       isRttapa: '',
-      grant: {
+      grants: [{
         id: 1,
         number: '1',
         programs: [{
           programType: 'EHS',
         }],
         status: 'Active',
-      },
+      }],
       objectives: [
         {
           id: 1238474,
@@ -836,14 +836,14 @@ describe('create goal', () => {
       endDate: '2021-10-08',
       goalNumbers: ['G-12389'],
       isRttapa: 'Yes',
-      grant: {
+      grants: [{
         id: 1,
         number: '1',
         programs: [{
           programType: 'EHS',
         }],
         status: 'Active',
-      },
+      }],
       objectives: [
         {
           id: 1238474,
@@ -874,14 +874,14 @@ describe('create goal', () => {
       endDate: '2021-10-08',
       goalNumbers: ['G-12389'],
       isRttapa: 'No',
-      grant: {
+      grants: [{
         id: 1,
         number: '1',
         programs: [{
           programType: 'EHS',
         }],
         status: 'Active',
-      },
+      }],
       objectives: [
         {
           id: 1238474,
@@ -922,14 +922,14 @@ describe('create goal', () => {
       endDate: '2021-10-08',
       goalNumbers: ['G-12389'],
       isRttapa: 'Yes',
-      grant: {
+      grants: [{
         id: 1,
         number: '1',
         programs: [{
           programType: 'EHS',
         }],
         status: 'Active',
-      },
+      }],
       objectives: [
         {
           id: 1238474,

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -146,7 +146,9 @@ export default function GoalForm({
         setDatePickerKey(goal.endDate ? `DPK-${goal.endDate}` : '00');
         setIsRttapa(goal.isRttapa);
         initialRttapa.current = goal.isRttapa;
-        setSelectedGrants(formatGrantsFromApi([goal.grant]));
+        // We must update with all grants from the DB here,
+        // otherwise we will not update all rolled up goals and objectives.
+        setSelectedGrants(formatGrantsFromApi(goal.grants));
         setGoalNumbers(goal.goalNumbers);
         setGoalOnApprovedReport(goal.onApprovedAR);
 


### PR DESCRIPTION
## Description of change

When updating a rolled up Goal from the RTR we only update the status of one of the Objectives.

The issue here was that when we edit the rolled up goal it would only set one of the Grants. This was causing the BE save to only update the Goal associated with one of the grants.

I have fixed the code to update with all Goal grants.

## How to test

To test the core of the issue edit: **http://localhost:3000/recipient-tta-records/706/region/1/goals?id[]=27525,27528**

Change the status for some of the goals and make sure these changes are reflected in the database for all Objectives (Obj Ids: 60752, 60758).

**Note:** You should also be able to test with any rolled up goal that from RTR.

We should also re-test creating and updating Goals and Objectives from AR and RTR (ie no duplication or errors).

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1320


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
