### PR TITLE
[TTAHUB-168]1 Anticipated close date on approved AR's (v2)

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
@@ -164,6 +164,34 @@ describe('Approved Activity Report V2 component', () => {
     expect(await screen.findByText(/None provided/i)).toBeInTheDocument();
   });
 
+  it('hides the goal close anticipation date', async () => {
+    render(<ApprovedReportV2 data={{
+      ...report,
+      goalsAndObjectives: [{
+        name: 'Goal without close date',
+        goalNumbers: ['1'],
+        objectives: mockObjectives,
+      }],
+    }}
+    />);
+    expect(screen.queryAllByText(/anticipated close date/i).length).toBe(0);
+  });
+
+  it('shows the goal close anticipation date', async () => {
+    render(<ApprovedReportV2 data={{
+      ...report,
+      goalsAndObjectives: [{
+        name: 'Goal without close date',
+        goalNumbers: ['1'],
+        objectives: mockObjectives,
+        endDate: '05/02/2023',
+      }],
+    }}
+    />);
+    expect(await screen.findByText(/anticipated close date/i)).toBeInTheDocument();
+    expect(await screen.findByText('05/02/2023')).toBeInTheDocument();
+  });
+
   it('in person', async () => {
     render(<ApprovedReportV2 data={{
       ...report, deliveryMethod: 'in-person',

--- a/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
@@ -185,11 +185,14 @@ describe('Approved Activity Report V2 component', () => {
         goalNumbers: ['1'],
         objectives: mockObjectives,
         endDate: '05/02/2023',
+        activityReportGoals: [{
+          endDate: '05/03/2023',
+        }],
       }],
     }}
     />);
     expect(await screen.findByText(/anticipated close date/i)).toBeInTheDocument();
-    expect(await screen.findByText('05/02/2023')).toBeInTheDocument();
+    expect(await screen.findByText('05/03/2023')).toBeInTheDocument();
   });
 
   it('in person', async () => {

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -109,7 +109,7 @@ function calculateGoalsAndObjectives(report) {
     report.goalsAndObjectives.forEach((goal) => {
       striped = !striped;
 
-      const goalSection = {
+      let goalSection = {
         heading: 'Goal summary',
         data: {
           'Recipient\'s goal': (
@@ -123,6 +123,22 @@ function calculateGoalsAndObjectives(report) {
         },
         striped,
       };
+
+      // Add anticipated close date if we have it.
+      if (goal.endDate) {
+        goalSection = {
+          ...goalSection.heading,
+          data: {
+            ...goalSection.data,
+            'Anticipated close date': (
+              <>
+                {goal.endDate}
+              </>
+            ),
+          },
+          striped: true,
+        };
+      }
 
       const { prompts } = goal;
       if (prompts && prompts.length) {
@@ -193,7 +209,7 @@ export default function ApprovedReportV2({ data }) {
   const submittedAt = data.submittedDate ? moment(data.submittedDate).format(DATE_DISPLAY_FORMAT) : '';
 
   const creator = data.author.fullName;
-
+  console.log('goal:',goalSections );
   return (
     <Container className="ttahub-activity-report-view margin-top-2">
       <h1 className="landing">

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -125,14 +125,14 @@ function calculateGoalsAndObjectives(report) {
       };
 
       // Add anticipated close date if we have it.
-      if (goal.endDate) {
+      if (goal.activityReportGoals && goal.activityReportGoals.length) {
         goalSection = {
           ...goalSection.heading,
           data: {
             ...goalSection.data,
             'Anticipated close date': (
               <>
-                {goal.endDate}
+                { goal.activityReportGoals[0].endDate}
               </>
             ),
           },

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -209,7 +209,6 @@ export default function ApprovedReportV2({ data }) {
   const submittedAt = data.submittedDate ? moment(data.submittedDate).format(DATE_DISPLAY_FORMAT) : '';
 
   const creator = data.author.fullName;
-  console.log('goal:',goalSections );
   return (
     <Container className="ttahub-activity-report-view margin-top-2">
       <h1 className="landing">


### PR DESCRIPTION
## Description of change

Added anticipated goal close date to the approved AR screen for V2 reports.

## How to test

Set a anticipated close date on an approved report you should see it when viewing the approved report.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1681

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
