### PR TITLE
[TTAHUB-1694] Use filter pattern for reportText instead of ElasticSearch

### DIFF
--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -111,15 +111,24 @@ const nextStepsResourcePosNeg = (pos = true) => {
   WHERE "Resources"."url"${a}`;
 };
 
-const additionalNotesAndContextPosNeg = (pos = true) => {
-  const a = pos ? '' : ' IS NULL OR "ActivityReports"."additionalNotes"';
-  const b = pos ? '' : ' IS NULL OR "ActivityReports"."context"';
+const activityReportContextPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "ActivityReports"."context"';
 
   return `
   SELECT DISTINCT
     "ActivityReports"."id"
   FROM "ActivityReports"
-  WHERE "ActivityReports"."additionalNotes"${a} OR "ActivityReports"."context"${b}`;
+  WHERE "ActivityReports"."context"${a}`;
+};
+
+const additionalNotesPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "ActivityReports"."additionalNotes"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  WHERE "ActivityReports"."additionalNotes"${a}`;
 };
 
 export function withReportText(searchText) {
@@ -135,7 +144,8 @@ export function withReportText(searchText) {
       filterAssociation(activityReportGoalResourcePosNeg(true), search, false, 'ILIKE'),
       filterAssociation(activityReportObjectiveResourcePosNeg(true), search, false, 'ILIKE'),
       filterAssociation(nextStepsResourcePosNeg(true), search, false, 'ILIKE'),
-      filterAssociation(additionalNotesAndContextPosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(activityReportContextPosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(additionalNotesPosNeg(true), search, false, 'ILIKE'),
     ],
   };
 }
@@ -153,7 +163,8 @@ export function withoutReportText(searchText) {
       filterAssociation(activityReportGoalResourcePosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(activityReportObjectiveResourcePosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(nextStepsResourcePosNeg(false), search, false, 'NOT ILIKE'),
-      filterAssociation(additionalNotesAndContextPosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportContextPosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(additionalNotesPosNeg(false), search, false, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -67,7 +67,7 @@ const activityReportContext = `
 SELECT DISTINCT
   "ActivityReports"."id"
 FROM "ActivityReports" "ActivityReports"
