### PR TITLE
[TTAHUB-1130] Orphaned goal cleanup

### DIFF
--- a/src/migrations/20230328124028-remove-orphan-goals.js
+++ b/src/migrations/20230328124028-remove-orphan-goals.js
@@ -23,42 +23,135 @@ module.exports = {
             page that are NOT associated with a report.
         */
         -- 1.) Create Orphan GOALS Id's Temp Table.
-        SELECT
-            g."id" AS "goalId"
-            INTO TEMP temp_orphan_goal_ids
-        FROM "Goals" g
-        WHERE COALESCE(g."createdVia", 'activityReport')  = 'activityReport'
-        AND COALESCE(g."isFromSmartsheetTtaPlan", FALSE) = FALSE
-        AND g."id" NOT IN
-            (SELECT DISTINCT "goalId" FROM "ActivityReportGoals");
+        SELECT G."id" AS "goalId" INTO TEMP TEMP_ORPHAN_GOAL_IDS
+        FROM "Goals" G
+        WHERE COALESCE(G."createdVia",
+                      'activityReport') = 'activityReport'
+          AND COALESCE(G."isFromSmartsheetTtaPlan",
+                    FALSE) = FALSE
+          AND G."id" NOT IN
+            (SELECT DISTINCT "goalId"
+              FROM "ActivityReportGoals");
 
         -- 2.) Create Orphan OBJECTIVE Id's Temp Table.
-        SELECT
-            o."id" AS "objectiveId",
-            g."goalId"
-            INTO TEMP temp_orphan_objective_ids
-        FROM "Objectives" o
-        INNER JOIN temp_orphan_goal_ids g
-            ON o."goalId" = g."goalId"
-        WHERE o."id" NOT IN (SELECT DISTINCT "objectiveId" from "ActivityReportObjectives");
+        SELECT * INTO TEMP TEMP_ORPHAN_OBJECTIVE_IDS
+        FROM
+          (
+            -- Orphan Objectives linked to orphan Goals.
+            SELECT O."id" AS "objectiveId"
+            FROM "Objectives" O
+            INNER JOIN TEMP_ORPHAN_GOAL_IDS G ON O."goalId" = G."goalId"
+            WHERE O."id" NOT IN
+                (SELECT DISTINCT "objectiveId"
+                  FROM "ActivityReportObjectives")
+            UNION -- Orphan Objectives not linked to Goals.
+          SELECT O."id" AS "objectiveId"
+            FROM "Objectives" O
+            LEFT JOIN "ActivityReportObjectives" ARO ON O.ID = ARO."objectiveId"
+            WHERE ARO.ID IS NULL
+              AND COALESCE(O."createdVia", 'activityReport') = 'activityReport' ) AS TMP;
 
         -- 3.) Clean Objective Orphan Topics.
-        DELETE FROM "ObjectiveTopics" WHERE "objectiveId" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+        DELETE
+        FROM "ObjectiveTopics"
+        WHERE "objectiveId" IN
+            (SELECT "objectiveId"
+              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
 
         -- 4.) Clean Objective Orphan Resources.
-        DELETE FROM "ObjectiveResources" WHERE "objectiveId" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+        DELETE
+        FROM "ObjectiveResources"
+        WHERE "objectiveId" IN
+            (SELECT "objectiveId"
+              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
 
         -- 5.) Clean Objective Orphan Files.
-        DELETE FROM "ObjectiveFiles" WHERE "objectiveId" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+        -- 5a.) Create Temp Table of Files being used by reports or non-orphan Objectives.
+        SELECT * INTO TEMP_USED_OBJECTIVE_FILES_IDS
+        FROM
+          (
+            SELECT o."fileId"
+            FROM "ObjectiveFiles" o
+            WHERE o."objectiveId" NOT IN
+                (SELECT "objectiveId"
+                  FROM TEMP_ORPHAN_OBJECTIVE_IDS)
+            UNION
+            SELECT DISTINCT AROF."fileId"
+            FROM "ActivityReportObjectiveFiles" AROF
+            UNION
+            SELECT DISTINCT ARF."fileId"
+            FROM "ActivityReportFiles" ARF) AS TMP;
+
+        -- 5b.) Clean Objective Files.
+        DELETE
+        FROM "ObjectiveFiles"
+        WHERE "objectiveId" IN
+            (SELECT "objectiveId"
+              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
+
+        -- 5c.) Clean files only used by Orphan Objectives.
+        DELETE
+        FROM "Files"
+        WHERE "id" NOT IN
+            (SELECT "fileId"
+              FROM TEMP_USED_OBJECTIVE_FILES_IDS);
 
         -- 6.) Clean Objective Orphan's.
