### PR TITLE
[TTAHUB-1543] Include objective topics in topics frequency graph

### DIFF
--- a/src/widgets/topicFrequencyGraph.js
+++ b/src/widgets/topicFrequencyGraph.js
@@ -4,7 +4,7 @@ import {
   Topic,
   ActivityReportObjective,
 } from '../models';
-import { REPORT_STATUSES, TOPICS } from '../constants';
+import { REPORT_STATUSES } from '../constants';
 
 export default async function topicFrequencyGraph(scopes) {
   const topicsAndParticipants = await ActivityReport.findAll({
@@ -28,7 +28,13 @@ export default async function topicFrequencyGraph(scopes) {
     }],
   });
 
-  const topicsResponse = TOPICS.map((topic) => ({
+  // Get all DB topics.
+  const dbTopics = await Topic.findAll({
+    attributes: ['id', 'name', 'deletedAt'],
+    order: [['name', 'ASC']],
+  });
+  const topics = dbTopics.map((t) => t.name);
+  const topicsResponse = topics.map((topic) => ({
     topic,
     count: 0,
   }));

--- a/src/widgets/topicFrequencyGraph.test.js
+++ b/src/widgets/topicFrequencyGraph.test.js
@@ -461,15 +461,15 @@ describe('Topics and frequency graph widget', () => {
         count: 0,
       },
       {
-        topic: 'ERSEA',
-        count: 0,
-      },
-      {
         topic: 'Environmental Health and Safety / EPRR',
         count: 0,
       },
       {
         topic: 'Equity',
+        count: 0,
+      },
+      {
+        topic: 'ERSEA',
         count: 0,
       },
       {
@@ -630,15 +630,15 @@ describe('Topics and frequency graph widget', () => {
         count: 0,
       },
       {
-        topic: 'ERSEA',
-        count: 0,
-      },
-      {
         topic: 'Environmental Health and Safety / EPRR',
         count: 0,
       },
       {
         topic: 'Equity',
+        count: 0,
+      },
+      {
+        topic: 'ERSEA',
         count: 0,
       },
       {
@@ -799,15 +799,15 @@ describe('Topics and frequency graph widget', () => {
         count: 0,
       },
       {
-        topic: 'ERSEA',
-        count: 0,
-      },
-      {
         topic: 'Environmental Health and Safety / EPRR',
         count: 0,
       },
       {
         topic: 'Equity',
+        count: 0,
+      },
+      {
+        topic: 'ERSEA',
         count: 0,
       },
       {
@@ -967,15 +967,15 @@ describe('Topics and frequency graph widget', () => {
         count: 0,
       },
       {
-        topic: 'ERSEA',
-        count: 0,
-      },
-      {
         topic: 'Environmental Health and Safety / EPRR',
         count: 0,
       },
       {
         topic: 'Equity',
+        count: 0,
+      },
+      {
+        topic: 'ERSEA',
         count: 0,
       },
       {

--- a/src/widgets/topicFrequencyGraph.test.js
+++ b/src/widgets/topicFrequencyGraph.test.js
@@ -9,10 +9,17 @@ import db, {
   Region,
   Role,
   UserRole,
+  Goal,
+  ActivityReportObjective,
+  Objective,
+  ActivityReportObjectiveTopic,
+  Topic,
 } from '../models';
 import filtersToScopes from '../scopes';
 import { REPORT_STATUSES } from '../constants';
 import topicFrequencyGraph from './topicFrequencyGraph';
+
+jest.mock('bull');
 
 const GRANT_ID = 4040;
 const RECIPIENT_ID = 5050;
@@ -96,6 +103,24 @@ const regionOneReportWithDifferentTopics = {
 };
 
 describe('Topics and frequency graph widget', () => {
+  // Goals.
+  let firstGoal;
+  let secondGoal;
+  let thirdGoal;
+
+  // Objectives.
+  let firstGoalObjA;
+  let firstGoalObjB;
+  let secondGoalObjA;
+  let thirdGoalObjA;
+
+  // ARO's.
+  let regionOneReportAroA;
+  let regionOneReportAroB;
+  let regionTwoReportAroA;
+  let regionOneReportDistinctDateAroA;
+  let regionOneReportWithDifferentTopicsAroA;
+
   beforeAll(async () => {
     await User.bulkCreate([
       mockUser,
@@ -103,6 +128,22 @@ describe('Topics and frequency graph widget', () => {
       mockUserThree,
     ]);
 
+    // Create Topics.
+    const [coachingTopic] = await Topic.findOrCreate({
+      where: {
+        name: 'Coaching',
+      },
+    });
+    const [communicationTopic] = await Topic.findOrCreate({
+      where: {
+        name: 'Communication',
+      },
+    });
+    const [cultureAndLanguageTopic] = await Topic.findOrCreate({
+      where: {
+        name: 'Culture & Language',
+      },
+    });
     const [grantsSpecialist] = await Role.findOrCreate({
       where: {
         fullName: 'Grants Specialist',
@@ -146,12 +187,141 @@ describe('Topics and frequency graph widget', () => {
       status: 'Active',
       startDate: new Date('2000/01/01'),
     });
+
+    // Create Goals.
+    firstGoal = await Goal.create({
+      name: 'First Topics Goal',
+      status: 'In Progress',
+      grantId: GRANT_ID,
+      previousStatus: 'Not Started',
+      createdVia: 'activityReport',
+    });
+
+    secondGoal = await Goal.create({
+      name: 'Second Topics Goal',
+      status: 'In Progress',
+      grantId: GRANT_ID,
+      previousStatus: 'Not Started',
+      createdVia: 'activityReport',
+    });
+
+    thirdGoal = await Goal.create({
+      name: 'Third Topics Goal',
+      status: 'In Progress',
+      grantId: GRANT_ID,
+      previousStatus: 'Not Started',
+      createdVia: 'activityReport',
+    });
+
+    // Create Objectives.
+    firstGoalObjA = await Objective.create(
+      {
+        title: 'Topics Graph First Goal - Obj A',
+        goalId: firstGoal.id,
+        status: 'Not Started',
+      },
+    );
+
+    firstGoalObjB = await Objective.create(
+      {
+        title: 'Topics Graph First Goal - Obj B',
+        goalId: firstGoal.id,
+        status: 'Not Started',
+      },
+    );
+
+    secondGoalObjA = await Objective.create(
+      {
+        title: 'Topics Graph Second Goal - Obj A',
+        goalId: secondGoal.id,
+        status: 'Not Started',
+      },
+    );
+
+    thirdGoalObjA = await Objective.create(
+      {
+        title: 'Topics Graph Third Goal - Obj A',
+        goalId: thirdGoal.id,
+        status: 'Not Started',
+      },
+    );
+
     await ActivityReport.bulkCreate([
       regionOneReport,
       regionOneReportDistinctDate,
       regionTwoReport,
       regionOneReportWithDifferentTopics,
     ]);
+
+    // Create ARO's.
+    // First ARO.
+    regionOneReportAroA = await ActivityReportObjective.create({
+      activityReportId: regionOneReport.id,
+      objectiveId: firstGoalObjA.id,
+      status: 'In Progress',
+    });
+
+    // First ARO A Topic.
+    await ActivityReportObjectiveTopic.create({
+      activityReportObjectiveId: regionOneReportAroA.id,
+      topicId: coachingTopic.id,
+    });
+
+    regionOneReportAroB = await ActivityReportObjective.create({
+      activityReportId: regionOneReport.id,
+      objectiveId: firstGoalObjB.id,
+      status: 'In Progress',
+    });
+
+    // First ARO B Topic's.
+    await ActivityReportObjectiveTopic.create({
+      activityReportObjectiveId: regionOneReportAroB.id,
+      topicId: coachingTopic.id,
+    });
+
+    await ActivityReportObjectiveTopic.create({
+      activityReportObjectiveId: regionOneReportAroB.id,
+      topicId: communicationTopic.id,
+    });
+
+    // Region Two ARO.
+    regionTwoReportAroA = await ActivityReportObjective.create({
+      activityReportId: regionTwoReport.id,
+      objectiveId: firstGoalObjA.id,
+      status: 'In Progress',
+    });
+
+    // Region Two ARO A Topic.
+    await ActivityReportObjectiveTopic.create({
+      activityReportObjectiveId: regionTwoReportAroA.id,
+      topicId: coachingTopic.id,
+    });
+
+    // Second ARO.
+    regionOneReportDistinctDateAroA = await ActivityReportObjective.create({
+      activityReportId: regionOneReportDistinctDate.id,
+      objectiveId: secondGoalObjA.id,
+      status: 'In Progress',
+    });
+
+    // Second ARO A Topic.
+    await ActivityReportObjectiveTopic.create({
+      activityReportObjectiveId: regionOneReportDistinctDateAroA.id,
+      topicId: cultureAndLanguageTopic.id,
+    });
+
+    // Third ARO.
+    regionOneReportWithDifferentTopicsAroA = await ActivityReportObjective.create({
+      activityReportId: regionOneReportWithDifferentTopics.id,
+      objectiveId: thirdGoalObjA.id,
+      status: 'In Progress',
+    });
+
+    // Third ARO A Topic.
+    await ActivityReportObjectiveTopic.create({
+      activityReportObjectiveId: regionOneReportWithDifferentTopicsAroA.id,
+      topicId: communicationTopic.id,
+    });
 
     await ActivityReportCollaborator.create({
       id: 2000,
@@ -182,7 +352,39 @@ describe('Topics and frequency graph widget', () => {
     const ids = [17772, 17773, 17774, 17775];
     await NextStep.destroy({ where: { activityReportId: ids } });
     await ActivityRecipient.destroy({ where: { activityReportId: ids } });
+    await ActivityReportObjectiveTopic.destroy({
+      where: {
+        activityReportObjectiveId: [
+          regionOneReportAroA.id,
+          regionOneReportAroB.id,
+          regionOneReportDistinctDateAroA.id,
+          regionOneReportWithDifferentTopicsAroA.id,
+          regionTwoReportAroA.id,
+        ],
+      },
+    });
+    await ActivityReportObjective.destroy({
+      where: {
+        objectiveId: [
+          firstGoalObjA.id,
+          firstGoalObjB.id,
+          secondGoalObjA.id,
+          thirdGoalObjA.id,
+        ],
+      },
+    });
     await ActivityReport.destroy({ where: { id: ids } });
+    await Objective.destroy({
+      where: {
+        id: [
+          firstGoalObjA.id,
+          firstGoalObjB.id,
+          secondGoalObjA.id,
+          thirdGoalObjA.id,
+        ],
+      },
+    });
+    await Goal.destroy({ where: { id: [firstGoal.id, secondGoal.id, thirdGoal.id] } });
     await UserRole.destroy({ where: { userId: [mockUser.id, mockUserTwo.id, mockUserThree.id] } });
     await User.destroy({ where: { id: [mockUser.id, mockUserTwo.id, mockUserThree.id] } });
     await Grant.destroy({
@@ -232,11 +434,11 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Coaching',
-        count: 1,
+        count: 3, // 1 from AR 3 from ARO's.
       },
       {
         topic: 'Communication',
-        count: 0,
+        count: 2, // 2 from ARO's.
       },
       {
         topic: 'Community and Self-Assessment',
@@ -401,7 +603,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Coaching',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'Communication',
@@ -570,11 +772,11 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Coaching',
-        count: 1,
+        count: 3,
       },
       {
         topic: 'Communication',
-        count: 0,
+        count: 2,
       },
       {
         topic: 'Community and Self-Assessment',
@@ -582,7 +784,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Culture & Language',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'Curriculum (Instructional or Parenting)',
@@ -715,7 +917,6 @@ describe('Topics and frequency graph widget', () => {
     const query = { 'region.in': [17], 'role.in': ['System Specialist'] };
     const scopes = await filtersToScopes(query);
     const data = await topicFrequencyGraph(scopes);
-
     expect(data).toStrictEqual([
       {
         topic: 'Behavioral / Mental Health / Trauma',
@@ -739,11 +940,11 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Coaching',
-        count: 0,
+        count: 2,
       },
       {
         topic: 'Communication',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'Community and Self-Assessment',
@@ -751,7 +952,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Culture & Language',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'Curriculum (Instructional or Parenting)',

--- a/src/widgets/topicFrequencyGraph.test.js
+++ b/src/widgets/topicFrequencyGraph.test.js
@@ -70,7 +70,7 @@ const reportObject = {
   targetPopulations: ['pop'],
   reason: ['reason'],
   participants: ['participants', 'genies'],
-  topics: ['Program Planning and Services'],
+  topics: ['Program Planning and Services', 'Child Assessment, Development, Screening'], // One to be mapped from legacy.
   ttaType: ['technical-assistance'],
 };
 
@@ -418,7 +418,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Child Screening and Assessment',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'CLASS: Classroom Organization',
@@ -587,7 +587,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Child Screening and Assessment',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'CLASS: Classroom Organization',
@@ -756,7 +756,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Child Screening and Assessment',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'CLASS: Classroom Organization',
@@ -924,7 +924,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Child Screening and Assessment',
-        count: 0,
+        count: 1,
       },
       {
         topic: 'CLASS: Classroom Organization',


### PR DESCRIPTION
## Description of change

On the regional dashboard the topics and frequency graph only shows topics from AR's. We want to include topics from objectives on the AR.

## How to test

Topic counts should reflect both AR's and AR objective topics.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1543


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
