### PR TITLE
Fix typo in .production.sequelizerc

### DIFF
--- a/.production.sequelizerc
+++ b/.production.sequelizerc
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  'config': path.resolve('build', 'server', config', 'config.js'),
+  'config': path.resolve('build', 'server', 'config', 'config.js'),
   'models-path': path.resolve('build', 'server', 'src', 'models'),
   'seeders-path': path.resolve('build', 'server', 'src', 'seeders'),
   'migrations-path': path.resolve('build', 'server', 'src', 'migrations')


### PR DESCRIPTION
## Description of change
We were missing a quotation in a config file that was preventing the migrations from running.

## How to test
CI passes, migrations run

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
