### PR TITLE
[TTAHUB-1419] Remove "in progress" from "not started" dropdown

### DIFF
--- a/frontend/src/components/GoalCards/components/StatusDropdown.js
+++ b/frontend/src/components/GoalCards/components/StatusDropdown.js
@@ -113,7 +113,7 @@ export default function StatusDropdown({
       ];
     }
 
-    if (status === 'In Progress') {
+    if (status === 'In Progress' || status === 'Not Started') {
       return [
         {
           label: 'Closed',

--- a/frontend/src/components/GoalCards/components/__tests__/StatusDropdown.js
+++ b/frontend/src/components/GoalCards/components/__tests__/StatusDropdown.js
@@ -50,12 +50,7 @@ describe('StatusDropdown', () => {
     userEvent.click(select);
 
     options = await screen.findAllByRole('button');
-    expect(options.length).toBe(4);
-
-    const inProgress = await screen.findByRole('button', { name: /in progress/i });
-    userEvent.click(inProgress);
-
-    expect(onUpdate).toHaveBeenCalledWith('In Progress');
+    expect(options.length).toBe(3);
   });
 
   it('displays the correct number of options for in progress', async () => {
@@ -131,6 +126,15 @@ describe('StatusDropdown', () => {
 
   describe('passes the correct parameters', () => {
     describe('not started', () => {
+      test('does not offer "in progress" as an option', async () => {
+        const onUpdate = jest.fn();
+        renderStatusDropdown('Not Started', onUpdate);
+
+        const select = await screen.findByRole('button', { name: /change status for goal 345345/i });
+        userEvent.click(select);
+
+        expect(screen.queryByRole('button', { name: /in progress/i })).toBeNull();
+      });
       test('suspended', async () => {
         const onUpdate = jest.fn();
         renderStatusDropdown('Not Started', onUpdate);

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -195,6 +195,7 @@ describe('Goals and Objectives', () => {
 
     const response = [{
       id: 4598,
+      ids: [4598],
       goalStatus: 'Not Started',
       createdOn: '2021-06-15',
       goalText: 'This is goal text 1.',
@@ -215,9 +216,16 @@ describe('Goals and Objectives', () => {
     fetchMock.restore();
     expect(fetchMock.called()).toBe(false);
     fetchMock.put('/api/goals/changeStatus', [response[0]]);
-    userEvent.click(statusMenuToggle);
-    userEvent.click(await screen.findByRole('button', { name: /In Progress/i }));
-    expect(fetchMock.called()).toBeTruthy();
+
+    act(() => userEvent.click(statusMenuToggle));
+    act(() => userEvent.click(screen.getByRole('button', { name: /Closed/i })));
+    act(() => userEvent.click(screen.getByRole('radio', { name: /duplicate/i })));
+
+    const submit = await screen.findByRole('button', { name: /change goal status/i });
+
+    act(() => userEvent.click(submit));
+
+    await waitFor(() => expect(fetchMock.called()).toBeTruthy());
   });
 
   it('will sort by the dropdown', async () => {

--- a/src/services/goalServices/goalUpdate.test.js
+++ b/src/services/goalServices/goalUpdate.test.js
@@ -1,60 +1,224 @@
+import faker from '@faker-js/faker';
 import {
   updateGoalStatusById,
+  verifyAllowedGoalStatusTransition,
 } from '../goals';
 import {
   Goal,
+  Grant,
+  Recipient,
   sequelize,
 } from '../../models';
+import { GOAL_STATUS } from '../../constants';
 
-/* TODO:
-   Once we determine who has permission to update a goal.
-   We can update the function and enable the test.
-*/
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Change Goal Status', () => {
+describe('Change Goal Status', () => {
   let goal;
+  let grant;
+  let recipient;
+
   beforeAll(async () => {
-    // Create Goal.
+    // create recipient
+    recipient = await Recipient.create({
+      id: faker.datatype.number(),
+      name: faker.name.firstName(),
+    });
+
+    // create grant
+    grant = await Grant.create({
+      id: faker.datatype.number(),
+      number: faker.datatype.string(),
+      recipientId: recipient.id,
+      regionId: 1,
+    });
+
+    // create goal
     goal = await Goal.create({
-      name: 'Goal with Objectives',
-      status: 'Not Started',
+      name: 'Goal with Objectives (BUT WHERE ARE THEY?)',
+      status: GOAL_STATUS.NOT_STARTED,
       timeframe: '12 months',
       isFromSmartsheetTtaPlan: false,
       createdAt: new Date('2021-01-02'),
-      grantId: 1,
+      grantId: grant.id,
+      previousStatus: null,
     });
   });
+
   afterAll(async () => {
     // Cleanup Goal.
     await Goal.destroy({
       where: {
-        id: goal.id,
+        grantId: grant.id,
       },
     });
+
+    // Cleanup Grant.
+    await Grant.destroy({
+      where: {
+        id: grant.id,
+      },
+    });
+
+    // Cleanup Recipient.
+    await Recipient.destroy({
+      where: {
+        id: recipient.id,
+      },
+    });
+
     await sequelize.close();
   });
-  it('Updates goal status', async () => {
-    const newStatus = 'In Progress';
-    const oldStatus = 'Not Started';
-    const updatedGoal = await updateGoalStatusById(goal.id.toString(), newStatus, oldStatus);
-    expect(updatedGoal.status).toEqual(newStatus);
-    expect(updatedGoal.closeSuspendReason).toEqual(null);
-    expect(updatedGoal.closeSuspendContext).toEqual(null);
-    expect(updatedGoal.previousStatus).toEqual(oldStatus);
+  describe('verifyAllowedGoalStatusTransition', () => {
+    it('returns false if the goal status change is not allowed', async () => {
+    // can't change from not started to in progress
+      let result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.NOT_STARTED,
+        GOAL_STATUS.IN_PROGRESS,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can change from not started to closed
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.NOT_STARTED,
+        GOAL_STATUS.CLOSED,
+        [],
+      );
+      expect(result).toEqual(true);
+
+      // can change from not started to suspended
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.NOT_STARTED,
+        GOAL_STATUS.SUSPENDED,
+        [],
+      );
+      expect(result).toEqual(true);
+
+      // can't change from draft to not started
+      result = verifyAllowedGoalStatusTransition(
+
+        GOAL_STATUS.DRAFT,
+        GOAL_STATUS.NOT_STARTED,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can't change from draft to in progress
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.DRAFT,
+        GOAL_STATUS.IN_PROGRESS,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can't change from draft to closed
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.DRAFT,
+        GOAL_STATUS.CLOSED,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can't change from draft to suspended
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.DRAFT,
+        GOAL_STATUS.SUSPENDED,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can't change from in progress to not started
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.IN_PROGRESS,
+        GOAL_STATUS.NOT_STARTED,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can't change from in progress to draft
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.IN_PROGRESS,
+        GOAL_STATUS.DRAFT,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can change from in progress to closed
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.IN_PROGRESS,
+        GOAL_STATUS.CLOSED,
+        [],
+      );
+      expect(result).toEqual(true);
+
+      // can change from in progress to suspended
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.IN_PROGRESS,
+        GOAL_STATUS.SUSPENDED,
+        [],
+      );
+
+      // can't change from suspended to not started
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.SUSPENDED,
+        GOAL_STATUS.NOT_STARTED,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // cant change from suspended to draft
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.SUSPENDED,
+        GOAL_STATUS.DRAFT,
+        [],
+      );
+      expect(result).toEqual(false);
+
+      // can't change from suspended to in progress
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.SUSPENDED,
+        GOAL_STATUS.IN_PROGRESS,
+        [],
+      );
+
+      expect(result).toEqual(false);
+
+      // can change from suspended to closed
+      result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.SUSPENDED,
+        GOAL_STATUS.CLOSED,
+        [],
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('queries the previous status when the old status is suspended', async () => {
+      // can't change from suspended to in progress
+      const result = verifyAllowedGoalStatusTransition(
+        GOAL_STATUS.SUSPENDED,
+        GOAL_STATUS.IN_PROGRESS,
+        [GOAL_STATUS.IN_PROGRESS],
+      );
+
+      expect(result).toEqual(true);
+    });
   });
 
   it('Updates goal status with reason', async () => {
-    const newStatus = 'Complete';
-    const oldStatus = 'In Progress';
+    const newStatus = GOAL_STATUS.CLOSED;
+    const oldStatus = GOAL_STATUS.IN_PROGRESS;
     const reason = 'TTA complete';
     const context = 'This goal has been completed.';
-    const updatedGoal = await updateGoalStatusById(
+    const updatedGoals = await updateGoalStatusById(
       goal.id.toString(),
-      newStatus,
       oldStatus,
+      newStatus,
       reason,
       context,
+      [],
     );
+
+    expect(updatedGoals.length).toEqual(1);
+    const updatedGoal = updatedGoals[0];
     expect(updatedGoal.status).toEqual(newStatus);
     expect(updatedGoal.closeSuspendReason).toEqual(reason);
     expect(updatedGoal.closeSuspendContext).toEqual(context);


### PR DESCRIPTION
## Description of change
Remove the option to set a "not started" goal to "in progress" from the RTR.

## How to test
Confirm that the option is no longer present

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1419


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
