### PR TITLE
Remove button to show topic guidance for now

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveTopics.js
+++ b/frontend/src/components/GoalForm/ObjectiveTopics.js
@@ -89,13 +89,6 @@ export default function ObjectiveTopics({
             Topics
             {' '}
             <span className="smart-hub--form-required font-family-sans font-ui-xs">*</span>
-            <button
-              type="button"
-              className="usa-button usa-button--unstyled margin-left-1"
-              ref={drawerTriggerRef}
-            >
-              View topic guidance
-            </button>
           </>
         </Label>
         {error}

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -87,6 +87,7 @@ describe('ObjectiveForm', () => {
     renderObjectiveForm(objective, removeObjective, setObjectiveError, setObjective);
 
     // Topic guidance.
+    /*
     const topicGuidance = await screen.findByRole('button', { name: /view topic guidance/i });
     userEvent.click(topicGuidance);
     expect(await screen.findByText('Topic guidance')).toBeInTheDocument();
@@ -95,9 +96,11 @@ describe('ObjectiveForm', () => {
     userEvent.click(closeTopicGuidance);
 
     // Topics.
-    const topicsText = screen.queryAllByLabelText(/topics \*/i);
+    const topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     const topics = document.querySelector('#topics');
+    */
+    const topics = await screen.findByLabelText(/topics \*/i);
     userEvent.click(topics);
 
     const resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -191,9 +191,12 @@ describe('create goal', () => {
     const objectiveText = await screen.findByRole('textbox', { name: /TTA objective \*/i });
     userEvent.type(objectiveText, 'test');
 
-    const topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    const topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     const topics = document.querySelector('#topics');
+    */
+    const topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['CLASS: Instructional Support']);
 
     const resourceOne = document.querySelector('#resource-1');
@@ -330,9 +333,12 @@ describe('create goal', () => {
     const objectiveText = await screen.findByRole('textbox', { name: /TTA objective \*/i });
     userEvent.type(objectiveText, 'test');
 
-    const topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    const topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     const topics = document.querySelector('#topics');
+    */
+    const topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['CLASS: Instructional Support']);
 
     const resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });
@@ -388,9 +394,13 @@ describe('create goal', () => {
     const objectiveText = await screen.findByRole('textbox', { name: /TTA objective \*/i });
     userEvent.type(objectiveText, 'test');
 
-    const topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    const topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     const topics = document.querySelector('#topics');
+    */
+
+    const topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['CLASS: Instructional Support']);
 
     const resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });
@@ -449,9 +459,12 @@ describe('create goal', () => {
     let objectiveText = await screen.findByRole('textbox', { name: /TTA objective \*/i });
     userEvent.type(objectiveText, 'test');
 
-    let topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    let topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     let topics = document.querySelector('#topics');
+    */
+    let topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['CLASS: Instructional Support']);
 
     let resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });
@@ -492,9 +505,12 @@ describe('create goal', () => {
     objectiveText = await screen.findByRole('textbox', { name: /TTA objective \*/i });
     userEvent.type(objectiveText, 'test');
 
-    topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     topics = document.querySelector('#topics');
+    */
+    topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['CLASS: Instructional Support']);
 
     resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });
@@ -548,9 +564,12 @@ describe('create goal', () => {
     const objectiveText = await screen.findByRole('textbox', { name: /TTA objective \*/i });
     userEvent.type(objectiveText, 'test');
 
-    const topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    const topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     const topics = document.querySelector('#topics');
+    */
+    const topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['CLASS: Instructional Support']);
 
     const resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });
@@ -621,9 +640,12 @@ describe('create goal', () => {
 
     await screen.findByText(objectiveTopicsError);
 
-    const topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    const topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     const topics = document.querySelector('#topics');
+    */
+    const topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['Coaching']);
 
     userEvent.click(save);
@@ -671,9 +693,12 @@ describe('create goal', () => {
     const objectiveText = await screen.findByRole('textbox', { name: /TTA objective \*/i });
     userEvent.type(objectiveText, 'This is objective text');
 
-    const topicsText = screen.queryAllByLabelText(/topics \*/i);
+    /*
+    const topicsText = screen.queryAllByLabelText(/topics *i);
     expect(topicsText.length).toBe(2);
     const topics = document.querySelector('#topics');
+    */
+    const topics = await screen.findByLabelText(/topics \*/i);
     await selectEvent.select(topics, ['Coaching']);
 
     const resourceOne = await screen.findByRole('textbox', { name: 'Resource 1' });


### PR DESCRIPTION
## Description of change

Patrice want's to finalize the language before we move this to prod. This change temporarily removes the 'Topic Guidance'.


## How to test

Create a new AR make sure the topic guidance button is no longer selectable.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