-        DELETE FROM "Objectives" WHERE "id" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+        DELETE
+        FROM "Objectives"
+        WHERE "id" IN
+            (SELECT "objectiveId"
+              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
 
         -- 7.) Clean Goal Orphan Resources.
-        DELETE FROM "GoalResources" WHERE "goalId" IN (SELECT "goalId" FROM temp_orphan_goal_ids);
+        -- 7a.) Create Temp Table of Resources being used by reports or non-orphan Objectives.
+        SELECT * INTO TEMP_USED_OBJECTIVE_RESOURCE_IDS
+        FROM
+          (
+            SELECT O."resourceId"
+            FROM "ObjectiveResources" O
+            WHERE O."objectiveId" NOT IN
+                (SELECT "objectiveId"
+                  FROM TEMP_ORPHAN_OBJECTIVE_IDS)
+            UNION
+            SELECT DISTINCT ARR."resourceId"
+            FROM "ActivityReportResources" ARR
+            UNION
+            SELECT DISTINCT NSR."resourceId"
+            FROM "NextStepResources" NSR
+            UNION
+            SELECT DISTINCT OTR."resourceId"
+            FROM "ObjectiveTemplateResources" OTR
+            UNION
+            SELECT DISTINCT AROR."resourceId"
+            FROM "ActivityReportObjectiveResources" AROR) AS TMP;
+
+        -- 7b.) Clean Objective Resources.
+        DELETE
+        FROM "GoalResources"
+        WHERE "goalId" IN
+            (SELECT "goalId"
+              FROM TEMP_ORPHAN_GOAL_IDS);
+
+        -- 7c.) Clean resources only used by Orphan Objectives.
+        DELETE
+        FROM "Resources"
+        WHERE "id" NOT IN
+            (SELECT "resourceId"
+              FROM TEMP_USED_OBJECTIVE_RESOURCE_IDS);
 
         -- 8.) Clean Goal Orphan's.
