### PR TITLE
Await each bulk before starting a new one

### DIFF
--- a/src/tools/createAwsElasticSearchIndexes.js
+++ b/src/tools/createAwsElasticSearchIndexes.js
@@ -136,22 +136,19 @@ export default async function createAwsElasticSearchIndexes(batchSize = 100) {
       : wholeIterations;
 
     // Bulk import.
-    const toBulkImport = [];
-
     for (let i = 1; i <= iterations; i += 1) {
       // If we are on the last loop iteration get from 0-remaining.
       const addToProcess = documents.splice(0, i === iterations ? documents.length : batchSize * 2);
       totalCount += addToProcess.length;
       // Add to bulk import batch.
-      toBulkImport.push(bulkIndex(
+      // eslint-disable-next-line no-await-in-loop
+      await bulkIndex(
         addToProcess,
         AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
         client,
-      ));
+      );
       logger.info(`- Bulk Group #${i}: Importing ${addToProcess.length} reports`);
     }
-    // Wait to Resolve all promises.
-    await Promise.all(toBulkImport);
 
     logger.info(`Search Index Job Info: ...Bulk import completed for ${totalCount / 2} reports in ${iterations} iterations of ${batchSize} each`);
     const finishBulkImport = moment();


### PR DESCRIPTION
## Description of change

It seems that the issue we are having might have to do with overloading the ES queue.

This attempts to fix it by awaiting each batch call in the loop.


```
Write rejections

A 429 error message as a write rejection indicates a bulk queue error. The es_rejected_execution_exception[bulk] indicates that your queue is full and that any new requests are rejected. This bulk queue error occurs when the number of requests to the cluster exceeds the bulk queue size (threadpool.bulk.queue_size). A bulk queue on each node can hold between 50 and 200 requests, depending on which Elasticsearch version you are using.
```

https://aws.amazon.com/premiumsupport/knowledge-center/opensearch-resolve-429-error/


## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
