### PR TITLE
[Ttahub-1186] single auditlog db interaction per request

### DIFF
--- a/src/routes/transactionWrapper.js
+++ b/src/routes/transactionWrapper.js
@@ -1,4 +1,5 @@
 import { sequelize } from '../models';
+import { addAuditTransactionSettings, removeFromAuditedTransactions } from '../models/auditModelGenerator';
 import handleErrors from '../lib/apiErrorHandler';
 
 const namespace = 'SERVICE:WRAPPER';
@@ -14,7 +15,9 @@ export default function transactionWrapper(originalFunction) {
       return sequelize.transaction(async () => {
         let result;
         try {
+          await addAuditTransactionSettings(sequelize, null, null, 'transaction', originalFunction.name);
           result = await originalFunction(req, res, next);
+          removeFromAuditedTransactions();
         } catch (err) {
           error = err;
           throw err;


### PR DESCRIPTION
## Description of change
in order to minimize db interaction move the setting of audit log variables to the transaction wrapper.


## How to test
preform any modifying action via the web site. notice that only a single instance of setting the audit log is done per transaction.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1186


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
