### PR TITLE
Goal dashboard - default filter and only show percentage of regional goals

### DIFF
--- a/frontend/src/pages/RegionalGoalDashboard/__tests__/GoalsPercentage.js
+++ b/frontend/src/pages/RegionalGoalDashboard/__tests__/GoalsPercentage.js
@@ -21,16 +21,4 @@ describe('Goals Percentage', () => {
     const percentage = await screen.findByText('10%');
     expect(percentage).toBeInTheDocument();
   });
-
-  it('shows the numerator', async () => {
-    renderGoalsPercentage();
-    const numerator = await screen.findByText('100');
-    expect(numerator).toBeInTheDocument();
-  });
-
-  it('shows the denominator', async () => {
-    renderGoalsPercentage();
-    const denominator = await screen.findByText('1000');
-    expect(denominator).toBeInTheDocument();
-  });
 });

--- a/frontend/src/pages/RegionalGoalDashboard/__tests__/index.js
+++ b/frontend/src/pages/RegionalGoalDashboard/__tests__/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   render, screen, act, within,
 } from '@testing-library/react';
+import moment from 'moment';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import join from 'url-join';
@@ -48,8 +49,9 @@ const WIDGET_MOCKS = {
 describe('RegionalGoalDashboard', () => {
   const lastThirtyDays = `startDate.win=${encodeURIComponent(
     formatDateRange({
-      lastThirtyDays: true,
       forDateTime: true,
+      string: `2022/07/01-${moment().format('YYYY/MM/DD')}`,
+      withSpaces: false,
     }),
   )}`;
 

--- a/frontend/src/pages/RegionalGoalDashboard/index.js
+++ b/frontend/src/pages/RegionalGoalDashboard/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { Grid, GridContainer } from '@trussworks/react-uswds';
 import { v4 as uuidv4 } from 'uuid';
+import moment from 'moment';
 import useSessionFiltersAndReflectInUrl from '../../hooks/useSessionFiltersAndReflectInUrl';
 import { getUserRegions } from '../../permissions';
 import UserContext from '../../UserContext';
@@ -17,8 +18,9 @@ import TotalHrsAndRecipientGraphWidget from '../../widgets/TotalHrsAndRecipientG
 import TopicsTable from '../../widgets/RegionalGoalDashboard/TopicsTable';
 
 const defaultDate = formatDateRange({
-  lastThirtyDays: true,
   forDateTime: true,
+  string: `2022/07/01-${moment().format('YYYY/MM/DD')}`,
+  withSpaces: false,
 });
 
 const FILTER_KEY = 'regional-goal-dashboard-filters';

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -165,14 +165,14 @@ export function GoalStatusChart({ data, loading }) {
               <div className="display-flex flex-justify">
                 <div>
                   {bars.map(({ label }) => (
-                    <div className="display-flex height-6 margin-right-1">
+                    <div key={label} className="display-flex height-6 margin-right-1">
                       <span>{label}</span>
                     </div>
                   ))}
                 </div>
                 <div className="flex-1">
-                  {bars.map(({ percentage, color }) => (
-                    <div className="display-flex height-6">
+                  {bars.map(({ label, percentage, color }) => (
+                    <div key={label} className="display-flex height-6">
                       <div className="display-flex width-full" key={color}>
                         <Bar
                           key={color}
@@ -184,8 +184,8 @@ export function GoalStatusChart({ data, loading }) {
                   ))}
                 </div>
                 <div>
-                  {bars.map(({ ratio, readableRatio }) => (
-                    <div className="display-flex height-6 margin-left-1">
+                  {bars.map(({ label, ratio, readableRatio }) => (
+                    <div key={label} className="display-flex height-6 margin-left-1">
                       <span aria-label={readableRatio}>{ratio}</span>
                     </div>
                   ))}

--- a/frontend/src/widgets/RegionalGoalDashboard/GoalsPercentage.js
+++ b/frontend/src/widgets/RegionalGoalDashboard/GoalsPercentage.js
@@ -24,7 +24,8 @@ export function GoalsPercentageWidget({ data, loading }) {
               {percentage}
               %
             </h2>
-            <div className="">
+            <div>Regional goals</div>
+            {/* <div className="">
               <span className="">
                 {data.numerator}
               </span>
@@ -38,7 +39,7 @@ export function GoalsPercentageWidget({ data, loading }) {
                 {' '}
                 {data.denominator}
               </span>
-            </div>
+            </div> */}
           </div>
         </span>
       </Container>


### PR DESCRIPTION
## Description of change

- Only show the percentage of goals in the percentage widget.
- Change the default date filter to 7/1/2022 - current day.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
