### PR TITLE
[TTAHUB-1770] only count topics once

### DIFF
--- a/src/widgets/topicFrequencyGraph.js
+++ b/src/widgets/topicFrequencyGraph.js
@@ -1,4 +1,5 @@
 import { Op, QueryTypes } from 'sequelize';
+import { uniq } from 'lodash';
 import { REPORT_STATUSES } from '@ttahub/common';
 import {
   ActivityReport,
@@ -76,6 +77,8 @@ export async function topicFrequencyGraph(scopes) {
     getAllTopics(),
   ]);
 
+  console.log('topicsAndParticipants', topicsAndParticipants.length, topicsAndParticipants);
+
   const lookUpTopic = new Map(topicMappings.map((i) => [i.name, i.final_name]));
 
   // Get all DB topics.
@@ -86,7 +89,7 @@ export async function topicFrequencyGraph(scopes) {
 
   return topicsAndParticipants.reduce((acc, report) => {
     // Get array of all topics from this reports and this reports objectives.
-    const allTopics = report.topics.map((t) => lookUpTopic.get(t));
+    const allTopics = uniq(report.topics).map((t) => lookUpTopic.get(t));
 
     // Loop all topics array and update totals.
     allTopics.forEach((topic) => {

--- a/src/widgets/topicFrequencyGraph.js
+++ b/src/widgets/topicFrequencyGraph.js
@@ -77,8 +77,6 @@ export async function topicFrequencyGraph(scopes) {
     getAllTopics(),
   ]);
 
-  console.log('topicsAndParticipants', topicsAndParticipants.length, topicsAndParticipants);
-
   const lookUpTopic = new Map(topicMappings.map((i) => [i.name, i.final_name]));
 
   // Get all DB topics.

--- a/src/widgets/topicFrequencyGraph.js
+++ b/src/widgets/topicFrequencyGraph.js
@@ -1,5 +1,4 @@
 import { Op, QueryTypes } from 'sequelize';
-import { uniq } from 'lodash';
 import { REPORT_STATUSES } from '@ttahub/common';
 import {
   ActivityReport,
@@ -37,7 +36,7 @@ export async function topicFrequencyGraph(scopes) {
       attributes: [
         [
           sequelize.literal(`(
-            SELECT ARRAY_REMOVE(ARRAY_AGG(x.topic), null)
+            SELECT ARRAY_REMOVE(ARRAY_AGG(DISTINCT x.topic), null)
             FROM (
               SELECT ar.topic
               FROM UNNEST(COALESCE("ActivityReport"."topics",array[]::varchar[])) ar(topic)
@@ -87,7 +86,7 @@ export async function topicFrequencyGraph(scopes) {
 
   return topicsAndParticipants.reduce((acc, report) => {
     // Get array of all topics from this reports and this reports objectives.
-    const allTopics = uniq(report.topics).map((t) => lookUpTopic.get(t));
+    const allTopics = report.topics.map((t) => lookUpTopic.get(t));
 
     // Loop all topics array and update totals.
     allTopics.forEach((topic) => {

--- a/src/widgets/topicFrequencyGraph.test.js
+++ b/src/widgets/topicFrequencyGraph.test.js
@@ -435,7 +435,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Coaching',
-        count: 3, // 1 from AR 3 from ARO's.
+        count: 2, // 1 from AR 3 from ARO's.
       },
       {
         topic: 'Communication',
@@ -781,7 +781,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Coaching',
-        count: 3,
+        count: 2,
       },
       {
         topic: 'Communication',
@@ -953,7 +953,7 @@ describe('Topics and frequency graph widget', () => {
       },
       {
         topic: 'Coaching',
-        count: 2,
+        count: 1,
       },
       {
         topic: 'Communication',


### PR DESCRIPTION
## Description of change
Topics that appeared multiple times on a report were being counted multiple times on the topic frequency graph, so that the count was showing a topic's total usage on all filtered reports, not a count of said reports.

## How to test
- Visit regional dashboard
- Filter by a single topic
- Confirm that the number in the tooltip on the topic frequency graph and the total number of activity reports all agree

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1770


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
