### PR TITLE
Overview widget responsive; padding-3 on Container

### DIFF
--- a/frontend/src/components/Container.js
+++ b/frontend/src/components/Container.js
@@ -46,8 +46,8 @@ Container.propTypes = {
 
 Container.defaultProps = {
   className: '',
-  paddingX: 5,
-  paddingY: 5,
+  paddingX: 3,
+  paddingY: 3,
   skipTopPadding: false,
   skipBottomPadding: false,
   loading: false,

--- a/frontend/src/widgets/FrequencyGraph.js
+++ b/frontend/src/widgets/FrequencyGraph.js
@@ -58,7 +58,7 @@ export function FreqGraph({ data, loading }) {
   }
 
   return (
-    <Container className="ttahub--frequency-graph" paddingX={3} paddingY={3} loading={loading} loadingLabel={`${selectedGraph} frequency loading`}>
+    <Container className="ttahub--frequency-graph" loading={loading} loadingLabel={`${selectedGraph} frequency loading`}>
       <Grid row className="position-relative margin-bottom-2">
         <Grid className="flex-align-self-center desktop:display-flex flex-align-center" desktop={{ col: 'auto' }} mobileLg={{ col: 10 }}>
           <h2 className="display-inline desktop:margin-y-0 margin-left-1" aria-live="polite">

--- a/frontend/src/widgets/GoalStatusGraph.js
+++ b/frontend/src/widgets/GoalStatusGraph.js
@@ -96,7 +96,7 @@ export function GoalStatusChart({ data, loading }) {
   }
 
   return (
-    <Container className="ttahub--goal-status-graph width-full" paddingX={3} paddingY={3} loading={loading} loadingLabel="goal statuses by number loading">
+    <Container className="ttahub--goal-status-graph width-full" loading={loading} loadingLabel="goal statuses by number loading">
       <Grid row className="position-relative margin-bottom-1">
         <Grid className="flex-align-self-center desktop:display-flex flex-align-center" desktop={{ col: 'auto' }} mobileLg={{ col: 10 }}>
           <h2 className="ttahub--dashboard-widget-heading margin-0">

--- a/frontend/src/widgets/Overview.css
+++ b/frontend/src/widgets/Overview.css
@@ -1,18 +1,15 @@
-.smart-hub--overview-header {
-  margin-top: -35px;
-  margin-left: -20px;
+.smart-hub--overview-data {
+  flex-direction: column;
 }
 
-.smart-hub--overview-data {
-  margin-left: -36px !important;
+@media all and (min-width: 64em){
+  .smart-hub--overview-data {
+    flex-direction: row;
+  }
 }
 
 .smart-hub--overview-nowrap {
   white-space: nowrap;
-}
-
-.smart-hub--overview  h2 {
-  font-size: 21px;
 }
 
 .smart-hub--overview-font-size {

--- a/frontend/src/widgets/Overview.js
+++ b/frontend/src/widgets/Overview.js
@@ -6,10 +6,10 @@ import Container from '../components/Container';
 import './Overview.css';
 
 function Field({
-  label, labelExt, data, col,
+  label, labelExt, data,
 }) {
   return (
-    <Grid col={col} className="smart-hub--overview">
+    <Grid className="grid-col smart-hub--overview margin-bottom-2 desktop:margin-bottom-0">
       <span className="text-bold smart-hub--overview-font-size">{data}</span>
       <br />
       {label}
@@ -22,15 +22,10 @@ Field.propTypes = {
   label: PropTypes.string.isRequired,
   labelExt: PropTypes.string,
   data: PropTypes.string,
-  col: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
 };
 
 Field.defaultProps = {
   labelExt: '',
-  col: 2,
   data: '',
 };
 
@@ -49,16 +44,16 @@ function Overview({
   return (
     <Container loading={loading} loadingLabel="Overview loading">
       <Grid row className="smart-hub--overview-header">
-        <h2>
+        <h2 className="margin-top-0">
           {title}
         </h2>
       </Grid>
-      <Grid row gap className="smart-hub--overview-data">
-        <Field col="fill" tablet={{ col: true }} label="Grants served " data={data.numGrants} />
-        <Field col="fill" label="Other entities served" data={data.numOtherEntities} />
-        <Field col="fill" label="Activity reports" data={data.numReports} />
-        <Field col="fill" label="Participants" data={data.numParticipants} />
-        <Field col={2} label="Hours of TTA" data={data.sumDuration} decimalPlaces={1} />
+      <Grid row className="smart-hub--overview-data">
+        <Field label="Grants served" data={data.numGrants} />
+        <Field label="Other entities served" data={data.numOtherEntities} />
+        <Field label="Activity reports" data={data.numReports} />
+        <Field label="Participants" data={data.numParticipants} />
+        <Field label="Hours of TTA" data={data.sumDuration} decimalPlaces={1} />
       </Grid>
     </Container>
   );
@@ -75,6 +70,10 @@ Overview.propTypes = {
   }),
   loading: PropTypes.bool.isRequired,
   tableCaption: PropTypes.string,
+  // gridGap: PropTypes.number,
+  // mobile: PropTypes.string,
+  // tablet: PropTypes.string,
+  // desktop: PropTypes.string,
 };
 
 Overview.defaultProps = {

--- a/frontend/src/widgets/TableWidget.js
+++ b/frontend/src/widgets/TableWidget.js
@@ -15,7 +15,7 @@ export default function TableWidget(
   },
 ) {
   return (
-    <Container className="smarthub-table-widget shadow-2" paddingX={3} paddingY={3} loading={loading} loadingLabel={loadingLabel}>
+    <Container className="smarthub-table-widget shadow-2" loading={loading} loadingLabel={loadingLabel}>
       {/* a scrollable element must be keyboard accessible */}
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
       <div className="usa-table-container--scrollable margin-top-0" tabIndex={0}>

--- a/frontend/src/widgets/TopicFrequencyGraph.js
+++ b/frontend/src/widgets/TopicFrequencyGraph.js
@@ -174,7 +174,7 @@ export function TopicFrequencyGraphWidget({
   }
 
   return (
-    <Container className="ttahub--topic-frequency-graph" paddingX={3} paddingY={3} loading={loading} loadingLabel="Topic frequency loading">
+    <Container className="ttahub--topic-frequency-graph" loading={loading} loadingLabel="Topic frequency loading">
       <Grid row className="margin-bottom-2 bg-white">
         <Grid className="flex-align-self-center" desktop={{ col: 'auto' }} mobileLg={{ col: 8 }}>
           <h2 className="ttahub--dashboard-widget-heading margin-0">Number of Activity Reports by Topic</h2>

--- a/frontend/src/widgets/TotalHrsAndRecipientGraph.js
+++ b/frontend/src/widgets/TotalHrsAndRecipientGraph.js
@@ -234,7 +234,7 @@ export function TotalHrsAndRecipientGraph({ data, loading, hideYAxis }) {
   }
 
   return (
-    <Container ref={widget} className="ttahub-total-hours-container shadow-2" paddingX={3} paddingY={3} loading={loading} loadingLabel="Total hours loading">
+    <Container ref={widget} className="ttahub-total-hours-container shadow-2" loading={loading} loadingLabel="Total hours loading">
       <div className="ttahub--total-hrs-recipient-graph">
         <Grid row className="position-relative margin-bottom-2">
           <Grid desktop={{ col: 'auto' }} mobileLg={{ col: 8 }}><h2 className="ttahub--dashboard-widget-heading margin-0">Total TTA hours</h2></Grid>


### PR DESCRIPTION
## Description of change

- Changed the default Container component padding (to padding-x-3, padding-y-3), as it was affecting the overview widget.
- Stacked overview data at tablet size and below with margin bottom to vertically space out data
- Corrected font size of overview widget H2
- Removed unnecessary padding declarations on other files that used the container component, since they were set to the new default.


## How to test
Use device emulator, responsive design mode or zooming to see how the overview data changes to stacked mode at <1024px device width. Use inspector to verify 24px padding around the following widgets that use the Container component: topic frequency graphs (2 pages), reasons table widget, goals status widget, and total hours widget.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1589


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
