### PR TITLE
[NO-TICKET] Create redis admin page

### DIFF
--- a/frontend/src/fetchers/Admin.js
+++ b/frontend/src/fetchers/Admin.js
@@ -72,3 +72,13 @@ export const setFeatureFlag = async (data) => {
   const result = await post((join('/', 'api', 'users', 'feature-flags')), data);
   return result;
 };
+
+export const getRedisInfo = async () => {
+  const info = await get((join('/', 'api', 'admin', 'redis', 'info')));
+  return info.json();
+};
+
+export const flushRedis = async () => {
+  const result = await post((join('/', 'api', 'admin', 'redis', 'flush')));
+  return result.json();
+};

--- a/frontend/src/fetchers/__tests__/Admin.js
+++ b/frontend/src/fetchers/__tests__/Admin.js
@@ -2,7 +2,14 @@ import join from 'url-join';
 import fetchMock from 'fetch-mock';
 
 import {
-  getUsers, updateUser, getCDIGrants, getRecipients, assignCDIGrant, getFeatures,
+  getUsers,
+  updateUser,
+  getCDIGrants,
+  getRecipients,
+  assignCDIGrant,
+  getFeatures,
+  getRedisInfo,
+  flushRedis,
 } from '../Admin';
 
 describe('Admin', () => {
@@ -79,6 +86,24 @@ describe('Admin', () => {
       fetchMock.put(join('/', 'api', 'admin', 'grants', 'cdi', '1'), grants[0]);
       const updatedGrant = await assignCDIGrant(1, 2, 3);
       expect(updatedGrant).toEqual(grants[0]);
+    });
+  });
+
+  describe('getRedisInfo', () => {
+    it('gets redis info', async () => {
+      const info = { info: 'info' };
+      fetchMock.get(join('/', 'api', 'admin', 'redis', 'info'), info);
+      const fetchedInfo = await getRedisInfo();
+      expect(fetchedInfo).toEqual(info);
+    });
+  });
+
+  describe('flushRedis', () => {
+    it('flushes redis', async () => {
+      const res = { flushed: true };
+      fetchMock.post(join('/', 'api', 'admin', 'redis', 'flush'), res);
+      const flushed = await flushRedis();
+      expect(flushed).toEqual(res);
     });
   });
 });

