### PR TITLE
[TTAHUB-1391] Use `faPenCircle` instead of `faPencilAlt` as the draft icon

### DIFF
--- a/frontend/src/components/GoalCards/icons.js
+++ b/frontend/src/components/GoalCards/icons.js
@@ -7,7 +7,7 @@ import {
   faMinusCircle,
   faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons';
-import { faPenCircle } from '@fortawesome/pro-regular-svg-icons';
+import { faPenCircle } from '@fortawesome/pro-solid-svg-icons';
 import colors from '../../colors';
 
 const InProgress = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.ttahubMediumBlue} icon={faClock} />;

--- a/frontend/src/components/GoalCards/icons.js
+++ b/frontend/src/components/GoalCards/icons.js
@@ -4,17 +4,17 @@ import {
   faClock,
   faCheckCircle,
   faExclamationCircle,
-  faPencilAlt,
   faMinusCircle,
   faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons';
+import { faPenCircle } from '@fortawesome/pro-regular-svg-icons';
 import colors from '../../colors';
 
 const InProgress = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.ttahubMediumBlue} icon={faClock} />;
 const Closed = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.successDarker} icon={faCheckCircle} />;
 const NotStarted = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.ttahubOrange} icon={faMinusCircle} />;
 const NoStatus = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.baseLighter} icon={faExclamationCircle} />;
-const Draft = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.baseDarkest} icon={faPencilAlt} />;
+const Draft = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.baseDarkest} icon={faPenCircle} />;
 const Ceased = () => <FontAwesomeIcon className="margin-right-1 flex-align-self-center" size="1x" color={colors.errorDark} icon={faTimesCircle} />;
 
 export {


### PR DESCRIPTION
## Description of change

The title says it all.

Began here: https://adhoc.slack.com/archives/C0492R8BN4Q/p1674590379426339

before

![image](https://user-images.githubusercontent.com/17074357/214427583-1eb2b9c1-7c57-4aa5-bc75-f12eff21aa15.png)

after

![image](https://user-images.githubusercontent.com/17074357/214427608-d227a44a-26f1-49a5-ab6d-2a03b00a7e95.png)


## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1391


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
