### PR TITLE
[TTAHUB-1679] alphabetize close and suspend reasons

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2230,7 +2230,7 @@
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
 "@ttahub/common@file:../packages/common":
-  version "1.0.0"
+  version "1.0.1"
 
 "@turf/area@^6.4.0":
   version "6.5.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ttahub/common",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "The purpose of this package is to reduce code duplication between the frontend and backend projects.",
     "main": "src/index.js",
     "types": "src/index.d.ts",

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -147,21 +147,14 @@ const USER_ROLES = [
 ];
 exports.USER_ROLES = USER_ROLES;
 
-const CLOSE_SUSPEND_REASONS = [
-  'Duplicate goal',
-  'Recipient request',
-  'TTA complete',
-  'Key staff turnover / vacancies',
-  'Recipient is not responding',
-  'Regional Office request',
-];
+const CLOSE_SUSPEND_REASONS = [ "Duplicate goal", "Key staff turnover / vacancies", "Recipient is not responding", "Recipient request", "Regional Office request", "TTA complete" ];
 exports.CLOSE_SUSPEND_REASONS = CLOSE_SUSPEND_REASONS;
 
 const GOAL_CLOSE_REASONS = [
   'Duplicate goal',
   'Recipient request',
-  'TTA complete',
   'Regional Office request',
+  'TTA complete',
 ];
 exports.GOAL_CLOSE_REASONS = GOAL_CLOSE_REASONS;
 


### PR DESCRIPTION
## Description of change
Update @ttahub/common to make sure that the goal close and goal suspend reasons are alphabetized.

## How to test
View the goal close and goal suspend reasons and ensure that they are alphabetized within the modal.

Note that you'll need to re-run ```yarn deps locally``` to get the update.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1679


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
