### PR TITLE
Fix flaky tests on the groups scope

### DIFF
--- a/frontend/src/pages/RecipientSearch/index.js
+++ b/frontend/src/pages/RecipientSearch/index.js
@@ -19,6 +19,7 @@ import useSession from '../../hooks/useSession';
 import FilterPanel from '../../components/filter/FilterPanel';
 import useSessionFiltersAndReflectInUrl from '../../hooks/useSessionFiltersAndReflectInUrl';
 import { RECIPIENT_SEARCH_FILTER_CONFIG } from './constants';
+import { expandFilters } from '../../utils';
 
 const DEFAULT_SORT = {
   sortBy: 'name',
@@ -112,7 +113,7 @@ function RecipientSearch({ user }) {
       try {
         const response = await searchRecipients(
           query,
-          filters,
+          expandFilters(filters),
           { ...sortConfig, offset },
         );
         setResults(response);

--- a/src/scopes/activityReport/group.ts
+++ b/src/scopes/activityReport/group.ts
@@ -9,13 +9,7 @@ import { sequelize } from '../../models';
  * @see withoutGroup
  */
 export function withGroup(query: string[], userId: number): WhereOptions {
-  /**
-   * this looks a little funky but they come from the frontend query string like so:
-   * ?group=group1,group2,group3, and so they are passed through as ['group1,group2,group3']
-   */
   const nameClause = query
-    .map((q) => q.split(','))
-    .flat()
     .map((name) => sequelize.escape(name)).join(',');
   return {
     id: {
@@ -36,8 +30,6 @@ export function withGroup(query: string[], userId: number): WhereOptions {
  */
 export function withoutGroup(query: string[], userId: number): WhereOptions {
   const nameClause = query
-    .map((q) => q.split(','))
-    .flat()
     .map((name) => sequelize.escape(name)).join(',');
   return {
     id: {

--- a/src/scopes/grants/group.ts
+++ b/src/scopes/grants/group.ts
@@ -9,13 +9,7 @@ import { sequelize } from '../../models';
  * @see withoutGroup
  */
 export function withGroup(query: string[], userId: number): WhereOptions {
-  /**
-   * this looks a little funky but they come from the frontend query string like so:
-   * ?group=group1,group2,group3, and so they are passed through as ['group1,group2,group3']
-   */
   const nameClause = query
-    .map((q) => q.split(','))
-    .flat()
     .map((name) => sequelize.escape(name)).join(',');
   return {
     id: {
@@ -32,8 +26,6 @@ export function withGroup(query: string[], userId: number): WhereOptions {
  */
 export function withoutGroup(query: string[], userId: number): WhereOptions {
   const nameClause = query
-    .map((q) => q.split(','))
-    .flat()
     .map((name) => sequelize.escape(name)).join(',');
   return {
     id: {


### PR DESCRIPTION
## Description of change
This PR addresses an issue revealed by some flaky unit tests where commas would disrupt the "my groups" filter. Upon further investigation, I had added some "cleverness" that isn't needed. (I knew how the backend expects query parameters but I misunderstood how they'd be coming from the frontend.)

## How to test
CI passes. You can add a group with a comma in it.

## Issue(s)
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1380

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
