### PR TITLE
Fixed border width and added hover styles

### DIFF
--- a/frontend/src/components/Navigator/components/SideNav.scss
+++ b/frontend/src/components/Navigator/components/SideNav.scss
@@ -3,7 +3,7 @@
 .smart-hub--navigator-link-active {
   color: $ttahub-medium-blue;
   font-weight: bold;
-  border-left: 2px solid $ttahub-medium-blue;
+  border-left: 4px solid $ttahub-medium-blue;
   text-decoration-line: none;
 }
 
@@ -16,6 +16,11 @@
   font-size: 16px;
   color: $ttahub-blue;
   line-height: 24px;
+}
+
+.smart-hub--navigator-link:hover {
+  background-color: $base-lightest;
+  color: $ttahub-medium-blue;
 }
 
 .smart-hub--navigator-list {


### PR DESCRIPTION
## Description of change

- Updated border-width of side-nav active link from 2px to 4px to match design library
- Added hover state to side-nav links to match design library (background-color and text color)


## How to test
Create an activity report, then navigate to different sections of the report using the form navigator. When hovering over one of the list items in the navigator, the background will turn grey. The active state of the list item will have a 4px blue border, and the link text will not have a text underline and the text will be bold.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1286


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