-        DELETE FROM "Goals" WHERE "id" IN (SELECT "goalId" FROM temp_orphan_goal_ids);
+        DELETE
+        FROM "Goals"
+        WHERE "id" IN
+            (SELECT "goalId"
+              FROM TEMP_ORPHAN_GOAL_IDS);
+
+        -- 9.) DROP temp tables.
+        DROP TABLE TEMP_ORPHAN_GOAL_IDS;
+        DROP TABLE TEMP_ORPHAN_OBJECTIVE_IDS;
+        DROP TABLE TEMP_USED_OBJECTIVE_FILES_IDS;
+        DROP TABLE TEMP_USED_OBJECTIVE_RESOURCE_IDS;
         `,
         { transaction },
       );

--- a/src/migrations/20230328124028-remove-orphan-goals.js
+++ b/src/migrations/20230328124028-remove-orphan-goals.js
@@ -23,7 +23,8 @@ module.exports = {
             page that are NOT associated with a report.
         */
         -- 1.) Create Orphan GOALS Id's Temp Table.
-        SELECT G."id" AS "goalId" INTO TEMP TEMP_ORPHAN_GOAL_IDS
+        SELECT G."id" AS "goalId"
+        INTO TEMP TEMP_ORPHAN_GOAL_IDS
         FROM "Goals" G
         WHERE COALESCE(G."createdVia",
                       'activityReport') = 'activityReport'
@@ -34,7 +35,8 @@ module.exports = {
               FROM "ActivityReportGoals");
 
         -- 2.) Create Orphan OBJECTIVE Id's Temp Table.
-        SELECT * INTO TEMP TEMP_ORPHAN_OBJECTIVE_IDS
+        SELECT *
+        INTO TEMP TEMP_ORPHAN_OBJECTIVE_IDS
         FROM
           (
             -- Orphan Objectives linked to orphan Goals.
@@ -52,22 +54,32 @@ module.exports = {
               AND COALESCE(O."createdVia", 'activityReport') = 'activityReport' ) AS TMP;
 
         -- 3.) Clean Objective Orphan Topics.
+        WITH deletedObjectiveTopics AS (
         DELETE
         FROM "ObjectiveTopics"
         WHERE "objectiveId" IN
             (SELECT "objectiveId"
-              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
+              FROM TEMP_ORPHAN_OBJECTIVE_IDS)
+        RETURNING *)
+        SELECT 'Objective Topics', count(*)
+        INTO TEMP temp_results_count FROM deletedObjectiveTopics;
 
         -- 4.) Clean Objective Orphan Resources.
-        DELETE
-        FROM "ObjectiveResources"
-        WHERE "objectiveId" IN
-            (SELECT "objectiveId"
-              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
+        WITH objectiveResources AS (
+          DELETE
+          FROM "ObjectiveResources"
+          WHERE "objectiveId" IN
+              (SELECT "objectiveId"
+                FROM TEMP_ORPHAN_OBJECTIVE_IDS)
+        RETURNING *)
+        INSERT INTO temp_results_count
+        SELECT 'Objective Resources', count(*)
+        temp_results_count FROM objectiveResources;
 
         -- 5.) Clean Objective Orphan Files.
         -- 5a.) Create Temp Table of Files being used by reports or non-orphan Objectives.
-        SELECT * INTO TEMP_USED_OBJECTIVE_FILES_IDS
+        SELECT *
+        INTO TEMP TEMP_USED_OBJECTIVE_FILES_IDS
         FROM
           (
             SELECT o."fileId"
@@ -82,76 +94,110 @@ module.exports = {
             SELECT DISTINCT ARF."fileId"
             FROM "ActivityReportFiles" ARF) AS TMP;
 
-        -- 5b.) Clean Objective Files.
-        DELETE
-        FROM "ObjectiveFiles"
-        WHERE "objectiveId" IN
-            (SELECT "objectiveId"
-              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
+      -- 5b.) Clean Objective Files.
+      WITH objectiveFiless AS (
+          DELETE
+          FROM "ObjectiveFiles"
+          WHERE "objectiveId" IN
+              (SELECT "objectiveId"
+                FROM TEMP_ORPHAN_OBJECTIVE_IDS)
+      RETURNING *)
+      INSERT INTO temp_results_count
+      SELECT 'Objective Files', count(*)
+      FROM objectiveFiless;
 
-        -- 5c.) Clean files only used by Orphan Objectives.
-        DELETE
-        FROM "Files"
-        WHERE "id" NOT IN
-            (SELECT "fileId"
-              FROM TEMP_USED_OBJECTIVE_FILES_IDS);
+      -- 5c.) Clean files only used by Orphan Objectives.
+      WITH files AS (
+          DELETE
+          FROM "Files"
+          WHERE "id" NOT IN
+              (SELECT "fileId"
+                FROM TEMP_USED_OBJECTIVE_FILES_IDS)
+      RETURNING *)
+      INSERT INTO temp_results_count
+      SELECT 'Files', count(*)
+      FROM files;
 
-        -- 6.) Clean Objective Orphan's.
-        DELETE
-        FROM "Objectives"
-        WHERE "id" IN
-            (SELECT "objectiveId"
-              FROM TEMP_ORPHAN_OBJECTIVE_IDS);
+      -- 6.) Clean Objective Orphan's.
+      WITH objectives AS (
+          DELETE
+          FROM "Objectives"
+          WHERE "id" IN
+              (SELECT "objectiveId"
+                FROM TEMP_ORPHAN_OBJECTIVE_IDS)
+      RETURNING *)
+      INSERT INTO temp_results_count
+      SELECT 'Objectives', count(*)
+      FROM objectives;
 
-        -- 7.) Clean Goal Orphan Resources.
-        -- 7a.) Create Temp Table of Resources being used by reports or non-orphan Objectives.
-        SELECT * INTO TEMP_USED_OBJECTIVE_RESOURCE_IDS
-        FROM
-          (
-            SELECT O."resourceId"
-            FROM "ObjectiveResources" O
-            WHERE O."objectiveId" NOT IN
-                (SELECT "objectiveId"
-                  FROM TEMP_ORPHAN_OBJECTIVE_IDS)
-            UNION
-            SELECT DISTINCT ARR."resourceId"
-            FROM "ActivityReportResources" ARR
-            UNION
-            SELECT DISTINCT NSR."resourceId"
-            FROM "NextStepResources" NSR
-            UNION
-            SELECT DISTINCT OTR."resourceId"
-            FROM "ObjectiveTemplateResources" OTR
-            UNION
-            SELECT DISTINCT AROR."resourceId"
-            FROM "ActivityReportObjectiveResources" AROR) AS TMP;
+      -- 7.) Clean Goal Orphan Resources.
+      -- 7a.) Create Temp Table of Resources being used by reports or non-orphan Objectives.
+          SELECT *
+      INTO TEMP TEMP_USED_OBJECTIVE_RESOURCE_IDS
+          FROM
+            (
+              SELECT O."resourceId"
+              FROM "ObjectiveResources" O
+              WHERE O."objectiveId" NOT IN
+                  (SELECT "objectiveId"
+                    FROM TEMP_ORPHAN_OBJECTIVE_IDS)
+              UNION
+              SELECT DISTINCT ARR."resourceId"
+              FROM "ActivityReportResources" ARR
+              UNION
+              SELECT DISTINCT NSR."resourceId"
+              FROM "NextStepResources" NSR
+              UNION
+              SELECT DISTINCT OTR."resourceId"
+              FROM "ObjectiveTemplateResources" OTR
+              UNION
+              SELECT DISTINCT AROR."resourceId"
+              FROM "ActivityReportObjectiveResources" AROR) AS TMP;
 
-        -- 7b.) Clean Objective Resources.
-        DELETE
-        FROM "GoalResources"
-        WHERE "goalId" IN
-            (SELECT "goalId"
-              FROM TEMP_ORPHAN_GOAL_IDS);
+      -- 7b.) Clean Objective Resources.
+      WITH goalResources AS (
+          DELETE
+          FROM "GoalResources"
+          WHERE "goalId" IN
+              (SELECT "goalId"
+                FROM TEMP_ORPHAN_GOAL_IDS)
+      RETURNING *)
+      INSERT INTO temp_results_count
+      SELECT 'Goal Resources', count(*)
+      FROM goalResources;
 
-        -- 7c.) Clean resources only used by Orphan Objectives.
-        DELETE
-        FROM "Resources"
-        WHERE "id" NOT IN
-            (SELECT "resourceId"
-              FROM TEMP_USED_OBJECTIVE_RESOURCE_IDS);
+      -- 7c.) Clean resources only used by Orphan Objectives.
+      WITH resources AS (
+          DELETE
+          FROM "Resources"
+          WHERE "id" NOT IN
+              (SELECT "resourceId"
+                FROM TEMP_USED_OBJECTIVE_RESOURCE_IDS)
+      RETURNING *)
+      INSERT INTO temp_results_count
+      SELECT 'Resources', count(*)
+      FROM resources;
 
-        -- 8.) Clean Goal Orphan's.
-        DELETE
-        FROM "Goals"
-        WHERE "id" IN
-            (SELECT "goalId"
-              FROM TEMP_ORPHAN_GOAL_IDS);
+      -- 8.) Clean Goal Orphan's.
+      WITH goals AS (
+            DELETE
+            FROM "Goals"
+            WHERE "id" IN
+                (SELECT "goalId"
+                  FROM TEMP_ORPHAN_GOAL_IDS)
+        RETURNING *)
+        INSERT INTO temp_results_count
+        SELECT 'Goals', count(*)
+        FROM goals;
 
         -- 9.) DROP temp tables.
         DROP TABLE TEMP_ORPHAN_GOAL_IDS;
         DROP TABLE TEMP_ORPHAN_OBJECTIVE_IDS;
         DROP TABLE TEMP_USED_OBJECTIVE_FILES_IDS;
         DROP TABLE TEMP_USED_OBJECTIVE_RESOURCE_IDS;
+
+        -- 10.) Select Results.
+        SELECT * FROM temp_results_count;
         `,
         { transaction },
       );

