### PR TITLE
[TTAHUB-1503] remove "not approved" from review attachments section

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/FileReviewItem.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/FileReviewItem.js
@@ -15,8 +15,6 @@ const FileReviewItem = ({ filename, url, status }) => {
         <div className="flex-align-end display-flex flex-column no-print">
           {approved
           && <a href={url}>Download</a>}
-          {!approved
-          && <div>Not Approved</div>}
         </div>
       </Grid>
     </Grid>

--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/FileReviewItem.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/FileReviewItem.js
@@ -27,9 +27,9 @@ describe('ReviewPage', () => {
     expect(link).toHaveAttribute('href', 'http://localhost:3000');
   });
 
-  it('displays "not approved" if the file has not been approved', async () => {
+  it('does not display the download link if the file has not been approved', async () => {
     render(<RenderFileReviewItem status="" />);
-    const status = await screen.findByText('Not Approved');
-    expect(status).toBeVisible();
+    const link = screen.queryByRole('link');
+    expect(link).toBeNull();
   });
 });


### PR DESCRIPTION
## Description of change
If virus scanning fails for a supporting attachments, a "not approved" message is displayed in the review page for supporting attachments. The failure does not indicate that the file is not uploaded, or that it has failed the virus scan. It simply means that the virus scan was not yet successful. This "not approved" message is causing confusion as it does not clearly communicate the situation to the end user. 

This PR removes that message and simply shows nothing if the file is not approved.

## How to test
Upload a file to supporting attachments. Manually set the file to one of the statuses besides approved in your database. Review the report. You should see nothing.

## Issue(s)
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1503

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
