### PR TITLE
[TTAHUB-1607] Test to verify correct number of objectives are returned and objective remove e2e

### DIFF
--- a/src/services/goalServices/getGoalsForReport.test.js
+++ b/src/services/goalServices/getGoalsForReport.test.js
@@ -1,0 +1,141 @@
+import faker from '@faker-js/faker';
+import {
+  getGoalsForReport,
+} from '../goals';
+import {
+  Goal,
+  Objective,
+  ActivityReport,
+  ActivityReportGoal,
+  ActivityReportObjective,
+  User,
+  sequelize,
+} from '../../models';
+import { REPORT_STATUSES, OBJECTIVE_STATUS } from '../../constants';
+
+describe('getGoalsForReport', () => {
+  let goal;
+  let objective1;
+  let objective2;
+  let excludedGoal;
+  let excludeObjective;
+  let report;
+  let user;
+
+  beforeAll(async () => {
+    // Create User.
+    const userName = faker.random.word();
+
+    user = await User.create({
+      id: faker.datatype.number({ min: 1000 }),
+      homeRegionId: 1,
+      name: userName,
+      hsesUsername: userName,
+      hsesUserId: userName,
+    });
+
+    // Create Included Goal.
+    goal = await Goal.create({
+      name: 'goal with multiple objectives',
+      status: 'Not Started',
+      timeframe: '12 months',
+      isFromSmartsheetTtaPlan: false,
+      createdAt: new Date('2023-04-03'),
+      grantId: 1,
+    });
+
+    // Create Included Objectives.
+    objective1 = await Objective.create({
+      title: 'Include Goal - Excluded Objective 1',
+      goalId: goal.id,
+      status: OBJECTIVE_STATUS.DRAFT,
+    }, { individualHooks: true });
+
+    objective2 = await Objective.create({
+      title: 'Include Goal - Included Objective 2',
+      goalId: goal.id,
+      status: OBJECTIVE_STATUS.DRAFT,
+    }, { individualHooks: true });
+
+    // Create Exclude Goal.
+    excludedGoal = await Goal.create({
+      name: 'goal to exclude',
+      status: 'Not Started',
+      timeframe: '12 months',
+      isFromSmartsheetTtaPlan: false,
+      createdAt: new Date('2023-04-03'),
+      grantId: 1,
+    });
+
+    // Create Excluded Objectives.
+    excludeObjective = await Objective.create({
+      title: 'Excluded Goal - Excluded Objective 1',
+      goalId: goal.id,
+      status: OBJECTIVE_STATUS.DRAFT,
+    }, { individualHooks: true });
+
+    // create report
+    report = await ActivityReport.create({
+      activityRecipientType: 'recipient',
+      submissionStatus: REPORT_STATUSES.DRAFT,
+      userId: user.id,
+      regionId: 1,
+      lastUpdatedById: user.id,
+      ECLKCResourcesUsed: ['test'],
+      activityRecipients: [{ activityRecipientId: 30 }],
+    });
+
+    // Create activity report objective
+    await ActivityReportObjective.create({
+      activityReportId: report.id,
+      status: 'Complete',
+      objectiveId: objective2.id,
+    });
+
+    // create activity report goal
+    await ActivityReportGoal.create({
+      activityReportId: report.id,
+      goalId: goal.id,
+      isActivelyEdited: false,
+    });
+  });
+  afterAll(async () => {
+    await ActivityReportObjective.destroy({
+      where: {
+        activityReportId: report.id,
+      },
+    });
+
+    await ActivityReportGoal.destroy({
+      where: {
+        activityReportId: report.id,
+      },
+    });
+
+    await Objective.destroy({
+      where: {
+        id: [objective1.id, objective2.id, excludeObjective.id],
+      },
+    });
+
+    await Goal.destroy({
+      where: {
+        id: [goal.id, excludedGoal.id],
+      },
+    });
+
+    await ActivityReport.destroy({
+      where: {
+        id: report.id,
+      },
+    });
+
+    await sequelize.close();
+  });
+  it('returns the correct number of goals and objectives', async () => {
+    const goalsForReport = await getGoalsForReport(report.id);
+    expect(goalsForReport).toHaveLength(1);
+    expect(goalsForReport[0].objectives).toHaveLength(1);
+    expect(goalsForReport[0].objectives[0].id).toBe(objective2.id);
+  });
+});

