### PR TITLE
[TTAHUB-1598] remove separate: true from goal/objectives query

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1822,7 +1822,7 @@ export async function getGoalsForReport(reportId) {
         include: [
           {
             required: true,
-            separate: true,
+            // separate: true,
             model: ActivityReportObjective,
             as: 'activityReportObjectives',
             where: {
@@ -1830,7 +1830,6 @@ export async function getGoalsForReport(reportId) {
             },
             include: [
               {
-                separate: true,
                 model: ActivityReportObjectiveTopic,
                 as: 'activityReportObjectiveTopics',
                 required: false,
@@ -1842,7 +1841,6 @@ export async function getGoalsForReport(reportId) {
                 ],
               },
               {
-                separate: true,
                 model: ActivityReportObjectiveFile,
                 as: 'activityReportObjectiveFiles',
                 required: false,
@@ -1854,7 +1852,6 @@ export async function getGoalsForReport(reportId) {
                 ],
               },
               {
-                separate: true,
                 model: ActivityReportObjectiveResource,
                 as: 'activityReportObjectiveResources',
                 required: false,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1822,7 +1822,6 @@ export async function getGoalsForReport(reportId) {
         include: [
           {
             required: true,
-            // separate: true,
             model: ActivityReportObjective,
             as: 'activityReportObjectives',
             where: {
@@ -1830,6 +1829,7 @@ export async function getGoalsForReport(reportId) {
             },
             include: [
               {
+                separate: true,
                 model: ActivityReportObjectiveTopic,
                 as: 'activityReportObjectiveTopics',
                 required: false,
@@ -1841,6 +1841,7 @@ export async function getGoalsForReport(reportId) {
                 ],
               },
               {
+                separate: true,
                 model: ActivityReportObjectiveFile,
                 as: 'activityReportObjectiveFiles',
                 required: false,
@@ -1852,6 +1853,7 @@ export async function getGoalsForReport(reportId) {
                 ],
               },
               {
+                separate: true,
                 model: ActivityReportObjectiveResource,
                 as: 'activityReportObjectiveResources',
                 required: false,


### PR DESCRIPTION
## Description of change
"separate: true" is causing queries to behave unexpectedly

## How to test
Most recent prod dump:
On branch main: load report 29122 as user 10
Try to delete first objective from second goal
Notice that it is impossible

Load this branch and refresh
Note that the objective disappears.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1598


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
