### PR TITLE
Switch ES to phrase matching

### DIFF
--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -167,9 +167,18 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     let body = {
       size: batchSize,
       query: {
-        query_string: {
-          query: `*${query}*`,
-          fields,
+        bool: {
+          should: [
+            { match_phrase: { context: { slop: 0, query } } },
+            { match_phrase: { nonECLKCResources: { slop: 0, query } } },
+            { match_phrase: { ECLKCResources: { slop: 0, query } } },
+            { match_phrase: { recipientNextSteps: { slop: 0, query } } },
+            { match_phrase: { specialistNextSteps: { slop: 0, query } } },
+            { match_phrase: { activityReportGoals: { slop: 0, query } } },
+            { match_phrase: { activityReportObjectives: { slop: 0, query } } },
+            { match_phrase: { activityReportObjectivesTTA: { slop: 0, query } } },
+            { match_phrase: { activityReportObjectiveResources: { slop: 0, query } } },
+          ],
         },
       },
       sort: [

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -164,7 +164,7 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     let searchAfter;
 
     // Create query section.
-    // ReadMe: 
+    // ReadMe:
     // If we have more than one word (term) then use phrase matching
     // If we have only one word (term) use query string with wildcards.
     // Site Ref: https://opensearch.org/docs/latest/opensearch/query-dsl/full-text/

--- a/src/tools/createAwsElasticSearchIndexes.test.js
+++ b/src/tools/createAwsElasticSearchIndexes.test.js
@@ -94,7 +94,7 @@ describe('Create AWS Elastic Search Indexes', () => {
       // Approved Reports.
       reportOne = await ActivityReport.create({
         ...approvedReport,
-        context: 'Lets give some',
+        context: 'Some houses had lead water in the pipes.',
         userId: user.id,
         nonECLKCResourcesUsed: ['https://www.youtube.com'],
         ECLKCResourcesUsed: ['https://www.smartsheet.com'],
@@ -102,14 +102,14 @@ describe('Create AWS Elastic Search Indexes', () => {
       reportTwo = await ActivityReport.create(
         {
           ...approvedReport,
-          context: 'New context to test',
+          context: 'Students should each pack a water.',
           userId: user.id,
         },
       );
       reportThree = await ActivityReport.create(
         {
           ...approvedReport,
-          context: 'If the search works',
+          context: 'We need to detect any lead in the pipes. Bring a water its going to be hot.',
           userId: user.id,
         },
       );
@@ -297,7 +297,7 @@ describe('Create AWS Elastic Search Indexes', () => {
     await createAwsElasticSearchIndexes();
 
     // Context Search.
-    let query = 'context to test';
+    let query = 'lead water';
     let searchResult = await search(
       AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
       ['context'],
@@ -305,7 +305,7 @@ describe('Create AWS Elastic Search Indexes', () => {
     );
 
     expect(searchResult.hits.length).toBe(1);
-    expect(searchResult.hits[0]['_id']).toBe(reportTwo.id.toString());
+    expect(searchResult.hits[0]['_id']).toBe(reportOne.id.toString());
 
     // Recipient Next Steps.
     query = 'bold';
@@ -396,9 +396,8 @@ describe('Create AWS Elastic Search Indexes', () => {
       [],
       query,
     );
-    expect(searchResult.hits.length).toBe(2);
+    expect(searchResult.hits.length).toBe(1);
     expect(searchResult.hits[0]['_id']).toBe(reportOne.id.toString());
-    expect(searchResult.hits[1]['_id']).toBe(reportThree.id.toString());
   });
 });
 


### PR DESCRIPTION
## Description of change

Users want to be able to search for phrases like 'lead water' and ONLY return reports that contain that exact phrase. They don't want to return reports that contain the words 'lead' or 'water'.

Decided to try two different approaches here:
1. If they search a single word we use wild card matching %query% (this will find parts or URL's like 'ECLKC' or 'tta').
2. If they search for two or more words we use phrase matching (this will find matches for 'lead water' in the exact order).

## How to test

I'm hoping this fixes two issues.
1. Users get exact phrase matching reports.
3. It limits the number of matches speeding up most searches.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
