### PR TITLE
[TTAHUB-1368] RTR showing incorrect grant number and status on objective

### DIFF
--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -224,12 +224,20 @@ function reduceObjectivesForRecipientRecord(currentModel, goal, grantNumbers) {
         return { ...acc, topics: [...acc.topics, ...objectiveTopics] };
       }
 
+      // Look up grant number by index.
+      let grantNumberToUse = currentModel.grant.number;
+      const indexOfGoal = goal.ids.indexOf(objective.goalId);
+      if (indexOfGoal !== -1 && goal.grantNumbers[indexOfGoal]) {
+        grantNumberToUse = goal.grantNumbers[indexOfGoal];
+      }
+
       return {
         objectives: [...acc.objectives, {
           ...objective.dataValues,
           title: objective.title.trim(),
           endDate,
-          grantNumbers: [currentModel.grant.number],
+          status: objectiveStatus,
+          grantNumbers: [grantNumberToUse],
           reasons: uniq(r),
           activityReports: objective.activityReports || [],
         }],


### PR DESCRIPTION
## Description of change

Creating a goal with two grants would show incorrect grant number and status on the RTR.

## How to test

1.     Create a common goal for a recipient with 2 grants
2.     Create a draft report for the first grant and use the common goal
3.     Create a second draft report for the second grant and use the common goal
4.     Note that on the RTR page, one of the objectives for the recipient show an incorrect grant numbert and status (screeshot)
5.     Complete and approve the first AR
6.     On the RTR page the goals are separated and the grant numbers and statuses are correct
7.     Complete and approve the second AR
8.     Note that the goals are now combined and display an incorrect grant numbert and status (screeshot)


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1368


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
