### PR TITLE
[TTAHUB-1133] Update layout on approved AR to match mockup

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.js
@@ -23,7 +23,7 @@ export default function ApprovedReportSection({
             {subheadings.map((subheading) => (
               <div className="ttahub-approved-report-section--heading--section-row tablet:display-flex" key={uuidv4()}>
                 <p className="ttahub-approved-report-section--heading--section-row-title text-bold usa-prose margin-0 margin-bottom-1 font-sans-3xs">{subheading}</p>
-                <p className="usa-prose margin-0 margin-bottom-1 font-sans-3xs">{renderData(subheading, section.data[subheading])}</p>
+                <p className="ttahub-approved-report-section--heading--section-row-data usa-prose margin-0 margin-bottom-1 font-sans-3xs">{renderData(subheading, section.data[subheading])}</p>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportSection.scss
@@ -1,7 +1,7 @@
 @use '../../../colors.scss' as *;
 
 // these next two style blocks will only apply on desktop
-.ttahub-approved-report-section--heading--section-row > p {
+.ttahub-approved-report-section--heading--section-row-data  {
   flex-basis: max(300px, 75%)
 }
 


### PR DESCRIPTION
## Description of change
The first column side of the Approved AR didn't match the mockup, per the ticket


### Current
![Screenshot 2023-04-04 at 3 31 17 PM](https://user-images.githubusercontent.com/3288586/229900138-71fee232-8808-4fbc-a2b3-aac6bc3dde07.png)

### Updated
![Screenshot 2023-04-04 at 3 30 30 PM](https://user-images.githubusercontent.com/3288586/229900286-f4338e06-1aa6-4e9d-9130-38a565816d4b.png)

## How to test
Create and approve a report, you'll see the width of the first column has tightened.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1133


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
