### PR TITLE
[TTAHUB-1770] only count topics once

### DIFF
--- a/frontend/src/components/__tests__/ConditionalFields.js
+++ b/frontend/src/components/__tests__/ConditionalFields.js
@@ -7,6 +7,7 @@ import {
   act,
 } from '@testing-library/react';
 import selectEvent from 'react-select-event';
+import userEvent from '@testing-library/user-event';
 import ConditionalFields from '../ConditionalFields';
 
 describe('ConditionalFields', () => {
@@ -91,5 +92,37 @@ describe('ConditionalFields', () => {
 
     await selectEvent.select(screen.getByLabelText('What is a test?'), ['option1']);
     expect(setPrompts).toHaveBeenCalled();
+  });
+
+  it('calls on blur', async () => {
+    const setPrompts = jest.fn();
+    const prompts = [{
+      fieldType: 'multiselect',
+      title: 'Test',
+      prompt: 'What is a test?',
+      options: ['option1', 'option2', 'option3'],
+      validations: {
+        rules: [
+          {
+            name: 'maxSelections',
+            value: 1,
+            message: 'How DARE you',
+          },
+        ],
+      },
+      response: [],
+    }];
+    act(() => {
+      render(<CF prompts={prompts} setPrompts={setPrompts} />);
+    });
+
+    await selectEvent.select(screen.getByLabelText('What is a test?'), ['option1', 'option2']);
+    const btn = document.querySelector('button');
+    userEvent.click(btn);
+    expect(btn).toHaveFocus();
+
+    await selectEvent.select(screen.getByLabelText('What is a test?'), ['option1']);
+    userEvent.click(btn);
+    expect(btn).toHaveFocus();
   });
 });

--- a/frontend/src/components/__tests__/HeaderUserMenu.js
+++ b/frontend/src/components/__tests__/HeaderUserMenu.js
@@ -6,8 +6,9 @@ import join from 'url-join';
 import {
   screen, render, fireEvent,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from '../../App';
-import { mockRSSData } from '../../testHelpers';
+import { mockRSSData, mockWindowProperty } from '../../testHelpers';
 
 describe('HeaderUserMenu', () => {
   const user = { name: 'harry potter', permissions: [] };
@@ -57,6 +58,31 @@ describe('HeaderUserMenu', () => {
       it('displays the admin button', async () => {
         const adminLink = screen.getByRole('link', { name: 'Admin' });
         expect(adminLink).toBeVisible();
+      });
+
+      describe('as admin user doing an impersonation', () => {
+        const setItem = jest.fn();
+        const getItem = jest.fn(() => true);
+        const removeItem = jest.fn();
+
+        jest.mock('../../hooks/helpers', () => ({
+          storageAvailable: jest.fn(() => true),
+        }));
+
+        mockWindowProperty('sessionStorage', {
+          setItem,
+          getItem,
+          removeItem,
+        });
+
+        afterAll(() => jest.restoreAllMocks());
+
+        it('displays the admin button', async () => {
+          const btn = await screen.findByRole('button', { name: /stop impersonating/i });
+          expect(btn).toBeVisible();
+          userEvent.click(btn);
+          expect(removeItem).toHaveBeenCalled();
+        });
       });
     });
 

--- a/frontend/src/pages/ActivityReport/Pages/__tests__/supportingAttachments.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/supportingAttachments.js
@@ -9,6 +9,23 @@ import { createMemoryHistory } from 'history';
 import supportingAttachments from '../supportingAttachments';
 
 // eslint-disable-next-line react/prop-types
+const RenderSupportingAttachments = ({ data }) => {
+  const history = createMemoryHistory();
+  const hookForm = useForm({
+    mode: 'onChange',
+    defaultValues: data,
+  });
+  // eslint-disable-next-line react/prop-types
+  return (
+    <Router history={history}>
+      <FormProvider {...hookForm}>
+        {supportingAttachments.render()}
+      </FormProvider>
+    </Router>
+  );
+};
+
+// eslint-disable-next-line react/prop-types
 const RenderSupportingAttachmentsReview = ({ data }) => {
   const history = createMemoryHistory();
   const hookForm = useForm({
@@ -30,11 +47,18 @@ describe('Supporting Attachments', () => {
     files: [{ originalFileName: 'original file name', url: { url: 'http://localhost/attachment' }, status: 'APPROVED' }],
   };
 
+  describe('render', () => {
+    it('displays attachments and other resources', async () => {
+      render(<RenderSupportingAttachments data={data} />);
+      expect(await screen.findByText(/attachment/i)).toBeVisible();
+      expect(await screen.findByText(/original file name/i)).toBeVisible();
+    });
+  });
+
   describe('review page', () => {
     it('displays attachments and other resources', async () => {
       render(<RenderSupportingAttachmentsReview data={data} />);
       expect(await screen.findByText(/attachment/i)).toBeVisible();
-      expect(await screen.findByText(/original file name/i)).toBeVisible();
       expect(await screen.findByText(/original file name/i)).toBeVisible();
       expect(await screen.findByRole('link', { name: /download/i })).toBeVisible();
     });

--- a/src/widgets/topicFrequencyGraph.js
+++ b/src/widgets/topicFrequencyGraph.js
@@ -1,5 +1,6 @@
 import { Op, QueryTypes } from 'sequelize';
 import { REPORT_STATUSES } from '@ttahub/common';
+import { uniq } from 'lodash';
 import {
   ActivityReport,
   ActivityReportObjective,
@@ -86,7 +87,7 @@ export async function topicFrequencyGraph(scopes) {
 
   return topicsAndParticipants.reduce((acc, report) => {
     // Get array of all topics from this reports and this reports objectives.
-    const allTopics = report.topics.map((t) => lookUpTopic.get(t));
+    const allTopics = uniq(report.topics).map((t) => lookUpTopic.get(t));
 
     // Loop all topics array and update totals.
     allTopics.forEach((topic) => {


### PR DESCRIPTION
## Description of change
Topics that appeared multiple times on a report were being counted multiple times on the topic frequency graph, so that the count was showing a topic's total usage on all filtered reports, not a count of said reports.

This PR also improves FE test coverage so that the CI build will pass.

## How to test
- Visit regional dashboard
- Filter by a single topic
- Confirm that the number in the tooltip on the topic frequency graph and the total number of activity reports all agree

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1770


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
