### PR TITLE
[TTAHUB-1639] Get ARO files first then delete

### DIFF
--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -502,20 +502,32 @@ async function deleteActivityReportObjectiveFile(req, res) {
       return;
     }
 
-    await ActivityReportObjectiveFile.destroy({
+    // Get ARO files to delete (destroy does NOT support join's).
+    const aroFilesToDelete = await ActivityReportObjectiveFile.findAll({
       where: {
         fileId: parseInt(fileId, DECIMAL_BASE),
       },
       include: [
         {
+          as: 'activityReportObjective',
           model: ActivityReportObjective,
           where: {
             activityReportId: parseInt(reportId, DECIMAL_BASE),
-            objectiveIds,
+            objectiveId: objectiveIds,
           },
           required: true,
         },
       ],
+    });
+
+    // Get ARO file ids.
+    const aroFileIds = aroFilesToDelete.map((arof) => arof.id);
+
+    // Delete ARO files.
+    await ActivityReportObjectiveFile.destroy({
+      where: {
+        id: aroFileIds,
+      },
       hookMetadata: { objectiveIds },
       individualHooks: true,
     });

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -14,6 +14,7 @@ import {
   createObjectiveFileMetaData,
   createObjectiveTemplateFileMetaData,
   createObjectivesFileMetaData,
+  deleteSpecificActivityReportObjectiveFile,
 } from '../../services/files';
 import { ActivityReportObjective, ActivityReportObjectiveFile } from '../../models';
 import ActivityReportPolicy from '../../policies/activityReport';
@@ -502,35 +503,8 @@ async function deleteActivityReportObjectiveFile(req, res) {
       return;
     }
 
-    // Get ARO files to delete (destroy does NOT support join's).
-    const aroFilesToDelete = await ActivityReportObjectiveFile.findAll({
-      where: {
-        fileId: parseInt(fileId, DECIMAL_BASE),
-      },
-      include: [
-        {
-          as: 'activityReportObjective',
-          model: ActivityReportObjective,
-          where: {
-            activityReportId: parseInt(reportId, DECIMAL_BASE),
-            objectiveId: objectiveIds,
-          },
-          required: true,
-        },
-      ],
-    });
-
-    // Get ARO file ids.
-    const aroFileIds = aroFilesToDelete.map((arof) => arof.id);
-
-    // Delete ARO files.
-    await ActivityReportObjectiveFile.destroy({
-      where: {
-        id: aroFileIds,
-      },
-      hookMetadata: { objectiveIds },
-      individualHooks: true,
-    });
+    // Delete specific ARO file.
+    await deleteSpecificActivityReportObjectiveFile(reportId, fileId, objectiveIds);
 
     res.status(204).send();
   } catch (error) {

--- a/src/services/deleteSpecificActivityReportObjectiveFile.test.js
+++ b/src/services/deleteSpecificActivityReportObjectiveFile.test.js
@@ -1,0 +1,255 @@
+/* eslint-disable jest/no-disabled-tests */
+import faker from '@faker-js/faker';
+import { REPORT_STATUSES, FILE_STATUSES } from '../constants';
+import db, {
+  Goal,
+  Grant,
+  Recipient,
+  Objective,
+  ActivityReport,
+  ActivityReportGoal,
+  ActivityReportObjective,
+  User,
+  ActivityReportObjectiveFile,
+  File,
+} from '../models';
+import { deleteSpecificActivityReportObjectiveFile } from './files';
+
+jest.mock('bull');
+
+const mockUser = {
+  id: faker.datatype.number(),
+  homeRegionId: 1,
+  name: 'user1134265161',
+  hsesUsername: 'user1134265161',
+  hsesUserId: 'user1134265161',
+};
+
+const report = {
+  regionId: 1,
+  activityRecipientType: 'recipient',
+  submissionStatus: REPORT_STATUSES.DRAFT,
+  numberOfParticipants: 1,
+  deliveryMethod: 'method',
+  duration: 0,
+  endDate: '2020-09-01T12:00:00Z',
+  startDate: '2020-09-01T12:00:00Z',
+  requester: 'requester',
+  targetPopulations: ['pop'],
+  reason: ['reason'],
+  participants: ['participants'],
+  topics: ['topics'],
+  ttaType: ['type'],
+  lastUpdatedById: mockUser.id,
+  ECLKCResourcesUsed: ['test'],
+  objectivesWithoutGoals: [],
+  goals: [],
+};
+
+describe('deleteSpecificActivityReportObjectiveFile', () => {
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  let grant;
+  let file;
+  let activityReport1;
+  let activityReport2;
+  let user;
+  let recipient;
+  let goal;
+  let objective;
+  let aro1;
+  let aro2;
+
+  let arof1;
+  let arof2;
+
+  const mockGrant = {
+    id: faker.datatype.number(),
+    number: faker.random.alphaNumeric(5),
+    cdi: false,
+    regionId: 1,
+  };
+
+  beforeAll(async () => {
+    // User.
+    user = await User.create(mockUser);
+
+    // Recipient.
+    recipient = await Recipient.create({ name: 'recipient', id: faker.datatype.number(), uei: faker.datatype.string(12) });
+
+    // Grant.
+    grant = await Grant.create({ ...mockGrant, recipientId: recipient.id });
+
+    // File.
+    file = await File.create({
+      originalFileName: 'specific-delete.txt',
+      key: 'specific-delete.key',
+      status: FILE_STATUSES.UPLOADED,
+      fileSize: 1234,
+    });
+
+    // Recipient Reports.
+    activityReport1 = await ActivityReport.create(
+      {
+        ...report,
+        userId: user.id,
+        lastUpdatedById: user.id,
+        activityRecipients: { activityRecipientId: recipient.id },
+      },
+    );
+
+    activityReport2 = await ActivityReport.create(
+      {
+        ...report,
+        userId: user.id,
+        lastUpdatedById: user.id,
+        activityRecipients: { activityRecipientId: recipient.id },
+      },
+    );
+
+    // Goal.
+    goal = await Goal.create({
+      name: 'Goal shared between two reports',
+      status: 'In Progress',
+      grantId: grant.id,
+      previousStatus: 'Not Started',
+    });
+
+    // Objective.
+    objective = await Objective.create(
+      {
+        title: 'Objective shared between two reports',
+        goalId: goal.id,
+        status: 'Not Started',
+      },
+    );
+
+    // Activity Report Goal (two reports).
+    await ActivityReportGoal.create({
+      activityReportId: activityReport1.id,
+      goalId: goal.id,
+      name: 'Goal shared between two reports 1',
+    });
+
+    await ActivityReportGoal.create({
+      activityReportId: activityReport2.id,
+      goalId: goal.id,
+      name: 'Goal shared between two reports 2',
+    });
+
+    // Activity Report Objective (two reports).
+    aro1 = await ActivityReportObjective.create({
+      activityReportId: activityReport1.id,
+      objectiveId: objective.id,
+      title: 'Objective shared between two reports 1',
+      ttaProvided: 'Objective shared between two reports tta 1',
+      status: 'Complete',
+    });
+
+    aro2 = await ActivityReportObjective.create({
+      activityReportId: activityReport2.id,
+      objectiveId: objective.id,
+      title: 'Objective shared between two reports 2',
+      ttaProvided: 'Objective shared between two reports tta 2',
+      status: 'Complete',
+    });
+
+    // Activity Report Objective File (two reports).
+    arof1 = await ActivityReportObjectiveFile.create({
+      activityReportObjectiveId: aro1.id,
+      fileId: file.id,
+    });
+
+    arof2 = await ActivityReportObjectiveFile.create({
+      activityReportObjectiveId: aro2.id,
+      fileId: file.id,
+    });
+  });
+
+  afterAll(async () => {
+    // Delete ARO File.
+    await ActivityReportObjectiveFile.destroy({
+      where: {
+        fileId: file.id,
+      },
+    });
+
+    // Delete ARO.
+    await ActivityReportObjective.destroy({
+      where: {
+        activityReportId: [activityReport1.id, activityReport2.id],
+      },
+    });
+
+    // Delete ARG.
+    await ActivityReportGoal.destroy({
+      where: {
+        activityReportId: [activityReport1.id, activityReport2.id],
+      },
+    });
+
+    // Delete Recipient AR.
+    await ActivityReport.destroy({ where: { id: [activityReport1.id, activityReport2.id] } });
+
+    // Delete Recipient Obj's
+    await Objective.destroy({ where: { goalId: goal.id } });
+
+    // Delete Goal.
+    await Goal.destroy({
+      where: {
+        id: goal.id,
+      },
+    });
+
+    // Delete Grant.
+    await Grant.destroy({
+      where: {
+        id: grant.id,
+      },
+    });
+
+    // Delete Recipient.
+    await Recipient.destroy({
+      where: {
+        id: recipient.id,
+      },
+    });
+
+    // Delete file.
+    await File.destroy({
+      where: {
+        id: file.id,
+      },
+      individualHooks: true,
+    });
+
+    // Delete User.
+    await User.destroy({
+      where: {
+        id: user.id,
+      },
+    });
+
+    // Close Conn.
+    await db.sequelize.close();
+  });
+
+  it('deletes a specified file for a reports objectives', async () => {
+    // Remove file from report 2.
+    await deleteSpecificActivityReportObjectiveFile(activityReport2.id, file.id, [objective.id]);
+
+    // Make sure file is removed from report 2.
+    let aroFiles = await ActivityReportObjectiveFile.findAll({
+      where: { id: arof2.id },
+    });
+    expect(aroFiles.length).toBe(0);
+
+    // Make sure file is NOT removed from report 1.
+    aroFiles = await ActivityReportObjectiveFile.findAll({
+      where: { activityReportObjectiveId: aro1.id },
+    });
+    expect(aroFiles.length).toBe(1);
+  });
+});

--- a/src/services/files.js
+++ b/src/services/files.js
@@ -8,6 +8,7 @@ import {
   ObjectiveTemplate,
   ObjectiveTemplateFile,
   ActivityReportObjective,
+  sequelize,
 } from '../models';
 import { FILE_STATUSES, DECIMAL_BASE } from '../constants';
 
@@ -283,7 +284,10 @@ const deleteSpecificActivityReportObjectiveFile = async (reportId, fileId, objec
   // Get ARO files to delete (destroy does NOT support join's).
   const aroFileToDelete = await ActivityReportObjectiveFile.findAll({
     raw: true,
-    attributes: ['id'],
+    attributes: [[
+      sequelize.fn('ARRAY_AGG', sequelize.fn('DISTINCT', sequelize.col('"ActivityReportObjectiveFile"."id"'))),
+      'ids',
+    ]],
     where: {
       fileId: parseInt(fileId, DECIMAL_BASE),
     },
@@ -303,7 +307,7 @@ const deleteSpecificActivityReportObjectiveFile = async (reportId, fileId, objec
   });
 
   // Get ARO file ids.
-  const aroFileIdsToDelete = aroFileToDelete.map((arof) => arof.id);
+  const aroFileIdsToDelete = aroFileToDelete[0].ids;
 
   // Delete ARO files.
   await ActivityReportObjectiveFile.destroy({


### PR DESCRIPTION
## Description of change

A bug was found when ARO files from other reports are being deleted.


## How to test

1. Create a ARO with a new goal and objective with a file attachment.
2. Approve the first report (or don't).
3. Create a new Report use the same goal created in step 1.
4. Delete the file attachment and submit the report.
5. Check the database (or the first report) you should still see an entry for the ActivityReportObjectiveFile linked to the first report.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1639


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
