### PR TITLE
Anniversary Statistics Performance Fix for Read-only Users

### DIFF
--- a/src/services/users.js
+++ b/src/services/users.js
@@ -129,6 +129,7 @@ export async function statisticsByUser(user, regions, readonly = false, reportId
   WHERE ar."legacyId" IS NULL AND
   ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
   ${!readonly ? `AND ar."userId" = ${user.id}` : ''}
+  ${reportIds.length ? ` AND ar."id" IN (${reportIds.join(',')})` : ''}
   GROUP BY ar."id", ar."duration", ar."numberOfParticipants";
 
   -- Get Created Goals and Objectives.
@@ -183,7 +184,8 @@ export async function statisticsByUser(user, regions, readonly = false, reportId
     arp."grantId" = g."id"
   WHERE ar."legacyId" IS NULL AND
   ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
-  ${!readonly ? `AND arc."userId" = ${user.id}` : ''}
+  AND arc."userId" = ${user.id}
+  ${reportIds.length ? ` AND ar."id" IN (${reportIds.join(',')})` : ''}
   GROUP BY ar."id", ar."duration", ar."numberOfParticipants";
 
   -- Get Created Goals and Objectives.
@@ -237,7 +239,8 @@ export async function statisticsByUser(user, regions, readonly = false, reportId
       arp."grantId" = g."id"
     WHERE ar."legacyId" IS NULL AND
     ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
-    ${!readonly ? `AND ara."userId" = ${user.id}` : ''}
+    AND ara."userId" = ${user.id}
+    ${reportIds.length ? ` AND ar."id" IN (${reportIds.join(',')})` : ''}
     GROUP BY ar."id", ar."duration", ar."numberOfParticipants";
 
     -- Get Created Goals and Objectives.

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -126,8 +126,9 @@ export async function statisticsByUser(user, regions, readonly = false, reportId
     ar."id" = arp."activityReportId"
   LEFT JOIN "Grants" g ON
     arp."grantId" = g."id"
-  WHERE ar."legacyId" IS NULL AND
-  ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
+  WHERE ar."legacyId" IS NULL
+  AND ar."submissionStatus" != 'deleted'
+  AND ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
   ${!readonly ? `AND ar."userId" = ${user.id}` : ''}
   ${reportIds.length ? ` AND ar."id" IN (${reportIds.join(',')})` : ''}
   GROUP BY ar."id", ar."duration", ar."numberOfParticipants";
@@ -182,8 +183,9 @@ export async function statisticsByUser(user, regions, readonly = false, reportId
     ar."id" = arp."activityReportId"
   LEFT JOIN "Grants" g ON
     arp."grantId" = g."id"
-  WHERE ar."legacyId" IS NULL AND
-  ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
+  WHERE ar."legacyId" IS NULL
+  AND ar."submissionStatus" != 'deleted'
+  AND ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
   AND arc."userId" = ${user.id}
   ${reportIds.length ? ` AND ar."id" IN (${reportIds.join(',')})` : ''}
   GROUP BY ar."id", ar."duration", ar."numberOfParticipants";
@@ -237,8 +239,9 @@ export async function statisticsByUser(user, regions, readonly = false, reportId
       ar."id" = arp."activityReportId"
     LEFT JOIN "Grants" g ON
       arp."grantId" = g."id"
-    WHERE ar."legacyId" IS NULL AND
-    ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
+    WHERE ar."legacyId" IS NULL
+    AND ar."submissionStatus" != 'deleted'
+    AND ar."calculatedStatus" = 'approved' AND ar."regionId" IN (${regions.join(',')})
     AND ara."userId" = ${user.id}
     ${reportIds.length ? ` AND ar."id" IN (${reportIds.join(',')})` : ''}
     GROUP BY ar."id", ar."duration", ar."numberOfParticipants";


### PR DESCRIPTION
## Description of change

This is a re-write for Sequelize to raw SQL to fix the perf issue of users who have ONLY read only access to all regions.

## How to test

- Review the code.
- Make sure all tests pass.
- Using a user that has ONLY read-only access to ALL regions should return data within a few seconds (ie NOT 30 seconds).


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
