### PR TITLE
remove console log from backend service and make groups test less flaky

### DIFF
--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -174,7 +174,7 @@ describe('filtersToScopes', () => {
 
     beforeAll(async () => {
       group = await Group.create({
-        name: faker.company.companyName(),
+        name: `${faker.company.companyName()} - ${faker.animal.cetacean()} - ${faker.datatype.number()}`,
         userId: mockUser.id,
       });
 
@@ -182,7 +182,7 @@ describe('filtersToScopes', () => {
         userId: mockUser.id,
         regionId: 1,
         status: 'Active',
-        name: faker.company.companyName(),
+        name: `${faker.company.companyName()} - ${faker.animal.cetacean()} - ${faker.datatype.number()}`,
       });
 
       await GroupGrant.create({

--- a/src/scopes/grants/index.test.js
+++ b/src/scopes/grants/index.test.js
@@ -40,7 +40,7 @@ const possibleIds = recipients.map((recipient) => recipient.id);
 describe('grant filtersToScopes', () => {
   let mockUser;
   let group;
-  const groupName = faker.company.companyName();
+  const groupName = `${faker.company.companyName()} - ${faker.animal.cetacean()} - ${faker.datatype.number()}`;
   const specialGrantNumber = String(faker.datatype.number({ min: 2800 }));
   let grantGroupOne;
   let grantGroupTwo;

--- a/src/scopes/grants/index.test.js
+++ b/src/scopes/grants/index.test.js
@@ -385,7 +385,7 @@ describe('grant filtersToScopes', () => {
         where: { [Op.and]: [scope.grant, { id: possibleIds }] },
       });
 
-      // expect(found.length).toBe(2);
+      expect(found.length).toBe(2);
       const foundGrants = found.map((f) => f.id).sort();
       expect(foundGrants).toEqual(expectedGrants);
     });
@@ -398,7 +398,7 @@ describe('grant filtersToScopes', () => {
         where: { [Op.and]: [scope.grant, { id: possibleIds }] },
       });
 
-      // expect(found.length).toBe(2);
+      expect(found.length).toBe(2);
       const foundGrants = found.map((f) => f.id).sort();
       expectedGrants.forEach((grant) => {
         expect(foundGrants).not.toContain(grant);

--- a/src/scopes/grants/index.test.js
+++ b/src/scopes/grants/index.test.js
@@ -11,10 +11,10 @@ import {
   sequelize,
 } from '../../models';
 
-const recipientOneName = faker.company.companyName();
-const recipientTwoName = faker.company.companyName();
-const recipientThreeName = faker.company.companyName();
-const recipientFourName = faker.company.companyName();
+const recipientOneName = `${faker.company.companyName()} - ${faker.animal.cetacean()} - ${faker.datatype.number()}`;
+const recipientTwoName = `${faker.company.companyName()} - ${faker.animal.cetacean()} - ${faker.datatype.number()}`;
+const recipientThreeName = `${faker.company.companyName()} - ${faker.animal.cetacean()} - ${faker.datatype.number()}`;
+const recipientFourName = `${faker.company.companyName()} - ${faker.animal.cetacean()} - ${faker.datatype.number()}`;
 
 const recipients = [
   {
@@ -44,10 +44,11 @@ describe('grant filtersToScopes', () => {
   const specialGrantNumber = String(faker.datatype.number({ min: 2800 }));
   let grantGroupOne;
   let grantGroupTwo;
+  let grants;
 
   beforeAll(async () => {
     await Promise.all(recipients.map((g) => Recipient.create(g)));
-    const grants = await Promise.all([
+    grants = await Promise.all([
       Grant.create({
         id: recipients[3].id,
         number: String(faker.datatype.number({ min: 2800 })),
@@ -384,7 +385,7 @@ describe('grant filtersToScopes', () => {
         where: { [Op.and]: [scope.grant, { id: possibleIds }] },
       });
 
-      expect(found.length).toBe(2);
+      // expect(found.length).toBe(2);
       const foundGrants = found.map((f) => f.id).sort();
       expect(foundGrants).toEqual(expectedGrants);
     });
@@ -397,7 +398,7 @@ describe('grant filtersToScopes', () => {
         where: { [Op.and]: [scope.grant, { id: possibleIds }] },
       });
 
-      expect(found.length).toBe(2);
+      // expect(found.length).toBe(2);
       const foundGrants = found.map((f) => f.id).sort();
       expectedGrants.forEach((grant) => {
         expect(foundGrants).not.toContain(grant);

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -847,7 +847,6 @@ export async function activityReportAlerts(userId, {
   const { activityReport: scopes } = await filtersToScopes(updatedFilters, { userId });
   const reports = await ActivityReport.findAndCountAll(
     {
-      logging: console.log,
       where: {
         [Op.and]: scopes,
         [Op.or]: [


### PR DESCRIPTION
## Description of change
Not sure [this branch](https://github.com/HHS/Head-Start-TTADP/pull/1350) was passing CI before I merged it, but I guess there was an errant console log hanging out. This PR removes the console.log so that the CI can pass.

I also added some additional stuff to make sure we don't get duplicate group names

## How to test
CI passes

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1380


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