--- a/src/migrations/20230328124028-remove-orphan-goals.js
+++ b/src/migrations/20230328124028-remove-orphan-goals.js
@@ -1,0 +1,63 @@
+/* eslint-disable max-len */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const loggedUser = '0';
+      const sessionSig = __filename;
+      const auditDescriptor = 'RUN MIGRATIONS';
+      await queryInterface.sequelize.query(
+        `SELECT
+                set_config('audit.loggedUser', '${loggedUser}', TRUE) as "loggedUser",
+                set_config('audit.transactionId', NULL, TRUE) as "transactionId",
+                set_config('audit.sessionSig', '${sessionSig}', TRUE) as "sessionSig",
+                set_config('audit.auditDescriptor', '${auditDescriptor}', TRUE) as "auditDescriptor";`,
+        { transaction },
+      );
+
+      // Disable allow null and unique.
+      await queryInterface.sequelize.query(
+        `
+        -- 1.) Create Orphan GOALS Id's Temp Table.
+        SELECT
+            g."id" AS "goalId"
+            INTO TEMP temp_orphan_goal_ids
+        FROM "Goals" g
+        WHERE COALESCE(g."createdVia", 'activityReport')  = 'activityReport'
+        AND COALESCE(g."isFromSmartsheetTtaPlan", FALSE) = FALSE
+        AND g."id" NOT IN
+            (SELECT DISTINCT "goalId" FROM "ActivityReportGoals");
+
+        -- 2.) Create Orphan OBJECTIVE Id's Temp Table.
+        SELECT
+            o."id" AS "objectiveId",
+            g."goalId"
+            INTO TEMP temp_orphan_objective_ids
+        FROM "Objectives" o
+        INNER JOIN temp_orphan_goal_ids g
+            ON o."goalId" = g."goalId"
+        WHERE o."id" NOT IN (SELECT DISTINCT "objectiveId" from "ActivityReportObjectives");
+
+        -- 3.) Clean Objective Orphan Topics.
+        DELETE FROM "ObjectiveTopics" WHERE "objectiveId" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+
+        -- 4.) Clean Objective Orphan Resources.
+        DELETE FROM "ObjectiveResources" WHERE "objectiveId" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+
+        -- 5.) Clean Objective Orphan Files.
+        DELETE FROM "ObjectiveFiles" WHERE "objectiveId" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+
+        -- 6.) Clean Objective Orphan's.
+        DELETE FROM "Objectives" WHERE "id" IN (SELECT "objectiveId" FROM temp_orphan_objective_ids);
+
+        -- 7.) Clean Goal Orphan Resources.
+        DELETE FROM "GoalResources" WHERE "goalId" IN (SELECT "goalId" FROM temp_orphan_goal_ids);
+
+        -- 8.) Clean Goal Orphan's.
+        DELETE FROM "Goals" WHERE "id" IN (SELECT "goalId" FROM temp_orphan_goal_ids);
+        `,
+        { transaction },
+      );
+    });
+  },
+  down: async () => {},
+};

