### PR TITLE
[TTAHUB-1586] Add default date filter to resources dashboard

### DIFF
--- a/frontend/src/pages/ResourcesDashboard/__tests__/index.js
+++ b/frontend/src/pages/ResourcesDashboard/__tests__/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import '@testing-library/jest-dom';
 import React from 'react';
+import moment from 'moment';
 import join from 'url-join';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
@@ -14,8 +15,16 @@ import ResourcesDashboard from '../index';
 import { SCOPE_IDS } from '../../../Constants';
 import UserContext from '../../../UserContext';
 import AriaLiveContext from '../../../AriaLiveContext';
+import { formatDateRange } from '../../../utils';
 
 const history = createMemoryHistory();
+
+const defaultDate = formatDateRange({
+  forDateTime: true,
+  string: `2022/07/01-${moment().format('YYYY/MM/DD')}`,
+  withSpaces: false,
+});
+const defaultDateParam = `startDate.win=${encodeURIComponent(defaultDate)}`;
 
 const resourcesUrl = join('api', 'resources');
 
@@ -51,7 +60,7 @@ const resourcesDefault = {
           },
           {
             title: 'total',
-            value: '20',
+            value: '26',
           },
         ],
       },
@@ -161,6 +170,7 @@ describe('Resources Dashboard page', () => {
 
   it('renders correctly', async () => {
     // Page Load.
+    fetchMock.get(`${resourcesUrl}?${allRegions}&${defaultDateParam}`, resourcesDefault);
     fetchMock.get(`${resourcesUrl}?${allRegions}`, resourcesDefault);
 
     // Region 1.
@@ -205,7 +215,8 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/Jan-22/i)).toBeInTheDocument();
     expect(screen.getByText(/test1.gov/i)).toBeInTheDocument();
     expect(screen.getByText(/17/i)).toBeInTheDocument();
-    expect(screen.getByText(/20/i)).toBeInTheDocument();
+    screen.debug(undefined, 100000);
+    expect(screen.getByText(/26/i)).toBeInTheDocument();
 
     // Remove existing filter.
 
@@ -277,7 +288,7 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/Jan-22/i)).toBeInTheDocument();
     expect(screen.getByText(/test1.gov/i)).toBeInTheDocument();
     expect(screen.getByText(/17/i)).toBeInTheDocument();
-    expect(screen.getByText(/20/i)).toBeInTheDocument();
+    expect(screen.getByText(/26/i)).toBeInTheDocument();
 
     // Add region filter test pill remove.
     open = await screen.findByRole('button', { name: /open filters for this page/i });
@@ -337,7 +348,7 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/Jan-22/i)).toBeInTheDocument();
     expect(screen.getByText(/test1.gov/i)).toBeInTheDocument();
     expect(screen.getByText(/17/i)).toBeInTheDocument();
-    expect(screen.getByText(/20/i)).toBeInTheDocument();
+    expect(screen.getByText(/26/i)).toBeInTheDocument();
 
     // Add non-region filter.
     open = await screen.findByRole('button', { name: /open filters for this page/i });
@@ -397,7 +408,7 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/Jan-22/i)).toBeInTheDocument();
     expect(screen.getByText(/test1.gov/i)).toBeInTheDocument();
     expect(screen.getByText(/17/i)).toBeInTheDocument();
-    expect(screen.getByText(/20/i)).toBeInTheDocument();
+    expect(screen.getByText(/26/i)).toBeInTheDocument();
   });
 
   it('handles errors by displaying an error message', async () => {

--- a/frontend/src/pages/ResourcesDashboard/index.js
+++ b/frontend/src/pages/ResourcesDashboard/index.js
@@ -4,6 +4,7 @@ import React, {
   useState,
   useEffect,
 } from 'react';
+import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
@@ -15,13 +16,19 @@ import useSessionFiltersAndReflectInUrl from '../../hooks/useSessionFiltersAndRe
 import AriaLiveContext from '../../AriaLiveContext';
 import ResourcesDashboardOverview from '../../widgets/ResourcesDashboardOverview';
 import ResourceUse from '../../widgets/ResourceUse';
-import { expandFilters, filtersToQueryString } from '../../utils';
+import { expandFilters, filtersToQueryString, formatDateRange } from '../../utils';
 import './index.scss';
 import fetchResourceData from '../../fetchers/Resources';
 
 import UserContext from '../../UserContext';
 import { RESOURCES_DASHBOARD_FILTER_CONFIG } from './constants';
 import RegionPermissionModal from '../../components/RegionPermissionModal';
+
+const defaultDate = formatDateRange({
+  forDateTime: true,
+  string: `2022/07/01-${moment().format('YYYY/MM/DD')}`,
+  withSpaces: false,
+});
 
 const FILTER_KEY = 'regional-resources-dashboard-filters';
 export default function ResourcesDashboard() {
@@ -45,8 +52,19 @@ export default function ResourcesDashboard() {
         topic: 'region',
         condition: 'is',
         query: defaultRegion,
+      },
+      {
+        id: uuidv4(),
+        topic: 'startDate',
+        condition: 'is within',
+        query: defaultDate,
       }]
-      : allRegionsFilters,
+      : [...allRegionsFilters, {
+        id: uuidv4(),
+        topic: 'startDate',
+        condition: 'is within',
+        query: defaultDate,
+      }],
   );
 
   // Remove Filters.


### PR DESCRIPTION
## Description of change

Add a default filter to the resources dashboard from 07/01/2022 to today.

## How to test

When you go to the resources dashboard there should be default date filter applied.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1586


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
