### PR TITLE
[TTAHUB-1393] wonky chart lines

### DIFF
--- a/frontend/src/widgets/TotalHrsAndRecipientGraph.js
+++ b/frontend/src/widgets/TotalHrsAndRecipientGraph.js
@@ -149,7 +149,7 @@ export function TotalHrsAndRecipientGraph({ data, loading }) {
         ticks: 'outside',
         tick0: 0,
         dtick: xTickStep,
-        ticklen: 14,
+        ticklen: 5,
         tickwidth: 1,
         tickcolor: '#000',
         title: {

--- a/src/widgets/totalHrsAndRecipientGraph.js
+++ b/src/widgets/totalHrsAndRecipientGraph.js
@@ -116,7 +116,7 @@ export default async function totalHrsAndRecipientGraph(scopes, query) {
       // Get X Axis value to use.
       let xValue;
       if (useDays) {
-        xValue = moment(r.startDate).format('MMM-DD-YY');
+        xValue = moment(r.startDate).format('MMM-DD');
       } else if (multipleYrs) {
         xValue = moment(r.startDate).format('MMM-YY');
       } else {

--- a/src/widgets/totalHrsAndRecipientGraph.js
+++ b/src/widgets/totalHrsAndRecipientGraph.js
@@ -116,7 +116,7 @@ export default async function totalHrsAndRecipientGraph(scopes, query) {
       // Get X Axis value to use.
       let xValue;
       if (useDays) {
-        xValue = moment(r.startDate).format('D');
+        xValue = moment(r.startDate).format('MMM-DD-YY');
       } else if (multipleYrs) {
         xValue = moment(r.startDate).format('MMM-YY');
       } else {

--- a/src/widgets/totalHrsAndRecipientGraph.test.js
+++ b/src/widgets/totalHrsAndRecipientGraph.test.js
@@ -214,16 +214,16 @@ describe('Total Hrs and Recipient Graph widget', () => {
     expect(data.length).toEqual(3);
 
     // Hours of Training.
-    expect(data[0].x).toEqual(['10', '15', '20']);
+    expect(data[0].x).toEqual(['Jun-10', 'Jun-15', 'Jun-20']);
     expect(data[0].y).toStrictEqual([1, 0, 0]);
     expect(data[0].month).toStrictEqual(['Jun', 'Jun', 'Jun']);
 
     // Hours of Technical Assistance.
-    expect(data[1].x).toEqual(['10', '15', '20']);
+    expect(data[1].x).toEqual(['Jun-10', 'Jun-15', 'Jun-20']);
     expect(data[1].y).toStrictEqual([0, 2, 4]);
 
     // Both.
-    expect(data[2].x).toEqual(['10', '15', '20']);
+    expect(data[2].x).toEqual(['Jun-10', 'Jun-15', 'Jun-20']);
     expect(data[2].y).toStrictEqual([0, 0, 3.3]);
   });
 


### PR DESCRIPTION
## Description of change

before:

<img width="613" alt="Screen Shot 2023-02-01 at 11 59 22 AM" src="https://user-images.githubusercontent.com/17074357/216137783-d399eff7-eb07-46b4-81ff-860d0a49e444.png">

after (same date range, same data set):

<img width="612" alt="Screen Shot 2023-02-01 at 1 16 51 PM" src="https://user-images.githubusercontent.com/17074357/216153853-b606b03d-2983-4e2e-95a0-a2c5098a5774.png">


when you have a date range of about a 30 days, covering the end of the month and the beginning of another, you end up with an x-axis of day numbers that might look like: `[26, 27, 28, 29, 30, 1, 2, 3, 4, ...]`

when plotly renders this, it will draw that sixth number in position 1, the next in position 2, etc. that's why we're seeing that weird line reversal.

this PR just makes sure the x-axis values can be parsed in the correct order by using a date in MMM-DD format.

## How to test

change the date range, ensuring:

- the range in total is less than 31 days
- the range overlaps the end of one month and the beginning of another
- make sure there's no wonky lines

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1393


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
