### PR TITLE
[NO-TICKET] `/event` -> `/events` & add GET `/events/:status` endpoint

### DIFF
--- a/src/routes/apiDirectory.js
+++ b/src/routes/apiDirectory.js
@@ -72,7 +72,7 @@ router.use('/alerts', siteAlertsRouter);
 router.use('/feeds', feedRouter);
 router.use('/resources', resourcesRouter);
 router.use('/goal-templates', goalTemplatesRouter);
-router.use('/event', eventRouter);
+router.use('/events', eventRouter);
 router.use('/session-reports', sessionReportsRouter);
 
 const getUser = async (req, res) => {

--- a/src/routes/events/handlers.js
+++ b/src/routes/events/handlers.js
@@ -9,11 +9,23 @@ import {
   findEventsByRegionId,
   updateEvent,
   destroyEvent,
+  findEventsByStatus,
 } from '../../services/event';
 
 const namespace = 'SERVICE:EVENTS';
 
 const logContext = { namespace };
+
+export const getByStatus = async (req, res) => {
+  try {
+    const { status } = req.params;
+    const events = await findEventsByStatus(status);
+
+    return res.status(httpCodes.OK).send(events);
+  } catch (error) {
+    return handleErrors(req, res, error, logContext);
+  }
+};
 
 export const getHandler = async (req, res) => {
   try {

--- a/src/routes/events/handlers.test.js
+++ b/src/routes/events/handlers.test.js
@@ -3,6 +3,7 @@ import {
   createHandler,
   updateHandler,
   deleteHandler,
+  getByStatus,
 } from './handlers';
 import { EventReportPilot } from '../../models';
 import { createEvent } from '../../services/event';
@@ -15,7 +16,9 @@ describe('event handlers', () => {
       pocId: 99_999,
       regionId: 99_999,
       collaboratorIds: [99_998, 99_999],
-      data: {},
+      data: {
+        status: 'not-started',
+      },
     });
   });
 
@@ -158,6 +161,21 @@ describe('event handlers', () => {
       });
 
       await deleteHandler({ params: { eventId: event.id } }, mockResponse);
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('getByStatus', () => {
+    const mockResponse = {
+      send: jest.fn(),
+      status: jest.fn(() => ({
+        send: jest.fn(),
+        end: jest.fn(),
+      })),
+    };
+
+    it('works', async () => {
+      await getByStatus({ params: { status: 'not-started' } }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(200);
     });
   });

--- a/src/routes/events/index.js
+++ b/src/routes/events/index.js
@@ -5,12 +5,14 @@ import {
   updateHandler,
   getHandler,
   deleteHandler,
+  getByStatus,
 } from './handlers';
 
 const router = express.Router();
 
 router.get('/id/:eventId', transactionWrapper(getHandler));
 router.get('/regionId/:regionId', transactionWrapper(getHandler));
+router.get('/:status', transactionWrapper(getByStatus));
 router.get('/ownerId/:ownerId', transactionWrapper(getHandler));
 router.get('/pocId/:pocId', transactionWrapper(getHandler));
 router.get('/collaboratorId/:collaboratorId', transactionWrapper(getHandler));

--- a/src/services/event.test.js
+++ b/src/services/event.test.js
@@ -7,6 +7,7 @@ import {
   findEventsByPocId,
   findEventsByCollaboratorId,
   findEventsByRegionId,
+  findEventsByStatus,
 } from './event';
 
 describe('event service', () => {
@@ -15,7 +16,9 @@ describe('event service', () => {
     regionId: num,
     pocId: num,
     collaboratorIds: [num],
-    data: {},
+    data: {
+      status: 'active',
+    },
   });
 
   describe('createEvent', () => {
@@ -110,6 +113,16 @@ describe('event service', () => {
         const found = await findEventsByRegionId(created.regionId);
         expect(found[0]).toHaveProperty('id');
         expect(found[0]).toHaveProperty('ownerId', 98_989);
+        await destroyEvent(created.id);
+      });
+    });
+
+    describe('findEventsByStatus', () => {
+      it('works', async () => {
+        const created = await createAnEvent(98_989);
+        const found = await findEventsByStatus('active');
+        expect(found[0]).toHaveProperty('id');
+        expect(found[0]).toHaveProperty('data.status', 'active');
         await destroyEvent(created.id);
       });
     });


### PR DESCRIPTION
## Description of change

- Change `/event` to `/events` to match other endpoints.
- Add `GET /events/:status`.

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
