### PR TITLE
[TTAHUB-1709] Don't show 'Delete' if user is not creator or collaborator on AR

### DIFF
--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -18,7 +18,10 @@ import TableHeader from '../../components/TableHeader';
 import { cleanupLocalStorage } from '../ActivityReport';
 import UserContext from '../../UserContext';
 
-const userIsAnApprover = (id, approvers) => approvers.some((approver) => approver.user.id === id);
+const userIsAnApprover = (id, approvers) => {
+  if (!approvers || !approvers.length) return false;
+  return approvers.some((approver) => approver.user.id === id);
+};
 
 export function ReportsRow({ reports, removeAlert, message }) {
   const history = useHistory();

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -18,10 +18,12 @@ import TableHeader from '../../components/TableHeader';
 import { cleanupLocalStorage } from '../ActivityReport';
 import UserContext from '../../UserContext';
 
-const userIsAnApprover = (id, approvers) => {
-  if (!approvers || !approvers.length) return false;
-  return approvers.some((approver) => approver.user.id === id);
+const isCollaborator = (report, user) => {
+  if (!report.activityReportCollaborators) return false;
+  return report.activityReportCollaborators.find((u) => u.userId === user.id);
 };
+
+const isCreator = (report, user) => report.userId === user.id;
 
 export function ReportsRow({ reports, removeAlert, message }) {
   const history = useHistory();
@@ -79,7 +81,7 @@ export function ReportsRow({ reports, removeAlert, message }) {
       },
     ];
 
-    if (!userIsAnApprover(user.id, approvers)) {
+    if (isCollaborator(report, user) || isCreator(report, user)) {
       menuItems.push({
         label: 'Delete',
         onClick: () => { updateIdToDelete(id); modalRef.current.toggleModal(true); },

--- a/frontend/src/pages/Landing/MyAlerts.js
+++ b/frontend/src/pages/Landing/MyAlerts.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Tag, Table } from '@trussworks/react-uswds';
 import { Link, useHistory } from 'react-router-dom';
@@ -16,11 +16,15 @@ import TooltipWithCollection from '../../components/TooltipWithCollection';
 import Tooltip from '../../components/Tooltip';
 import TableHeader from '../../components/TableHeader';
 import { cleanupLocalStorage } from '../ActivityReport';
+import UserContext from '../../UserContext';
+
+const userIsAnApprover = (id, approvers) => approvers.some((approver) => approver.user.id === id);
 
 export function ReportsRow({ reports, removeAlert, message }) {
   const history = useHistory();
   const [idToDelete, updateIdToDelete] = useState(0);
   const modalRef = useRef();
+  const { user } = useContext(UserContext);
 
   const onDelete = async (reportId) => {
     if (modalRef && modalRef.current) {
@@ -70,11 +74,14 @@ export function ReportsRow({ reports, removeAlert, message }) {
         label: 'View',
         onClick: () => { history.push(idLink); },
       },
-      {
+    ];
+
+    if (!userIsAnApprover(user.id, approvers)) {
+      menuItems.push({
         label: 'Delete',
         onClick: () => { updateIdToDelete(id); modalRef.current.toggleModal(true); },
-      },
-    ];
+      });
+    }
 
     return (
       <tr key={idKey}>

--- a/frontend/src/pages/Landing/__tests__/MyAlerts.js
+++ b/frontend/src/pages/Landing/__tests__/MyAlerts.js
@@ -10,6 +10,13 @@ import { createMemoryHistory } from 'history';
 import MyAlerts from '../MyAlerts';
 import activityReports from '../mocks';
 import { ALERTS_PER_PAGE } from '../../../Constants';
+import UserContext from '../../../UserContext';
+
+const user = {
+  name: 'test@test.com',
+  fullName: 'a',
+  id: 999,
+};
 
 const renderMyAlerts = (report = false) => {
   const history = createMemoryHistory();
@@ -25,22 +32,24 @@ const renderMyAlerts = (report = false) => {
 
   render(
     <Router history={history}>
-      <MyAlerts
-        loading={false}
-        reports={report ? [...activityReports, report] : activityReports}
-        newBtn={newBtn}
-        alertsSortConfig={alertsSortConfig}
-        alertsOffset={alertsOffset}
-        alertsPerPage={alertsPerPage}
-        alertsActivePage={alertsActivePage}
-        alertReportsCount={alertReportsCount}
-        sortHandler={requestAlertsSort}
-        updateReportAlerts={updateReportAlerts}
-        setAlertReportsCount={setAlertReportsCount}
-        fetchReports={() => { }}
-        updateReportFilters={() => { }}
-        handleDownloadAllAlerts={() => { }}
-      />
+      <UserContext.Provider value={{ user }}>
+        <MyAlerts
+          loading={false}
+          reports={report ? [report] : activityReports}
+          newBtn={newBtn}
+          alertsSortConfig={alertsSortConfig}
+          alertsOffset={alertsOffset}
+          alertsPerPage={alertsPerPage}
+          alertsActivePage={alertsActivePage}
+          alertReportsCount={alertReportsCount}
+          sortHandler={requestAlertsSort}
+          updateReportAlerts={updateReportAlerts}
+          setAlertReportsCount={setAlertReportsCount}
+          fetchReports={() => { }}
+          updateReportFilters={() => { }}
+          handleDownloadAllAlerts={() => { }}
+        />
+      </UserContext.Provider>
     </Router>,
   );
   return history;
@@ -131,8 +140,8 @@ describe('My Alerts', () => {
     expect(needsAction).toBeVisible();
   });
 
-  test('displays the context menu buttons', async () => {
-    renderMyAlerts();
+  test('displays the context menu buttons when I am not an approver', async () => {
+    renderMyAlerts(false);
     const menuButtons = await screen.findAllByTestId('ellipsis-button');
     userEvent.click(menuButtons[0]);
 
@@ -146,6 +155,74 @@ describe('My Alerts', () => {
 
     expect(viewButton.length).toBe(1);
     expect(deleteButton.length).toBe(1);
+  });
+
+  test('does not show Delete when I am an approver', async () => {
+    const report = {
+      startDate: '02/08/2021',
+      lastSaved: '02/05/2021',
+      id: 1,
+      displayId: 'R14-AR-1',
+      regionId: 14,
+      topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],
+      status: 'draft',
+      approvers: [{ user: { ...user } }],
+      activityRecipients: [
+        {
+          activityRecipientId: 5,
+          name: 'Johnston-Romaguera - 14CH00003',
+          id: 1,
+          grant: {
+            id: 5,
+            number: '14CH00003',
+            recipient: { name: 'Johnston-Romaguera' },
+          },
+          otherEntity: null,
+        },
+        {
+          activityRecipientId: 4,
+          name: 'Johnston-Romaguera - 14CH00002',
+          id: 2,
+          grant: {
+            id: 4,
+            number: '14CH00002',
+            recipient: { name: 'Johnston-Romaguera' },
+          },
+          otherEntity: null,
+        },
+        {
+          activityRecipientId: 1,
+          name: 'Recipient Name - 14CH1234',
+          id: 3,
+          grant: {
+            id: 1,
+            number: '14CH1234',
+            recipient: { name: 'Recipient Name' },
+          },
+          otherEntity: null,
+        },
+      ],
+      author: {
+        fullName: 'Kiwi, GS',
+        name: 'Kiwi',
+        role: 'Grants Specialist',
+        homeRegionId: 14,
+      },
+      collaborators: [],
+    };
+
+    renderMyAlerts(report);
+
+    const menuButtons = await screen.findAllByTestId('ellipsis-button');
+    userEvent.click(menuButtons[0]);
+
+    const viewButton = await screen.findAllByRole('button', {
+      name: 'View',
+    });
+
+    expect(viewButton.length).toBe(1);
+
+    expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
   });
 
   test('redirects to view activity report when clicked from context menu', async () => {

--- a/frontend/src/pages/Landing/__tests__/MyAlerts.js
+++ b/frontend/src/pages/Landing/__tests__/MyAlerts.js
@@ -140,7 +140,7 @@ describe('My Alerts', () => {
     expect(needsAction).toBeVisible();
   });
 
-  test('displays the context menu buttons when I am not an approver', async () => {
+  test('shows both context menu items when I am creator or collaborator', async () => {
     renderMyAlerts(false);
     const menuButtons = await screen.findAllByTestId('ellipsis-button');
     userEvent.click(menuButtons[0]);
@@ -157,7 +157,7 @@ describe('My Alerts', () => {
     expect(deleteButton.length).toBe(1);
   });
 
-  test('does not show Delete when I am an approver', async () => {
+  test('does not show Delete when I am not a creator or collaborator', async () => {
     const report = {
       startDate: '02/08/2021',
       lastSaved: '02/05/2021',
@@ -243,6 +243,7 @@ describe('My Alerts', () => {
       startDate: '02/08/2021',
       lastSaved: '02/05/2021',
       id: 1,
+      userId: user.id,
       displayId: 'R14-AR-1',
       regionId: 14,
       topics: ['Behavioral / Mental Health', 'CLASS: Instructional Support'],

--- a/frontend/src/pages/Landing/__tests__/ReportsRow.js
+++ b/frontend/src/pages/Landing/__tests__/ReportsRow.js
@@ -10,6 +10,11 @@ import { createMemoryHistory } from 'history';
 import { mockWindowProperty } from '../../../testHelpers';
 import { ReportsRow } from '../MyAlerts';
 import activityReports from '../mocks';
+import UserContext from '../../../UserContext';
+
+const user = {
+  name: 'test@test.com',
+};
 
 describe('ReportsRow', () => {
   const removeItem = jest.fn();
@@ -34,13 +39,15 @@ describe('ReportsRow', () => {
     const history = createMemoryHistory();
 
     render(
-      <Router history={history}>
-        <ReportsRow
-          reports={[report, activityReports[1]]}
-          removeAlert={removeAlert}
-          message={message}
-        />
-      </Router>,
+      <UserContext.Provider value={{ user }}>
+        <Router history={history}>
+          <ReportsRow
+            reports={[report, activityReports[1]]}
+            removeAlert={removeAlert}
+            message={message}
+          />
+        </Router>
+      </UserContext.Provider>,
     );
   };
 

--- a/frontend/src/pages/Landing/mocks.js
+++ b/frontend/src/pages/Landing/mocks.js
@@ -1,5 +1,6 @@
 const activityReports = [
   {
+    userId: 999,
     startDate: '02/08/2021',
     lastSaved: '02/05/2021',
     id: 1,


### PR DESCRIPTION
## Description of change

On the MyAlerts table, we should not show the "Delete" context menu item if the user is not the creator or collaborator on the AR. If the are neither, and are just the approver, the delete operation silently fails with a 403. This PR only adds this menu item if the user is creator/collaborator.

## How to test

- Be a user that has alerts for an AR that they are ONLY an approver on
- Notice you only see "View"


- Be a user that has alerts for an AR that they are creator/collaborator of
- Notice that you additionally see "Delete"


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1709


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
