### PR TITLE
[TTAHUB-1578] Add comma's to anniversary statistics

### DIFF
--- a/src/services/users.js
+++ b/src/services/users.js
@@ -2,6 +2,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Op, QueryTypes } from 'sequelize';
 import SCOPES from '../middleware/scopeConstants';
+import { formatNumber } from '../widgets/helpers';
 
 import {
   User,
@@ -376,14 +377,14 @@ export async function statisticsByUser(user, regions, readonly = false, reportId
 
   return {
     daysSinceJoined: totalDaysSinceJoined,
-    arsCreated: createdReports.length,
-    arsCollaboratedOn: collaboratorReports.length,
+    arsCreated: formatNumber(createdReports.length),
+    arsCollaboratedOn: formatNumber(collaboratorReports.length),
     ttaProvided: totalTTASentence,
-    recipientsReached: totalRecipientIds.size,
-    grantsServed: totalGrantIds.size,
-    participantsReached: totalParticipants,
-    goalsApproved: totalGoalIds.size,
-    objectivesApproved: totalObjectivesIds.size,
+    recipientsReached: formatNumber(totalRecipientIds.size),
+    grantsServed: formatNumber(totalGrantIds.size),
+    participantsReached: formatNumber(totalParticipants),
+    goalsApproved: formatNumber(totalGoalIds.size),
+    objectivesApproved: formatNumber(totalObjectivesIds.size),
   };
 }
 


### PR DESCRIPTION
## Description of change

This change add comma's to the anniversary statistics.

## How to test

Viewing the anniversary statistics now shows comma's (see jira).

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1578


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