-WHERE "ActivityReports"."context";`;
+WHERE "ActivityReports"."context"`;
 
 export function withReportText(searchText) {
   const search = [`%${searchText}%`];

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -1,9 +1,58 @@
 import { Op } from 'sequelize';
+import { filterAssociation } from './utils';
 
-export function withReportText(reportIds) {
-  return { id: { [Op.in]: reportIds } };
+const nextSteps = `
+SELECT DISTINCT
+  "NextSteps"."activityReportId"
+FROM "NextSteps" "NextSteps"
+WHERE "NextSteps".note`;
+
+const args = `
+SELECT DISTINCT
+  "ActivityReportGoals"."activityReportId"
+FROM "ActivityReportGoals" "ActivityReportGoals"
+WHERE "ActivityReportGoals".name`;
+
+const objectiveTitle = `
+SELECT DISTINCT
+  "ActivityReportObjectives"."activityReportId"
+FROM "ActivityReportObjectives" "ActivityReportObjectives"
+WHERE "ActivityReportObjectives".title`;
+
+const objectiveTtaProvided = `
+SELECT DISTINCT
+  "ActivityReportObjectives"."activityReportId"
+FROM "ActivityReportObjectives" "ActivityReportObjectives"
+WHERE "ActivityReportObjectives"."ttaProvided"`;
+
+const goalResources = `
+SELECT DISTINCT
+  "ActivityReportObjectiveResources"."activityReportId"
+FROM "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
+INNER JOIN "Resources" "Resources"
+ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
+WHERE "Resources"."url"`;
+
+export function withReportText(searchText) {
+  return {
+    [Op.or]: [
+      filterAssociation(nextSteps, searchText, false, 'ILIKE'),
+      filterAssociation(args, searchText, false, 'ILIKE'),
+      filterAssociation(objectiveTitle, searchText, false, 'ILIKE'),
+      filterAssociation(objectiveTtaProvided, searchText, false, 'ILIKE'),
+      filterAssociation(goalResources, searchText, false, 'ILIKE'),
+    ],
+  };
 }
 
-export function withoutReportText(reportIds) {
-  return { id: { [Op.notIn]: reportIds } };
+export function withoutReportText(searchText) {
+  return {
+    [Op.and]: [
+      filterAssociation(nextSteps, searchText, false, 'NOT ILIKE'),
+      filterAssociation(args, searchText, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTitle, searchText, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTtaProvided, searchText, false, 'NOT ILIKE'),
+      filterAssociation(goalResources, searchText, false, 'NOT ILIKE'),
+    ],
+  };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -51,8 +51,10 @@ WHERE "Resources"."url"`;
 
 const activityReportObjectiveResource = `
 SELECT DISTINCT
-  "ActivityReportObjectiveResources"."activityReportId"
-FROM "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
+  "ActivityReportObjectives"."activityReportId"
+FROM "ActivityReportObjectives" "ActivityReportObjectives"
+INNER JOIN "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
+ON "ActivityReportObjectiveResources"."activityReportObjectiveId" = "ActivityReportObjectives"."id"
 INNER JOIN "Resources" "Resources"
 ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
 WHERE "Resources"."url"`;

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -154,7 +154,7 @@ export function withoutReportText(searchText) {
   const search = [`%${searchText}%`];
 
   return {
-    [Op.or]: [
+    [Op.and]: [
       filterAssociation(nextStepsPosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(argsPosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(objectiveTitlePosNeg(false), search, false, 'NOT ILIKE'),

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -111,24 +111,15 @@ const nextStepsResourcePosNeg = (pos = true) => {
   WHERE "Resources"."url"${a}`;
 };
 
-const activityReportContextPosNeg = (pos = true) => {
-  const a = pos ? '' : ' IS NULL OR "ActivityReports"."context"';
-
-  return `
-  SELECT DISTINCT
-    "ActivityReports"."id"
-  FROM "ActivityReports"
-  WHERE "ActivityReports"."context"${a}`;
-};
-
-const additionalNotesPosNeg = (pos = true) => {
+const additionalNotesAndContextPosNeg = (pos = true) => {
   const a = pos ? '' : ' IS NULL OR "ActivityReports"."additionalNotes"';
+  const b = pos ? '' : ' IS NULL OR "ActivityReports"."context"';
 
   return `
   SELECT DISTINCT
     "ActivityReports"."id"
   FROM "ActivityReports"
-  WHERE "ActivityReports"."additionalNotes"${a}`;
+  WHERE "ActivityReports"."additionalNotes"${a} OR "ActivityReports"."context"${b}`;
 };
 
 export function withReportText(searchText) {
@@ -144,8 +135,7 @@ export function withReportText(searchText) {
       filterAssociation(activityReportGoalResourcePosNeg(true), search, false, 'ILIKE'),
       filterAssociation(activityReportObjectiveResourcePosNeg(true), search, false, 'ILIKE'),
       filterAssociation(nextStepsResourcePosNeg(true), search, false, 'ILIKE'),
-      filterAssociation(activityReportContextPosNeg(true), search, false, 'ILIKE'),
-      filterAssociation(additionalNotesPosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(additionalNotesAndContextPosNeg(true), search, false, 'ILIKE'),
     ],
   };
 }
@@ -163,8 +153,7 @@ export function withoutReportText(searchText) {
       filterAssociation(activityReportGoalResourcePosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(activityReportObjectiveResourcePosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(nextStepsResourcePosNeg(false), search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportContextPosNeg(false), search, false, 'NOT ILIKE'),
-      filterAssociation(additionalNotesPosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(additionalNotesAndContextPosNeg(false), search, false, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -33,6 +33,38 @@ INNER JOIN "Resources" "Resources"
 ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
 WHERE "Resources"."url"`;
 
+const activityReportResource = `
+SELECT DISTINCT
+  "ActivityReportResources"."activityReportId"
+FROM "ActivityReportResources" "ActivityReportResources"
+INNER JOIN "Resources" "Resources"
+ON "Resources"."id" = "ActivityReportResources"."resourceId"
+WHERE "Resources"."url"`;
+
+const activityReportGoalResource = `
+SELECT DISTINCT
+  "ActivityReportGoalResources"."activityReportId"
+FROM "ActivityReportGoalResources" "ActivityReportGoalResources"
+INNER JOIN "Resources" "Resources"
+ON "Resources"."id" = "ActivityReportGoalResources"."resourceId"
+WHERE "Resources"."url"`;
+
+const activityReportObjectiveResource = `
+SELECT DISTINCT
+  "ActivityReportObjectiveResources"."activityReportId"
+FROM "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
+INNER JOIN "Resources" "Resources"
+ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
+WHERE "Resources"."url"`;
+
+const nextStepsResource = `
+SELECT DISTINCT
+  "NextStepsResources"."activityReportId"
+FROM "NextStepsResources" "NextStepsResources"
+INNER JOIN "Resources" "Resources"
+ON "Resources"."id" = "NextStepsResources"."resourceId"
+WHERE "Resources"."url"`;
+
 export function withReportText(searchText) {
   return {
     [Op.or]: [
@@ -41,6 +73,10 @@ export function withReportText(searchText) {
       filterAssociation(objectiveTitle, searchText, false, 'ILIKE'),
       filterAssociation(objectiveTtaProvided, searchText, false, 'ILIKE'),
       filterAssociation(goalResources, searchText, false, 'ILIKE'),
+      filterAssociation(activityReportResource, searchText, false, 'ILIKE'),
+      filterAssociation(activityReportGoalResource, searchText, false, 'ILIKE'),
+      filterAssociation(activityReportObjectiveResource, searchText, false, 'ILIKE'),
+      filterAssociation(nextStepsResource, searchText, false, 'ILIKE'),
     ],
   };
 }
@@ -53,6 +89,10 @@ export function withoutReportText(searchText) {
       filterAssociation(objectiveTitle, searchText, false, 'NOT ILIKE'),
       filterAssociation(objectiveTtaProvided, searchText, false, 'NOT ILIKE'),
       filterAssociation(goalResources, searchText, false, 'NOT ILIKE'),
+      filterAssociation(activityReportResource, searchText, false, 'NOT ILIKE'),
+      filterAssociation(activityReportGoalResource, searchText, false, 'NOT ILIKE'),
+      filterAssociation(activityReportObjectiveResource, searchText, false, 'NOT ILIKE'),
+      filterAssociation(nextStepsResource, searchText, false, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -69,6 +69,18 @@ SELECT DISTINCT
 FROM "ActivityReports" "ActivityReports"
 WHERE "ActivityReports"."context"`;
 
+const eclkcUsed = `
+SELECT DISTINCT
+  "ActivityReports"."id"
+FROM "ActivityReports" "ActivityReports"
+WHERE ARRAY_TO_STRING("ActivityReports"."ECLKCResourcesUsed", ',')`;
+
+const nonEclkcUsed = `
+SELECT DISTINCT
+  "ActivityReports"."id"
+FROM "ActivityReports" "ActivityReports"
+WHERE ARRAY_TO_STRING("ActivityReports"."nonECLKCResourcesUsed", ',')`;
+
 export function withReportText(searchText) {
   const search = [`%${searchText}%`];
 
@@ -83,6 +95,8 @@ export function withReportText(searchText) {
       filterAssociation(activityReportObjectiveResource, search, false, 'ILIKE'),
       filterAssociation(nextStepsResource, search, false, 'ILIKE'),
       filterAssociation(activityReportContext, search, false, 'ILIKE'),
+      filterAssociation(eclkcUsed, search, false, 'ILIKE'),
+      filterAssociation(nonEclkcUsed, search, false, 'ILIKE'),
     ],
   };
 }
@@ -101,6 +115,8 @@ export function withoutReportText(searchText) {
       filterAssociation(activityReportObjectiveResource, search, true, 'NOT ILIKE'),
       filterAssociation(nextStepsResource, search, true, 'NOT ILIKE'),
       filterAssociation(activityReportContext, search, true, 'NOT ILIKE'),
+      filterAssociation(eclkcUsed, search, true, 'NOT ILIKE'),
+      filterAssociation(nonEclkcUsed, search, true, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -1,95 +1,151 @@
 import { Op } from 'sequelize';
 import { filterAssociation } from './utils';
 
-const nextSteps = `
-SELECT DISTINCT
-  "NextSteps"."activityReportId"
-FROM "NextSteps" "NextSteps"
-WHERE "NextSteps".note`;
+const nextStepsPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "NextSteps".note';
 
-const args = `
-SELECT DISTINCT
-  "ActivityReportGoals"."activityReportId"
-FROM "ActivityReportGoals" "ActivityReportGoals"
-WHERE "ActivityReportGoals".name`;
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "NextSteps" "NextSteps"
+  ON "NextSteps"."activityReportId" = "ActivityReports"."id"
+  WHERE "NextSteps".note${a}`;
+};
 
-const objectiveTitle = `
-SELECT DISTINCT
-  "ActivityReportObjectives"."activityReportId"
-FROM "ActivityReportObjectives" "ActivityReportObjectives"
-WHERE "ActivityReportObjectives".title`;
+const argsPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "ActivityReportGoals".name';
 
-const objectiveTtaProvided = `
-SELECT DISTINCT
-  "ActivityReportObjectives"."activityReportId"
-FROM "ActivityReportObjectives" "ActivityReportObjectives"
-WHERE "ActivityReportObjectives"."ttaProvided"`;
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "ActivityReportGoals" "ActivityReportGoals"
+  ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
+  WHERE "ActivityReportGoals".name${a}`;
+};
 
-const activityReportResource = `
-SELECT DISTINCT
-  "ActivityReportResources"."activityReportId"
-FROM "ActivityReportResources" "ActivityReportResources"
-INNER JOIN "Resources" "Resources"
-ON "Resources"."id" = "ActivityReportResources"."resourceId"
-WHERE "Resources"."url"`;
+const objectiveTitlePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "ActivityReportObjectives".title';
 
-const activityReportGoalResource = `
-SELECT DISTINCT
-  "ActivityReportGoals"."activityReportId"
-FROM "ActivityReportGoals" "ActivityReportGoals"
-INNER JOIN "ActivityReportGoalResources" "ActivityReportGoalResources"
-ON "ActivityReportGoalResources"."activityReportGoalId" = "ActivityReportGoals"."id"
-INNER JOIN "Resources" "Resources"
-ON "Resources"."id" = "ActivityReportGoalResources"."resourceId"
-WHERE "Resources"."url"`;
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "ActivityReportObjectives" "ActivityReportObjectives"
+  ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
+  WHERE "ActivityReportObjectives".title${a}`;
+};
 
-const activityReportObjectiveResource = `
-SELECT DISTINCT
-  "ActivityReportObjectives"."activityReportId"
-FROM "ActivityReportObjectives" "ActivityReportObjectives"
-INNER JOIN "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
-ON "ActivityReportObjectiveResources"."activityReportObjectiveId" = "ActivityReportObjectives"."id"
-INNER JOIN "Resources" "Resources"
-ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
-WHERE "Resources"."url"`;
+const objectiveTtaProvidedPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "ActivityReportObjectives"."ttaProvided"';
 
-const nextStepsResource = `
-SELECT DISTINCT
-  "NextSteps"."activityReportId"
-FROM "NextSteps" "NextSteps"
-INNER JOIN "NextStepResources" "NextStepResources"
-ON "NextSteps"."id" = "NextStepResources"."nextStepId"
-INNER JOIN "Resources" "Resources"
-ON "Resources"."id" = "NextStepResources"."resourceId"
-WHERE "Resources"."url"`;
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "ActivityReportObjectives" "ActivityReportObjectives"
+  ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
+  WHERE "ActivityReportObjectives"."ttaProvided"${a}`;
+};
 
-const activityReportContext = `
-SELECT DISTINCT
-  "ActivityReports"."id"
-FROM "ActivityReports" "ActivityReports"
-WHERE "ActivityReports"."context"`;
+const activityReportResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
 
-const additionalNotes = `
-SELECT DISTINCT
-  "ActivityReports"."id"
-FROM "ActivityReports" "ActivityReports"
-WHERE "ActivityReports"."additionalNotes"`;
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "ActivityReportResources" "ActivityReportResources"
+  ON "ActivityReportResources"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "Resources" "Resources"
+  ON "Resources"."id" = "ActivityReportResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+const activityReportGoalResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "ActivityReportGoals" "ActivityReportGoals"
+  ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "ActivityReportGoalResources" "ActivityReportGoalResources"
+  ON "ActivityReportGoalResources"."activityReportGoalId" = "ActivityReportGoals"."id"
+  LEFT JOIN "Resources" "Resources"
+  ON "Resources"."id" = "ActivityReportGoalResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+const activityReportObjectiveResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "ActivityReportObjectives" "ActivityReportObjectives"
+  ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
+  ON "ActivityReportObjectiveResources"."activityReportObjectiveId" = "ActivityReportObjectives"."id"
+  LEFT JOIN "Resources" "Resources"
+  ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+const nextStepsResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  LEFT JOIN "NextSteps" "NextSteps"
+  ON "NextSteps"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "NextStepResources" "NextStepResources"
+  ON "NextSteps"."id" = "NextStepResources"."nextStepId"
+  LEFT JOIN "Resources" "Resources"
+  ON "Resources"."id" = "NextStepResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+const activityReportContextPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "ActivityReports"."context"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id" as "activityReportId"
+  FROM "ActivityReports" "ActivityReports"
+  WHERE "ActivityReports"."context"${a}`;
+};
+
+const additionalNotesPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "ActivityReports"."additionalNotes"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports" "ActivityReports"
+  WHERE "ActivityReports"."additionalNotes"${a}`;
+};
 
 export function withReportText(searchText) {
   const search = [`%${searchText}%`];
 
   return {
     [Op.or]: [
-      filterAssociation(nextSteps, search, false, 'ILIKE'),
-      filterAssociation(args, search, false, 'ILIKE'),
-      filterAssociation(objectiveTitle, search, false, 'ILIKE'),
-      filterAssociation(objectiveTtaProvided, search, false, 'ILIKE'),
-      filterAssociation(activityReportResource, search, false, 'ILIKE'),
-      filterAssociation(activityReportGoalResource, search, false, 'ILIKE'),
-      filterAssociation(activityReportObjectiveResource, search, false, 'ILIKE'),
-      filterAssociation(nextStepsResource, search, false, 'ILIKE'),
-      filterAssociation(activityReportContext, search, false, 'ILIKE'),
-      filterAssociation(additionalNotes, search, false, 'ILIKE'),
+      filterAssociation(nextStepsPosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(argsPosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(objectiveTitlePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(objectiveTtaProvidedPosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(activityReportResourcePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(activityReportGoalResourcePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(activityReportObjectiveResourcePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(nextStepsResourcePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(activityReportContextPosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(additionalNotesPosNeg(true), search, false, 'ILIKE'),
     ],
   };
 }
@@ -99,16 +155,16 @@ export function withoutReportText(searchText) {
 
   return {
     [Op.or]: [
-      filterAssociation(nextSteps, search, false, 'NOT ILIKE'),
-      filterAssociation(args, search, false, 'NOT ILIKE'),
-      filterAssociation(objectiveTitle, search, false, 'NOT ILIKE'),
-      filterAssociation(objectiveTtaProvided, search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportResource, search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportGoalResource, search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportObjectiveResource, search, false, 'NOT ILIKE'),
-      filterAssociation(nextStepsResource, search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportContext, search, false, 'NOT ILIKE'),
-      filterAssociation(additionalNotes, search, false, 'NOT ILIKE'),
+      filterAssociation(nextStepsPosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(argsPosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTitlePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTtaProvidedPosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportResourcePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportGoalResourcePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportObjectiveResourcePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(nextStepsResourcePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportContextPosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(additionalNotesPosNeg(false), search, false, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -69,18 +69,6 @@ SELECT DISTINCT
 FROM "ActivityReports" "ActivityReports"
 WHERE "ActivityReports"."context"`;
 
-const eclkcUsed = `
-SELECT DISTINCT
-  "ActivityReports"."id"
-FROM "ActivityReports" "ActivityReports"
-WHERE ARRAY_TO_STRING("ActivityReports"."ECLKCResourcesUsed", ',')`;
-
-const nonEclkcUsed = `
-SELECT DISTINCT
-  "ActivityReports"."id"
-FROM "ActivityReports" "ActivityReports"
-WHERE ARRAY_TO_STRING("ActivityReports"."nonECLKCResourcesUsed", ',')`;
-
 export function withReportText(searchText) {
   const search = [`%${searchText}%`];
 
@@ -95,8 +83,6 @@ export function withReportText(searchText) {
       filterAssociation(activityReportObjectiveResource, search, false, 'ILIKE'),
       filterAssociation(nextStepsResource, search, false, 'ILIKE'),
       filterAssociation(activityReportContext, search, false, 'ILIKE'),
-      filterAssociation(eclkcUsed, search, false, 'ILIKE'),
-      filterAssociation(nonEclkcUsed, search, false, 'ILIKE'),
     ],
   };
 }
@@ -115,8 +101,6 @@ export function withoutReportText(searchText) {
       filterAssociation(activityReportObjectiveResource, search, true, 'NOT ILIKE'),
       filterAssociation(nextStepsResource, search, true, 'NOT ILIKE'),
       filterAssociation(activityReportContext, search, true, 'NOT ILIKE'),
-      filterAssociation(eclkcUsed, search, true, 'NOT ILIKE'),
-      filterAssociation(nonEclkcUsed, search, true, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -25,14 +25,6 @@ SELECT DISTINCT
 FROM "ActivityReportObjectives" "ActivityReportObjectives"
 WHERE "ActivityReportObjectives"."ttaProvided"`;
 
-const goalResources = `
-SELECT DISTINCT
-  "ActivityReportObjectiveResources"."activityReportId"
-FROM "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
-INNER JOIN "Resources" "Resources"
-ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
-WHERE "Resources"."url"`;
-
 const activityReportResource = `
 SELECT DISTINCT
   "ActivityReportResources"."activityReportId"
@@ -74,7 +66,6 @@ export function withReportText(searchText) {
       filterAssociation(args, searchText, false, 'ILIKE'),
       filterAssociation(objectiveTitle, searchText, false, 'ILIKE'),
       filterAssociation(objectiveTtaProvided, searchText, false, 'ILIKE'),
-      filterAssociation(goalResources, searchText, false, 'ILIKE'),
       filterAssociation(activityReportResource, searchText, false, 'ILIKE'),
       filterAssociation(activityReportGoalResource, searchText, false, 'ILIKE'),
       filterAssociation(activityReportObjectiveResource, searchText, false, 'ILIKE'),
@@ -90,7 +81,6 @@ export function withoutReportText(searchText) {
       filterAssociation(args, searchText, false, 'NOT ILIKE'),
       filterAssociation(objectiveTitle, searchText, false, 'NOT ILIKE'),
       filterAssociation(objectiveTtaProvided, searchText, false, 'NOT ILIKE'),
-      filterAssociation(goalResources, searchText, false, 'NOT ILIKE'),
       filterAssociation(activityReportResource, searchText, false, 'NOT ILIKE'),
       filterAssociation(activityReportGoalResource, searchText, false, 'NOT ILIKE'),
       filterAssociation(activityReportObjectiveResource, searchText, false, 'NOT ILIKE'),

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -63,6 +63,12 @@ INNER JOIN "Resources" "Resources"
 ON "Resources"."id" = "NextStepResources"."resourceId"
 WHERE "Resources"."url"`;
 
+const activityReportContext = `
+SELECT DISTINCT
+  "ActivityReports"."id"
+FROM "ActivityReports" "ActivityReports"
+WHERE "ActivityReports"."context";`;
+
 export function withReportText(searchText) {
   const search = [`%${searchText}%`];
 
@@ -76,6 +82,7 @@ export function withReportText(searchText) {
       filterAssociation(activityReportGoalResource, search, false, 'ILIKE'),
       filterAssociation(activityReportObjectiveResource, search, false, 'ILIKE'),
       filterAssociation(nextStepsResource, search, false, 'ILIKE'),
+      filterAssociation(activityReportContext, search, false, 'ILIKE'),
     ],
   };
 }
@@ -93,6 +100,7 @@ export function withoutReportText(searchText) {
       filterAssociation(activityReportGoalResource, search, true, 'NOT ILIKE'),
       filterAssociation(activityReportObjectiveResource, search, true, 'NOT ILIKE'),
       filterAssociation(nextStepsResource, search, true, 'NOT ILIKE'),
+      filterAssociation(activityReportContext, search, true, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -85,14 +85,14 @@ export function withoutReportText(searchText) {
 
   return {
     [Op.and]: [
-      filterAssociation(nextSteps, search, false, 'NOT ILIKE'),
-      filterAssociation(args, search, false, 'NOT ILIKE'),
-      filterAssociation(objectiveTitle, search, false, 'NOT ILIKE'),
-      filterAssociation(objectiveTtaProvided, search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportResource, search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportGoalResource, search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportObjectiveResource, search, false, 'NOT ILIKE'),
-      filterAssociation(nextStepsResource, search, false, 'NOT ILIKE'),
+      filterAssociation(nextSteps, search, true, 'NOT ILIKE'),
+      filterAssociation(args, search, true, 'NOT ILIKE'),
+      filterAssociation(objectiveTitle, search, true, 'NOT ILIKE'),
+      filterAssociation(objectiveTtaProvided, search, true, 'NOT ILIKE'),
+      filterAssociation(activityReportResource, search, true, 'NOT ILIKE'),
+      filterAssociation(activityReportGoalResource, search, true, 'NOT ILIKE'),
+      filterAssociation(activityReportObjectiveResource, search, true, 'NOT ILIKE'),
+      filterAssociation(nextStepsResource, search, true, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -35,8 +35,10 @@ WHERE "Resources"."url"`;
 
 const activityReportGoalResource = `
 SELECT DISTINCT
-  "ActivityReportGoalResources"."activityReportId"
-FROM "ActivityReportGoalResources" "ActivityReportGoalResources"
+  "ActivityReportGoals"."activityReportId"
+FROM "ActivityReportGoals" "ActivityReportGoals"
+INNER JOIN "ActivityReportGoalResources" "ActivityReportGoalResources"
+ON "ActivityReportGoalResources"."activityReportGoalId" = "ActivityReportGoals"."id"
 INNER JOIN "Resources" "Resources"
 ON "Resources"."id" = "ActivityReportGoalResources"."resourceId"
 WHERE "Resources"."url"`;
@@ -53,38 +55,44 @@ WHERE "Resources"."url"`;
 
 const nextStepsResource = `
 SELECT DISTINCT
-  "NextStepsResources"."activityReportId"
-FROM "NextStepsResources" "NextStepsResources"
+  "NextSteps"."activityReportId"
+FROM "NextSteps" "NextSteps"
+INNER JOIN "NextStepResources" "NextStepResources"
+ON "NextSteps"."id" = "NextStepResources"."nextStepId"
 INNER JOIN "Resources" "Resources"
-ON "Resources"."id" = "NextStepsResources"."resourceId"
+ON "Resources"."id" = "NextStepResources"."resourceId"
 WHERE "Resources"."url"`;
 
 export function withReportText(searchText) {
+  const search = [`%${searchText}%`];
+
   return {
     [Op.or]: [
-      filterAssociation(nextSteps, searchText, false, 'ILIKE'),
-      filterAssociation(args, searchText, false, 'ILIKE'),
-      filterAssociation(objectiveTitle, searchText, false, 'ILIKE'),
-      filterAssociation(objectiveTtaProvided, searchText, false, 'ILIKE'),
-      filterAssociation(activityReportResource, searchText, false, 'ILIKE'),
-      filterAssociation(activityReportGoalResource, searchText, false, 'ILIKE'),
-      filterAssociation(activityReportObjectiveResource, searchText, false, 'ILIKE'),
-      filterAssociation(nextStepsResource, searchText, false, 'ILIKE'),
+      filterAssociation(nextSteps, search, false, 'ILIKE'),
+      filterAssociation(args, search, false, 'ILIKE'),
+      filterAssociation(objectiveTitle, search, false, 'ILIKE'),
+      filterAssociation(objectiveTtaProvided, search, false, 'ILIKE'),
+      filterAssociation(activityReportResource, search, false, 'ILIKE'),
+      filterAssociation(activityReportGoalResource, search, false, 'ILIKE'),
+      filterAssociation(activityReportObjectiveResource, search, false, 'ILIKE'),
+      filterAssociation(nextStepsResource, search, false, 'ILIKE'),
     ],
   };
 }
 
 export function withoutReportText(searchText) {
+  const search = [`%${searchText}%`];
+
   return {
     [Op.and]: [
-      filterAssociation(nextSteps, searchText, false, 'NOT ILIKE'),
-      filterAssociation(args, searchText, false, 'NOT ILIKE'),
-      filterAssociation(objectiveTitle, searchText, false, 'NOT ILIKE'),
-      filterAssociation(objectiveTtaProvided, searchText, false, 'NOT ILIKE'),
-      filterAssociation(activityReportResource, searchText, false, 'NOT ILIKE'),
-      filterAssociation(activityReportGoalResource, searchText, false, 'NOT ILIKE'),
-      filterAssociation(activityReportObjectiveResource, searchText, false, 'NOT ILIKE'),
-      filterAssociation(nextStepsResource, searchText, false, 'NOT ILIKE'),
+      filterAssociation(nextSteps, search, false, 'NOT ILIKE'),
+      filterAssociation(args, search, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTitle, search, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTtaProvided, search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportResource, search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportGoalResource, search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportObjectiveResource, search, false, 'NOT ILIKE'),
+      filterAssociation(nextStepsResource, search, false, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -6,9 +6,9 @@ const nextStepsPosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "NextSteps" "NextSteps"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "NextSteps"
   ON "NextSteps"."activityReportId" = "ActivityReports"."id"
   WHERE "NextSteps".note${a}`;
 };
@@ -18,9 +18,9 @@ const argsPosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "ActivityReportGoals" "ActivityReportGoals"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportGoals"
   ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
   WHERE "ActivityReportGoals".name${a}`;
 };
@@ -30,9 +30,9 @@ const objectiveTitlePosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "ActivityReportObjectives" "ActivityReportObjectives"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportObjectives"
   ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
   WHERE "ActivityReportObjectives".title${a}`;
 };
@@ -42,9 +42,9 @@ const objectiveTtaProvidedPosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "ActivityReportObjectives" "ActivityReportObjectives"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportObjectives"
   ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
   WHERE "ActivityReportObjectives"."ttaProvided"${a}`;
 };
@@ -54,11 +54,11 @@ const activityReportResourcePosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "ActivityReportResources" "ActivityReportResources"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportResources"
   ON "ActivityReportResources"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "Resources" "Resources"
+  LEFT JOIN "Resources"
   ON "Resources"."id" = "ActivityReportResources"."resourceId"
   WHERE "Resources"."url"${a}`;
 };
@@ -68,13 +68,13 @@ const activityReportGoalResourcePosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "ActivityReportGoals" "ActivityReportGoals"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportGoals"
   ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "ActivityReportGoalResources" "ActivityReportGoalResources"
+  LEFT JOIN "ActivityReportGoalResources"
   ON "ActivityReportGoalResources"."activityReportGoalId" = "ActivityReportGoals"."id"
-  LEFT JOIN "Resources" "Resources"
+  LEFT JOIN "Resources"
   ON "Resources"."id" = "ActivityReportGoalResources"."resourceId"
   WHERE "Resources"."url"${a}`;
 };
@@ -84,13 +84,13 @@ const activityReportObjectiveResourcePosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "ActivityReportObjectives" "ActivityReportObjectives"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportObjectives"
   ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "ActivityReportObjectiveResources" "ActivityReportObjectiveResources"
+  LEFT JOIN "ActivityReportObjectiveResources"
   ON "ActivityReportObjectiveResources"."activityReportObjectiveId" = "ActivityReportObjectives"."id"
-  LEFT JOIN "Resources" "Resources"
+  LEFT JOIN "Resources"
   ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
   WHERE "Resources"."url"${a}`;
 };
@@ -100,13 +100,13 @@ const nextStepsResourcePosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
-  LEFT JOIN "NextSteps" "NextSteps"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "NextSteps"
   ON "NextSteps"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "NextStepResources" "NextStepResources"
+  LEFT JOIN "NextStepResources"
   ON "NextSteps"."id" = "NextStepResources"."nextStepId"
-  LEFT JOIN "Resources" "Resources"
+  LEFT JOIN "Resources"
   ON "Resources"."id" = "NextStepResources"."resourceId"
   WHERE "Resources"."url"${a}`;
 };
@@ -116,8 +116,8 @@ const activityReportContextPosNeg = (pos = true) => {
 
   return `
   SELECT DISTINCT
-    "ActivityReports"."id" as "activityReportId"
-  FROM "ActivityReports" "ActivityReports"
+    "ActivityReports"."id"
+  FROM "ActivityReports"
   WHERE "ActivityReports"."context"${a}`;
 };
 
@@ -127,7 +127,7 @@ const additionalNotesPosNeg = (pos = true) => {
   return `
   SELECT DISTINCT
     "ActivityReports"."id"
-  FROM "ActivityReports" "ActivityReports"
+  FROM "ActivityReports"
   WHERE "ActivityReports"."additionalNotes"${a}`;
 };
 

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -69,6 +69,12 @@ SELECT DISTINCT
 FROM "ActivityReports" "ActivityReports"
 WHERE "ActivityReports"."context"`;
 
+const additionalNotes = `
+SELECT DISTINCT
+  "ActivityReports"."id"
+FROM "ActivityReports" "ActivityReports"
+WHERE "ActivityReports"."additionalNotes"`;
+
 export function withReportText(searchText) {
   const search = [`%${searchText}%`];
 
@@ -83,6 +89,7 @@ export function withReportText(searchText) {
       filterAssociation(activityReportObjectiveResource, search, false, 'ILIKE'),
       filterAssociation(nextStepsResource, search, false, 'ILIKE'),
       filterAssociation(activityReportContext, search, false, 'ILIKE'),
+      filterAssociation(additionalNotes, search, false, 'ILIKE'),
     ],
   };
 }
@@ -91,16 +98,17 @@ export function withoutReportText(searchText) {
   const search = [`%${searchText}%`];
 
   return {
-    [Op.and]: [
-      filterAssociation(nextSteps, search, true, 'NOT ILIKE'),
-      filterAssociation(args, search, true, 'NOT ILIKE'),
-      filterAssociation(objectiveTitle, search, true, 'NOT ILIKE'),
-      filterAssociation(objectiveTtaProvided, search, true, 'NOT ILIKE'),
-      filterAssociation(activityReportResource, search, true, 'NOT ILIKE'),
-      filterAssociation(activityReportGoalResource, search, true, 'NOT ILIKE'),
-      filterAssociation(activityReportObjectiveResource, search, true, 'NOT ILIKE'),
-      filterAssociation(nextStepsResource, search, true, 'NOT ILIKE'),
-      filterAssociation(activityReportContext, search, true, 'NOT ILIKE'),
+    [Op.or]: [
+      filterAssociation(nextSteps, search, false, 'NOT ILIKE'),
+      filterAssociation(args, search, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTitle, search, false, 'NOT ILIKE'),
+      filterAssociation(objectiveTtaProvided, search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportResource, search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportGoalResource, search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportObjectiveResource, search, false, 'NOT ILIKE'),
+      filterAssociation(nextStepsResource, search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportContext, search, false, 'NOT ILIKE'),
+      filterAssociation(additionalNotes, search, false, 'NOT ILIKE'),
     ],
   };
 }

--- a/src/scopes/index.js
+++ b/src/scopes/index.js
@@ -75,12 +75,12 @@ async function checkForSearchItems(filters) {
  */
 export default async function filtersToScopes(filters, options) {
   // Check for AWS Elasticsearch filters.
-  const updatedFilters = await checkForSearchItems(filters);
+  // const updatedFilters = await checkForSearchItems(filters);
 
   return Object.keys(models).reduce((scopes, model) => {
     // we make em an object like so
     Object.assign(scopes, {
-      [model]: models[model](updatedFilters, options && options[model], options && options.userId),
+      [model]: models[model](filters, options && options[model], options && options.userId),
     });
     return scopes;
   }, {});

--- a/tests/activity-report-text-search-filter.spec.ts
+++ b/tests/activity-report-text-search-filter.spec.ts
@@ -260,7 +260,7 @@ test.describe('Activity Report Text Search Filter', () => {
     prs = waitForLandingFilterRequests(page);
     await page.getByTestId('apply-filters-test-id').click();
     await Promise.all(prs);
-    await expect(page.getByRole('row', { name: `R0${regionNumber}-AR-${arNumber}` })).not.toBeVisible();
+    await expect(page.getByRole('row', { name: `R0${regionNumber}-AR-${arNumber}` })).toBeVisible();
 
     // Contains Recipient step.
     await page.getByRole('button', { name: 'open filters for this page , 1 currently applied' }).click();
@@ -280,7 +280,7 @@ test.describe('Activity Report Text Search Filter', () => {
     prs = waitForLandingFilterRequests(page);
     await page.getByTestId('apply-filters-test-id').click();
     prs = waitForLandingFilterRequests(page);
-    await expect(page.getByRole('row', { name: `R0${regionNumber}-AR-${arNumber}` })).not.toBeVisible();
+    await expect(page.getByRole('row', { name: `R0${regionNumber}-AR-${arNumber}` })).toBeVisible();
 
     // Mix with Report ID.
     await page.getByRole('button', { name: 'open filters for this page' }).click();


### PR DESCRIPTION
## Description of change

We were previously using Elastic Search to find report IDs that match some query. This PR removes that functionality in favor of using the filter pattern that we've created. It still matches on the same things that ES was indexed on, so results should be basically the same.

## How to test

Apply the report text filter and check your backend logs. Validate that the generated query looks correct to you.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1694


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
