### PR TITLE
Rollback ES results to 2k

### DIFF
--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -153,10 +153,10 @@ const search = async (indexName, fields, query, passedClient) => {
 
     // Create search body.
     const body = {
-      size: 2000,
+      size: 2001,
       query: {
-        multi_match: {
-          query,
+        query_string: {
+          query: `*${query}*`,
           fields,
         },
       },

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -142,80 +142,33 @@ const bulkIndex = async (documents, indexName, passedClient) => {
     throw error;
   }
 };
+
 /*
   Search index documents.
-  Note: Right now we use search with search_after.
-  This allows us to return all results in batches of 10k.
 */
-const search = async (indexName, fields, query, passedClient, overrideBatchSize) => {
+const search = async (indexName, fields, query, passedClient) => {
   try {
     // Initialize the client.
     const client = passedClient || await getClient();
 
-    // Total hits.
-    let totalHits = [];
-
-    // Loop vars.
-    const maxLoopIterations = 9;
-    let retrieveAgain = true;
-    const batchSize = overrideBatchSize || 10000; // Default batch size to 10k.
-    let loopIterations = 0;
-    let res;
-    let searchAfter;
-
     // Create search body.
-    let body = {
-      size: batchSize,
+    const body = {
+      size: 2000,
       query: {
-        query_string: {
-          query: `*${query}*`,
+        multi_match: {
+          query,
           fields,
         },
       },
-      sort: [
-        {
-          id: {
-            order: 'asc', // necessary for batch processing.
-          },
-        },
-      ],
     };
 
-    while (retrieveAgain && loopIterations <= maxLoopIterations) {
-      // Search an index.
-      res = await client.search({
-        index: indexName,
-        body,
-      });
-
-      // Get hits.
-      const hits = res.body.hits.hits || res.body.hits;
-
-      // Check if these are new results.
-      if (hits && hits.length > 0) {
-        // Append new hits.
-        totalHits = [...totalHits, ...hits];
-
-        // Get search_after from last hit.
-        const lastHit = hits.pop();
-
-        // Set search_after.
-        searchAfter = lastHit.sort;
-
-        // Update search_after.
-        body = { ...body, search_after: searchAfter };
-
-        // Increase loop count.
-        loopIterations += 1;
-
-        // If we don't have a sort after (undefined) stop looping.
-        retrieveAgain = searchAfter;
-      } else {
-        retrieveAgain = false;
-      }
-    }
+    // Search an index.
+    const res = await client.search({
+      index: indexName,
+      body,
+    });
     logger.info(`AWS OpenSearch: Successfully searched the index ${indexName} using query '${query}`);
-    return { hits: totalHits };
+    return res.body.hits;
   } catch (error) {
     auditLogger.error(`AWS OpenSearch Error: Unable to search the index '${indexName}' with query '${query}': ${error.message}`);
     throw error;

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -142,7 +142,6 @@ const bulkIndex = async (documents, indexName, passedClient) => {
     throw error;
   }
 };
-
 /*
   Search index documents.
 */
@@ -155,8 +154,8 @@ const search = async (indexName, fields, query, passedClient) => {
     const body = {
       size: 2001,
       query: {
-        query_string: {
-          query: `*${query}*`,
+        simple_query_string: {
+          query,
           fields,
         },
       },
@@ -174,7 +173,6 @@ const search = async (indexName, fields, query, passedClient) => {
     throw error;
   }
 };
-
 /*
   Update index document.
 */

--- a/src/lib/awsElasticSearch/index.test.js
+++ b/src/lib/awsElasticSearch/index.test.js
@@ -149,7 +149,7 @@ describe('Tests aws elastic search', () => {
 
   it('calls search', async () => {
     const res = await search(indexName, ['specialist'], 'potter', myMockClient);
-    await expect(res.hits).toStrictEqual(expectedSearchResult.body.hits);
+    await expect(res).toStrictEqual(expectedSearchResult.body.hits);
   });
 
   it('updates index document', async () => {

--- a/src/lib/awsElasticSearch/returnsAllResults.test.js
+++ b/src/lib/awsElasticSearch/returnsAllResults.test.js
@@ -1,4 +1,7 @@
+/* eslint-disable max-len */
+/* eslint-disable jest/no-commented-out-tests */
 /* eslint-disable dot-notation */
+/*
 import faker from '@faker-js/faker';
 import db, {
   ActivityReport,
@@ -147,3 +150,4 @@ describe('returnsAllResults', () => {
     expect(foundIds).toStrictEqual([report1.id, report2.id, report3.id]);
   });
 });
+*/

--- a/src/tools/createAwsElasticSearchIndexes.test.js
+++ b/src/tools/createAwsElasticSearchIndexes.test.js
@@ -360,7 +360,7 @@ describe('Create AWS Elastic Search Indexes', () => {
 
     // ARO Resources.
     // query = 'https://eclkc.ohs.acf.hhs.gov/';
-    query = 'eclkc';
+    query = 'https://eclkc.ohs.acf.hhs.gov/';
     searchResult = await search(
       AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
       ['activityReportObjectiveResources'],
@@ -370,7 +370,7 @@ describe('Create AWS Elastic Search Indexes', () => {
     expect(searchResult.hits[0]['_id']).toBe(reportTwo.id.toString());
 
     // non ECLKC Resource.
-    query = 'youtube';
+    query = 'https://www.youtube.com';
     searchResult = await search(
       AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
       ['nonECLKCResources'],
@@ -380,7 +380,7 @@ describe('Create AWS Elastic Search Indexes', () => {
     expect(searchResult.hits[0]['_id']).toBe(reportOne.id.toString());
 
     // ECLKC Resource.
-    query = 'smartsheet';
+    query = 'https://www.youtube.com';
     searchResult = await search(
       AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
       ['ECLKCResources'],


### PR DESCRIPTION
## Description of change

We are having timeouts in staging when we get a large number of results. For now lets roll this back to 2k results.


## How to test

Search should return a max of 2k results and not hang on staging.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