--- a/src/migrations/20230328124028-remove-orphan-goals.js
+++ b/src/migrations/20230328124028-remove-orphan-goals.js
@@ -17,6 +17,11 @@ module.exports = {
       // Disable allow null and unique.
       await queryInterface.sequelize.query(
         `
+        /*
+        TTAHUB-1130: Delete Orphan Goals
+            This removes any goals created via the Activity Report
+            page that are NOT associated with a report.
+        */
         -- 1.) Create Orphan GOALS Id's Temp Table.
         SELECT
             g."id" AS "goalId"

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -70,6 +70,8 @@ describe('Goals DB service', () => {
         goalTemplateId: mockGoalTemplateId,
         update: existingGoalUpdate,
         id: mockGoalId,
+        activityReports: [],
+        objectives: [],
       }]);
       Goal.findOne = jest.fn();
       Goal.findByPk = jest.fn().mockResolvedValue({
@@ -138,7 +140,92 @@ describe('Goals DB service', () => {
         expect(ActivityReportObjective.destroy).not.toHaveBeenCalled();
       });
 
+      it('deletes goals not being used by ActivityReportGoals or Objectives', async () => {
+        ActivityReportObjective.findAll.mockResolvedValue([
+          {
+            objectiveId: mockObjectiveId,
+            objective: {
+              goalId: mockGoalId,
+              goal: {
+                id: mockGoalId,
+                objectives: [{ id: mockObjectiveId }],
+              },
+            },
+          },
+          {
+            objectiveId: mockObjectiveId + 1,
+            objective: {
+              goalId: mockGoalId + 1,
+              goal: {
+                id: mockGoalId + 1,
+                objectives: [{ id: mockObjectiveId + 1 }],
+              },
+            },
+          },
+        ]);
+
+        ActivityReportGoal.findAll.mockResolvedValue([
+          {
+            goalId: mockGoalId,
+          },
+        ]);
+
+        await saveGoalsForReport([], { id: mockActivityReportId });
+
+        expect(Goal.destroy).toHaveBeenCalled();
+      });
+
       it('does not delete goals not being used by ActivityReportGoals', async () => {
+        Goal.findAll = jest.fn().mockResolvedValue([{
+          goalTemplateId: mockGoalTemplateId,
+          update: existingGoalUpdate,
+          id: mockGoalId,
+          activityReports: [{ id: 1 }],
+          objectives: [],
+        }]);
+
+        ActivityReportObjective.findAll.mockResolvedValue([
+          {
+            objectiveId: mockObjectiveId,
+            objective: {
+              goalId: mockGoalId,
+              goal: {
+                id: mockGoalId,
+                objectives: [{ id: mockObjectiveId }],
+              },
+            },
+          },
+          {
+            objectiveId: mockObjectiveId + 1,
+            objective: {
+              goalId: mockGoalId + 1,
+              goal: {
+                id: mockGoalId + 1,
+                objectives: [{ id: mockObjectiveId + 1 }],
+              },
+            },
+          },
+        ]);
+
+        ActivityReportGoal.findAll.mockResolvedValue([
+          {
+            goalId: mockGoalId,
+          },
+        ]);
+
+        await saveGoalsForReport([], { id: mockActivityReportId });
+        expect(Goal.destroy).not.toHaveBeenCalled();
+      });
+
+      it('does not delete goals not being used by Objectives', async () => {
+        Goal.findAll = jest.fn().mockResolvedValue([{
+          goalTemplateId: mockGoalTemplateId,
+          update: existingGoalUpdate,
+          id: mockGoalId,
+          activityReports: [],
+          objectives: [{ id: 1 }],
+        }]);
+
         ActivityReportObjective.findAll.mockResolvedValue([
           {
             objectiveId: mockObjectiveId,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1262,7 +1262,7 @@ export async function setActivityReportGoalAsActivelyEdited(goalIdsAsString, rep
   }
 }
 
-async function removeUnusedActivityReportGoals(goalsToRemove, reportId) {
+async function removeUnusedGoalsCreatedViaAr(goalsToRemove, reportId) {
   // If we don't have goals return.
   if (!goalsToRemove.length) {
     return Promise.resolve();
@@ -1299,7 +1299,7 @@ async function removeUnusedActivityReportGoals(goalsToRemove, reportId) {
   let unusedGoals = goals.filter((g) => !g.activityReports.length);
 
   // Get Goals without Objectives.
-  unusedGoals = goals.filter((g) => !g.objectives.length);
+  unusedGoals = unusedGoals.filter((g) => !g.objectives.length);
 
   // If we have activity report goals without activity reports delete.
   if (unusedGoals.length) {
@@ -1792,7 +1792,7 @@ export async function saveGoalsForReport(goals, report) {
   );
 
   // Delete Goal's if not being used and created from AR.
-  return removeUnusedActivityReportGoals(goalsToRemove, report.id);
+  return removeUnusedGoalsCreatedViaAr(goalsToRemove, report.id);
 }
 
 /**


### PR DESCRIPTION
## Description of change

This PR does two things:
- Adds a script to cleanup orphan goals and objectives along with associated tables.
- Deletes goals created via AR if they are not being used.

## How to test
- Review all code and SQL.
- Run the migration make sure it competes successfully. 
**NOTE:** A script Garrett wrote should give you an idea of what we can expect to be deleted on the JIRA TTAHUB-1130.
- Create a goal on a report and remove the Goal from the report and save. The goal should be removed from the DB.
- Create a goal on another report then use the same goal on a new report and remove it and save. The goal should NOT be removed from the db.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1130


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
