### PR TITLE
Hook up phrase matching with limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "TTAHUB-1340/kw-class-pilot"
+    default: "hook-up-phrase-matching-with-limit"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "TTAHUB-1245/fix-date-filters-graph"

--- a/src/lib/awsElasticSearch/index.test.js
+++ b/src/lib/awsElasticSearch/index.test.js
@@ -149,7 +149,7 @@ describe('Tests aws elastic search', () => {
 
   it('calls search', async () => {
     const res = await search(indexName, ['specialist'], 'potter', myMockClient);
-    await expect(res.hits).toStrictEqual(expectedSearchResult.body.hits);
+    await expect(res).toStrictEqual(expectedSearchResult.body.hits);
   });
 
   it('updates index document', async () => {

--- a/src/lib/awsElasticSearch/returnsAllResults.test.js
+++ b/src/lib/awsElasticSearch/returnsAllResults.test.js
@@ -1,4 +1,7 @@
+/* eslint-disable max-len */
+/* eslint-disable jest/no-commented-out-tests */
 /* eslint-disable dot-notation */
+/*
 import faker from '@faker-js/faker';
 import db, {
   ActivityReport,
@@ -147,3 +150,4 @@ describe('returnsAllResults', () => {
     expect(foundIds).toStrictEqual([report1.id, report2.id, report3.id]);
   });
 });
+*/

--- a/src/lib/awsElasticSearch/returnsAllResults.test.js
+++ b/src/lib/awsElasticSearch/returnsAllResults.test.js
@@ -1,7 +1,5 @@
-/* eslint-disable max-len */
 /* eslint-disable jest/no-commented-out-tests */
 /* eslint-disable dot-notation */
-/*
 import faker from '@faker-js/faker';
 import db, {
   ActivityReport,
@@ -96,6 +94,23 @@ describe('returnsAllResults', () => {
     await db.sequelize.close();
   });
 
+  it('returns all matches', async () => {
+    // Search (set per page to 1 + per page).
+    const searchResult = await search(
+      AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
+      ['context'],
+      'simple',
+    );
+
+    // Assert results.
+    expect(searchResult.hits.length).toBe(3);
+
+    // Check found Ids.
+    const foundIds = searchResult.hits.map((h) => h['_source'].id);
+    expect(foundIds).toStrictEqual([report1.id, report2.id, report3.id]);
+  });
+
+  /*
   it('returns all pages of data at two per page', async () => {
     // Search (set per page to 1 + per page).
     const searchResult = await search(
@@ -149,5 +164,5 @@ describe('returnsAllResults', () => {
     const foundIds = searchResult.hits.map((h) => h['_source'].id);
     expect(foundIds).toStrictEqual([report1.id, report2.id, report3.id]);
   });
+  */
 });
-*/

--- a/src/tools/createAwsElasticSearchIndexes.test.js
+++ b/src/tools/createAwsElasticSearchIndexes.test.js
@@ -94,7 +94,7 @@ describe('Create AWS Elastic Search Indexes', () => {
       // Approved Reports.
       reportOne = await ActivityReport.create({
         ...approvedReport,
-        context: 'Lets give some',
+        context: 'Some houses had lead water in the pipes.',
         userId: user.id,
         nonECLKCResourcesUsed: ['https://www.youtube.com'],
         ECLKCResourcesUsed: ['https://www.smartsheet.com'],
@@ -102,14 +102,14 @@ describe('Create AWS Elastic Search Indexes', () => {
       reportTwo = await ActivityReport.create(
         {
           ...approvedReport,
-          context: 'New context to test',
+          context: 'Students should each pack a water.',
           userId: user.id,
         },
       );
       reportThree = await ActivityReport.create(
         {
           ...approvedReport,
-          context: 'If the search works',
+          context: 'We need to detect any lead in the pipes. Bring a water its going to be hot.',
           userId: user.id,
         },
       );
@@ -297,7 +297,7 @@ describe('Create AWS Elastic Search Indexes', () => {
     await createAwsElasticSearchIndexes();
 
     // Context Search.
-    let query = 'context to test';
+    let query = 'lead water';
     let searchResult = await search(
       AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
       ['context'],
@@ -305,7 +305,7 @@ describe('Create AWS Elastic Search Indexes', () => {
     );
 
     expect(searchResult.hits.length).toBe(1);
-    expect(searchResult.hits[0]['_id']).toBe(reportTwo.id.toString());
+    expect(searchResult.hits[0]['_id']).toBe(reportOne.id.toString());
 
     // Recipient Next Steps.
     query = 'bold';
@@ -396,9 +396,8 @@ describe('Create AWS Elastic Search Indexes', () => {
       [],
       query,
     );
-    expect(searchResult.hits.length).toBe(2);
+    expect(searchResult.hits.length).toBe(1);
     expect(searchResult.hits[0]['_id']).toBe(reportOne.id.toString());
-    expect(searchResult.hits[1]['_id']).toBe(reportThree.id.toString());
   });
 });
 


### PR DESCRIPTION
## Description of change

Per Patrice we can keep phrase matching and limit results (2k).

## How to test

Searching for phrase like "lead water" should only return reports that contain those terms in that order.

Searching for a single word like 'water' will use a wild card match to find anything that contains 'water'.

We need to make sure that staging no longer hangs and returns only 2k results.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
