### PR TITLE
[TTAHUB-NO-TICKET] Fix permissions helper with seeded data

### DIFF
--- a/frontend/src/pages/Admin/PermissionHelpers.js
+++ b/frontend/src/pages/Admin/PermissionHelpers.js
@@ -40,10 +40,11 @@ export function userRegionalPermissions(user) {
     return regionalPermissions;
   }
 
-  user.permissions.filter((permission) => regionalScopeIds.includes(permission.scopeId))
-    .forEach(({ regionId, scopeId }) => {
-      regionalPermissions[regionId][scopeId] = true;
-    });
+  user.permissions.filter((permission) => (
+    regionalScopeIds.includes(permission.scopeId) && permission.regionId !== 14
+  )).forEach(({ regionId, scopeId }) => {
+    regionalPermissions[regionId][scopeId] = true;
+  });
 
   return regionalPermissions;
 }


### PR DESCRIPTION
## Description of change
Discovered an issue when using certain seeded users. Essentially, some of the users have permissions for region 14, which isn't a region. This would cause javascript errors when exploring the app as a seeded user. I didn't want to remove or change the seed data because I'm not sure how it might be used in tests, so I wrote a line of code to prevent the issue on the frontend.

## How to test
Load the test/seed db (you can probably do this with the script bin/load-test-db). In the admin interface, view user 1. You should not get a white screen of death.

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
