### PR TITLE
Remove search endpoint (for now)

### DIFF
--- a/src/routes/search/index.js
+++ b/src/routes/search/index.js
@@ -1,9 +1,11 @@
 import express from 'express';
+/*
 import {
   searchIndex,
 } from './handlers';
 import transactionWrapper from '../transactionWrapper';
-
+*/
+// TODO: If we expose this route we need to add authorization logic.
 const router = express.Router();
-router.get('/', transactionWrapper(searchIndex));
+// router.get('/', transactionWrapper(searchIndex));
 export default router;


### PR DESCRIPTION
## Description of change

Because we are going to be populating Elasticsearch data shortly we need to remove this unused endpoint for now.

## How to test

Make sure this endpoint is NOT accessible: 

http://localhost:3000/api/search?index=activityreports&fields=context&fields=specialistNextSteps&query=zero

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
