### PR TITLE
fix issue when cancelling filter

### DIFF
--- a/frontend/src/components/filter/FilterMenu.js
+++ b/frontend/src/components/filter/FilterMenu.js
@@ -49,6 +49,11 @@ export default function FilterMenu({
   }, [itemLength, items.length]);
 
   const totalValidation = () => {
+    // If we don't have any filter's no need to validate.
+    if (!items.length) {
+      return true;
+    }
+
     const hasErrors = errors.reduce((acc, curr) => {
       if (acc || curr) {
         return true;
@@ -166,6 +171,7 @@ export default function FilterMenu({
     // this will add an empty item into the list if there
     // are no filters, to cut down on user clicking
     if (!items.length) {
+      setErrors([]); // Reset errors.
       onAddFilter();
     }
   };

--- a/frontend/src/components/filter/__tests__/FilterMenu.js
+++ b/frontend/src/components/filter/__tests__/FilterMenu.js
@@ -203,6 +203,50 @@ describe('Filter Menu', () => {
     expect(message).toBeVisible();
   });
 
+  /*
+       id: uuidv4(),
+        display: '',
+        conditions: [],
+        */
+
+  it('adds back filter on cancel', async () => {
+    const filters = [
+      {
+        id: 'cancel-filter',
+        display: '',
+        conditions: [],
+      },
+    ];
+
+    // Render.
+    renderFilterMenu(filters);
+
+    // Open menu.
+    const button = screen.getByRole('button', {
+      name: /filters/i,
+    });
+    userEvent.click(button);
+
+    // Add new filter for blur.
+    const addNew = screen.getByRole('button', { name: /Add new filter/i });
+    act(() => userEvent.click(addNew));
+
+    const [topic] = Array.from(document.querySelectorAll('[name="topic"]')).slice(-1);
+    expect(topic).toHaveFocus();
+    userEvent.tab();
+    userEvent.tab();
+    userEvent.tab();
+    expect(screen.getByText(/please enter a filter/i)).toBeVisible();
+
+    // Cancel.
+    const cancel = await screen.findByRole('button', { name: /discard changes and close filter menu/i });
+    userEvent.click(cancel);
+
+    // Open filters again.
+    userEvent.click(button);
+    expect(screen.getByText(/Select a filter/i)).toBeVisible();
+  });
+
   it('the clear all button works', async () => {
     const filters = [
       {


### PR DESCRIPTION
## Description of change

Opening the filter menu and triggering the onBlur validation then cancelling leaves the filter in a bad state.


## How to test

- Go to AR landing (with no preexisting filters)
- Click the filter menu to trigger the 'blur' validation
- Click cancel
- Reopen the filter menu 
- You should still see the original filter with the validation

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
