### PR TITLE
[TTAHUB-1566] simplify logic for fetching topics, exclude unused topics

### DIFF
--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -53,7 +53,10 @@ function combineTopics(report, expandedTopics) {
   const reportTopics = expandedTopics.filter((topic) => report.id === topic.activityReportId)
     .map((t) => t.name);
 
-  const exclusiveTopics = new Set([...report.sortedTopics, ...reportTopics]);
+  const exclusiveTopics = new Set([
+    ...report.sortedTopics,
+    ...reportTopics,
+  ]);
   const topicsArr = [...exclusiveTopics];
   topicsArr.sort();
 
@@ -67,25 +70,12 @@ export const getReports = async (sortBy = 'updatedAt', sortDir = 'desc', offset 
     count, rows: rawRows, recipients, topics,
   } = json;
 
-  const expandedTopics = topics.reduce((acc, topic) => {
-    const { name, objectives } = topic;
-    const aros = objectives.map((objective) => objective.activityReportObjectives).flat();
-
-    return [
-      ...acc,
-      ...aros.map((aro) => ({
-        activityReportId: aro.activityReportId,
-        name,
-      })),
-    ];
-  }, []);
-
   const rows = rawRows.map((row) => ({
     ...row,
     activityRecipients: recipients.filter(
       (recipient) => recipient.activityReportId === row.id,
     ),
-    sortedTopics: combineTopics(row, expandedTopics),
+    sortedTopics: combineTopics(row, topics),
   }));
 
   return {

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -26,6 +26,7 @@ import {
   ActivityReportGoal,
   ActivityReportObjective,
   ActivityReportObjectiveResource,
+  ActivityReportObjectiveTopic,
   ObjectiveResource,
   Topic,
   CollaboratorRole,
@@ -714,29 +715,28 @@ export async function activityReports(
     ],
   });
 
-  const topics = await Topic.findAll({
-    attributes: ['name', 'id'],
+  const arots = await ActivityReportObjectiveTopic.findAll({
     include: [
       {
-        model: Objective,
-        attributes: ['id'],
-        as: 'objectives',
-        required: true,
-        include: {
-          attributes: ['activityReportId', 'objectiveId'],
-          model: ActivityReportObjective,
-          as: 'activityReportObjectives',
-          required: true,
-          where: {
-            activityReportId: reportIds,
-          },
+        model: ActivityReportObjective,
+        as: 'activityReportObjective',
+        where: {
+          activityReportId: reportIds,
         },
+        required: true,
+      },
+      {
+        model: Topic,
+        as: 'topic',
+        required: true,
       },
     ],
-    order: [
-      [sequelize.col('name'), sortDir],
-    ],
   });
+
+  const topics = arots.map((arot) => ({
+    activityReportId: arot.activityReportObjective.activityReportId,
+    name: arot.topic.name,
+  }));
 
   // Get all grant programs at once to reduce DB calls.
   const grantIds = recipients.map((a) => a.grantId);
@@ -749,7 +749,9 @@ export async function activityReports(
   // Populate Activity Recipient info.
   await populateRecipientInfo(recipients, grantPrograms);
 
-  return { ...reports, recipients, topics };
+  return {
+    ...reports, recipients, topics,
+  };
 }
 
 export async function activityReportsForCleanup(userId) {


### PR DESCRIPTION
## Description of change
Incorrect topic data was being fetched for the Activity Reports table. Based on some of the changed models, the logic had to be rearranged, which allowed work to be delegated away from the frontend and into the service.

## How to test
Removal of topics from objectives on an unlocked activity report, is not reflected in the activity report table.

Steps:
The bug as reported in the jira is below. Follow the steps and ensure that only one topic is listed.
- Create an AR with an objective that has topic A
- Submit and approve
- Unlock the report
- Select B for a topic instead of A
- Submit and approve
- Note in the AR table both topics are listed


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1566


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
