### PR TITLE
TTAHUB-1721 Trim Goals and Objectives prior to creating in db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ newrelic_agent.log
 
 # DB files
 *.sql
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ those services are already running on your machine.
 6. Change the `FONTAWESOME_NPM_AUTH_TOKEN`, `AUTH_CLIENT_ID` and `AUTH_CLIENT_SECRET` variables to to values found in the team Keybase account. If you don't have access to Keybase, please ask in the acf-head-start-eng slack channel for access.
 7. Optionally, set `CURRENT_USER` to your current user's uid:gid. This will cause files created by docker compose to be owned by your user instead of root.
 3. Run `yarn docker:reset`. This builds the frontend and backend, installs dependencies, then runs database migrations and seeders. If this returns errors that the version of nodejs is incorrect, you may have older versions of the containers built. Delete those images and it should rebuild them.
-10. Run `yarn docker:start` to start the application. The frontend will be available on `localhost:3000` and the backend will run on `localhost:8080`, API documentation will run on `localhost:5003`, and minio will run on `localhost:9000`.
+10. Run `yarn docker:start` to start the application. The [frontend][frontend] will be available on `localhost:3000`  and the [backend][backend] will run on `localhost:8080`, [API documentation][API documentation] will run on `localhost:5003`, and [minio][minio] will run on `localhost:9000`.
 11. Run `yarn docker:stop` to stop the servers and remove the docker containers.
 
 The frontend [proxies requests](https://create-react-app.dev/docs/proxying-api-requests-in-development/) to paths it doesn't recognize to the backend.
@@ -533,3 +533,8 @@ ex:
 [cf-service-connect]: https://github.com/cloud-gov/cf-service-connect
 [hhs-main]: https://github.com/HHS/Head-Start-TTADP/tree/main
 [hhs-prod]: https://github.com/HHS/Head-Start-TTADP/tree/production
+[frontend]:http://localhost:3000
+[backend]:http://localhost:8080
+[API documentation]:http://localhost:5003
+[minio]:http://localhost:3000
+[elasticsearch]:http://localhost:9200

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -50,7 +50,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
   attributes: [
     'id',
     'endDate',
-    'name'.trim(),
+    'name',
     'status',
     [sequelize.col('grant.regionId'), 'regionId'],
     [sequelize.col('grant.recipient.id'), 'recipientId'],
@@ -72,7 +72,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
   include: [
     {
       attributes: [
-        'title'.trim(),
+        'title',
         'id',
         'status',
         'onApprovedAR',
@@ -129,7 +129,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
             {
               model: Topic,
               as: 'topic',
-              attributes: ['id', 'name'.trim()],
+              attributes: ['id', 'name'],
             },
           ],
         },
@@ -204,7 +204,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
       attributes: [
         ['id', 'promptId'],
         'ordinal',
-        'title'.trim(),
+        'title',
         'prompt',
         'hint',
         'fieldType',
@@ -665,9 +665,9 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
       'endDate',
       'status',
       ['id', 'value'],
-      ['name'.trim(), 'label'],
+      ['name', 'label'],
       'id',
-      'name'.trim(),
+      'name',
     ],
     where: {
       id,
@@ -691,7 +691,7 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
         },
         attributes: [
           'id',
-          ['title'.trim(), 'label'],
+          ['title', 'label'],
           'title',
           'status',
           'goalId',
@@ -750,7 +750,7 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
         attributes: [
           'id',
           'ordinal',
-          'title'.trim(),
+          'title',
           'prompt',
           'hint',
           'fieldType',
@@ -811,9 +811,9 @@ export function goalByIdAndActivityReport(goalId, activityReportId) {
       'endDate',
       'status',
       ['id', 'value'],
-      ['name'.trim(), 'label'],
+      ['name', 'label'],
       'id',
-      'name'.trim(),
+      'name',
     ],
     where: {
       id: goalId,
@@ -836,8 +836,8 @@ export function goalByIdAndActivityReport(goalId, activityReportId) {
         },
         attributes: [
           'id',
-          'title'.trim(),
-          'title'.trim(),
+          'title',
+          'title',
           'status',
         ],
         model: Objective,
@@ -874,7 +874,7 @@ export function goalByIdAndActivityReport(goalId, activityReportId) {
             as: 'topics',
             attributes: [
               ['id', 'value'],
-              ['name'.trim(), 'label'],
+              ['name', 'label'],
             ],
             required: false,
           },
@@ -974,7 +974,7 @@ export async function goalsByIdAndRecipient(ids, recipientId) {
 export async function goalByIdWithActivityReportsAndRegions(goalId) {
   return Goal.findOne({
     attributes: [
-      'name'.trim(),
+      'name',
       'id',
       'status',
       'createdVia',
@@ -1325,7 +1325,7 @@ export async function goalsForGrants(grantIds) {
           sequelize.col('"Goal"."goalTemplateId"'),
         ),
       ), 'goalTemplateId'],
-      'name'.trim(),
+      'name',
       'status',
       'onApprovedAR',
       'endDate',
@@ -1481,7 +1481,7 @@ async function removeUnusedGoalsCreatedViaAr(goalsToRemove, reportId) {
         },
       },
       {
-        attributes: ['id', 'goalId', 'title'.trim()],
+        attributes: ['id', 'goalId', 'title'],
         model: Objective,
         as: 'objectives',
         required: false,
@@ -2030,7 +2030,7 @@ export async function getGoalsForReport(reportId) {
             jsonb_agg( DISTINCT jsonb_build_object(
               'promptId', gtfp.id ,
               'ordinal', gtfp.ordinal,
-              'title'.trim(), gtfp.title,
+              'title', gtfp,
               'prompt', gtfp.prompt,
               'hint', gtfp.hint,
               'caution', gtfp.caution,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1873,6 +1873,7 @@ export async function saveGoalsForReport(goals, report) {
       if (!newOrUpdatedGoal) {
         newOrUpdatedGoal = await Goal.create({
           createdVia: 'activityReport',
+          name: goal.name.trim(),
           grantId,
           ...fields,
           status,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1145,8 +1145,8 @@ export async function createOrUpdateGoals(goals) {
       await newGoal.update(
         {
           ...options,
+          ...(options && options.name && { name: options.name.trim() }),
           status,
-          name: options.name.trim(),
           // if the createdVia column is populated, keep what's there
           // otherwise, if the goal is imported, we say so
           // otherwise, we've got ourselves an rtr goal, baby

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1161,7 +1161,7 @@ export async function createOrUpdateGoals(goals) {
         { endDate: endDate || null },
         { individualHooks: true },
       );
-    } 
+    }
 
     const newObjectives = await Promise.all(
       objectives.map(async (o, index) => {

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -50,7 +50,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
   attributes: [
     'id',
     'endDate',
-    'name',
+    'name'.trim(),
     'status',
     [sequelize.col('grant.regionId'), 'regionId'],
     [sequelize.col('grant.recipient.id'), 'recipientId'],
@@ -72,7 +72,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
   include: [
     {
       attributes: [
-        'title',
+        'title'.trim(),
         'id',
         'status',
         'onApprovedAR',
@@ -129,7 +129,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
             {
               model: Topic,
               as: 'topic',
-              attributes: ['id', 'name'],
+              attributes: ['id', 'name'.trim()],
             },
           ],
         },
@@ -204,7 +204,7 @@ const OPTIONS_FOR_GOAL_FORM_QUERY = (id, recipientId) => ({
       attributes: [
         ['id', 'promptId'],
         'ordinal',
-        'title',
+        'title'.trim(),
         'prompt',
         'hint',
         'fieldType',
@@ -377,7 +377,7 @@ export function reduceObjectives(newObjectives, currentObjectives = []) {
       ...(objective.dataValues
         ? objective.dataValues
         : objective),
-      title: objective.title,
+      title: objective.title.trim(),
       value: id,
       ids: [id],
       // Make sure we pass back a list of recipient ids for subsequent saves.
@@ -462,7 +462,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
 
     return [...objectives, {
       ...objective.dataValues,
-      title: objective.title,
+      title: objective.title.trim(),
       value: id,
       ids: [id],
       ttaProvided,
@@ -665,9 +665,9 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
       'endDate',
       'status',
       ['id', 'value'],
-      ['name', 'label'],
+      ['name'.trim(), 'label'],
       'id',
-      'name',
+      'name'.trim(),
     ],
     where: {
       id,
@@ -691,7 +691,7 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
         },
         attributes: [
           'id',
-          ['title', 'label'],
+          ['title'.trim(), 'label'],
           'title',
           'status',
           'goalId',
@@ -750,7 +750,7 @@ export async function goalsByIdsAndActivityReport(id, activityReportId) {
         attributes: [
           'id',
           'ordinal',
-          'title',
+          'title'.trim(),
           'prompt',
           'hint',
           'fieldType',
@@ -811,9 +811,9 @@ export function goalByIdAndActivityReport(goalId, activityReportId) {
       'endDate',
       'status',
       ['id', 'value'],
-      ['name', 'label'],
+      ['name'.trim(), 'label'],
       'id',
-      'name',
+      'name'.trim(),
     ],
     where: {
       id: goalId,
@@ -836,8 +836,8 @@ export function goalByIdAndActivityReport(goalId, activityReportId) {
         },
         attributes: [
           'id',
-          'title',
-          'title',
+          'title'.trim(),
+          'title'.trim(),
           'status',
         ],
         model: Objective,
@@ -874,7 +874,7 @@ export function goalByIdAndActivityReport(goalId, activityReportId) {
             as: 'topics',
             attributes: [
               ['id', 'value'],
-              ['name', 'label'],
+              ['name'.trim(), 'label'],
             ],
             required: false,
           },
@@ -974,7 +974,7 @@ export async function goalsByIdAndRecipient(ids, recipientId) {
 export async function goalByIdWithActivityReportsAndRegions(goalId) {
   return Goal.findOne({
     attributes: [
-      'name',
+      'name'.trim(),
       'id',
       'status',
       'createdVia',
@@ -1122,13 +1122,13 @@ export async function createOrUpdateGoals(goals) {
           status: {
             [Op.not]: 'Closed',
           },
-          name: options.name,
+          name: options.name.trim(),
         },
       });
       if (!newGoal) {
         newGoal = await Goal.create({
           grantId,
-          name: options.name,
+          name: options.name.trim(),
           status: 'Draft', // if we are creating a goal for the first time, it should be set to 'Draft'
           isFromSmartsheetTtaPlan: false,
           rtrOrder: rtrOrder + 1,
@@ -1146,6 +1146,7 @@ export async function createOrUpdateGoals(goals) {
         {
           ...options,
           status,
+          name: options.name.trim(),
           // if the createdVia column is populated, keep what's there
           // otherwise, if the goal is imported, we say so
           // otherwise, we've got ourselves an rtr goal, baby
@@ -1160,7 +1161,7 @@ export async function createOrUpdateGoals(goals) {
         { endDate: endDate || null },
         { individualHooks: true },
       );
-    }
+    } 
 
     const newObjectives = await Promise.all(
       objectives.map(async (o, index) => {
@@ -1324,7 +1325,7 @@ export async function goalsForGrants(grantIds) {
           sequelize.col('"Goal"."goalTemplateId"'),
         ),
       ), 'goalTemplateId'],
-      'name',
+      'name'.trim(),
       'status',
       'onApprovedAR',
       'endDate',
@@ -1480,7 +1481,7 @@ async function removeUnusedGoalsCreatedViaAr(goalsToRemove, reportId) {
         },
       },
       {
-        attributes: ['id', 'goalId', 'title'],
+        attributes: ['id', 'goalId', 'title'.trim()],
         model: Objective,
         as: 'objectives',
         required: false,
@@ -1861,7 +1862,7 @@ export async function saveGoalsForReport(goals, report) {
       if (!newOrUpdatedGoal) {
         newOrUpdatedGoal = await Goal.findOne({
           where: {
-            name: goal.name,
+            name: goal.name.trim(),
             grantId,
             status: { [Op.not]: GOAL_STATUS.CLOSED },
           },
@@ -1880,7 +1881,7 @@ export async function saveGoalsForReport(goals, report) {
 
       if (!newOrUpdatedGoal.onApprovedAR) {
         if (fields.name !== newOrUpdatedGoal.name) {
-          newOrUpdatedGoal.set({ name: fields.name }, { individualHooks: true });
+          newOrUpdatedGoal.set({ name: fields.name.trim() }, { individualHooks: true });
         }
 
         if (endDate && endDate !== 'Invalid date' && endDate !== newOrUpdatedGoal.endDate) {
@@ -2029,7 +2030,7 @@ export async function getGoalsForReport(reportId) {
             jsonb_agg( DISTINCT jsonb_build_object(
               'promptId', gtfp.id ,
               'ordinal', gtfp.ordinal,
-              'title', gtfp.title,
+              'title'.trim(), gtfp.title,
               'prompt', gtfp.prompt,
               'hint', gtfp.hint,
               'caution', gtfp.caution,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -2030,7 +2030,7 @@ export async function getGoalsForReport(reportId) {
             jsonb_agg( DISTINCT jsonb_build_object(
               'promptId', gtfp.id ,
               'ordinal', gtfp.ordinal,
-              'title', gtfp,
+              'title', gtfp.title,
               'prompt', gtfp.prompt,
               'hint', gtfp.hint,
               'caution', gtfp.caution,

--- a/src/services/goals.test.js
+++ b/src/services/goals.test.js
@@ -69,7 +69,7 @@ describe('Goals DB service', () => {
 
       // Goal.
       goal = await Goal.create({
-        name: 'Goal for Objectives with leading and trailing values',
+        name: '    Goal for Objectives with leading and trailing values    ',
         status: 'Draft',
         endDate: null,
         isFromSmartsheetTtaPlan: false,


### PR DESCRIPTION
## Description of change
Apply whitespace trim during goal creation to prevent duplicate goal templates from being created due to prefix and suffix adds.  


## How to test
Create a goal with excess whitespace. From both AR Goals & recipient-tta. Check db for trimmed goals

```
     <---There are 5 spaces--->     
```

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1721


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
