### PR TITLE
[TTAHUB-1487] Add submitted date for approvers to see

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import { useFormContext } from 'react-hook-form/dist/index.ie11';
 import _ from 'lodash';
@@ -7,7 +8,7 @@ import {
 } from '@trussworks/react-uswds';
 import { Editor } from 'react-draft-wysiwyg';
 import IncompletePages from '../IncompletePages';
-import { managerReportStatuses } from '../../../../../Constants';
+import { managerReportStatuses, DATE_DISPLAY_FORMAT } from '../../../../../Constants';
 import { getEditorState } from '../../../../../utils';
 import FormItem from '../../../../../components/FormItem';
 import HookFormRichEditor from '../../../../../components/HookFormRichEditor';
@@ -21,6 +22,7 @@ const Review = ({
   onFormReview,
   approverStatusList,
   pendingOtherApprovals,
+  dateSubmitted,
   pages,
   showDraftViewForApproverAndCreator,
 }) => {
@@ -44,7 +46,7 @@ const Review = ({
   const filtered = pages.filter((p) => !(p.state === 'Complete' || p.review));
   const incompletePages = filtered.map((f) => f.label);
   const hasIncompletePages = incompletePages.length > 0;
-
+  const formattedDateSubmitted = dateSubmitted ? moment(dateSubmitted).format(DATE_DISPLAY_FORMAT) : '';
   return (
     <>
       <h2>{pendingOtherApprovals ? 'Pending other approvals' : 'Review and approve report'}</h2>
@@ -80,24 +82,35 @@ const Review = ({
           </div>
         </Fieldset>
         { !showDraftViewForApproverAndCreator ? (
-          <FormItem
-            name="status"
-            label="Choose report status"
-            className="margin-bottom-3"
-          >
-            <Dropdown
-              id="status"
+          <>
+            {
+            dateSubmitted
+              ? (
+                <Fieldset className="smart-hub--report-legend margin-top-3" legend="Date Submitted">
+                  <Label className="margin-top-2" htmlFor="date_submitted">{formattedDateSubmitted}</Label>
+                </Fieldset>
+              )
+              : null
+            }
+            <FormItem
               name="status"
-              defaultValue={hasBeenReviewed
-                ? thisApprovingManager[0].status : ''}
-              inputRef={register({ required: true })}
+              label="Choose report status"
+              className="margin-bottom-3"
             >
-              <option name="default" value="" disabled hidden>- Select -</option>
-              {managerReportStatuses.map((status) => (
-                <option key={status} value={status}>{_.startCase(status)}</option>
-              ))}
-            </Dropdown>
-          </FormItem>
+              <Dropdown
+                id="status"
+                name="status"
+                defaultValue={hasBeenReviewed
+                  ? thisApprovingManager[0].status : ''}
+                inputRef={register({ required: true })}
+              >
+                <option name="default" value="" disabled hidden>- Select -</option>
+                {managerReportStatuses.map((status) => (
+                  <option key={status} value={status}>{_.startCase(status)}</option>
+                ))}
+              </Dropdown>
+            </FormItem>
+          </>
         ) : <div className="margin-bottom-3" />}
         <ApproverStatusList approverStatus={approverStatusList} />
         {hasIncompletePages && <IncompletePages incompletePages={incompletePages} />}
@@ -110,6 +123,7 @@ const Review = ({
 Review.propTypes = {
   additionalNotes: PropTypes.string,
   onFormReview: PropTypes.func.isRequired,
+  dateSubmitted: PropTypes.string,
   pendingOtherApprovals: PropTypes.bool,
   approverStatusList: PropTypes.arrayOf(PropTypes.shape({
     approver: PropTypes.string,
@@ -127,6 +141,7 @@ Review.defaultProps = {
   pendingOtherApprovals: false,
   additionalNotes: '',
   approverStatusList: [],
+  dateSubmitted: null,
 };
 
 export default Review;

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -87,7 +87,7 @@ const Review = ({
             dateSubmitted
               ? (
                 <Fieldset className="smart-hub--report-legend margin-top-3" legend="Date Submitted">
-                  <Label className="margin-top-2" htmlFor="date_submitted">{formattedDateSubmitted}</Label>
+                  <Label className="margin-top-1" htmlFor="date_submitted">{formattedDateSubmitted}</Label>
                 </Fieldset>
               )
               : null

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import moment from 'moment-timezone';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import { useFormContext } from 'react-hook-form/dist/index.ie11';
 import _ from 'lodash';
@@ -86,9 +86,10 @@ const Review = ({
             {
             dateSubmitted
               ? (
-                <Fieldset className="smart-hub--report-legend margin-top-3" legend="Date Submitted">
+                <>
+                  <Label className="source-sans-pro text-bold margin-top-3" htmlFor="date_submitted">Date Submitted</Label>
                   <Label className="margin-top-1" htmlFor="date_submitted">{formattedDateSubmitted}</Label>
-                </Fieldset>
+                </>
               )
               : null
             }

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -87,8 +87,8 @@ const Review = ({
             dateSubmitted
               ? (
                 <>
-                  <p className="source-sans-pro text-bold margin-top-3 margin-bottom-0" htmlFor="date_submitted">Date Submitted</p>
-                  <p className="margin-top-0" htmlFor="date_submitted">{formattedDateSubmitted}</p>
+                  <p className="source-sans-pro text-bold margin-top-3 margin-bottom-0">Date Submitted</p>
+                  <p className="margin-top-0">{formattedDateSubmitted}</p>
                 </>
               )
               : null

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -87,8 +87,8 @@ const Review = ({
             dateSubmitted
               ? (
                 <>
-                  <Label className="source-sans-pro text-bold margin-top-3" htmlFor="date_submitted">Date Submitted</Label>
-                  <Label className="margin-top-1" htmlFor="date_submitted">{formattedDateSubmitted}</Label>
+                  <p className="source-sans-pro text-bold margin-top-3 margin-bottom-0" htmlFor="date_submitted">Date Submitted</p>
+                  <p className="margin-top-0" htmlFor="date_submitted">{formattedDateSubmitted}</p>
                 </>
               )
               : null

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/__tests__/index.js
@@ -66,13 +66,19 @@ const RenderApprover = ({
 };
 
 const renderReview = (
-  calculatedStatus, onFormReview, reviewed, approvers = defaultApprover, pages = defaultPages,
+  calculatedStatus,
+  onFormReview,
+  reviewed,
+  approvers = defaultApprover,
+  pages = defaultPages,
+  extraFormData = {},
 ) => {
   const formData = {
     author: { name: 'user', id: 4 },
     additionalNotes: '',
     calculatedStatus,
     approvers,
+    ...extraFormData,
   };
 
   const history = createMemoryHistory();
@@ -118,6 +124,22 @@ describe('Approver review page', () => {
       renderReview(REPORT_STATUSES.SUBMITTED, () => { }, true);
       const notes = await screen.findByLabelText('additionalNotes');
       expect(notes.textContent).toContain('No creator notes');
+    });
+
+    it('shows date submitted', async () => {
+      renderReview(REPORT_STATUSES.SUBMITTED, () => { }, true, defaultApprover, defaultPages, { submittedDate: '2023-03-03' });
+      expect(await screen.findByText(/date submitted/i)).toBeVisible();
+      expect(await screen.findByText('03/03/2023')).toBeVisible();
+    });
+
+    it('hides date submitted if missing', async () => {
+      renderReview(REPORT_STATUSES.SUBMITTED,
+        () => { },
+        true,
+        defaultApprover,
+        defaultPages,
+        { submittedDate: null });
+      expect(screen.queryAllByText(/date submitted/i).length).toBe(0);
     });
 
     it('handles approver reviewing needs action', async () => {

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/index.js
@@ -22,6 +22,7 @@ const Approver = ({
     additionalNotes,
     calculatedStatus,
     approvers,
+    submittedDate,
   } = formData;
 
   // Approvers should be able to change their review until the report is approved.
@@ -116,6 +117,7 @@ const Approver = ({
             <Review
               pendingOtherApprovals={pendingOtherApprovals}
               additionalNotes={additionalNotes}
+              dateSubmitted={submittedDate}
               onFormReview={onFormReview}
               approverStatusList={approvers}
               pages={pages}
@@ -143,6 +145,7 @@ Approver.propTypes = {
   formData: PropTypes.shape({
     additionalNotes: PropTypes.string,
     calculatedStatus: PropTypes.string,
+    submittedDate: PropTypes.string,
     approvers: PropTypes.arrayOf(
       PropTypes.shape({
         status: PropTypes.string,


### PR DESCRIPTION
## Description of change

When reviewing a report for approval. We want the approver to see the submitted date if its available.

## How to test

Submit a report for approval. When reviewing the report the they should see the submission date.
If there is no submission date we hide it.

**Mockup:**
https://www.figma.com/file/7lFZynR1T97cfJbCIgBHD4/AR-date-submitted?node-id=1%3A2124&t=W6NMP4c5QWXV4G6S-0


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1487


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
