### PR TITLE
[TTAHUB-1422] Remove objective status dropdown from create goal form when goal is not started

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveStatus.js
+++ b/frontend/src/components/GoalForm/ObjectiveStatus.js
@@ -15,7 +15,7 @@ export default function ObjectiveStatus({
 
   // if the goal is closed, the objective status should be read-only
   const hideDropdown = useMemo(() => {
-    if (goalStatus === 'Closed' || !userCanEdit) {
+    if (['Closed', 'Not Started'].includes(goalStatus) || !userCanEdit) {
       return true;
     }
 

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveStatus.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveStatus.js
@@ -48,6 +48,26 @@ describe('ObjectiveStatus', () => {
     expect(options).toHaveLength(2);
   });
 
+  it('shows the read only view when the goal is not started', async () => {
+    const onChangeStatus = jest.fn();
+
+    render(<ObjectiveStatus
+      status="Not Started"
+      goalStatus="Not Started"
+      onChangeStatus={onChangeStatus}
+      inputName="objective-status"
+      isOnReport={false}
+      userCanEdit
+    />);
+
+    const label = await screen.findByText('Objective status');
+
+    expect(label).toBeVisible();
+    expect(label.tagName).toEqual('P');
+
+    expect(document.querySelector('select')).toBe(null);
+  });
+
   it('shows the read only view when the goal is closed', async () => {
     const onChangeStatus = jest.fn();
 

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -714,7 +714,11 @@ export async function goalByIdAndRecipient(id, recipientId) {
       topics: objective.objectiveTopics
         .map((objectiveTopic) => ({
           ...objectiveTopic.dataValues,
-          ...objectiveTopic.topic.dataValues,
+          ...(
+            objectiveTopic.topic && objectiveTopic.topic.dataValues
+              ? objectiveTopic.topic.dataValues
+              : []
+          ),
         }))
         .map((o) => ({ ...o, topic: undefined })),
       files: objective.objectiveFiles
@@ -741,7 +745,11 @@ export async function goalsByIdAndRecipient(ids, recipientId) {
             .map((objectiveTopic) => {
               const ot = {
                 ...objectiveTopic.dataValues,
-                ...objectiveTopic.topic.dataValues,
+                ...(
+                  objectiveTopic.topic && objectiveTopic.topic.dataValues
+                    ? objectiveTopic.topic.dataValues
+                    : []
+                ),
               };
               delete ot.topic;
               return ot;


### PR DESCRIPTION
## Description of change
Removes the objective status dropdown from the the create goals from if the goal is "not started," show the read only value instead. 

## How to test
Confirm that the dropdown has been removed.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1422


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
