### PR TITLE
[TTAHUB-1413] Toggle button language depending on whether objectives are expanded

### DIFF
--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -351,7 +351,7 @@ describe('Goals Table', () => {
       act(() => renderTable({ goals: goalWithObjectives, goalsCount: 1 }, defaultUser));
       await screen.findByText('TTA goals and objectives');
 
-      const expandObjectives = await screen.findByRole('button', { name: /Expand objectives for goal/i });
+      const expandObjectives = await screen.findByRole('button', { name: /View objectives for goal/i });
       fireEvent.click(expandObjectives);
 
       // Objective 1.
@@ -401,12 +401,12 @@ describe('Goals Table', () => {
       expect(document.querySelector('.ttahub-goal-card__objective-list[hidden]')).toBeInTheDocument();
 
       // Expand Objectives via click.
-      const expandObjectives = await screen.findByRole('button', { name: 'Expand objectives for goal G-4598' });
+      const expandObjectives = await screen.findByRole('button', { name: 'View objectives for goal G-4598' });
       fireEvent.click(expandObjectives);
       expect(document.querySelector('.ttahub-goal-card__objective-list[hidden]')).not.toBeInTheDocument();
 
       // Collapse Objectives via click.
-      const collapseButton = await screen.findByRole('button', { name: 'Collapse objectives for goal G-4598' });
+      const collapseButton = await screen.findByRole('button', { name: 'Hide objectives for goal G-4598' });
       fireEvent.click(collapseButton);
       expect(document.querySelector('.ttahub-goal-card__objective-list[hidden]')).toBeInTheDocument();
     });

--- a/frontend/src/components/GoalCards/components/ObjectiveButton.js
+++ b/frontend/src/components/GoalCards/components/ObjectiveButton.js
@@ -23,9 +23,11 @@ export default function ObjectiveButton({
       type="button"
       className="usa-button--outline usa-button text-no-underline text-middle tta-smarthub--goal-row-objectives tta-smarthub--goal-row-objectives-enabled"
       onClick={() => closeOrOpenObjectives()}
-      aria-label={`${objectivesExpanded ? 'Collapse' : 'Expand'} objectives for goal ${goalNumber}`}
+      aria-label={`${objectivesExpanded ? 'Hide' : 'View'} objectives for goal ${goalNumber}`}
     >
-      View objective
+      {objectivesExpanded ? 'Hide' : 'View'}
+      {' '}
+      objective
       {objectiveCount > 1 ? 's' : ''}
       <strong className="margin-left-1">
         (

--- a/tests/activity-report.spec.ts
+++ b/tests/activity-report.spec.ts
@@ -397,7 +397,7 @@ test.describe('Activity Report', () => {
     await expect(page.getByText('g1o1', { exact: true }).locator('..').locator('..').getByText('Not started')).toBeVisible();
 
     // expand objectives for g2
-    await page.getByRole('button', { name: `Expand objectives for goal ${g2GoalsForObjectives}` }).click();
+    await page.getByRole('button', { name: `View objectives for goal ${g2GoalsForObjectives}` }).click();
 
     await expect(page.getByText('g2o1', { exact: true })).toBeVisible();
     // verify a link to the activity report is found in the objective section
@@ -439,7 +439,7 @@ test.describe('Activity Report', () => {
     await page.getByRole('button', { name: 'Save' }).click();
 
     // expand the objective for g1
-    await page.getByRole('button', { name: `Expand objectives for goal ${g1GoalsForObjectives}` }).click();
+    await page.getByRole('button', { name: `View objectives for goal ${g1GoalsForObjectives}` }).click();
     // verify the 'In Progress' status is now visible
     await expect(page.getByRole('listitem').filter({ hasText: 'Objective status In progress' })).toBeVisible();
 
@@ -468,7 +468,7 @@ test.describe('Activity Report', () => {
     await page.getByRole('link', { name: 'Cancel' }).click();
 
     // expand the objective for g2
-    await page.getByRole('button', { name: `Expand objectives for goal ${g2GoalsForObjectives}` }).click();
+    await page.getByRole('button', { name: `View objectives for goal ${g2GoalsForObjectives}` }).click();
     // follow the AR link for g2
     await page.getByText('g2', { exact: true }).locator('..').locator('..').locator('..')
       .getByRole('link', { name: `R0${regionNumber}-AR-${arNumber}` })

--- a/tests/activity-report.spec.ts
+++ b/tests/activity-report.spec.ts
@@ -377,7 +377,7 @@ test.describe('Activity Report', () => {
     expect(g2Topics).toBeVisible();
 
     // expand objectives for g1
-    await page.getByRole('button', { name: `Expand objectives for goal ${g1GoalsForObjectives}` }).click();
+    await page.getByRole('button', { name: `View objectives for goal ${g1GoalsForObjectives}` }).click();
 
     await expect(page.getByText('g1o1', { exact: true })).toBeVisible();
     // verify a link to the activity report is found in the objective section
@@ -597,7 +597,7 @@ test.describe('Activity Report', () => {
     expect(await page.title()).toBe('Goals and Objectives - Agency 2 in region 1, Inc. - TTA Hub');
 
     await expect(page.getByText('This is a goal for multiple grants')).toBeVisible();
-    await page.getByRole('button', { name: /Expand objectives for goal G-(\d)/i }).click();
+    await page.getByRole('button', { name: /View objectives for goal G-(\d)/i }).click();
     await expect(page.getByText('A new objective')).toBeVisible();
     await expect(page.getByText(`Activity reports R01-AR-${arNumber}`)).toBeVisible();
   });


### PR DESCRIPTION
## Description of change
On the recipient record/goals and objectives, when the objectives is shown, the button says "hide." When the objectives are hidden, the button says "view."

## How to test
Visit the recipient record page and confirm the above behavior

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1413


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
