### PR TITLE
prevent long insertions into the mailer log

### DIFF
--- a/src/services/mailerLog.js
+++ b/src/services/mailerLog.js
@@ -23,18 +23,18 @@ export async function createMailerLog({
   success,
   result,
 }) {
-  let logRresult = null;
+  let logResult = null;
   try {
     const mailerLogEntry = {
-      jobId, emailTo, action, subject, activityReports, success, result,
+      jobId, emailTo, action, subject: subject.slice(0, 255), activityReports, success, result,
     };
 
-    logRresult = await sequelize.transaction(async (t) => {
+    logResult = await sequelize.transaction(async (t) => {
       const mailerLog = await models.MailerLogs.create(mailerLogEntry, { transaction: t });
       return mailerLog;
     });
   } catch (err) {
     auditLogger.error(`Error creating a MailerLog entry for job id: ${jobId} error ${err}`);
   }
-  return logRresult;
+  return logResult;
 }

--- a/src/services/mailerLog.test.js
+++ b/src/services/mailerLog.test.js
@@ -1,3 +1,4 @@
+import faker from '@faker-js/faker';
 import { EMAIL_ACTIONS } from '../constants';
 import db, {
   MailerLogs,
@@ -20,7 +21,7 @@ describe('MailerLog DB service', () => {
   });
 
   describe('createMailerLog', () => {
-    it('creates mailer log entry', async () => {
+    it('creates a mailer log entry', async () => {
       const mailerLog = await createMailerLog({
         jobId,
         emailTo,
@@ -39,6 +40,36 @@ describe('MailerLog DB service', () => {
       expect(retrievedMailerLog.id).toEqual(String(mailerLog.id));
       expect(retrievedMailerLog.action).toEqual(action);
       expect(retrievedMailerLog.subject).toEqual(subject);
+      expect(retrievedMailerLog.activityReports).toEqual(activityReports);
+      expect(retrievedMailerLog.success).toEqual(success);
+      expect(retrievedMailerLog.result).toEqual(result);
+      expect(retrievedMailerLog.createdAt).toBeDefined();
+      expect(retrievedMailerLog.updatedAt).toBeDefined();
+      await MailerLogs.destroy({ where: { id: mailerLog.id } });
+    });
+
+    it('abbreviates a long subject', async () => {
+      const longSentence = faker.lorem.sentence(300);
+
+      const mailerLog = await createMailerLog({
+        jobId,
+        emailTo,
+        action,
+        subject: longSentence,
+        activityReports,
+        success,
+        result,
+      });
+      const retrievedMailerLog = await MailerLogs.findOne({
+        where: {
+          id: mailerLog.id,
+        },
+      });
+      expect(retrievedMailerLog).toBeDefined();
+      expect(retrievedMailerLog.id).toEqual(String(mailerLog.id));
+      expect(retrievedMailerLog.action).toEqual(action);
+      expect(retrievedMailerLog.subject.length).toBe(255);
+      expect(retrievedMailerLog.subject.length).toBeLessThan(longSentence.length);
       expect(retrievedMailerLog.activityReports).toEqual(activityReports);
       expect(retrievedMailerLog.success).toEqual(success);
       expect(retrievedMailerLog.result).toEqual(result);


### PR DESCRIPTION
## Description of change
This fixes an error where a email subjects longer than 255 characters were trying to be inserted into a varchar255 column in the mailer logs table.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
