### PR TITLE
Increase db container's shared memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "5432:5432"
     volumes:
       - dbdata:/var/lib/postgresql/data
+    shm_size: 1g
   minio:
     image: minio/minio:RELEASE.2021-01-16T02-19-44Z
     env_file: .env


### PR DESCRIPTION
## Description of change

my migrations were failing because the docker container runs out of shared memory (by default 64mb), so this PR just increases shared memory for this container to 1gb

before:

<img width="1060" alt="Screen Shot 2023-02-03 at 2 57 50 PM" src="https://user-images.githubusercontent.com/17074357/216719127-f73ee1d1-e08e-440a-88af-58aaa0d2fa8c.png">

after:

<img width="510" alt="Screen Shot 2023-02-03 at 3 00 48 PM" src="https://user-images.githubusercontent.com/17074357/216719178-9b67ba52-93d1-4c2a-b4af-140e14e534da.png">


## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
