### PR TITLE
[TTAHUB-1703] Resource filters

### DIFF
--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -49,68 +49,6 @@ const objectiveTtaProvidedPosNeg = (pos = true) => {
   WHERE "ActivityReportObjectives"."ttaProvided"${a}`;
 };
 
-const activityReportResourcePosNeg = (pos = true) => {
-  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
-
-  return `
-  SELECT DISTINCT
-    "ActivityReports"."id"
-  FROM "ActivityReports"
-  LEFT JOIN "ActivityReportResources"
-  ON "ActivityReportResources"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "Resources"
-  ON "Resources"."id" = "ActivityReportResources"."resourceId"
-  WHERE "Resources"."url"${a}`;
-};
-
-const activityReportGoalResourcePosNeg = (pos = true) => {
-  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
-
-  return `
-  SELECT DISTINCT
-    "ActivityReports"."id"
-  FROM "ActivityReports"
-  LEFT JOIN "ActivityReportGoals"
-  ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "ActivityReportGoalResources"
-  ON "ActivityReportGoalResources"."activityReportGoalId" = "ActivityReportGoals"."id"
-  LEFT JOIN "Resources"
-  ON "Resources"."id" = "ActivityReportGoalResources"."resourceId"
-  WHERE "Resources"."url"${a}`;
-};
-
-const activityReportObjectiveResourcePosNeg = (pos = true) => {
-  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
-
-  return `
-  SELECT DISTINCT
-    "ActivityReports"."id"
-  FROM "ActivityReports"
-  LEFT JOIN "ActivityReportObjectives"
-  ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "ActivityReportObjectiveResources"
-  ON "ActivityReportObjectiveResources"."activityReportObjectiveId" = "ActivityReportObjectives"."id"
-  LEFT JOIN "Resources"
-  ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
-  WHERE "Resources"."url"${a}`;
-};
-
-const nextStepsResourcePosNeg = (pos = true) => {
-  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
-
-  return `
-  SELECT DISTINCT
-    "ActivityReports"."id"
-  FROM "ActivityReports"
-  LEFT JOIN "NextSteps"
-  ON "NextSteps"."activityReportId" = "ActivityReports"."id"
-  LEFT JOIN "NextStepResources"
-  ON "NextSteps"."id" = "NextStepResources"."nextStepId"
-  LEFT JOIN "Resources"
-  ON "Resources"."id" = "NextStepResources"."resourceId"
-  WHERE "Resources"."url"${a}`;
-};
-
 const activityReportContextPosNeg = (pos = true) => {
   const a = pos ? '' : ' IS NULL OR "ActivityReports"."context"';
 
@@ -140,10 +78,6 @@ export function withReportText(searchText) {
       filterAssociation(argsPosNeg(true), search, false, 'ILIKE'),
       filterAssociation(objectiveTitlePosNeg(true), search, false, 'ILIKE'),
       filterAssociation(objectiveTtaProvidedPosNeg(true), search, false, 'ILIKE'),
-      filterAssociation(activityReportResourcePosNeg(true), search, false, 'ILIKE'),
-      filterAssociation(activityReportGoalResourcePosNeg(true), search, false, 'ILIKE'),
-      filterAssociation(activityReportObjectiveResourcePosNeg(true), search, false, 'ILIKE'),
-      filterAssociation(nextStepsResourcePosNeg(true), search, false, 'ILIKE'),
       filterAssociation(activityReportContextPosNeg(true), search, false, 'ILIKE'),
       filterAssociation(additionalNotesPosNeg(true), search, false, 'ILIKE'),
     ],
@@ -159,10 +93,6 @@ export function withoutReportText(searchText) {
       filterAssociation(argsPosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(objectiveTitlePosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(objectiveTtaProvidedPosNeg(false), search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportResourcePosNeg(false), search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportGoalResourcePosNeg(false), search, false, 'NOT ILIKE'),
-      filterAssociation(activityReportObjectiveResourcePosNeg(false), search, false, 'NOT ILIKE'),
-      filterAssociation(nextStepsResourcePosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(activityReportContextPosNeg(false), search, false, 'NOT ILIKE'),
       filterAssociation(additionalNotesPosNeg(false), search, false, 'NOT ILIKE'),
     ],

--- a/src/scopes/activityReport/resourceAttachment.js
+++ b/src/scopes/activityReport/resourceAttachment.js
@@ -1,0 +1,36 @@
+import { Op } from 'sequelize';
+import { filterAssociation } from './utils';
+
+const activityReportFilesPosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Files"."originalFileName"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportFiles"
+  ON "ActivityReportFiles"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "Files"
+  ON "Files"."id" = "ActivityReportFiles"."fileId"
+  WHERE "Files"."originalFileName"${a}`;
+};
+
+export function withResourceAttachment(query) {
+  const search = [`%${query}%`];
+
+  return {
+    [Op.or]: [
+      filterAssociation(activityReportFilesPosNeg(true), search, false, 'ILIKE'),
+    ],
+  };
+}
+
+export function withoutResourceAttachment(query) {
+  const search = [`%${query}%`];
+
+  return {
+    [Op.and]: [
+      filterAssociation(activityReportFilesPosNeg(false), search, false, 'NOT ILIKE'),
+    ],
+  };
+}

