### PR TITLE
Put back AWS ElasticSearch search_after

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "hook-up-phrase-matching-with-limit"
+    default: "put-back-search-after"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "TTAHUB-1245/fix-date-filters-graph"

--- a/frontend/src/pages/Landing/index.js
+++ b/frontend/src/pages/Landing/index.js
@@ -328,7 +328,7 @@ function Landing() {
           <ActivityReportsTable
             filters={filtersToApply}
             showFilter={false}
-            tableCaption="Approved activity reports"
+            tableCaption="Test Approved activity reports"
             exportIdPrefix="ar-"
           />
         </FilterContext.Provider>

--- a/src/constants.js
+++ b/src/constants.js
@@ -266,3 +266,15 @@ export const DIGEST_SUBJECT_FREQ = {
 export const AWS_ELASTIC_SEARCH_INDEXES = {
   ACTIVITY_REPORTS: 'activityreports',
 };
+
+export const AWS_ELASTIC_SEARCH_FIELDS = [
+  'context',
+  'nonECLKCResources',
+  'ECLKCResources',
+  'recipientNextSteps',
+  'specialistNextSteps',
+  'activityReportGoals',
+  'activityReportObjectives',
+  'activityReportObjectivesTTA',
+  'activityReportObjectiveResources',
+];

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -161,7 +161,7 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     // Loop vars.
     const maxLoopIterations = 9;
     let retrieveAgain = true;
-    const batchSize = overrideBatchSize || 1000; // Default batch size to 10k.
+    const batchSize = overrideBatchSize || 500; // Default batch size to 10k.
     let loopIterations = 0;
     let res;
     let searchAfter;

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -199,6 +199,7 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     };
 
     const searchId = Math.floor(Math.random() * 10);
+    logger.info(`-- Entered #: ${searchId} - QUERY: '${query}'`);
     const timings = [];
     while (retrieveAgain && loopIterations <= maxLoopIterations) {
       const startTime = moment();

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -146,11 +146,24 @@ const bulkIndex = async (documents, indexName, passedClient) => {
 
 /*
   Search index documents.
+  Note: Right now we use search with search_after.
+  This allows us to return all results in batches of 10k.
 */
-const search = async (indexName, fields, query, passedClient) => {
+const search = async (indexName, fields, query, passedClient, overrideBatchSize) => {
   try {
     // Initialize the client.
     const client = passedClient || await getClient();
+
+    // Total hits.
+    let totalHits = [];
+
+    // Loop vars.
+    const maxLoopIterations = 9;
+    let retrieveAgain = true;
+    const batchSize = overrideBatchSize || 2001; // Default batch size to 10k.
+    let loopIterations = 0;
+    let res;
+    let searchAfter;
 
     // Create query section.
     // ReadMe:
@@ -171,23 +184,59 @@ const search = async (indexName, fields, query, passedClient) => {
       };
 
     // Create search body.
-    const body = {
-      size: 2001,
+    let body = {
+      size: batchSize,
       query: queryBody,
+      sort: [
+        {
+          id: {
+            order: 'asc', // necessary for batch processing.
+          },
+        },
+      ],
     };
 
-    // Search an index.
-    const res = await client.search({
-      index: indexName,
-      body,
-    });
+    while (retrieveAgain && loopIterations <= maxLoopIterations) {
+      // Search an index.
+      res = await client.search({
+        index: indexName,
+        body,
+      });
+
+      // Get hits.
+      const hits = res.body.hits.hits || res.body.hits;
+
+      // Check if these are new results.
+      if (hits && hits.length > 0) {
+        // Append new hits.
+        totalHits = [...totalHits, ...hits];
+
+        // Get search_after from last hit.
+        const lastHit = hits.pop();
+
+        // Set search_after.
+        searchAfter = lastHit.sort;
+
+        // Update search_after.
+        body = { ...body, search_after: searchAfter };
+
+        // Increase loop count.
+        loopIterations += 1;
+
+        // If we don't have a sort after (undefined) stop looping.
+        retrieveAgain = searchAfter;
+      } else {
+        retrieveAgain = false;
+      }
+    }
     logger.info(`AWS OpenSearch: Successfully searched the index ${indexName} using query '${query}`);
-    return res.body.hits;
+    return { hits: totalHits };
   } catch (error) {
     auditLogger.error(`AWS OpenSearch Error: Unable to search the index '${indexName}' with query '${query}': ${error.message}`);
     throw error;
   }
 };
+
 /*
   Update index document.
 */

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -160,7 +160,7 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     // Loop vars.
     const maxLoopIterations = 9;
     let retrieveAgain = true;
-    const batchSize = overrideBatchSize || 1000; // Default batch size to 10k.
+    const batchSize = overrideBatchSize || 10000; // Default batch size to 10k.
     let loopIterations = 0;
     let res;
     let searchAfter;

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -161,7 +161,7 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     // Loop vars.
     const maxLoopIterations = 9;
     let retrieveAgain = true;
-    const batchSize = overrideBatchSize || 10000; // Default batch size to 10k.
+    const batchSize = overrideBatchSize || 1000; // Default batch size to 10k.
     let loopIterations = 0;
     let res;
     let searchAfter;

--- a/src/lib/awsElasticSearch/index.js
+++ b/src/lib/awsElasticSearch/index.js
@@ -160,7 +160,7 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     // Loop vars.
     const maxLoopIterations = 9;
     let retrieveAgain = true;
-    const batchSize = overrideBatchSize || 2001; // Default batch size to 10k.
+    const batchSize = overrideBatchSize || 1000; // Default batch size to 10k.
     let loopIterations = 0;
     let res;
     let searchAfter;
@@ -186,6 +186,7 @@ const search = async (indexName, fields, query, passedClient, overrideBatchSize)
     // Create search body.
     let body = {
       size: batchSize,
+      timeout: '120s',
       query: queryBody,
       sort: [
         {

--- a/src/lib/awsElasticSearch/index.test.js
+++ b/src/lib/awsElasticSearch/index.test.js
@@ -149,7 +149,7 @@ describe('Tests aws elastic search', () => {
 
   it('calls search', async () => {
     const res = await search(indexName, ['specialist'], 'potter', myMockClient);
-    await expect(res).toStrictEqual(expectedSearchResult.body.hits);
+    await expect(res.hits).toStrictEqual(expectedSearchResult.body.hits);
   });
 
   it('updates index document', async () => {

--- a/src/lib/awsElasticSearch/queryGenerator.js
+++ b/src/lib/awsElasticSearch/queryGenerator.js
@@ -1,0 +1,94 @@
+export const matchPhraseQuery = (fields, query) => {
+  if (fields && fields.length) {
+    return fields.map((field) => {
+      if (field === 'context') {
+        return ({ match_phrase: { context: { slop: 0, query } } });
+      }
+      if (field === 'nonECLKCResources') {
+        return ({ match_phrase: { nonECLKCResources: { slop: 0, query } } });
+      }
+      if (field === 'ECLKCResources') {
+        return ({ match_phrase: { ECLKCResources: { slop: 0, query } } });
+      }
+      if (field === 'recipientNextSteps') {
+        return ({ match_phrase: { recipientNextSteps: { slop: 0, query } } });
+      }
+      if (field === 'specialistNextSteps') {
+        return ({ match_phrase: { specialistNextSteps: { slop: 0, query } } });
+      }
+      if (field === 'activityReportGoals') {
+        return ({ match_phrase: { activityReportGoals: { slop: 0, query } } });
+      }
+      if (field === 'activityReportObjectives') {
+        return ({ match_phrase: { activityReportObjectives: { slop: 0, query } } });
+      }
+      if (field === 'activityReportObjectivesTTA') {
+        return ({ match_phrase: { activityReportObjectivesTTA: { slop: 0, query } } });
+      }
+      if (field === 'activityReportObjectiveResources') {
+        return ({ match_phrase: { activityReportObjectiveResources: { slop: 0, query } } });
+      }
+      return null;
+    });
+  }
+
+  return ([
+    { match_phrase: { context: { slop: 0, query } } },
+    { match_phrase: { nonECLKCResources: { slop: 0, query } } },
+    { match_phrase: { ECLKCResources: { slop: 0, query } } },
+    { match_phrase: { recipientNextSteps: { slop: 0, query } } },
+    { match_phrase: { specialistNextSteps: { slop: 0, query } } },
+    { match_phrase: { activityReportGoals: { slop: 0, query } } },
+    { match_phrase: { activityReportObjectives: { slop: 0, query } } },
+    { match_phrase: { activityReportObjectivesTTA: { slop: 0, query } } },
+    { match_phrase: { activityReportObjectiveResources: { slop: 0, query } } },
+  ]);
+};
+
+export const wildCardQuery = (fields, query) => {
+  const queryWithWildCard = `*${query}*`;
+  if (fields && fields.length) {
+    return fields.map((field) => {
+      if (field === 'context') {
+        return ({ wildcard: { context: queryWithWildCard } });
+      }
+      if (field === 'nonECLKCResources') {
+        return ({ wildcard: { nonECLKCResources: queryWithWildCard } });
+      }
+      if (field === 'ECLKCResources') {
+        return ({ wildcard: { ECLKCResources: queryWithWildCard } });
+      }
+      if (field === 'recipientNextSteps') {
+        return ({ wildcard: { recipientNextSteps: queryWithWildCard } });
+      }
+      if (field === 'specialistNextSteps') {
+        return ({ wildcard: { specialistNextSteps: queryWithWildCard } });
+      }
+      if (field === 'activityReportGoals') {
+        return ({ wildcard: { activityReportGoals: queryWithWildCard } });
+      }
+      if (field === 'activityReportObjectives') {
+        return ({ wildcard: { activityReportObjectives: queryWithWildCard } });
+      }
+      if (field === 'activityReportObjectivesTTA') {
+        return ({ wildcard: { activityReportObjectivesTTA: queryWithWildCard } });
+      }
+      if (field === 'activityReportObjectiveResources') {
+        return ({ wildcard: { activityReportObjectiveResources: queryWithWildCard } });
+      }
+      return null;
+    });
+  }
+
+  return ([
+    { wildcard: { context: queryWithWildCard } },
+    { wildcard: { nonECLKCResources: queryWithWildCard } },
+    { wildcard: { ECLKCResources: queryWithWildCard } },
+    { wildcard: { recipientNextSteps: queryWithWildCard } },
+    { wildcard: { specialistNextSteps: queryWithWildCard } },
+    { wildcard: { activityReportGoals: queryWithWildCard } },
+    { wildcard: { activityReportObjectives: queryWithWildCard } },
+    { wildcard: { activityReportObjectivesTTA: queryWithWildCard } },
+    { wildcard: { activityReportObjectiveResources: queryWithWildCard } },
+  ]);
+};

--- a/src/lib/awsElasticSearch/queryGenerator.test.js
+++ b/src/lib/awsElasticSearch/queryGenerator.test.js
@@ -1,0 +1,155 @@
+import { expect } from '@playwright/test';
+import { wildCardQuery, matchPhraseQuery } from './queryGenerator';
+import { AWS_ELASTIC_SEARCH_FIELDS } from '../../constants';
+
+describe('query generator tests', () => {
+  it('test wild card query generator for all', async () => {
+    const query = wildCardQuery([], 'test');
+
+    expect(query.length).toBe(9);
+    expect(query[0]).toStrictEqual({ wildcard: { context: '*test*' } });
+    expect(query[1]).toStrictEqual({ wildcard: { nonECLKCResources: '*test*' } });
+    expect(query[3]).toStrictEqual({ wildcard: { recipientNextSteps: '*test*' } });
+    expect(query[4]).toStrictEqual({ wildcard: { specialistNextSteps: '*test*' } });
+    expect(query[5]).toStrictEqual({ wildcard: { activityReportGoals: '*test*' } });
+    expect(query[6]).toStrictEqual({ wildcard: { activityReportObjectives: '*test*' } });
+    expect(query[7]).toStrictEqual({ wildcard: { activityReportObjectivesTTA: '*test*' } });
+    expect(query[8]).toStrictEqual({ wildcard: { activityReportObjectiveResources: '*test*' } });
+  });
+
+  it('test wild card query generator for all specified', async () => {
+    const query = wildCardQuery(AWS_ELASTIC_SEARCH_FIELDS, 'test');
+    expect(query.length).toBe(9);
+    expect(query[0]).toStrictEqual({ wildcard: { context: '*test*' } });
+    expect(query[1]).toStrictEqual({ wildcard: { nonECLKCResources: '*test*' } });
+    expect(query[3]).toStrictEqual({ wildcard: { recipientNextSteps: '*test*' } });
+    expect(query[4]).toStrictEqual({ wildcard: { specialistNextSteps: '*test*' } });
+    expect(query[5]).toStrictEqual({ wildcard: { activityReportGoals: '*test*' } });
+    expect(query[6]).toStrictEqual({ wildcard: { activityReportObjectives: '*test*' } });
+    expect(query[7]).toStrictEqual({ wildcard: { activityReportObjectivesTTA: '*test*' } });
+    expect(query[8]).toStrictEqual({ wildcard: { activityReportObjectiveResources: '*test*' } });
+  });
+
+  it('test wild card query generator for specified', async () => {
+    // context.
+    let query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[0]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { context: '*test*' } });
+
+    // nonECLKCResources.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[1]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { nonECLKCResources: '*test*' } });
+
+    // ECLKCResources.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[2]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { ECLKCResources: '*test*' } });
+
+    // recipientNextSteps.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[3]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { recipientNextSteps: '*test*' } });
+
+    // specialistNextSteps.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[4]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { specialistNextSteps: '*test*' } });
+
+    // activityReportGoals.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[5]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { activityReportGoals: '*test*' } });
+
+    // activityReportObjectives.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[6]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { activityReportObjectives: '*test*' } });
+
+    // activityReportObjectivesTTA.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[7]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { activityReportObjectivesTTA: '*test*' } });
+
+    // activityReportObjectiveResources.
+    query = wildCardQuery([AWS_ELASTIC_SEARCH_FIELDS[8]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ wildcard: { activityReportObjectiveResources: '*test*' } });
+  });
+
+  it('test match phrase query generator for all', async () => {
+    const query = matchPhraseQuery([], 'test');
+
+    expect(query.length).toBe(9);
+    expect(query[0]).toStrictEqual({ match_phrase: { context: { slop: 0, query: 'test' } } });
+    expect(query[1]).toStrictEqual({ match_phrase: { nonECLKCResources: { slop: 0, query: 'test' } } });
+    expect(query[2]).toStrictEqual({ match_phrase: { ECLKCResources: { slop: 0, query: 'test' } } });
+    expect(query[3]).toStrictEqual({ match_phrase: { recipientNextSteps: { slop: 0, query: 'test' } } });
+    expect(query[4]).toStrictEqual({ match_phrase: { specialistNextSteps: { slop: 0, query: 'test' } } });
+    expect(query[5]).toStrictEqual({ match_phrase: { activityReportGoals: { slop: 0, query: 'test' } } });
+    expect(query[6]).toStrictEqual({ match_phrase: { activityReportObjectives: { slop: 0, query: 'test' } } });
+    expect(query[7]).toStrictEqual({ match_phrase: { activityReportObjectivesTTA: { slop: 0, query: 'test' } } });
+    expect(query[8]).toStrictEqual({ match_phrase: { activityReportObjectiveResources: { slop: 0, query: 'test' } } });
+  });
+
+  it('test match phrase query generator for all specified', async () => {
+    const query = matchPhraseQuery(AWS_ELASTIC_SEARCH_FIELDS, 'test');
+    expect(query.length).toBe(9);
+    expect(query[0]).toStrictEqual({ match_phrase: { context: { slop: 0, query: 'test' } } });
+    expect(query[1]).toStrictEqual({ match_phrase: { nonECLKCResources: { slop: 0, query: 'test' } } });
+    expect(query[2]).toStrictEqual({ match_phrase: { ECLKCResources: { slop: 0, query: 'test' } } });
+    expect(query[3]).toStrictEqual({ match_phrase: { recipientNextSteps: { slop: 0, query: 'test' } } });
+    expect(query[4]).toStrictEqual({ match_phrase: { specialistNextSteps: { slop: 0, query: 'test' } } });
+    expect(query[5]).toStrictEqual({ match_phrase: { activityReportGoals: { slop: 0, query: 'test' } } });
+    expect(query[6]).toStrictEqual({ match_phrase: { activityReportObjectives: { slop: 0, query: 'test' } } });
+    expect(query[7]).toStrictEqual({ match_phrase: { activityReportObjectivesTTA: { slop: 0, query: 'test' } } });
+    expect(query[8]).toStrictEqual({ match_phrase: { activityReportObjectiveResources: { slop: 0, query: 'test' } } });
+  });
+
+  it('test match phrase query generator for specified', async () => {
+    // context.
+    let query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[0]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { context: { slop: 0, query: 'test' } } });
+
+    // nonECLKCResources.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[1]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { nonECLKCResources: { slop: 0, query: 'test' } } });
+
+    // ECLKCResources.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[2]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { ECLKCResources: { slop: 0, query: 'test' } } });
+
+    // recipientNextSteps.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[3]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { recipientNextSteps: { slop: 0, query: 'test' } } });
+
+    // specialistNextSteps.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[4]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { specialistNextSteps: { slop: 0, query: 'test' } } });
+
+    // activityReportGoals.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[5]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { activityReportGoals: { slop: 0, query: 'test' } } });
+
+    // activityReportObjectives.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[6]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { activityReportObjectives: { slop: 0, query: 'test' } } });
+
+    // activityReportObjectivesTTA.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[7]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { activityReportObjectivesTTA: { slop: 0, query: 'test' } } });
+
+    // activityReportObjectiveResources.
+    query = matchPhraseQuery([AWS_ELASTIC_SEARCH_FIELDS[8]], 'test');
+    expect(query.length).toBe(1);
+    expect(query[0]).toStrictEqual({ match_phrase: { activityReportObjectiveResources: { slop: 0, query: 'test' } } });
+  });
+});

--- a/src/lib/awsElasticSearch/returnsAllResults.test.js
+++ b/src/lib/awsElasticSearch/returnsAllResults.test.js
@@ -94,23 +94,6 @@ describe('returnsAllResults', () => {
     await db.sequelize.close();
   });
 
-  it('returns all matches', async () => {
-    // Search (set per page to 1 + per page).
-    const searchResult = await search(
-      AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS,
-      ['context'],
-      'simple',
-    );
-
-    // Assert results.
-    expect(searchResult.hits.length).toBe(3);
-
-    // Check found Ids.
-    const foundIds = searchResult.hits.map((h) => h['_source'].id);
-    expect(foundIds).toStrictEqual([report1.id, report2.id, report3.id]);
-  });
-
-  /*
   it('returns all pages of data at two per page', async () => {
     // Search (set per page to 1 + per page).
     const searchResult = await search(
@@ -164,5 +147,4 @@ describe('returnsAllResults', () => {
     const foundIds = searchResult.hits.map((h) => h['_source'].id);
     expect(foundIds).toStrictEqual([report1.id, report2.id, report3.id]);
   });
-  */
 });


### PR DESCRIPTION
## Description of change

This PR does two things:

1. Returns more than 2k results (in smaller batches).
2. Cleans up the query building with unit tests.

## How to test

1. Test searching more than 2k results (currently on DEV). We expect response to be returned in a reasonable amount of time with no server errors.
2. New query creation makes sense and all tests pass. 


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
