### PR TITLE
[TTAHUB-1262] [TTAHUB-1357] API validation: /v1/

### DIFF
--- a/src/routes/externalApi/activityReports/handlers.js
+++ b/src/routes/externalApi/activityReports/handlers.js
@@ -16,17 +16,21 @@ export async function getReportByDisplayId(req, res) {
     const { displayId } = req.params;
     const id = displayId.replace(/^R\d{2}-AR-/, '');
     const [report] = await activityReportAndRecipientsById(id);
+
     if (!report) {
       notFound(res, `Report ${displayId} could not be found`);
       return;
     }
-    const user = await userById(currentUserId(req, res));
+
+    const userId = await currentUserId(req, res);
+    const user = await userById(userId);
     const authorization = new ActivityReport(user, report);
 
     if (!authorization.canGet()) {
       unauthorized(res, `User is not authorized to access ${displayId}`);
       return;
     }
+
     res.json(ActivityReportsPresenter.render(report));
   } catch (error) {
     handleErrors(req, res, error, logContext);

--- a/src/serializers/activityReports.js
+++ b/src/serializers/activityReports.js
@@ -12,7 +12,7 @@ ActivityReportsPresenter.prototype.attributes = function attributes(instance) {
       id: attrs.author.id.toString(),
       name: attrs.author.fullName,
     },
-    collaborators: attrs.collaborators.map((collab) => ({
+    collaborators: attrs.activityReportCollaborators.map((collab) => ({
       id: collab.id.toString(),
       name: collab.fullName,
     })),

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -992,7 +992,7 @@ describe('Activity report service', () => {
         const { rows } = await activityReports({
           sortBy: 'topics', sortDir: 'asc', offset: 0, limit: 12, 'region.in': ['1', '2'], 'reportId.nctn': idsToExclude,
         });
-        expect(rows.length).toBe(6);
+        expect(rows.length).toBe(7);
         expect(rows[0].sortedTopics[0]).toBe('topic a');
         expect(rows[0].sortedTopics[1]).toBe('topic b');
         expect(rows[1].sortedTopics[0]).toBe('topic c');

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -992,7 +992,7 @@ describe('Activity report service', () => {
         const { rows } = await activityReports({
           sortBy: 'topics', sortDir: 'asc', offset: 0, limit: 12, 'region.in': ['1', '2'], 'reportId.nctn': idsToExclude,
         });
-        expect(rows.length).toBe(7);
+        expect(rows.length).toBe(6);
         expect(rows[0].sortedTopics[0]).toBe('topic a');
         expect(rows[0].sortedTopics[1]).toBe('topic b');
         expect(rows[1].sortedTopics[0]).toBe('topic c');

--- a/tests/api/externalapi.spec.ts
+++ b/tests/api/externalapi.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import Joi from 'joi';
+import { root, validateSchema } from './common';
+
+test('get /v1/activity-reports/display/R01-AR-9999', async ({ request }) => {
+  const response = await request.get(
+    `${root}/v1/activity-reports/display/R01-AR-9999`,
+  );
+
+  expect(response.status()).toBe(200);
+
+  const schema = Joi.object({
+    data: Joi.object({
+      id: Joi.string().required(),
+      type: Joi.string().required(),
+      attributes: Joi.object({
+        author: Joi.object({
+          id: Joi.string().required(),
+          name: Joi.string().required(),
+        }).required(),
+        collaborators: Joi.array().items(Joi.any()).default([]),
+        displayId: Joi.string().required(),
+        duration: Joi.number().required(),
+        endDate: Joi.string().isoDate().required(),
+        reason: Joi.array().items(Joi.string()).required(),
+        region: Joi.number().required(),
+        reportCreationDate: Joi.string().isoDate().required(),
+        reportLastUpdated: Joi.string().isoDate().required(),
+        startDate: Joi.string().isoDate().required(),
+        topics: Joi.array().items(Joi.string()).required(),
+      }).required(),
+      links: Joi.object({
+        self: Joi.string().required(),
+        html: Joi.string().required(),
+      }).required(),
+    }).required(),
+  });
+
+  await validateSchema(response, schema, expect);
+});


### PR DESCRIPTION
## Description of change

validates the `/v1/activity-reports/display/:reportDisplay` endpoint

while writing this test I discovered that this handler just didn't work at all, so this PR also fixes that

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1262
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1355


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
