### PR TITLE
Update index job to run in batch

### DIFF
--- a/src/tools/createAwsElasticSearchIndexesCli.js
+++ b/src/tools/createAwsElasticSearchIndexesCli.js
@@ -12,10 +12,12 @@ rl.question('Are you sure you want to delete and recreate all search indexes? [y
     auditLogger.info('-- Aborted job --');
     process.exit();
   }
-  try {
-    await createAwsElasticSearchIndexes();
-    process.exit();
-  } catch (e) {
-    auditLogger.error(e);
-  }
+  rl.question('How many reports should we index at once (defaults to 100)?', async (batch) => {
+    try {
+      await createAwsElasticSearchIndexes(!batch || Number.isNaN(batch) ? 100 : batch);
+      process.exit();
+    } catch (e) {
+      auditLogger.error(e);
+    }
+  });
 });


### PR DESCRIPTION
## Description of change

The "bulk" index for OpenSearch seems to have a limit to how big a request can be. This change makes the job process each request in a batch of any size.

**Note:** I added a prompt that allows you to specify the number of reports to process in batch.

## How to test

- Review the code.
- Make sure the test passes.
- Run the script against a db.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
