### PR TITLE
[TTAHUB-1552] Fix csv to include other recipient goal ids

### DIFF
--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -283,6 +283,10 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
       value: convert(ttaProvided),
       enumerable: true,
     });
+
+    // Add this objective to the tracked list.
+    processedObjectivesTitles.set(titleMd5, goalNum);
+
     objectiveNum += 1;
 
     return accum;

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -188,20 +188,11 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
       goal, title, status, ttaProvided, topics, files, resources,
     } = objective;
     const goalId = goal ? goal.id : null;
-    const md5Title = `${goalId}-${title}`;
-    const titleMd5 = md5(md5Title);
+    const titleMd5 = md5(title);
 
-    const lookupGoalNum = processedObjectivesTitles.get(titleMd5);
+    const existingObjectiveTitle = processedObjectivesTitles.get(titleMd5);
     const goalName = goal ? goal.name : null;
     const newGoal = goalName && !Object.values(accum).includes(goalName);
-    if (lookupGoalNum) {
-      // Make sure its not another objective for the same goal.
-      if (goalIds[goalName] && !goalIds[goalName].includes(goalId)) {
-        accum[`goal-${lookupGoalNum}-id`] = `${accum[`goal-${lookupGoalNum}-id`]}\n${goalId}`;
-        goalIds[goalName].push(goalId);
-      }
-      return accum;
-    }
 
     if (newGoal) {
       goalNum += 1;
@@ -233,6 +224,13 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
       });
 
       objectiveNum = 1;
+    } else if (existingObjectiveTitle) {
+      // Make sure its not another objective for the same goal.
+      if (goalIds[goalName] && !goalIds[goalName].includes(goalId)) {
+        accum[`goal-${existingObjectiveTitle}-id`] = `${accum[`goal-${existingObjectiveTitle}-id`]}\n${goalId}`;
+        goalIds[goalName].push(goalId);
+      }
+      return accum;
     }
 
     // goal number should be at least 1

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -188,10 +188,12 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
       goal, title, status, ttaProvided, topics, files, resources,
     } = objective;
     const goalId = goal ? goal.id : null;
-    const titleMd5 = md5(title);
+    const md5Title = `${goalId}-${title}`;
+    const titleMd5 = md5(md5Title);
 
     const lookupGoalNum = processedObjectivesTitles.get(titleMd5);
     const goalName = goal ? goal.name : null;
+    const newGoal = goalName && !Object.values(accum).includes(goalName);
     if (lookupGoalNum) {
       // Make sure its not another objective for the same goal.
       if (goalIds[goalName] && !goalIds[goalName].includes(goalId)) {
@@ -200,7 +202,6 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
       }
       return accum;
     }
