### PR TITLE
[TTAHUB-1444] Reset AR table when the filters change

### DIFF
--- a/frontend/src/components/ActivityReportsTable/__tests__/index.js
+++ b/frontend/src/components/ActivityReportsTable/__tests__/index.js
@@ -37,7 +37,7 @@ const TableMock = ({ user, dateTime }) => {
         <UserContext.Provider value={{ user }}>
           <button
             type="button"
-            onClick={setResetPagination}
+            onClick={() => setResetPagination(!resetPagination)}
             data-testid="reset-pagination"
           >
             Reset pagination
@@ -571,6 +571,19 @@ describe('Table sorting', () => {
     );
 
     act(() => fireEvent.click(resetButton));
+
+    // confirm that the data has been refetched
     await waitFor(() => expect(fetchMock.called()).toBe(true));
+
+    // check the pagination has reset
+    const [pagination] = screen.getAllByText(/1-10 of 17/i);
+    expect(pagination).toBeVisible();
+
+    // check the active page is reset
+    const [activePage] = screen.getAllByRole('link', {
+      name: /go to page number 1/i,
+    });
+
+    expect(activePage).toBeVisible();
   });
 });

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -47,9 +47,10 @@ function ActivityReportsTable({
   useEffect(() => {
     if (resetPagination) {
       setSortConfig({ ...sortConfig, activePage: 1 });
+      setOffset(0); // 0 times perpage = 0
       setResetPagination(false);
     }
-  }, [resetPagination, setResetPagination, setSortConfig, sortConfig]);
+  }, [activePage, perPage, resetPagination, setResetPagination, setSortConfig, sortConfig]);
 
   useEffect(() => {
     async function fetchReports() {
@@ -75,8 +76,17 @@ function ActivityReportsTable({
         setLoading(false);
       }
     }
+
+    /**
+     * we don't want the state updates in reset pagination to trigger a fetch, except the last one
+     */
+
+    if (resetPagination) {
+      return;
+    }
+
     fetchReports();
-  }, [sortConfig, offset, perPage, filters]);
+  }, [sortConfig, offset, perPage, filters, resetPagination]);
 
   const makeReportCheckboxes = (reportsArr, checked) => (
     reportsArr.reduce((obj, r) => ({ ...obj, [r.id]: checked }), {})

--- a/frontend/src/components/ActivityReportsTable/index.js
+++ b/frontend/src/components/ActivityReportsTable/index.js
@@ -18,6 +18,8 @@ function ActivityReportsTable({
   filters,
   tableCaption,
   exportIdPrefix,
+  resetPagination,
+  setResetPagination,
 }) {
   const [reports, setReports] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -40,6 +42,14 @@ function ActivityReportsTable({
 
   const downloadAllButtonRef = useRef();
   const downloadSelectedButtonRef = useRef();
+
+  // a side effect that resets the pagination when the filters change
+  useEffect(() => {
+    if (resetPagination) {
+      setSortConfig({ ...sortConfig, activePage: 1 });
+      setResetPagination(false);
+    }
+  }, [resetPagination, setResetPagination, setSortConfig, sortConfig]);
 
   useEffect(() => {
     async function fetchReports() {
@@ -317,6 +327,15 @@ ActivityReportsTable.propTypes = {
     }),
   ).isRequired,
   tableCaption: PropTypes.string.isRequired,
+  resetPagination: PropTypes.bool,
+  setResetPagination: PropTypes.func,
+};
+
+ActivityReportsTable.defaultProps = {
+  resetPagination: false,
+  setResetPagination: () => {
+    // do nothing
+  },
 };
 
 export default ActivityReportsTable;

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useMemo,
   useRef,
+  useCallback,
 } from 'react';
 import {
   Alert, Grid, Button,
@@ -69,7 +70,7 @@ function Landing() {
 
   const allRegionsFilters = useMemo(() => buildDefaultRegionFilters(regions), [regions]);
 
-  const [filters, setFilters] = useSessionFiltersAndReflectInUrl(
+  const [filters, setFiltersInHook] = useSessionFiltersAndReflectInUrl(
     FILTER_KEY,
     defaultRegion !== 14
       && defaultRegion !== 0
@@ -88,6 +89,7 @@ function Landing() {
   const [reportAlerts, updateReportAlerts] = useState([]);
   const [error, updateError] = useState();
   const [showAlert, updateShowAlert] = useState(true);
+  const [resetPagination, setResetPagination] = useState(false);
 
   const [alertsSortConfig, setAlertsSortConfig] = React.useState({
     sortBy: 'startDate',
@@ -135,6 +137,16 @@ function Landing() {
       downloadAllAlertsButtonRef.current.focus();
     }
   };
+
+  const setFilters = useCallback((newFilters) => {
+    // pass through
+    setFiltersInHook(newFilters);
+
+    // reset pagination
+    setAlertsActivePage(1);
+    setAlertsOffset(0);
+    setResetPagination(true);
+  }, [setFiltersInHook]);
 
   const filtersToApply = useMemo(() => expandFilters(filters), [filters]);
 
@@ -330,6 +342,8 @@ function Landing() {
             showFilter={false}
             tableCaption="Approved activity reports"
             exportIdPrefix="ar-"
+            resetPagination={resetPagination}
+            setResetPagination={setResetPagination}
           />
         </FilterContext.Provider>
       </>

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -1,4 +1,6 @@
-import React, { useMemo, useContext } from 'react';
+import React, {
+  useMemo, useContext, useState, useCallback,
+} from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { Grid } from '@trussworks/react-uswds';
@@ -23,11 +25,12 @@ const defaultDate = formatDateRange({
 export default function TTAHistory({
   recipientName, recipientId, regionId,
 }) {
+  const [resetPagination, setResetPagination] = useState(false);
   const filterKey = `ttahistory-filters-${recipientId}`;
   const { user } = useContext(UserContext);
   const regions = useMemo(() => getUserRegions(user), [user]);
 
-  const [filters, setFilters] = useSessionFiltersAndReflectInUrl(
+  const [filters, setFiltersInHook] = useSessionFiltersAndReflectInUrl(
     filterKey,
     [
       {
@@ -38,6 +41,11 @@ export default function TTAHistory({
       },
     ],
   );
+
+  const setFilters = useCallback((newFilters) => {
+    setFiltersInHook(newFilters);
+    setResetPagination(true);
+  }, [setFiltersInHook]);
 
   if (!recipientName) {
     return null;
@@ -116,6 +124,8 @@ export default function TTAHistory({
             showFilter={false}
             tableCaption="Approved activity reports"
             exportIdPrefix="tta-history-"
+            resetPagination={resetPagination}
+            setResetPagination={setResetPagination}
           />
         </FilterContext.Provider>
       </div>

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -1,4 +1,6 @@
-import React, { useMemo, useContext } from 'react';
+import React, { 
+  useMemo, useContext, useState, useCallback,
+} from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { v4 as uuidv4 } from 'uuid';
@@ -27,7 +29,7 @@ const defaultDate = formatDateRange({
 const FILTER_KEY = 'regional-dashboard-filters';
 export default function RegionalDashboard() {
   const { user } = useContext(UserContext);
-
+  const [resetPagination, setResetPagination] = useState(false);
   /**
    * we are going to memoize all this stuff so it doesn't get recomputed each time
    * this is re-rendered. it would (generally) only get recomputed should the user change
@@ -76,7 +78,12 @@ export default function RegionalDashboard() {
     ];
   }, [defaultRegion, hasCentralOffice, centralOfficeWithAllRegionFilters]);
 
-  const [filters, setFilters] = useSessionFiltersAndReflectInUrl(FILTER_KEY, defaultFilters);
+  const [filters, setFiltersInHook] = useSessionFiltersAndReflectInUrl(FILTER_KEY, defaultFilters);
+
+  const setFilters = useCallback((newFilters) => {
+    setFiltersInHook(newFilters);
+    setResetPagination(true);
+  }, [setFiltersInHook]);
 
   // Apply filters.
   const onApplyFilters = (newFilters, addBackDefaultRegions) => {
@@ -171,6 +178,8 @@ export default function RegionalDashboard() {
                 showFilter={false}
                 tableCaption="Activity reports"
                 exportIdPrefix="rd-"
+                resetPagination={resetPagination}
+                setResetPagination={setResetPagination}
               />
             </FilterContext.Provider>
           </Grid>

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -1,5 +1,8 @@
-import React, { 
-  useMemo, useContext, useState, useCallback,
+import React, {
+  useMemo,
+  useContext,
+  useState,
+  useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';


### PR DESCRIPTION
## Description of change
The request was - when a filter is changed, reset the table's pagination elements to page 1. This change was only made to the activity report tables.

## How to test
Add a filter - change the page on the AR table. Change the filter, the page should revert to the first.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1444


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