--- a/frontend/src/pages/Admin/Redis.js
+++ b/frontend/src/pages/Admin/Redis.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-alert */
+/* eslint-disable react/no-danger */
+import React, { useEffect, useState } from 'react';
+import { getRedisInfo, flushRedis } from '../../fetchers/Admin';
+
+export default function Redis() {
+  const [redisInfo, setRedisInfo] = useState('');
+
+  const flushRedisCache = async () => {
+    if (window.confirm('Are you sure you want to flush the redis cache?')) {
+      try {
+        const { info } = await flushRedis();
+        setRedisInfo(`Cache flushed successfully \n\n\n\n\n\n\n  ${info}`);
+      } catch (err) {
+        setRedisInfo('Error flushing cache');
+      }
+    }
+  };
+
+  useEffect(() => {
+    async function fetchRedisInfo() {
+      try {
+        const { info } = await getRedisInfo();
+        setRedisInfo(info);
+      } catch (err) {
+        setRedisInfo('Error fetching redis info');
+      }
+    }
+
+    fetchRedisInfo();
+  }, []);
+
+  // convert all the \n & \r to <br> tags
+  const info = redisInfo.replace(/\\n/g, '<br>').replace(/\\r/g, '<br>');
+
+  return (
+    <div>
+      <button type="button" onClick={flushRedisCache}>
+        Flush redis cache
+      </button>
+      <pre
+        dangerouslySetInnerHTML={{ __html: info }}
+        style={{ whiteSpace: 'pre-line' }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/Admin/__tests__/Redis.js
+++ b/frontend/src/pages/Admin/__tests__/Redis.js
@@ -1,0 +1,91 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import {
+  render, screen, act,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import join from 'url-join';
+import Redis from '../Redis';
+
+const infoUrl = join('/', 'api', 'admin', 'redis', 'info');
+const flushUrl = join('/', 'api', 'admin', 'redis', 'flush');
+
+describe('Redis', () => {
+  const oldWindowConfirm = window.confirm;
+  global.window.confirm = () => true;
+  const renderRedis = () => {
+    render(<Redis />);
+  };
+
+  afterEach(() => fetchMock.restore());
+
+  afterAll(() => {
+    global.window.confirm = oldWindowConfirm;
+  });
+
+  it('renders redis page and fetches info', async () => {
+    fetchMock.get(infoUrl, { info: 'info' });
+    act(() => {
+      renderRedis();
+    });
+
+    expect(await screen.findByText('info')).toBeInTheDocument();
+    expect(fetchMock.called(infoUrl)).toBe(true);
+  });
+
+  it('handles errors to fetch info', async () => {
+    fetchMock.get(infoUrl, 500);
+    act(() => {
+      renderRedis();
+    });
+
+    expect(fetchMock.called(infoUrl)).toBe(true);
+  });
+
+  it('flushes the cache', async () => {
+    fetchMock.get(infoUrl, { info: 'info' });
+    fetchMock.post(flushUrl, { info: 'info' });
+    act(() => {
+      renderRedis();
+    });
+
+    const button = await screen.findByRole('button', { name: 'Flush redis cache' });
+    userEvent.click(button);
+
+    expect(fetchMock.called(infoUrl)).toBe(true);
+    expect(fetchMock.called(flushUrl)).toBe(true);
+    expect(await screen.findByText(/info/i)).toBeInTheDocument();
+  });
+
+  it('handles an error to flush the cache', async () => {
+    fetchMock.get(infoUrl, { info: 'info' });
+    fetchMock.post(flushUrl, 500);
+    act(() => {
+      renderRedis();
+    });
+
+    const button = await screen.findByRole('button', { name: 'Flush redis cache' });
+    userEvent.click(button);
+
+    expect(fetchMock.called(infoUrl)).toBe(true);
+    expect(fetchMock.called(flushUrl)).toBe(true);
+    expect(await screen.findByText(/info/i)).toBeInTheDocument();
+  });
+
+  it('handles users rejecting the confirm dialog', async () => {
+    fetchMock.get(infoUrl, { info: 'info' });
+    fetchMock.post(flushUrl, { info: 'info' });
+    global.window.confirm = () => false;
+    act(() => {
+      renderRedis();
+    });
+
+    const button = await screen.findByRole('button', { name: 'Flush redis cache' });
+    userEvent.click(button);
+
+    expect(fetchMock.called(infoUrl)).toBe(true);
+    expect(fetchMock.called(flushUrl)).toBe(false);
+    expect(await screen.findByText(/info/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Admin/index.js
+++ b/frontend/src/pages/Admin/index.js
@@ -7,6 +7,7 @@ import Cdi from './cdi';
 import Diag from './diag';
 import Flags from './Flags';
 import SiteAlerts from './SiteAlerts';
+import Redis from './Redis';
 
 function Admin() {
   return (
@@ -27,6 +28,9 @@ function Admin() {
         </NavLink>
         <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/site-alerts">
           Site alerts
+        </NavLink>
+        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/redis">
+          Redis info
         </NavLink>
       </div>
       <Switch>
@@ -49,6 +53,10 @@ function Admin() {
         <Route
           path="/admin/site-alerts/"
           render={({ match }) => <SiteAlerts match={match} />}
+        />
+        <Route
+          path="/admin/redis/"
+          render={({ match }) => <Redis match={match} />}
         />
       </Switch>
     </>

--- a/src/routes/admin/index.js
+++ b/src/routes/admin/index.js
@@ -1,11 +1,11 @@
 import express from 'express';
 import getRequestErrors, { getRequestError, deleteRequestErrors } from './handlers';
-
 import userRouter from './user';
 import recipientRouter from './recipient';
 import grantRouter from './grant';
 import roleRouter from './role';
 import siteAlertRouter from './siteAlert';
+import redisRouter from './redis';
 import userAdminAccessMiddleware from '../../middleware/userAdminAccessMiddleware';
 import transactionWrapper from '../transactionWrapper';
 
@@ -20,5 +20,6 @@ router.use('/recipients', recipientRouter);
 router.use('/grants', grantRouter);
 router.use('/roles', roleRouter);
 router.use('/alerts', siteAlertRouter);
+router.use('/redis', redisRouter);
 
 export default router;

--- a/src/routes/admin/redis.test.js
+++ b/src/routes/admin/redis.test.js
@@ -1,0 +1,63 @@
+import { getRedisInfo, flushRedis } from './redis';
+
+const redisClient = {
+  connect: () => Promise.resolve(),
+  quit: () => Promise.resolve(),
+  info: () => Promise.resolve(''),
+  flushAll: () => Promise.resolve(''),
+};
+
+jest.mock(('redis'), () => ({
+  createClient: jest.fn(() => redisClient),
+}));
+
+describe('redis', () => {
+  const json = jest.fn();
+  const mockResponse = {
+    attachment: jest.fn(),
+    json,
+    send: jest.fn(),
+    sendStatus: jest.fn(),
+    status: jest.fn(() => ({
+      end: jest.fn(),
+      json,
+    })),
+  };
+
+  const mockRequest = {
+    session: {
+      userId: 1,
+    },
+    query: {},
+  };
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('getRedisInfo', () => {
+    it('returns the redis info', async () => {
+      await getRedisInfo(mockRequest, mockResponse);
+      expect(json).toHaveBeenCalledWith({ info: '' });
+    });
+
+    it('handles errors', async () => {
+      const oldInfo = redisClient.info;
+      redisClient.info = () => Promise.reject(new Error('error'));
+      await getRedisInfo(mockRequest, mockResponse);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      redisClient.info = oldInfo;
+    });
+  });
+
+  describe('flushRedis', () => {
+    it('flushes redis', async () => {
+      await flushRedis(mockRequest, mockResponse);
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+    });
+
+    it('handles errors', async () => {
+      redisClient.flushAll = () => Promise.reject(new Error('error'));
+      await flushRedis(mockRequest, mockResponse);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/src/routes/admin/redis.ts
+++ b/src/routes/admin/redis.ts
@@ -1,0 +1,83 @@
+/* eslint-disable import/prefer-default-export */
+import { createClient } from 'redis';
+import express, { Response, Request } from 'express';
+import { generateRedisConfig } from '../../lib/queue';
+import { auditLogger } from '../../logger';
+import transactionWrapper from '../transactionWrapper';
+import { handleError } from '../../lib/apiErrorHandler';
+
+let redisClient = {
+  connect: () => Promise.resolve(),
+  quit: () => Promise.resolve(),
+  info: () => Promise.resolve(''),
+  flushAll: () => Promise.resolve(''),
+};
+
+const namespace = 'ADMIN:REDIS:INFO';
+const logContext = { namespace };
+
+/**
+   * Gets all roles from the database.
+   *
+   * @param {Request} _req - request
+   * @param {Response} res - response
+   */
+export async function getRedisInfo(req: Request, res: Response) {
+  // admin access is already checked in the middleware
+  try {
+    const {
+      uri: redisUrl,
+      tlsEnabled,
+    } = generateRedisConfig();
+
+    redisClient = createClient({
+      url: redisUrl,
+      socket: {
+        tls: tlsEnabled,
+      },
+    });
+
+    await redisClient.connect();
+
+    const info = await redisClient.info();
+
+    await redisClient.quit();
+    res.status(200).json({ info });
+  } catch (err) {
+    await handleError(req, res, err, logContext);
+  }
+}
+
+export async function flushRedis(req: Request, res: Response) {
+  // admin access is already checked in the middleware
+  try {
+    const {
+      uri: redisUrl,
+      tlsEnabled,
+    } = generateRedisConfig();
+
+    redisClient = createClient({
+      url: redisUrl,
+      socket: {
+        tls: tlsEnabled,
+      },
+    });
+
+    await redisClient.connect();
+    const flush = await redisClient.flushAll();
+    auditLogger.info(`Redis cache flushAll with response ${flush}`);
+
+    const info = await redisClient.info();
+    await redisClient.quit();
+    res.status(200).json({ info });
+  } catch (err) {
+    await handleError(req, res, err, logContext);
+  }
+}
+
+const router = express.Router();
+
+router.get('/info', transactionWrapper(getRedisInfo));
+router.post('/flush', transactionWrapper(flushRedis));
+
+export default router;

--- a/src/routes/admin/redis.ts
+++ b/src/routes/admin/redis.ts
@@ -17,7 +17,10 @@ const namespace = 'ADMIN:REDIS:INFO';
 const logContext = { namespace };
 
 /**
-   * Gets all roles from the database.
+   * Gets the redis info from the client, as if you'd run "info"
+   * redis cli
+   *
+   * https://redis.io/commands/info/
    *
    * @param {Request} _req - request
    * @param {Response} res - response
@@ -47,7 +50,16 @@ export async function getRedisInfo(req: Request, res: Response) {
     await handleError(req, res, err, logContext);
   }
 }
-
+/**
+   * Runs flush all and then returns info on the redis instance
+   * as if you'd run the two commands
+   *
+   * https://redis.io/commands/flushall/
+   * https://redis.io/commands/info/
+   *
+   * @param {Request} _req - request
+   * @param {Response} res - response
+   */
 export async function flushRedis(req: Request, res: Response) {
   // admin access is already checked in the middleware
   try {


### PR DESCRIPTION
## Description of change
Creates an admin page where we can view basic redis info and run the "flush all" queue.

![Screenshot 2023-05-05 at 2 39 08 PM](https://user-images.githubusercontent.com/3288586/236541202-60e4ba49-1d1f-4154-8db7-6d95a78da8e8.png)

## How to test
Log in as an admin with an active redis client. Confirm you can see the stats and that you can run "flush cache."

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
