### PR TITLE
[TTAHUB-716] add playwright test for recipient search page

### DIFF
--- a/tests/recipient-search-page.spec.ts
+++ b/tests/recipient-search-page.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('recipient search page', async ({ page }) => {
+  await page.goto('http://localhost:3000/');
+
+  //navigate to recipient search page
+  await page.getByRole('link', { name: 'Recipient TTA Records' }).click();
+
+  // search for recipient
+  await page.getByLabel('Search recipient records by name or grant id').fill('agency 1');
+
+  // submit form
+  await page.getByRole('button', { name: 'Search for matching recipients' }).click();
+
+  // click on first result
+  await page.getByRole('link', { name: 'Agency 1.a in region 1, Inc.' }).click();
+
+  await Promise.all([
+      expect(page.getByRole('heading', { name: 'Agency 1.a in region 1, Inc. - Region 1' })).toBeVisible(),
+      expect(page.getByRole('heading', { name: 'Recipient summary' })).toBeVisible(),
+      expect(page.getByRole('heading', { name: 'Grants' })).toBeVisible(),
+  ]);
+});


### PR DESCRIPTION
## Description of change

Add a simple playwright test to validate the recipient search page

## How to test
CI passes. Review test and make sure it makes sense

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-716


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
