### PR TITLE
[TTAHUB-1573] Alphabetize filters on /activity-reports

### DIFF
--- a/frontend/src/pages/Landing/constants.js
+++ b/frontend/src/pages/Landing/constants.js
@@ -43,10 +43,10 @@ export const LANDING_BASE_FILTER_CONFIG = [
 ];
 
 export const LANDING_FILTER_CONFIG_WITH_REGIONS = [
-  groupsFilter,
   startDateFilter,
   endDateFilter,
   grantNumberFilter,
+  groupsFilter,
   myReportsFilter,
   otherEntitiesFilter,
   participantsFilter,


### PR DESCRIPTION
## Description of change

This extremely small PR just ensures the filters dropdown on /activity-reports shows filters in alphabetical order, with the exception of `date started` and `date ended`, which I think make more sense to be in reverse-alphabetical order.

<img width="226" alt="Screenshot 2023-03-13 at 11 46 55 AM" src="https://user-images.githubusercontent.com/17074357/224785688-30aef366-9626-4dbd-9ddc-092b62d27d06.png">


## How to test

- Open the filters dropdown
- They are in alphabetical order

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
