### PR TITLE
[TTAHUB-1327] Add unique ids to buttons across the applications for analytics

### DIFF
--- a/frontend/src/components/ActivityReportsTable/__tests__/index.js
+++ b/frontend/src/components/ActivityReportsTable/__tests__/index.js
@@ -44,6 +44,7 @@ const renderTable = (user, dateTime) => {
             onUpdateFilters={() => { }}
             tableCaption="Activity Reports"
             dateTime={dateTime}
+            exportIdPrefix="activity-reports-"
           />
         </UserContext.Provider>
       </AriaLiveContext.Provider>

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -17,6 +17,7 @@ import './index.css';
 function ActivityReportsTable({
   filters,
   tableCaption,
+  exportIdPrefix,
 }) {
   const [reports, setReports] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -249,6 +250,7 @@ function ActivityReportsTable({
           isDownloading={isDownloading}
           downloadAllButtonRef={downloadAllButtonRef}
           downloadSelectedButtonRef={downloadSelectedButtonRef}
+          exportIdPrefix={exportIdPrefix}
         />
         <div className="usa-table-container--scrollable">
           <Table fullWidth striped>
@@ -300,6 +302,7 @@ function ActivityReportsTable({
 }
 
 ActivityReportsTable.propTypes = {
+  exportIdPrefix: PropTypes.string.isRequired,
   filters: PropTypes.arrayOf(
     PropTypes.shape({
       condition: PropTypes.string,

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -208,7 +208,7 @@ function ActivityReportsTable({
           onClick={() => {
             requestSort(name);
           }}
-          onKeyPress={() => requestSort(name)}
+          onKeyDown={() => requestSort(name)}
           className={`sortable ${sortClassName}`}
           aria-label={`${displayName}. Activate to sort ${sortClassName === 'asc' ? 'descending' : 'ascending'
           }`}

--- a/frontend/src/components/MediaCaptureButton.js
+++ b/frontend/src/components/MediaCaptureButton.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import html2canvas from 'html2canvas';
 import { Button } from '@trussworks/react-uswds';
 
-export default function ElementCaptureButton({ reference, className, buttonText }) {
+export default function ElementCaptureButton({
+  reference, className, buttonText, id,
+}) {
   const capture = async () => {
     try {
       // capture the element, setting the width and height
@@ -36,6 +38,7 @@ export default function ElementCaptureButton({ reference, className, buttonText 
       onClick={capture}
       data-html2canvas-ignore
       className={className}
+      id={id}
     >
       {buttonText}
     </Button>
@@ -46,6 +49,7 @@ ElementCaptureButton.propTypes = {
   reference: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
   className: PropTypes.string,
   buttonText: PropTypes.string,
+  id: PropTypes.string.isRequired,
 };
 
 ElementCaptureButton.defaultProps = {

--- a/frontend/src/components/Navigator/index.js
+++ b/frontend/src/components/Navigator/index.js
@@ -681,20 +681,20 @@ const Navigator = ({
                         {showSaveGoalsAndObjButton
                           ? (
                             <>
-                              <Button className="margin-right-1" type="button" disabled={isAppLoading || weAreAutoSaving} onClick={onGoalFormNavigate}>{`Save ${isOtherEntityReport ? 'objectives' : 'goal'}`}</Button>
-                              <Button className="usa-button--outline" type="button" disabled={isAppLoading || weAreAutoSaving} onClick={isOtherEntityReport ? () => onSaveDraftOetObjectives(false) : () => onSaveDraftGoal(false)}>Save draft</Button>
+                              <Button id={`draft-${page.path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading || weAreAutoSaving} onClick={onGoalFormNavigate}>{`Save ${isOtherEntityReport ? 'objectives' : 'goal'}`}</Button>
+                              <Button id={`draft-${page.path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading || weAreAutoSaving} onClick={isOtherEntityReport ? () => onSaveDraftOetObjectives(false) : () => onSaveDraftGoal(false)}>Save draft</Button>
                             </>
                           ) : (
                             <>
-                              <Button className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>
-                              <Button className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save draft</Button>
+                              <Button id={`draft-${page.path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>
+                              <Button id={`draft-${page.path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save draft</Button>
                             </>
                           )}
 
                         {
                           page.position <= 1
                             ? null
-                            : <Button outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(page.position - 1); }}>Back</Button>
+                            : <Button id={`draft-${page.path}-back`} outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(page.position - 1); }}>Back</Button>
                         }
                       </div>
                     </Form>

--- a/frontend/src/components/PrintToPDF.js
+++ b/frontend/src/components/PrintToPDF.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function PrintToPdf({ disabled, className }) {
+export default function PrintToPdf({ disabled, className, id }) {
   const classes = `usa-button no-print ${className}`;
-  return <button type="button" className={classes} disabled={disabled} onClick={() => window.print()}>Print to PDF</button>;
+  return <button type="button" id={id} className={classes} disabled={disabled} onClick={() => window.print()}>Print to PDF</button>;
 }
 
 PrintToPdf.propTypes = {
   disabled: PropTypes.bool,
   className: PropTypes.string,
+  id: PropTypes.string.isRequired,
 };
 
 PrintToPdf.defaultProps = {

--- a/frontend/src/components/TableHeader.js
+++ b/frontend/src/components/TableHeader.js
@@ -39,6 +39,7 @@ export default function TableHeader({
   downloadAllButtonRef,
   downloadSelectedButtonRef,
   paginationName,
+  exportIdPrefix,
 }) {
   return (
     <div className="desktop:display-flex">
@@ -80,6 +81,7 @@ export default function TableHeader({
               isDownloading={isDownloading}
               downloadAllButtonRef={downloadAllButtonRef}
               downloadSelectedButtonRef={downloadSelectedButtonRef}
+              exportIdPrefix={exportIdPrefix}
             />
           )}
         </span>
@@ -120,6 +122,7 @@ export default function TableHeader({
 }
 
 TableHeader.propTypes = {
+  exportIdPrefix: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   numberOfSelected: PropTypes.number,
   toggleSelectAll: PropTypes.func,

--- a/frontend/src/components/__tests__/MediaCaptureButton.js
+++ b/frontend/src/components/__tests__/MediaCaptureButton.js
@@ -8,7 +8,7 @@ describe('MediaCaptureButton', () => {
   const RenderCaptureButton = () => {
     const widget = useRef();
     return (
-      <div ref={widget}><MediaCaptureButton reference={widget} /></div>
+      <div ref={widget}><MediaCaptureButton id="mediaCaptureTest" reference={widget} /></div>
     );
   };
   it('renders', () => {

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
@@ -136,7 +136,7 @@ const Draft = ({
         <div className="margin-top-3">
           <ApproverStatusList approverStatus={approverStatusList} />
         </div>
-        <Button disabled={!connectionActive} type="submit">Submit for approval</Button>
+        <Button disabled={!connectionActive} id="draft-review-submit" type="submit">Submit for approval</Button>
         { !connectionActive && (
         <Alert type="warning" noIcon>
           There&#39;s an issue with your connection.
@@ -151,6 +151,7 @@ const Draft = ({
         </Alert>
         )}
         <Button
+          id="draft-review-save-draft"
           outline
           type="button"
           onClick={async () => {

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -223,7 +223,7 @@ export default function ApprovedActivityReport({ match, user }) {
         : null}
       <Grid row>
         {navigator && navigator.clipboard
-          ? <button id="approved-URL" type="button" className="usa-button no-print" disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false} onClick={handleCopyUrl}>Copy URL Link</button>
+          ? <button id="approved-url" type="button" className="usa-button no-print" disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false} onClick={handleCopyUrl}>Copy URL Link</button>
           : null}
         <PrintToPdf
           id="approved-print"

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -223,9 +223,10 @@ export default function ApprovedActivityReport({ match, user }) {
         : null}
       <Grid row>
         {navigator && navigator.clipboard
-          ? <button type="button" className="usa-button no-print" disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false} onClick={handleCopyUrl}>Copy URL Link</button>
+          ? <button id="approved-URL" type="button" className="usa-button no-print" disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false} onClick={handleCopyUrl}>Copy URL Link</button>
           : null}
         <PrintToPdf
+          id="approved-print"
           disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false}
         />
         {user && user.permissions && canUnlockReports(user)

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -280,6 +280,7 @@ function MyAlerts(props) {
             setDownloadError={setDownloadAlertsError}
             downloadAllButtonRef={downloadAllAlertsButtonRef}
             downloadSelectedButtonRef={downloadSelectedAlertsButtonRef}
+            exportIdPrefix="my-alerts-"
           />
           <div className="usa-table-container--scrollable">
             <Table fullWidth striped>

--- a/frontend/src/pages/Landing/ReportMenu.js
+++ b/frontend/src/pages/Landing/ReportMenu.js
@@ -21,6 +21,7 @@ function ReportMenu({
   isDownloading,
   downloadAllButtonRef,
   downloadSelectedButtonRef,
+  exportIdPrefix,
 }) {
   const [open, updateOpen] = useState(false);
 
@@ -63,6 +64,7 @@ function ReportMenu({
         className={`usa-button usa-button--outline font-sans-xs margin-left-1 ${openClass}`}
         aria-label={label}
         onClick={() => updateOpen((current) => !current)}
+        id={`${exportIdPrefix}export-button`}
       >
         Export reports
         {' '}
@@ -147,6 +149,7 @@ function ReportMenu({
                     type="button"
                     disabled={downloadError || isDownloading}
                     className="usa-button usa-button--unstyled display-block smart-hub--reports-button smart-hub--button__no-margin"
+                    id={`${exportIdPrefix}export-table`}
                   >
                     Export table data
                   </button>
@@ -161,6 +164,7 @@ function ReportMenu({
                 type="button"
                 disabled={isDownloading}
                 className="usa-button usa-button--unstyled display-block smart-hub--reports-button smart-hub--button__no-margin margin-top-2"
+                id={`${exportIdPrefix}export-reports`}
               >
                 Export selected reports
               </button>
@@ -189,6 +193,7 @@ ReportMenu.propTypes = {
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   ]),
   setDownloadError: PropTypes.func.isRequired,
+  exportIdPrefix: PropTypes.string.isRequired,
 };
 
 ReportMenu.defaultProps = {

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -329,6 +329,7 @@ function Landing() {
             filters={filtersToApply}
             showFilter={false}
             tableCaption="Approved activity reports"
+            exportIdPrefix="ar-"
           />
         </FilterContext.Provider>
       </>

--- a/frontend/src/pages/RecipientRecord/pages/PrintGoals.js
+++ b/frontend/src/pages/RecipientRecord/pages/PrintGoals.js
@@ -67,7 +67,7 @@ export default function PrintGoals({ location, recipientId, regionId }) {
 
   return (
     <div className="margin-top-2 margin-left-2 ttahub-print-goals">
-      <PrintToPdf />
+      <PrintToPdf id="print-goals" />
       <div className="bg-white radius-md shadow-2 margin-right-2">
         {goals.map((goal) => <PrintableGoal key={`printable-goal-${goal.id}`} goal={goal} />)}
       </div>

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -115,7 +115,7 @@ export default function TTAHistory({
             filters={filtersToApply}
             showFilter={false}
             tableCaption="Approved activity reports"
-            exportIdPrefix="ttahistory-"
+            exportIdPrefix="tta-history-"
           />
         </FilterContext.Provider>
       </div>

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -115,6 +115,7 @@ export default function TTAHistory({
             filters={filtersToApply}
             showFilter={false}
             tableCaption="Approved activity reports"
+            exportIdPrefix="ttahistory-"
           />
         </FilterContext.Provider>
       </div>

--- a/frontend/src/pages/RecipientSearch/components/RecipientResults.js
+++ b/frontend/src/pages/RecipientSearch/components/RecipientResults.js
@@ -77,6 +77,7 @@ export default function RecipientResults(
         offset={offset}
         perPage={perPage}
         handlePageChange={handlePageChange}
+        exportIdPrefix="recipient-search"
       />
       <table aria-live="polite" className="usa-table usa-table--borderless usa-table--striped width-full maxw-full margin-top-0">
         <caption className="usa-sr-only">

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -170,6 +170,7 @@ export default function RegionalDashboard() {
                 filters={filtersToApply}
                 showFilter={false}
                 tableCaption="Activity reports"
+                exportIdPrefix="rd-"
               />
             </FilterContext.Provider>
           </Grid>

--- a/frontend/src/widgets/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/TopicFrequencyGraph.js
@@ -212,6 +212,7 @@ export function TopicFrequencyGraphWidget({
             aria-label={showAccessibleData ? 'display number of activity reports by topic data as graph' : 'display number of activity reports by topic data as table'}
             onClick={toggleType}
             data-html2canvas-ignore
+            id="rd-display-table-topic-frequency"
           >
             {showAccessibleData ? 'Display graph' : 'Display table'}
           </button>

--- a/frontend/src/widgets/TotalHrsAndRecipientGraph.js
+++ b/frontend/src/widgets/TotalHrsAndRecipientGraph.js
@@ -229,13 +229,14 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
         <Grid row className="position-relative margin-bottom-2">
           <Grid desktop={{ col: 'auto' }} mobileLg={{ col: 8 }}><h2 className="ttahub--dashboard-widget-heading margin-0">Total TTA hours</h2></Grid>
           <Grid desktop={{ col: 'auto' }} className="ttahub--show-accessible-data-button desktop:margin-y-0 mobile-lg:margin-y-1">
-            { !showAccessibleData && <MediaCaptureButton className="margin-x-2" reference={widget} buttonText="Save screenshot" /> }
+            { !showAccessibleData && <MediaCaptureButton id="rd-save-screenshot" className="margin-x-2" reference={widget} buttonText="Save screenshot" /> }
             <button
               type="button"
               className="usa-button--unstyled"
               aria-label={showAccessibleData ? 'display total training and technical assistance hours as graph' : 'display total training and technical assistance hours as table'}
               onClick={toggleType}
               data-html2canvas-ignore
+              id="rd-display-table-tta-total-hours"
             >
               {showAccessibleData ? 'Display graph' : 'Display table'}
             </button>


### PR DESCRIPTION
## Description of change
Following the request in the Jira, unique ids were added to assorted buttons on assorted pages. This is for the easy attachment of handlers in Google Tag Manager.

## How to test
Compare the rendered DOM with the list in the Jira ticket. Note the comments where I've explained changes I made to the original request

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1327


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
