### PR TITLE
[TTAHUB-1590] Resource page issue with reports with null startDate

### DIFF
--- a/src/services/dashboards/resource.js
+++ b/src/services/dashboards/resource.js
@@ -374,7 +374,10 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       where: {
         [Op.and]: [
           scopes.activityReport,
-          { calculatedStatus: REPORT_STATUSES.APPROVED },
+          {
+            calculatedStatus: REPORT_STATUSES.APPROVED,
+            startDate: { [Op.ne]: null },
+          },
         ],
       },
       include: [
@@ -452,7 +455,10 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       where: {
         [Op.and]: [
           scopes.activityReport,
-          { calculatedStatus: REPORT_STATUSES.APPROVED },
+          {
+            calculatedStatus: REPORT_STATUSES.APPROVED,
+            startDate: { [Op.ne]: null },
+          },
         ],
       },
       include: [
@@ -539,7 +545,10 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       where: {
         [Op.and]: [
           scopes.activityReport,
-          { calculatedStatus: REPORT_STATUSES.APPROVED },
+          {
+            calculatedStatus: REPORT_STATUSES.APPROVED,
+            startDate: { [Op.ne]: null },
+          },
         ],
       },
       include: [
@@ -632,7 +641,10 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       where: {
         [Op.and]: [
           scopes.activityReport,
-          { calculatedStatus: REPORT_STATUSES.APPROVED },
+          {
+            calculatedStatus: REPORT_STATUSES.APPROVED,
+            startDate: { [Op.ne]: null },
+          },
         ],
       },
       include: [
@@ -734,7 +746,10 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       where: {
         [Op.and]: [
           scopes.activityReport,
-          { calculatedStatus: REPORT_STATUSES.APPROVED },
+          {
+            calculatedStatus: REPORT_STATUSES.APPROVED,
+            startDate: { [Op.ne]: null },
+          },
           {
             [Op.or]: [
               { '$activityRecipients.grantId$': { [Op.eq]: Sequelize.col('activityReportObjectives.objective.goal.grantId') } },
@@ -866,7 +881,10 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       where: {
         [Op.and]: [
           scopes.activityReport,
-          { calculatedStatus: REPORT_STATUSES.APPROVED },
+          {
+            calculatedStatus: REPORT_STATUSES.APPROVED,
+            startDate: { [Op.ne]: null },
+          },
           {
             [Op.or]: [
               { '$activityRecipients.grantId$': { [Op.eq]: Sequelize.col('activityReportGoals.goal.grantId') } },


### PR DESCRIPTION
## Description of change
exclude reports with null startDate
Some reports have a null startDate, these need to be excluded as they result in the tables converting the null startDate to Dec 1969 which appears as a column to the right of the total column.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1590


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