--- a/tests/activity-report.spec.ts
+++ b/tests/activity-report.spec.ts
@@ -685,4 +685,66 @@ test.describe('Activity Report', () => {
     await expect(page.getByRole('link', { name: `R0${regionNumber}-AR-${arNumber}` })).toBeVisible();
   });
 
+  test('can remove objective', async ({ page }) => {
+    await getFullName(page);
+
+    await page.getByRole('link', { name: 'Activity Reports' }).click();
+    await page.getByRole('button', { name: '+ New Activity Report' }).click();
+
+    await activitySummary(page);
+
+    await page.getByRole('button', { name: 'Save and continue' }).click();
+
+    await page.getByRole('button', { name: 'Supporting attachments not started' }).click();
+    await page.getByRole('button', { name: 'Goals and objectives not started' }).click();
+
+    // create the first goal
+    await page.getByTestId('label').locator('div').filter({ hasText: '- Select -' }).nth(2)
+      .click();
+    await page.locator('#react-select-15-option-0').getByText('Create new goal').click();
+    await page.getByTestId('textarea').click();
+    await page.getByTestId('textarea').fill('g1');
+    await page.getByText('RTTAPA', { exact: true }).click();
+    await page.getByRole('button', { name: 'Save goal' }).click();
+
+    // create first objective
+    await page.locator('.css-125guah-control > .css-g1d714-ValueContainer').click();
+    await page.keyboard.press('Enter');
+    await page.getByLabel('TTA objective *').click();
+    await page.getByLabel('TTA objective *').fill('g1 o1 title');
+    await page.locator('.css-125guah-control > .css-g1d714-ValueContainer').click();
+    await page.locator('#react-select-21-option-0').click();
+    await blur(page);
+    await page.getByRole('textbox', { name: 'TTA provided for objective' }).locator('div').nth(2).click();
+    await page.keyboard.type('g1 o1 tta');
+    await blur(page);
+
+    // create second objective
+    await page.getByRole('button', { name: 'Add new objective' }).click();
+    await page.locator('[id="goalForEditing\\.objectives\\[1\\]\\.title"]').fill('g1 o2 title');
+    await blur(page);
+    await page.locator('[id="goalForEditing\\.objectives\\[1\\]\\.topics"]').focus();
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await blur(page);
+
+    // remove first objective
+    await page.getByRole('button', { name: 'Remove this objective' }).first().click();
+    await page.getByRole('button', { name: 'This button will remove the objective from the activity report' }).click();
+
+    // add second objective tta
+    await page.getByRole('textbox', { name: 'TTA provided for objective' }).locator('div').nth(2).click();
+    await page.keyboard.type('g1 o2 tta');
+    await blur(page);
+
+    // Save goal
+    await page.getByRole('button', { name: 'Save goal' }).click();
+
+    // Verify we only have one objective
+    await expect(page.getByText('Recipient TTA goal', { exact: true })).toBeVisible();
+    await expect(page.getByText('g1 o2 title', { exact: true })).toBeVisible();
+    await expect(page.getByText('g1 o2 tta', { exact: true })).toBeVisible();
+    await expect(page.getByText('g1 o1 tta', { exact: true })).not.toBeVisible();
+    await expect(page.getByText('g1 o1 tta', { exact: true })).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
## Description of change

Added two tests:
- Unit test to verify correct number of objectives are returned.
- E2e test to verify user can remove objective.

## How to test

Test1: 
Adding a separate to the goals function caused extra objectives to be returned that were not in the ARO table.
The unit test aims to prevent this from occurring in the future.

In goals service **getGoalsForReport()** add a separate to the ActivityReportObjectives join the test should fail. Uncomment the separate the test should pass.

![image](https://user-images.githubusercontent.com/84350609/229612206-e034902e-113a-43d6-9408-f379e972ce1e.png)

Test2: 
E2e to ensure we can successfully remove an objective.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1607


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
