### PR TITLE
[TTAHUB-1526] Add alert size option

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -141,7 +141,7 @@ function App() {
         <Route
           path="/activity-reports/legacy/:legacyId([0-9RA\-]*)"
           render={({ match }) => (
-            <AppWrapper authenticated logout={logout}>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
               <LegacyReport
                 match={match}
               />
@@ -162,12 +162,16 @@ function App() {
         <Route
           exact
           path="/"
-          render={() => <AppWrapper authenticated logout={logout}><Home /></AppWrapper>}
+          render={() => (
+            <AppWrapper hasAlerts={!!(alert)} authenticated logout={logout}>
+              <Home />
+            </AppWrapper>
+          )}
         />
         <Route
           path="/activity-reports/view/:activityReportId([0-9]*)"
           render={({ match, location }) => (
-            <AppWrapper authenticated logout={logout}>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
               <ApprovedActivityReport location={location} match={match} user={user} />
             </AppWrapper>
           )}
@@ -175,7 +179,7 @@ function App() {
         <Route
           path="/activity-reports/:activityReportId(new|[0-9]*)/:currentPage([a-z\-]*)?"
           render={({ match, location }) => (
-            <AppWrapper authenticated logout={logout}>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
               <ActivityReport location={location} match={match} />
             </AppWrapper>
           )}
@@ -183,7 +187,7 @@ function App() {
         <Route
           path="/recipient-tta-records/:recipientId([0-9]*)/region/:regionId([0-9]*)"
           render={({ match, location }) => (
-            <AppWrapper authenticated logout={logout} padded={false}>
+            <AppWrapper authenticated logout={logout} padded={false} hasAlerts={!!(alert)}>
               <RecipientRecord
                 location={location}
                 match={match}
@@ -197,14 +201,16 @@ function App() {
           exact
           path="/regional-dashboard"
           render={() => (
-            <AppWrapper authenticated logout={logout}><RegionalDashboard user={user} /></AppWrapper>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
+              <RegionalDashboard user={user} />
+            </AppWrapper>
           )}
         />
         <Route
           exact
           path="/account"
           render={() => (
-            <AppWrapper authenticated logout={logout}>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
               <AccountManagement updateUser={updateUser} />
             </AppWrapper>
           )}
@@ -213,7 +219,7 @@ function App() {
           exact
           path="/account/verify-email/:token"
           render={() => (
-            <AppWrapper authenticated logout={logout}>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
               <AccountManagement updateUser={updateUser} />
             </AppWrapper>
           )}
@@ -227,7 +233,7 @@ function App() {
         <Route
           path="/admin"
           render={() => (
-            <AppWrapper authenticated logout={logout}><Admin /></AppWrapper>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}><Admin /></AppWrapper>
           )}
         />
         )}
@@ -235,13 +241,17 @@ function App() {
           exact
           path="/recipient-tta-records"
           render={() => (
-            <AppWrapper authenticated logout={logout}>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
               <RecipientSearch user={user} />
             </AppWrapper>
           )}
         />
         <Route
-          render={() => <AppWrapper authenticated logout={logout}><NotFound /></AppWrapper>}
+          render={() => (
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
+              <NotFound />
+            </AppWrapper>
+          )}
         />
       </Switch>
     </>

--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -309,7 +309,7 @@ export const ALL_PARTICIPANTS = [
   ...OTHER_ENTITY_PARTICIPANTS,
 ];
 
-// note that if this status or variant list is changed, it needs also to be changed in
+// note that if these alert status, size, or variant list is changed, it needs also to be changed in
 // - src/constants.js
 export const ALERT_STATUSES = {
   UNPUBLISHED: 'Unpublished',
@@ -319,4 +319,9 @@ export const ALERT_STATUSES = {
 export const ALERT_VARIANTS = {
   INFO: 'info',
   EMERGENCY: 'emergency',
+};
+
+export const ALERT_SIZES = {
+  SLIM: 'slim',
+  STANDARD: 'standard',
 };

--- a/frontend/src/components/AppWrapper.js
+++ b/frontend/src/components/AppWrapper.js
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import IdleModal from './IdleModal';
 
 export default function AppWrapper({
-  padded, authenticated, children, logout,
+  padded, authenticated, children, logout, hasAlerts,
 }) {
+  const appWrapperRef = useRef(null);
+
+  // This resizes the site nav content's gap to account for the header if there is an alert
+  useEffect(() => {
+    if (hasAlerts && appWrapperRef.current) {
+      const header = document.querySelector('.smart-hub-header.has-alerts');
+      if (header) {
+        appWrapperRef.current.style.marginTop = `${appWrapperRef.current.style.marginTop + header.offsetHeight}px`;
+      }
+    }
+  }, [hasAlerts]);
+
   if (!authenticated) {
     return children;
   }
@@ -23,7 +35,7 @@ export default function AppWrapper({
 
   if (padded) {
     return (
-      <div className="grid-row maxw-widescreen flex-align-start smart-hub-offset-nav tablet:smart-hub-offset-nav desktop:smart-hub-offset-nav margin-top-9 margin-right-5">
+      <div ref={appWrapperRef} id="appWrapper" className="grid-row maxw-widescreen flex-align-start smart-hub-offset-nav tablet:smart-hub-offset-nav desktop:smart-hub-offset-nav margin-top-9 margin-right-5">
         <div className="grid-col-12 margin-top-2 margin-right-2 margin-left-3">
           <section className="usa-section padding-top-3">
             {content}
@@ -34,7 +46,7 @@ export default function AppWrapper({
   }
 
   return (
-    <div id="appWrapper" className="grid-row flex-align-start smart-hub-offset-nav tablet:smart-hub-offset-nav desktop:smart-hub-offset-nav margin-top-9">
+    <div ref={appWrapperRef} id="appWrapper" className="grid-row flex-align-start smart-hub-offset-nav tablet:smart-hub-offset-nav desktop:smart-hub-offset-nav margin-top-9">
       <div className="grid-col-12">
         <section className="usa-section padding-top-0">
           {content}
@@ -49,9 +61,11 @@ AppWrapper.propTypes = {
   padded: PropTypes.bool,
   children: PropTypes.node.isRequired,
   logout: PropTypes.func.isRequired,
+  hasAlerts: PropTypes.bool,
 };
 
 AppWrapper.defaultProps = {
   authenticated: false,
   padded: true,
+  hasAlerts: false,
 };

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -33,6 +33,7 @@ function Header({ authenticated, alert }) {
           <SiteAlert
             heading={alert.title}
             variant={alert.variant}
+            size={alert.size}
           >
             <ReadOnlyEditor value={alert.message} ariaLabel="alert for the tta hub: " />
           </SiteAlert>
@@ -61,6 +62,7 @@ Header.propTypes = {
     title: PropTypes.string,
     message: PropTypes.string,
     variant: PropTypes.string,
+    size: PropTypes.string,
   }),
 };
 

--- a/frontend/src/components/SiteAlert.js
+++ b/frontend/src/components/SiteAlert.js
@@ -4,7 +4,7 @@ import { SiteAlert as BaseSiteAlert } from '@trussworks/react-uswds';
 import './SiteAlert.scss';
 
 export default function SiteAlert({
-  heading, children, style, variant,
+  heading, children, style, variant, size,
 }) {
   return (
     <BaseSiteAlert
@@ -12,7 +12,7 @@ export default function SiteAlert({
       heading={heading}
       showIcon
       style={{ ...style }}
-      className="usa-site-alert--ttahub"
+      className={`usa-site-alert--ttahub usa-site-alert--ttahub__${size}`}
     >
       {children}
     </BaseSiteAlert>
@@ -24,6 +24,7 @@ SiteAlert.propTypes = {
   children: PropTypes.node.isRequired,
   style: PropTypes.shape({}),
   variant: PropTypes.string.isRequired,
+  size: PropTypes.string.isRequired,
 };
 
 SiteAlert.defaultProps = {

--- a/frontend/src/components/SiteAlert.scss
+++ b/frontend/src/components/SiteAlert.scss
@@ -1,7 +1,7 @@
 @use '../colors.scss' as *;
 
 @media (min-width: 64rem) { 
-    .usa-site-alert--ttahub .usa-alert__body {
+    .usa-site-alert--ttahub__slim .usa-alert__body {
         align-items: center;
         display: grid;
         grid-template-columns: max-content 1fr;
@@ -27,7 +27,7 @@
   background-color: $error-dark;
 }
 
-.usa-site-alert--ttahub .usa-alert__heading {
+.usa-site-alert--ttahub__slim .usa-alert__heading {
    font-size: 1.06rem;
    margin: 0;
 }

--- a/frontend/src/pages/Admin/SiteAlerts.js
+++ b/frontend/src/pages/Admin/SiteAlerts.js
@@ -2,7 +2,7 @@ import { Button, Alert } from '@trussworks/react-uswds';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import Container from '../../components/Container';
-import { ALERT_STATUSES } from '../../Constants';
+import { ALERT_SIZES, ALERT_STATUSES, ALERT_VARIANTS } from '../../Constants';
 import { deleteSiteAlert, getSiteAlerts } from '../../fetchers/Admin';
 import AlertReview from './components/AlertReview';
 
@@ -14,7 +14,8 @@ export const DEFAULT_ALERT = {
   endDate: '',
   id: Math.random(),
   isNew: true,
-  variant: 'info',
+  variant: ALERT_VARIANTS.INFO,
+  size: ALERT_SIZES.STANDARD,
 };
 
 export default function SiteAlerts() {

--- a/frontend/src/pages/Admin/components/AlertReview.js
+++ b/frontend/src/pages/Admin/components/AlertReview.js
@@ -15,7 +15,7 @@ import SiteAlert from '../../../components/SiteAlert';
 import Req from '../../../components/Req';
 import { saveSiteAlert, createSiteAlert } from '../../../fetchers/Admin';
 import ReadOnlyEditor from '../../../components/ReadOnlyEditor';
-import { ALERT_STATUSES, ALERT_VARIANTS } from '../../../Constants';
+import { ALERT_SIZES, ALERT_STATUSES, ALERT_VARIANTS } from '../../../Constants';
 import './AlertReview.scss';
 
 const BASE_EDITOR_HEIGHT = '10rem';
@@ -31,6 +31,7 @@ export default function AlertReview({ alert, onDelete }) {
   const [startDate, setStartDate] = useState(alert.startDate);
   const [endDate, setEndDate] = useState(alert.endDate);
   const [status, setStatus] = useState(alert.status);
+  const [size, setSize] = useState(alert.size);
   const [isFetching, setIsFetching] = useState(false);
   const [offset, setOffset] = useState(71);
 
@@ -65,6 +66,7 @@ export default function AlertReview({ alert, onDelete }) {
       title,
       status,
       variant,
+      size,
     };
 
     if (isNew) {
@@ -112,6 +114,7 @@ export default function AlertReview({ alert, onDelete }) {
         <SiteAlert
           heading={title}
           className="z-index-100"
+          size={size}
           style={{
             minHeight: '3rem',
             position: isEditable ? 'sticky' : 'relative',
@@ -195,6 +198,28 @@ export default function AlertReview({ alert, onDelete }) {
               required
             >
               {Object.values(ALERT_VARIANTS).map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="margin-top-3">
+            <label htmlFor={`alert-${alert.id}-size`}>
+              Size
+              <Req />
+            </label>
+            <select
+              id={`alert-${alert.id}-size`}
+              className="usa-select"
+              name={`alert-${alert.id}-size`}
+              value={size}
+              onChange={(e) => setSize(e.target.value)}
+              disabled={isFetching}
+              required
+            >
+              {Object.values(ALERT_SIZES).map((v) => (
                 <option key={v} value={v}>
                   {v}
                 </option>
@@ -305,5 +330,6 @@ AlertReview.propTypes = {
     status: PropTypes.string.isRequired,
     isNew: PropTypes.bool,
     variant: PropTypes.string,
+    size: PropTypes.string,
   }).isRequired,
 };

--- a/frontend/src/pages/RecipientRecord/index.js
+++ b/frontend/src/pages/RecipientRecord/index.js
@@ -25,19 +25,7 @@ function PageWithHeading({
   recipientNameWithRegion,
   backLink,
   slug,
-  hasAlerts,
 }) {
-  // This resizes the site nav content's gap to account for the header if there is an alert
-  useEffect(() => {
-    const appWrapper = document.querySelector('#appWrapper');
-    if (hasAlerts && appWrapper) {
-      const header = document.querySelector('.smart-hub-header.has-alerts');
-      if (header) {
-        appWrapper.style.marginTop = `${appWrapper.style.marginTop + header.offsetHeight}px`;
-      }
-    }
-  }, [hasAlerts]);
-
   return (
     <div>
       <RecipientTabs region={regionId} recipientId={recipientId} backLink={backLink} />
@@ -71,7 +59,6 @@ PageWithHeading.propTypes = {
   recipientNameWithRegion: PropTypes.string.isRequired,
   backLink: PropTypes.node,
   slug: PropTypes.string,
-  hasAlerts: PropTypes.bool.isRequired,
 };
 
 PageWithHeading.defaultProps = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,11 @@ export const ALERT_VARIANTS = {
   EMERGENCY: 'emergency',
 };
 
+export const ALERT_SIZES = {
+  STANDARD: 'standard',
+  SLIM: 'slim',
+};
+
 export const DATE_FORMAT = 'MM/DD/YYYY';
 
 export const DECIMAL_BASE = 10;

--- a/src/migrations/20230223193406-add-alert-size-variant.js
+++ b/src/migrations/20230223193406-add-alert-size-variant.js
@@ -20,7 +20,7 @@ module.exports = {
         defaultValue: 'standard',
       }, { transaction });
 
-      return queryInterface.sequelize.query('UPDATE "SiteAlerts" SET "size" = \'slim\'', { transaction });
+      return queryInterface.sequelize.query('UPDATE "SiteAlerts" SET "size" = \'standard\'', { transaction });
     });
   },
 

--- a/src/migrations/20230223193406-add-alert-size-variant.js
+++ b/src/migrations/20230223193406-add-alert-size-variant.js
@@ -1,0 +1,44 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      const loggedUser = '0';
+      const sessionSig = __filename;
+      const auditDescriptor = 'RUN MIGRATIONS';
+      await queryInterface.sequelize.query(
+        `SELECT
+              set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+              set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+              set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+              set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+        { transaction },
+      );
+
+      await queryInterface.addColumn('SiteAlerts', 'size', {
+        type: Sequelize.ENUM('standard', 'slim'),
+        allowNull: false,
+        defaultValue: 'standard',
+      }, { transaction });
+
+      return queryInterface.sequelize.query('UPDATE "SiteAlerts" SET "size" = \'slim\'', { transaction });
+    });
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      const loggedUser = '0';
+      const sessionSig = __filename;
+      const auditDescriptor = 'RUN MIGRATIONS';
+      await queryInterface.sequelize.query(
+        `SELECT
+              set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+              set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+              set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+              set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+        { transaction },
+      );
+
+      return queryInterface.removeColumn('SiteAlerts', 'size', { transaction });
+    });
+  },
+};

--- a/src/models/siteAlert.js
+++ b/src/models/siteAlert.js
@@ -1,11 +1,12 @@
 const {
   Model,
 } = require('sequelize');
-const { ALERT_STATUSES, ALERT_VARIANTS } = require('../constants');
+const { ALERT_STATUSES, ALERT_VARIANTS, ALERT_SIZES } = require('../constants');
 const { formatDate } = require('../lib/modelHelpers');
 
 const possibleStatuses = Object.values(ALERT_STATUSES);
 const possibleVariants = Object.values(ALERT_VARIANTS);
+const possibleSizes = Object.values(ALERT_SIZES);
 
 /**
    *
@@ -53,6 +54,9 @@ export default (sequelize, DataTypes) => {
     },
     variant: {
       type: DataTypes.ENUM(possibleVariants),
+    },
+    size: {
+      type: DataTypes.ENUM(possibleSizes),
     },
   }, {
     sequelize,

--- a/src/routes/admin/siteAlert.js
+++ b/src/routes/admin/siteAlert.js
@@ -15,6 +15,7 @@ const ALERT_FIELDS = [
   'endDate',
   'startDate',
   'variant',
+  'size',
 ];
 
 /**
@@ -106,6 +107,7 @@ async function createAlert(req, res) {
         endDate,
         startDate,
         variant,
+        size,
       } = req.body;
 
       const alert = await SiteAlert.create({
@@ -116,6 +118,7 @@ async function createAlert(req, res) {
         endDate,
         startDate,
         variant,
+        size,
       });
 
       res.json(alert);

--- a/src/routes/admin/siteAlert.test.js
+++ b/src/routes/admin/siteAlert.test.js
@@ -1,7 +1,7 @@
 import faker from '@faker-js/faker';
 import moment from 'moment';
 import httpCodes from 'http-codes';
-import { ALERT_STATUSES, ALERT_VARIANTS } from '../../constants';
+import { ALERT_SIZES, ALERT_STATUSES, ALERT_VARIANTS } from '../../constants';
 import SCOPES from '../../middleware/scopeConstants';
 import {
   User,
@@ -50,6 +50,7 @@ describe('site alert admin handler', () => {
       status: ALERT_STATUSES.UNPUBLISHED,
       title: faker.lorem.sentence(),
       variant: ALERT_VARIANTS.INFO,
+      size: ALERT_SIZES.STANDARD,
     });
 
     await SiteAlert.create({
@@ -60,6 +61,7 @@ describe('site alert admin handler', () => {
       status: ALERT_STATUSES.PUBLISHED,
       title: faker.lorem.sentence(),
       variant: ALERT_VARIANTS.INFO,
+      size: ALERT_SIZES.STANDARD,
     });
 
     await SiteAlert.create({
@@ -70,6 +72,7 @@ describe('site alert admin handler', () => {
       status: ALERT_STATUSES.PUBLISHED,
       title: faker.lorem.sentence(),
       variant: ALERT_VARIANTS.INFO,
+      size: ALERT_SIZES.STANDARD,
     });
   });
 
@@ -134,6 +137,7 @@ describe('site alert admin handler', () => {
           message: existingAlert.message,
           status: ALERT_STATUSES.UNPUBLISHED,
           title: expect.any(String),
+          size: ALERT_STATUSES.STANDARD,
         }),
       );
     });
@@ -254,6 +258,7 @@ describe('site alert admin handler', () => {
           status: ALERT_STATUSES.UNPUBLISHED,
           title,
           variant: existingAlert.variant,
+          size: ALERT_STATUSES.STANDARD,
         }),
       );
     });

--- a/src/routes/siteAlerts/handlers.js
+++ b/src/routes/siteAlerts/handlers.js
@@ -9,7 +9,7 @@ export async function getSiteAlerts(req, res) {
   try {
     const today = moment().format('YYYY-MM-DD');
     const alert = await SiteAlert.findOne({
-      attributes: ['id', 'title', 'message', 'startDate', 'endDate', 'status', 'variant'],
+      attributes: ['id', 'title', 'message', 'startDate', 'endDate', 'status', 'variant', 'size'],
       where: {
         startDate: {
           [Op.lte]: today,


### PR DESCRIPTION
## Description of change

Add a new option to the site alerts - "size" - to match [the design library](https://www.figma.com/file/5Fr0NKQf9MQ5WGd8BWxA6i/TTA-Hub-Design-Library?node-id=2081%3A16917&t=kFE7PlUqykLTAv2s-0) more closely.

![Screenshot 2023-02-23 at 3 33 03 PM](https://user-images.githubusercontent.com/3288586/221023577-53969e19-3f3b-4242-be22-42edbaaab196.png)


## How to test

Add a site alert, choose different options. View them across the site and make sure that no content is cut off and that both size options display properly

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1526


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