-    const newGoal = goalName && !Object.values(accum).includes(goalName);
 
     if (newGoal) {
       goalNum += 1;

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -180,7 +180,7 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
   let goalNum = 0;
   const goalIds = {};
   let objectiveId;
-  const processedObjectivesTitles = [];
+  const processedObjectivesTitles = new Map();
 
   return objectiveRecords.reduce((prevAccum, objective) => {
     const accum = { ...prevAccum };
@@ -189,17 +189,19 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
     } = objective;
     const goalId = goal ? goal.id : null;
     const titleMd5 = md5(title);
-    if (processedObjectivesTitles.includes(titleMd5)) {
+
+    const lookupGoalNum = processedObjectivesTitles.get(titleMd5);
+    if (lookupGoalNum) {
+      accum[`goal-${lookupGoalNum}-id`] = `${accum[`goal-${lookupGoalNum}-id`]}\n${goalId}`;
       return accum;
     }
 
-    processedObjectivesTitles.push(titleMd5);
     const goalName = goal ? goal.name : null;
     const newGoal = goalName && !Object.values(accum).includes(goalName);
 
     if (newGoal) {
       goalNum += 1;
-
+      processedObjectivesTitles.set(titleMd5, goalNum);
       // Goal Id.
       Object.defineProperty(accum, `goal-${goalNum}-id`, {
         value: `${goalId}`,
@@ -227,10 +229,6 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
       });
 
       objectiveNum = 1;
-    } else if (goalIds[goalName] && !goalIds[goalName].includes(goalId)) {
-      // Update existing ids.
-      goalIds[goalName].push(goalId);
-      accum[`goal-${goalNum}-id`] = goalIds[goalName].join('\n');
     }
 
     // goal number should be at least 1

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -191,12 +191,15 @@ function makeGoalsAndObjectivesObject(objectiveRecords) {
     const titleMd5 = md5(title);
 
     const lookupGoalNum = processedObjectivesTitles.get(titleMd5);
+    const goalName = goal ? goal.name : null;
     if (lookupGoalNum) {
-      accum[`goal-${lookupGoalNum}-id`] = `${accum[`goal-${lookupGoalNum}-id`]}\n${goalId}`;
+      // Make sure its not another objective for the same goal.
+      if (goalIds[goalName] && !goalIds[goalName].includes(goalId)) {
+        accum[`goal-${lookupGoalNum}-id`] = `${accum[`goal-${lookupGoalNum}-id`]}\n${goalId}`;
+        goalIds[goalName].push(goalId);
+      }
       return accum;
     }
-
-    const goalName = goal ? goal.name : null;
     const newGoal = goalName && !Object.values(accum).includes(goalName);
 
     if (newGoal) {

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -76,6 +76,14 @@ describe('activityReportToCsvRecord', () => {
       timeframe: 'None',
       createdVia: 'activityReport',
     },
+    {
+      name: 'Goal 4',
+      id: 2084,
+      status: 'Not Started',
+      grantId: 3,
+      timeframe: 'None',
+      createdVia: 'activityReport',
+    },
   ];
 
   const mockObjectives = [
@@ -127,6 +135,21 @@ describe('activityReportToCsvRecord', () => {
       ttaProvided: 'Training',
       status: OBJECTIVE_STATUS.COMPLETE,
       goal: mockGoals[2],
+    },
+    // Duplicate Objective name for goal 3.
+    {
+      id: 18,
+      title: 'Objective 3.1',
+      ttaProvided: 'Training',
+      status: OBJECTIVE_STATUS.COMPLETE,
+      goal: mockGoals[4],
+    },
+    {
+      id: 19,
+      title: 'Objective 4.2',
+      ttaProvided: 'Training',
+      status: OBJECTIVE_STATUS.COMPLETE,
+      goal: mockGoals[4],
     },
   ];
 
@@ -422,7 +445,6 @@ describe('activityReportToCsvRecord', () => {
     }));
 
     const output = makeGoalsAndObjectivesObject(objectives);
-    console.log('\n\n\n---Output: ', output);
     expect(output).toEqual({
       'goal-1-id': '2080',
       'goal-1': 'Goal 1',
@@ -472,6 +494,22 @@ describe('activityReportToCsvRecord', () => {
       'objective-3.1-nonResourceLinks': 'TestFile.docx',
       'objective-3.1-ttaProvided': 'Training',
       'objective-3.1-status': 'Complete',
+      'goal-4-id': '2084',
+      'goal-4': 'Goal 4',
+      'goal-4-status': 'Not Started',
+      'goal-4-created-from': 'activityReport',
+      'objective-4.1': 'Objective 3.1',
+      'objective-4.1-topics': 'Topic 1',
+      'objective-4.1-resourcesLinks': 'https://test.gov',
+      'objective-4.1-nonResourceLinks': 'TestFile.docx',
+      'objective-4.1-ttaProvided': 'Training',
+      'objective-4.1-status': 'Complete',
+      'objective-4.2': 'Objective 4.2',
+      'objective-4.2-topics': 'Topic 1',
+      'objective-4.2-resourcesLinks': 'https://test.gov',
+      'objective-4.2-nonResourceLinks': 'TestFile.docx',
+      'objective-4.2-ttaProvided': 'Training',
+      'objective-4.2-status': 'Complete',
     });
   });
 

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -84,6 +84,15 @@ describe('activityReportToCsvRecord', () => {
       timeframe: 'None',
       createdVia: 'activityReport',
     },
+    // Same goal different recipient.
+    {
+      name: 'Goal 1',
+      id: 2085,
+      status: 'Not Started',
+      grantId: 4,
+      timeframe: 'None',
+      createdVia: 'activityReport',
+    },
   ];
 
   const mockObjectives = [
@@ -136,7 +145,7 @@ describe('activityReportToCsvRecord', () => {
       status: OBJECTIVE_STATUS.COMPLETE,
       goal: mockGoals[2],
     },
-    // Duplicate Objective name for goal 3.
+    // Duplicate Objective name for goal 4.
     {
       id: 18,
       title: 'Objective 3.1',
@@ -150,6 +159,21 @@ describe('activityReportToCsvRecord', () => {
       ttaProvided: 'Training',
       status: OBJECTIVE_STATUS.COMPLETE,
       goal: mockGoals[4],
+    },
+    // Same as goal 1 different recipient.
+    {
+      id: 20,
+      title: 'Objective 1.1',
+      ttaProvided: 'Training',
+      status: OBJECTIVE_STATUS.COMPLETE,
+      goal: mockGoals[5],
+    },
+    {
+      id: 21,
+      title: 'Objective 1.2',
+      ttaProvided: 'Training',
+      status: OBJECTIVE_STATUS.COMPLETE,
+      goal: mockGoals[5],
     },
   ];
 
@@ -446,7 +470,7 @@ describe('activityReportToCsvRecord', () => {
 
     const output = makeGoalsAndObjectivesObject(objectives);
     expect(output).toEqual({
-      'goal-1-id': '2080',
+      'goal-1-id': '2080\n2085',
       'goal-1': 'Goal 1',
       'goal-1-status': 'Not Started',
       'goal-1-created-from': 'activityReport',

--- a/src/lib/transform.test.js
+++ b/src/lib/transform.test.js
@@ -422,6 +422,7 @@ describe('activityReportToCsvRecord', () => {
     }));
 
     const output = makeGoalsAndObjectivesObject(objectives);
+    console.log('\n\n\n---Output: ', output);
     expect(output).toEqual({
       'goal-1-id': '2080',
       'goal-1': 'Goal 1',


### PR DESCRIPTION
## Description of change

The csv export was skipping objectives that contained goals for other recipients. This change makes sure if the goal number already exists we add the additional ids.

## How to test

- Review the code.
- Export a report that contains one or many goals for multiple recipient's (ID: 13091). 
   The goal Id column should contain and ID for each recipient.
- Make sure the export behaves the same as before when exporting multiple reports.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1552


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
