### PR TITLE
[TTAHUB-1528] Hide site alerts from print view

### DIFF
--- a/frontend/src/components/SiteAlert.js
+++ b/frontend/src/components/SiteAlert.js
@@ -12,7 +12,7 @@ export default function SiteAlert({
       heading={heading}
       showIcon
       style={{ ...style }}
-      className="usa-site-alert--ttahub"
+      className="usa-site-alert--ttahub no-print"
     >
       {children}
     </BaseSiteAlert>

--- a/frontend/src/pages/ApprovedActivityReport/index.scss
+++ b/frontend/src/pages/ApprovedActivityReport/index.scss
@@ -20,7 +20,8 @@
 
 @media print {
   .smart-hub-offset-nav {
-    max-width: none;
+    margin-top: 0 !important;
+    margin-right: 0;
   }
 
   .smart-hub-offset-nav, .ttahub-activity-report-view {
@@ -46,12 +47,7 @@
   .ttahub-activity-report-view hr {
     display: none;
   }
-
-  .smart-hub-offset-nav {
-    margin-top: 0;
-    margin-right: 0;
-  }
-
+ 
   .smart-hub-offset-nav > .grid-col-12 {
     margin: 0;
   }


### PR DESCRIPTION
## Description of change
Users should not see site alerts when printing. This change hides the site alerts from print view

## How to test
Print any page of the site, including the approved reports. You will notice that the site alert is not there.

## Issue(s)
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1528


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
