### PR TITLE
[TTAHUB-1719] delivery method filter bug: "in person" should be "in-person"

### DIFF
--- a/src/scopes/activityReport/deliveryMethod.js
+++ b/src/scopes/activityReport/deliveryMethod.js
@@ -1,20 +1,33 @@
 import { Op } from 'sequelize';
 import { sequelize } from '../../models';
 
+function formatDeliveryMethod(deliveryMethod) {
+  const method = deliveryMethod.toLowerCase();
+  if (method === 'in person') {
+    return 'in-person';
+  }
+
+  return method;
+}
+
 export function withDeliveryMethod(deliveryMethodValue) {
+  const methods = deliveryMethodValue.map(formatDeliveryMethod);
+
   return sequelize.where(
     sequelize.fn('LOWER', sequelize.col('"ActivityReport".deliveryMethod')),
     {
-      [Op.in]: deliveryMethodValue.map((d) => d.toLowerCase()),
+      [Op.in]: methods,
     },
   );
 }
 
 export function withoutDeliveryMethod(deliveryMethodValue) {
+  const methods = deliveryMethodValue.map(formatDeliveryMethod);
+
   return sequelize.where(
     sequelize.fn('LOWER', sequelize.col('"ActivityReport".deliveryMethod')),
     {
-      [Op.notIn]: deliveryMethodValue.map((d) => d.toLowerCase()),
+      [Op.notIn]: methods,
     },
   );
 }


### PR DESCRIPTION
## Description of change

The title kind of says it all. `in person` matches nothing, because in the database it's stored as `in-person`.

## How to test

Apply the delivery method filter and ensure results come back, whereas before nothing is found.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1719


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