--- a/src/scopes/activityReport/resourceUrl.js
+++ b/src/scopes/activityReport/resourceUrl.js
@@ -1,0 +1,90 @@
+import { Op } from 'sequelize';
+import { filterAssociation } from './utils';
+
+const activityReportResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportResources"
+  ON "ActivityReportResources"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "Resources"
+  ON "Resources"."id" = "ActivityReportResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+const activityReportGoalResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportGoals"
+  ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "ActivityReportGoalResources"
+  ON "ActivityReportGoalResources"."activityReportGoalId" = "ActivityReportGoals"."id"
+  LEFT JOIN "Resources"
+  ON "Resources"."id" = "ActivityReportGoalResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+const activityReportObjectiveResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "ActivityReportObjectives"
+  ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "ActivityReportObjectiveResources"
+  ON "ActivityReportObjectiveResources"."activityReportObjectiveId" = "ActivityReportObjectives"."id"
+  LEFT JOIN "Resources"
+  ON "Resources"."id" = "ActivityReportObjectiveResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+const nextStepsResourcePosNeg = (pos = true) => {
+  const a = pos ? '' : ' IS NULL OR "Resources"."url"';
+
+  return `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  LEFT JOIN "NextSteps"
+  ON "NextSteps"."activityReportId" = "ActivityReports"."id"
+  LEFT JOIN "NextStepResources"
+  ON "NextSteps"."id" = "NextStepResources"."nextStepId"
+  LEFT JOIN "Resources"
+  ON "Resources"."id" = "NextStepResources"."resourceId"
+  WHERE "Resources"."url"${a}`;
+};
+
+export function withResourceUrl(query) {
+  const search = [`%${query}%`];
+
+  return {
+    [Op.or]: [
+      filterAssociation(activityReportResourcePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(activityReportGoalResourcePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(activityReportObjectiveResourcePosNeg(true), search, false, 'ILIKE'),
+      filterAssociation(nextStepsResourcePosNeg(true), search, false, 'ILIKE'),
+    ],
+  };
+}
+
+export function withoutResourceUrl(query) {
+  const search = [`%${query}%`];
+
+  return {
+    [Op.and]: [
+      filterAssociation(activityReportResourcePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportGoalResourcePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(activityReportObjectiveResourcePosNeg(false), search, false, 'NOT ILIKE'),
+      filterAssociation(nextStepsResourcePosNeg(false), search, false, 'NOT ILIKE'),
+    ],
+  };
+}


### PR DESCRIPTION
## Description of change

Instead of using the `reportText` filter to match against resource URLs, this PR:

- changes `reportText` to forget about resources altogether
- adds a `resourceAttachment` filter to match against file names
- adds a `resourceUrl` filter to match against resource URLs.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1703


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
