### PR TITLE
[TTAHUB-1137] Add RTTAPA filter to goals & objectives page

### DIFF
--- a/frontend/src/components/filter/FilterGoalType.js
+++ b/frontend/src/components/filter/FilterGoalType.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown } from '@trussworks/react-uswds';
+
+export default function FilterGoalType({ onApply, goalType }) {
+  const onApplyGoalType = (e) => {
+    const { target: { value } } = e;
+    onApply(value);
+  };
+
+  return (
+    <>
+      { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+      <label className="sr-only" htmlFor="goalType">Select goal type to filter by</label>
+      <Dropdown name="goalType" id="goalType" value={goalType} onChange={onApplyGoalType}>
+        <option>
+          RTTAPA
+        </option>
+        <option>
+          Emergent
+        </option>
+      </Dropdown>
+    </>
+  );
+}
+
+FilterGoalType.propTypes = {
+  onApply: PropTypes.func.isRequired,
+  goalType: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};

--- a/frontend/src/components/filter/FilterGoalType.js
+++ b/frontend/src/components/filter/FilterGoalType.js
@@ -17,7 +17,7 @@ export default function FilterGoalType({ onApply, goalType }) {
           RTTAPA
         </option>
         <option>
-          Emergent
+          Non-RTTAPA
         </option>
       </Dropdown>
     </>

--- a/frontend/src/components/filter/__tests__/FilterGoalType.js
+++ b/frontend/src/components/filter/__tests__/FilterGoalType.js
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FilterGoalType from '../FilterGoalType';
+
+const { findByRole } = screen;
+
+describe('FilterGoalType', () => {
+  const renderFilterGoalType = (appliedType, onApply) => (
+    render(
+      <FilterGoalType
+        onApply={onApply}
+        goalType={appliedType}
+      />,
+    ));
+
+  it('calls the onapply handler', async () => {
+    const onApply = jest.fn();
+    renderFilterGoalType('RTTAPA', onApply);
+    const select = await findByRole('combobox', { name: /Select goal type to filter by/i });
+    userEvent.selectOptions(select, 'Emergent');
+    expect(onApply).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/filter/__tests__/FilterGoalType.js
+++ b/frontend/src/components/filter/__tests__/FilterGoalType.js
@@ -22,7 +22,7 @@ describe('FilterGoalType', () => {
     const onApply = jest.fn();
     renderFilterGoalType('RTTAPA', onApply);
     const select = await findByRole('combobox', { name: /Select goal type to filter by/i });
-    userEvent.selectOptions(select, 'Emergent');
+    userEvent.selectOptions(select, 'Non-RTTAPA');
     expect(onApply).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/filter/__tests__/goalFilters.js
+++ b/frontend/src/components/filter/__tests__/goalFilters.js
@@ -8,7 +8,12 @@ import {
   waitFor,
 } from '@testing-library/react';
 import {
-  createDateFilter, reasonsFilter, statusFilter, topicsFilter, grantNumberFilter,
+  createDateFilter,
+  reasonsFilter,
+  statusFilter,
+  topicsFilter,
+  grantNumberFilter,
+  goalTypeFilter,
 } from '../goalFilters';
 import FilterErrorContext from '../FilterErrorContext';
 
@@ -125,6 +130,22 @@ describe('goalFilters', () => {
       renderFilter(() => grantFilter.renderInput('1', 'test', [], apply));
       const grantNumberInput = await screen.findByLabelText('Select grant numbers to filter by');
       await selectEvent.select(grantNumberInput, ['number EHS']);
+      expect(apply).toHaveBeenCalled();
+    });
+  });
+
+  describe('goalTypeFilter', () => {
+    it('renders correctly', async () => {
+      renderFilter(() => goalTypeFilter.renderInput('1', 'is', 'RTTAPA', () => {}));
+      const goalTypeInput = await screen.findByLabelText('Select goal type to filter by');
+      expect(goalTypeInput).toBeInTheDocument();
+    });
+
+    it('calls onApply', async () => {
+      const apply = jest.fn();
+      renderFilter(() => goalTypeFilter.renderInput('1', 'is not', 'RTTAPA', apply));
+      const goalTypeInput = await screen.findByLabelText('Select goal type to filter by');
+      userEvent.selectOptions(goalTypeInput, 'Emergent');
       expect(apply).toHaveBeenCalled();
     });
   });

--- a/frontend/src/components/filter/__tests__/goalFilters.js
+++ b/frontend/src/components/filter/__tests__/goalFilters.js
@@ -145,7 +145,7 @@ describe('goalFilters', () => {
       const apply = jest.fn();
       renderFilter(() => goalTypeFilter.renderInput('1', 'is not', 'RTTAPA', apply));
       const goalTypeInput = await screen.findByLabelText('Select goal type to filter by');
-      userEvent.selectOptions(goalTypeInput, 'Emergent');
+      userEvent.selectOptions(goalTypeInput, 'Non-RTTAPA');
       expect(apply).toHaveBeenCalled();
     });
   });

--- a/frontend/src/components/filter/goalFilters.js
+++ b/frontend/src/components/filter/goalFilters.js
@@ -11,6 +11,7 @@ import FilterReasonSelect from './FilterReasonSelect';
 import FilterTopicSelect from './FilterTopicSelect';
 import FilterStatus from './FilterStatus';
 import FilterSelect from './FilterSelect';
+import FilterGoalType from './FilterGoalType';
 
 const LAST_THIRTY_DAYS = formatDateRange({ lastThirtyDays: true, forDateTime: true });
 
@@ -125,3 +126,20 @@ export const grantNumberFilter = (possibleGrants) => ({
     />
   ),
 });
+
+export const goalTypeFilter = {
+  id: 'goalType',
+  display: 'Goal type',
+  conditions: FILTER_CONDITIONS,
+  defaultValues: {
+    is: 'RTTAPA',
+    'is not': 'RTTAPA',
+  },
+  displayQuery: handleArrayQuery,
+  renderInput: (_id, _condition, query, onApplyQuery) => (
+    <FilterGoalType
+      onApply={onApplyQuery}
+      goalType={query}
+    />
+  ),
+};

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -2,11 +2,16 @@ import {
   specialistRoleFilter, endDateFilter, startDateFilter, myReportsFilter,
 } from '../../../components/filter/activityReportFilters';
 import {
-  statusFilter, createDateFilter, topicsFilter, reasonsFilter, grantNumberFilter,
+  statusFilter, createDateFilter, topicsFilter, reasonsFilter, grantNumberFilter, goalTypeFilter,
 } from '../../../components/filter/goalFilters';
 
 export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) => [
-  createDateFilter, grantNumberFilter(grantNumberParams), reasonsFilter, statusFilter, topicsFilter,
+  createDateFilter,
+  grantNumberFilter(grantNumberParams),
+  reasonsFilter,
+  statusFilter,
+  topicsFilter,
+  goalTypeFilter,
 ];
 
 export const TTAHISTORY_FILTER_CONFIG = [

--- a/src/models/goal.js
+++ b/src/models/goal.js
@@ -3,6 +3,8 @@ const { CLOSE_SUSPEND_REASONS } = require('../constants');
 const { formatDate } = require('../lib/modelHelpers');
 const { beforeValidate, beforeUpdate, afterUpdate } = require('./hooks/goal');
 
+export const RTTAPA_ENUM = ['Yes', 'No'];
+
 /**
  * Goals table. Stores goals for tta.
  *
@@ -81,7 +83,7 @@ export default (sequelize, DataTypes) => {
       default: false,
     },
     isRttapa: {
-      type: DataTypes.ENUM(['Yes', 'No']),
+      type: DataTypes.ENUM(RTTAPA_ENUM),
       allowNull: true,
     },
     firstNotStartedAt: {

--- a/src/scopes/goals/goalType.ts
+++ b/src/scopes/goals/goalType.ts
@@ -2,7 +2,7 @@ import { Op, WhereOptions } from 'sequelize';
 
 const ENUM = {
   RTTAPA: 'Yes',
-  Emergent: 'No',
+  'Non-RTTAPA': 'No',
 };
 
 const filterQuery = (query: string[]): string[] => query

--- a/src/scopes/goals/goalType.ts
+++ b/src/scopes/goals/goalType.ts
@@ -1,0 +1,43 @@
+import { Op, WhereOptions } from 'sequelize';
+
+const ENUM = {
+  RTTAPA: 'Yes',
+  Emergent: 'No',
+};
+
+const filterQuery = (query: string[]): string[] => query
+  .filter((q) => q && ENUM[q])
+  .map((q) => ENUM[q]);
+
+export function withGoalType(query: string[]): WhereOptions {
+  const filteredQuery = filterQuery(query);
+  if (!filteredQuery.length) {
+    return {};
+  }
+
+  return {
+    isRttapa: {
+      [Op.in]: filteredQuery,
+    },
+  };
+}
+
+export function withoutGoalType(query: string[]): WhereOptions {
+  const filteredQuery = filterQuery(query);
+  if (!filteredQuery.length) {
+    return {};
+  }
+
+  return {
+    [Op.or]: [
+      {
+        isRttapa: {
+          [Op.notIn]: filteredQuery,
+        },
+      },
+      {
+        isRttapa: null,
+      },
+    ],
+  };
+}

--- a/src/scopes/goals/index.js
+++ b/src/scopes/goals/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import { createFiltersToScopes } from '../utils';
 import { beforeCreateDate, afterCreateDate, withinCreateDate } from './createDate';
 import { withoutStatus, withStatus } from './status';
@@ -8,6 +7,7 @@ import { withRecipientId } from './recipientId';
 import { withRegion, withoutRegion } from './region';
 import { withRoles, withoutRoles } from './role';
 import { withGrantNumber, withoutGrantNumber } from './grantNumber';
+import { withGoalType, withoutGoalType } from './goalType';
 
 export const topicToQuery = {
   createDate: {
@@ -15,6 +15,10 @@ export const topicToQuery = {
     aft: (query) => afterCreateDate(query),
     win: (query) => withinCreateDate(query),
     in: (query) => withinCreateDate(query),
+  },
+  goalType: {
+    in: (query) => withGoalType(query),
+    nin: (query) => withoutGoalType(query),
   },
   status: {
     in: (query) => withStatus(query),

--- a/src/scopes/goals/index.test.js
+++ b/src/scopes/goals/index.test.js
@@ -668,7 +668,7 @@ describe('goal filtersToScopes', () => {
         expect(names).toContain('Goal 2');
       });
       it('no', async () => {
-        const filters = { 'goalType.in': 'Emergent' };
+        const filters = { 'goalType.in': 'Non-RTTAPA' };
         const { goal: scope } = await filtersToScopes(filters, 'goal');
         const found = await Goal.findAll({
           where: {
@@ -727,7 +727,7 @@ describe('goal filtersToScopes', () => {
         expect(names).not.toContain('Goal 2');
       });
       it('no', async () => {
-        const filters = { 'goalType.nin': 'Emergent' };
+        const filters = { 'goalType.nin': 'Non-RTTAPA' };
         const { goal: scope } = await filtersToScopes(filters, 'goal');
         const found = await Goal.findAll({
           where: {

--- a/src/scopes/goals/index.test.js
+++ b/src/scopes/goals/index.test.js
@@ -70,6 +70,7 @@ describe('goal filtersToScopes', () => {
           isFromSmartsheetTtaPlan: false,
           createdAt: new Date('2021-01-02'),
           grantId: reasonsGrant.id,
+          isRttapa: 'Yes',
         }),
         // goal for topics
         await Goal.create({
@@ -79,6 +80,7 @@ describe('goal filtersToScopes', () => {
           isFromSmartsheetTtaPlan: false,
           createdAt: new Date('2021-01-02'),
           grantId: topicsGrant.id,
+          isRttapa: 'Yes',
         }),
         // goal for status
         await Goal.create({
@@ -88,6 +90,7 @@ describe('goal filtersToScopes', () => {
           isFromSmartsheetTtaPlan: false,
           createdAt: new Date('2021-01-02'),
           grantId: goalGrant.id,
+          isRttapa: 'No',
         }),
         // goal for status
         await Goal.create({
@@ -97,6 +100,7 @@ describe('goal filtersToScopes', () => {
           isFromSmartsheetTtaPlan: false,
           createdAt: new Date('2021-01-02'),
           grantId: goalGrant.id,
+          isRttapa: 'No',
         }),
         // goal for startDate
         await Goal.create({
@@ -639,6 +643,126 @@ describe('goal filtersToScopes', () => {
 
       expect(found.length).toBe(6);
       expect(found[0].name).not.toContain('Goal 7');
+    });
+  });
+
+  describe('goalType', () => {
+    describe('withGoalType', () => {
+      it('RTTAPA', async () => {
+        const filters = { 'goalType.in': 'RTTAPA' };
+        const { goal: scope } = await filtersToScopes(filters, 'goal');
+        const found = await Goal.findAll({
+          where: {
+            [Op.and]: [
+              scope,
+              {
+                id: possibleGoalIds,
+              },
+            ],
+          },
+        });
+
+        expect(found.length).toBe(2);
+        const names = found.map((f) => f.name);
+        expect(names).toContain('Goal 1');
+        expect(names).toContain('Goal 2');
+      });
+      it('no', async () => {
+        const filters = { 'goalType.in': 'Emergent' };
+        const { goal: scope } = await filtersToScopes(filters, 'goal');
+        const found = await Goal.findAll({
+          where: {
+            [Op.and]: [
+              scope,
+              {
+                id: possibleGoalIds,
+              },
+            ],
+          },
+        });
+
+        expect(found.length).toBe(2);
+        const names = found.map((f) => f.name);
+        expect(names).toContain('Goal 3');
+        expect(names).toContain('Goal 4');
+      });
+
+      it('other', async () => {
+        const filters = { 'goalType.in': 'false' };
+        const { goal: scope } = await filtersToScopes(filters, 'goal');
+        const found = await Goal.findAll({
+          where: {
+            [Op.and]: [
+              scope,
+              {
+                id: possibleGoalIds,
+              },
+            ],
+          },
+        });
+
+        expect(possibleGoalIds.length).toBe(7);
+        expect(found.length).toBe(7);
+      });
+    });
+
+    describe('withoutRttapa', () => {
+      it('yes', async () => {
+        const filters = { 'goalType.nin': 'RTTAPA' };
+        const { goal: scope } = await filtersToScopes(filters, 'goal');
+        const found = await Goal.findAll({
+          where: {
+            [Op.and]: [
+              scope,
+              {
+                id: possibleGoalIds,
+              },
+            ],
+          },
+        });
+
+        expect(found.length).toBe(5);
+        const names = found.map((f) => f.name);
+        expect(names).not.toContain('Goal 1');
+        expect(names).not.toContain('Goal 2');
+      });
+      it('no', async () => {
+        const filters = { 'goalType.nin': 'Emergent' };
+        const { goal: scope } = await filtersToScopes(filters, 'goal');
+        const found = await Goal.findAll({
+          where: {
+            [Op.and]: [
+              scope,
+              {
+                id: possibleGoalIds,
+              },
+            ],
+          },
+        });
+
+        expect(found.length).toBe(5);
+        const names = found.map((f) => f.name);
+        expect(names).not.toContain('Goal 3');
+        expect(names).not.toContain('Goal 4');
+      });
+
+      it('other', async () => {
+        const filters = { 'goalType.nin': 'false' };
+        const { goal: scope } = await filtersToScopes(filters, 'goal');
+        const found = await Goal.findAll({
+          where: {
+            [Op.and]: [
+              scope,
+              {
+                id: possibleGoalIds,
+              },
+            ],
+          },
+        });
+
+        expect(possibleGoalIds.length).toBe(7);
+        expect(found.length).toBe(7);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description of change
Add an RTTAPA filter to the goals & objectives page. Filter by "RTTAPA" or "Non-RTTAPA" goals

## How to test
Check the filter on the page within the recipient record

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1137


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
