### PR TITLE
[TTAHUB-1737] Correct display recipient vs oe next steps

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/ApprovedReportV2.js
@@ -217,4 +217,67 @@ describe('Approved Activity Report V2 component', () => {
     />);
     expect(await screen.findByText(/Other entities next steps/i)).toBeInTheDocument();
   });
+
+  it('correctly displays recipient next steps', async () => {
+    render(<ApprovedReportV2 data={{
+      ...report,
+      activityRecipientType: 'recipient',
+      recipientNextSteps: [{
+        note: 'First step',
+        completeDate: '2021-01-01',
+      },
+      {
+        note: 'Second step',
+        completeDate: '2022-02-02',
+      }],
+      specialistNextSteps: [{
+        note: 'Third step',
+        completeDate: '2023-03-03',
+      },
+      {
+        note: 'Fourth step',
+        completeDate: '2024-04-04',
+      }],
+    }}
+    />);
+    expect(await screen.findByRole('heading', { name: /specialist's next steps/i })).toBeInTheDocument();
+    expect(await screen.findByText(/First Step/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Second Step/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /recipient's next steps/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Third Step/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Fourth Step/i)).toBeInTheDocument();
+    expect(screen.queryAllByRole('heading', { name: /other entities next steps/i }).length).toBe(0);
+  });
+
+  it('correctly displays other-entity next steps', async () => {
+    render(<ApprovedReportV2 data={{
+      ...report,
+      activityRecipientType: 'other-entity',
+      recipientNextSteps: [{
+        note: 'First step',
+        completeDate: '2021-01-01',
+      },
+      {
+        note: 'Second step',
+        completeDate: '2022-02-02',
+      }],
+      specialistNextSteps: [{
+        note: 'Third step',
+        completeDate: '2023-03-03',
+      },
+      {
+        note: 'Fourth step',
+        completeDate: '2024-04-04',
+      }],
+    }}
+    />);
+    expect(await screen.findByRole('heading', { name: /other entities next steps/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /specialist's next steps/i })).toBeInTheDocument();
+    expect(await screen.findByText(/First Step/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Second Step/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /other entities next steps/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Third Step/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Fourth Step/i)).toBeInTheDocument();
+    expect(screen.queryAllByRole('heading', { name: /recipient's next steps/i }).length).toBe(0);
+  });
 });

--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -186,7 +186,7 @@ export default function ApprovedReportV2({ data }) {
 
   // next steps table
   const specialistNextSteps = formatNextSteps(data.specialistNextSteps, 'Specialist\'s next steps', true);
-  const nextStepsLabel = recipientType === 'Recipients' ? 'Recipient\'s next steps' : 'Other entities next steps';
+  const nextStepsLabel = isRecipient ? 'Recipient\'s next steps' : 'Other entities next steps';
   const recipientNextSteps = formatNextSteps(data.recipientNextSteps, nextStepsLabel, false);
   const approvedAt = data.approvedAt ? moment(data.approvedAt).format(DATE_DISPLAY_FORMAT) : '';
   const createdAt = moment(data.createdAt).format(DATE_DISPLAY_FORMAT);


### PR DESCRIPTION
## Description of change

We found a bug that was using a display value that could be 'Recipient' OR 'Recipient's' for a IF check. This was causing recipient steps to show under the Other-Entity heading.

We shouldn't see the OE header on an approved Recipient report.
![image](https://github.com/HHS/Head-Start-TTADP/assets/84350609/e06386c0-a2b5-4c80-a453-b82647e0b4be)

## How to test

1. Create a single recipient report with next steps.
2. Approve the report.
3. View the approved report we should only recipient next steps.

--

1. Create a single other entity report with next steps.
2. Approve the report.
3. View the approved report we should only other entity next steps.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1737


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
