### PR TITLE
[TTAHUB-1153] Change goal resource link label and tool tip text

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -135,6 +135,7 @@ export default function ObjectiveForm({
         goalStatus={goalStatus}
         isLoading={isAppLoading}
         userCanEdit={userCanEdit}
+        toolTipText="Copy & paste web address of TTA resource you'll use for this objective. Usually an ECLKC page."
       />
       { title && (
       <ObjectiveFiles

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -24,6 +24,7 @@ export default function ResourceRepeater({
   goalStatus,
   userCanEdit,
   editingFromActivityReport,
+  toolTipText,
 }) {
   const readOnly = !editingFromActivityReport
   && ((goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit);
@@ -82,7 +83,7 @@ export default function ResourceRepeater({
     <>
       { fixedResources.length ? (
         <>
-          <p className="usa-prose text-bold margin-bottom-0">Link to TTA resource used</p>
+          <p className="usa-prose text-bold margin-bottom-0">Link to TTA resource</p>
           <ul className="usa-list usa-list--unstyled">
             {fixedResources.map((resource) => (
               <li key={resource.key}><a href={resource.value}>{resource.value}</a></li>
@@ -95,9 +96,9 @@ export default function ResourceRepeater({
         <FormGroup error={error.props.children}>
           <div>
             <Label htmlFor="resources" className={fixedResources.length ? 'text-bold' : ''}>
-              {!fixedResources.length ? 'Link to TTA resource used' : 'Add resource link'}
+              {!fixedResources.length ? 'Link to TTA resource' : 'Add resource link'}
               <QuestionTooltip
-                text="Copy and paste addresses of web pages describing resources used for this objective. Usually this is an ECLKC page."
+                text={toolTipText}
               />
             </Label>
             <span className="usa-hint">
@@ -159,9 +160,11 @@ ResourceRepeater.propTypes = {
   goalStatus: PropTypes.string.isRequired,
   userCanEdit: PropTypes.bool.isRequired,
   editingFromActivityReport: PropTypes.bool,
+  toolTipText: PropTypes.string,
 };
 
 ResourceRepeater.defaultProps = {
   isLoading: false,
   editingFromActivityReport: false,
+  toolTipText: 'Copy & paste web address of TTA resource used for this objective. Usually an ECLKC page.',
 };

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -138,7 +138,7 @@ describe('ObjectiveForm', () => {
       setObjective,
     );
 
-    const label = await screen.findByText('Link to TTA resource used');
+    const label = await screen.findByText('Link to TTA resource');
     expect(label).toBeVisible();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -28,6 +28,33 @@ describe('ResourceRepeater', () => {
     const resources2 = await screen.findByText('http://www.resources2.com');
     expect(resources2).toBeVisible();
     expect(resources2.tagName).toBe('A');
+    expect(screen.queryAllByText('Copy & paste web address of TTA resource used for this objective. Usually an ECLKC page.').length).toBe(2);
+  });
+
+  it('render with alternate tool tip', async () => {
+    render(<ResourceRepeater
+      error={<></>}
+      resources={[
+        { key: 1, value: 'http://www.resources.com', onAnyReport: false },
+        { key: 1, value: 'http://www.resources2.com', onAnyReport: true },
+      ]}
+      setResources={jest.fn()}
+      validateResources={jest.fn()}
+      status="In Progress"
+      isOnReport={false}
+      isLoading={false}
+      goalStatus="In Progress"
+      userCanEdit
+      toolTipText="Copy & paste web address of TTA resource you'll use for this objective. Usually an ECLKC page."
+    />);
+
+    expect(await screen.findByText('Link to TTA resource')).toBeVisible();
+    const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
+    expect(resources1).not.toBeNull();
+    const resources2 = await screen.findByText('http://www.resources2.com');
+    expect(resources2).toBeVisible();
+    expect(resources2.tagName).toBe('A');
+    expect(screen.queryAllByText("Copy & paste web address of TTA resource you'll use for this objective. Usually an ECLKC page.").length).toBe(2);
   });
 
   it('shows the read only view for used resources', async () => {

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -22,7 +22,7 @@ describe('ResourceRepeater', () => {
       userCanEdit
     />);
 
-    expect(await screen.findByText('Link to TTA resource used')).toBeVisible();
+    expect(await screen.findByText('Link to TTA resource')).toBeVisible();
     const resources1 = document.querySelector('input[value=\'http://www.resources.com\']');
     expect(resources1).not.toBeNull();
     const resources2 = await screen.findByText('http://www.resources2.com');


### PR DESCRIPTION
## Description of change

Update to goal resource link labels and tool tip text for AR vs RTR.

## How to test

It should be "Link to TTA resource"

The tooltip should be corrected to: "Copy & paste web address of TTA resource used for this objective. Usually an ECLKC page."

For RTR tooltip: "Copy & paste web address of TTA resource you'll use for this objective. Usually an ECLKC page."

Currently reads: "Copy and paste web addresses of TTA resource describing used for this objective. Usually this is an ECLKC page.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1153


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
