### PR TITLE
[TTAHUB-1560] fix parsing of goals when activityRecipients are updated

### DIFF
--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -242,6 +242,73 @@ describe('ActivityReport', () => {
       expect(result).toEqual({ startDate: null, creatorRole: null });
     });
 
+    it('access correct fields when diffing turns up activity recipients', () => {
+      const old = {
+        activityRecipients: [{
+          activityRecipientId: 1,
+        }],
+        goals: [],
+        goalsAndObjectives: [
+          { name: 'goal 1', activityReportGoals: [{ isActivelyEdited: true }] },
+          { name: 'goal 2', activityReportGoals: [{ isActivelyEdited: false }] },
+        ],
+      };
+
+      const young = {
+        activityRecipients: [{
+          activityRecipientId: 2,
+        }, {
+          activityRecipientId: 1,
+        }],
+        goals: [],
+        goalsAndObjectives: [
+          { name: 'goal 1', activityReportGoals: [{ isActivelyEdited: true }] },
+          { name: 'goal 2', activityReportGoals: [{ isActivelyEdited: false }] },
+        ],
+      };
+
+      const changed = findWhatsChanged(young, old);
+      expect(changed).toEqual({
+        activityRecipients: [
+          {
+            activityRecipientId: 2,
+          },
+          {
+            activityRecipientId: 1,
+          },
+        ],
+        goals: [
+          {
+            activityReportGoals: [
+              {
+                isActivelyEdited: true,
+              },
+            ],
+            grantIds: [
+              2,
+              1,
+            ],
+            isActivelyEdited: true,
+            name: 'goal 1',
+          },
+          {
+            activityReportGoals: [
+              {
+                isActivelyEdited: false,
+              },
+            ],
+            grantIds: [
+              2,
+              1,
+            ],
+            isActivelyEdited: false,
+            name: 'goal 2',
+          },
+        ],
+        recipientsWhoHaveGoalsThatShouldBeRemoved: [],
+      });
+    });
+
     it('displays the creator name', async () => {
       fetchMock.get('/api/activity-reports/1', formData());
       renderActivityReport(1);

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -1077,7 +1077,10 @@ export async function createOrUpdate(newActivityReport, report) {
 
   const activityRecipientType = recipientType();
 
-  if (recipientsWhoHaveGoalsThatShouldBeRemoved) {
+  if (
+    recipientsWhoHaveGoalsThatShouldBeRemoved
+    && recipientsWhoHaveGoalsThatShouldBeRemoved.length
+  ) {
     await removeRemovedRecipientsGoals(recipientsWhoHaveGoalsThatShouldBeRemoved, savedReport);
   }
 


### PR DESCRIPTION
## Description of change
Adding additional recipients to an activity report after creating a goal would clear the goal. This change fixes that bug.

## How to test
These are the steps from the original Jira. Follow them and ensure the bug is no longer present.
- create a new AR
- add one recipient
- create a new goal with one objective having resource links and tta
- instead of clicking "Save goal", navigate to the activity summary using the navigator's link
- use the navigator to enter the "Goals and Objectives" section
- confirm that the goal is there (write mode)
- navigate to the activity summary using the navigator's link
- add a second recipient
- use the navigator to enter the "Goals and Objectives" section
- note the goal is no longer there
- select the goal from the dropdown
- note the objective is gone along with the tta and resource links


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1560


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
