### PR TITLE
[TTAHUB-1289] Add "regional office request" as a goal closed reason

### DIFF
--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -259,6 +259,7 @@ export const GOAL_CLOSE_REASONS = [
   'Duplicate goal',
   'Recipient request',
   'TTA complete',
+  'Regional Office request',
 ];
 
 export const GOAL_SUSPEND_REASONS = [

--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -258,8 +258,8 @@ export const LOCAL_STORAGE_EDITABLE_KEY = (id) => `ar-can-edit-${id}-${LOCAL_STO
 export const GOAL_CLOSE_REASONS = [
   'Duplicate goal',
   'Recipient request',
-  'TTA complete',
   'Regional Office request',
+  'TTA complete',
 ];
 
 export const GOAL_SUSPEND_REASONS = [

--- a/frontend/src/components/__tests__/CloseSuspendReasonModal.js
+++ b/frontend/src/components/__tests__/CloseSuspendReasonModal.js
@@ -121,6 +121,7 @@ describe('Close Suspend Goal Reason', () => {
     expect(await screen.findByText(GOAL_CLOSE_REASONS[0])).toBeVisible();
     expect(await screen.findByText(GOAL_CLOSE_REASONS[1])).toBeVisible();
     expect(await screen.findByText(GOAL_CLOSE_REASONS[2])).toBeVisible();
+    expect(await screen.findByText(GOAL_CLOSE_REASONS[3])).toBeVisible(); // regional office request
 
     // Verify Context.
     expect(await screen.findByText('Additional context')).toBeVisible();


### PR DESCRIPTION
## Description of change
Add an additional reason to the modal that pops up when a goal is closed or suspended.

## How to test
Close a goal from the recipient record. Note that "Regional office request" now appears as a reason. Select it and note that the 1) the goal is closed and 2) the database shows the correct reason.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1289


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
