### PR TITLE
remove erroneous down

### DIFF
--- a/src/migrations/20230424000000-correct-model-db-misalignment.js
+++ b/src/migrations/20230424000000-correct-model-db-misalignment.js
@@ -106,7 +106,5 @@ module.exports = {
       );
     },
   ),
-  down: async (queryInterface) => {
-    await queryInterface.sequelize.transaction((transaction) => (queryInterface.removeColumn('Goals', 'rtrOrder', { transaction })));
-  },
+  down: async () => {},
 };


### PR DESCRIPTION
## Description of change

The existing `down` is a vestigial cut-and-paste error and we definitely don't want it to accidentally remove that column because `down` ran.
