### PR TITLE
remove auto generated type notations

### DIFF
--- a/src/services/goalTemplates.ts
+++ b/src/services/goalTemplates.ts
@@ -206,7 +206,7 @@ export async function setFieldPromptForCuratedTemplate(
   goalIds: number[],
   promptId: number,
   response: string[] | null,
-): Promise<void | [any, ...any[]]> {
+) {
   // Retrieve the current responses and prompt requirements for the given goals and prompt ID.
   const [currentResponses, promptRequirements] = await Promise.all([
     GoalModel.findAll({
@@ -342,7 +342,7 @@ Sets field prompts for a list of curated templates and their associated goals.
 export async function setFieldPromptsForCuratedTemplate(
   goalIds: number[],
   promptResponses: PromptResponse[],
-): Promise<(void | [any, ...any[]])[]> {
+) {
   return Promise.all(
     promptResponses
       .map(({


### PR DESCRIPTION
## Description of change
I let VS Code generate some inferred type notations from the JSDoc comments, which seem to sometimes (but weirdly, not always) spike the CI. They violate the no-implicit any tslint rule.

I'm sure it would be better to just write accurate type notation but given how poorly it interacts with sequelize, I'm not sure that's a priority right at the moment.

## How to test
CI passes

## Issue(s)
There's no ticket for this.


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
