### PR TITLE
[TTAHUB-1779] update some text & alphabetize filter configs

### DIFF
--- a/frontend/src/pages/AccountManagement/components/Groups.js
+++ b/frontend/src/pages/AccountManagement/components/Groups.js
@@ -116,7 +116,7 @@ export default function Groups() {
 
       <div className="margin-bottom-3 maxw-tablet-lg">
         <h3>Created by others (public)</h3>
-        {!groups || !groups.publicGroups.length ? <p className="usa-prose">No one has made any groups in your region public yet</p> : (
+        {!groups || !groups.publicGroups.length ? <p className="usa-prose">No one in your region has created a public group.</p> : (
           <>
             <Table fullWidth stackedStyle="default">
               <thead>

--- a/frontend/src/pages/AccountManagement/components/__tests__/Groups.js
+++ b/frontend/src/pages/AccountManagement/components/__tests__/Groups.js
@@ -127,7 +127,7 @@ describe('Groups', () => {
     const group1 = await screen.findByText(/group1/i);
     expect(group1).toBeInTheDocument();
 
-    expect(screen.getByText(/No one has made any groups in your region public yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/No one in your region has created a public group./i)).toBeInTheDocument();
   });
 
   it('handles fetch errors', async () => {
@@ -292,6 +292,6 @@ describe('Groups', () => {
       renderGroups();
     });
     expect(screen.getByText(/you haven't created any groups/i)).toBeInTheDocument();
-    expect(screen.getByText(/No one has made any groups in your region public yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/No one in your region has created a public group./i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Landing/constants.js
+++ b/frontend/src/pages/Landing/constants.js
@@ -22,7 +22,7 @@ import {
 
 import { groupsFilter } from '../../components/filter/grantFilters';
 
-export const LANDING_BASE_FILTER_CONFIG = [
+const LANDING_BASE_FILTER_CONFIG = [
   startDateFilter,
   endDateFilter,
   grantNumberFilter,
@@ -44,7 +44,7 @@ export const LANDING_BASE_FILTER_CONFIG = [
   ttaTypeFilter,
 ];
 
-export const LANDING_FILTER_CONFIG_WITH_REGIONS = [
+const LANDING_FILTER_CONFIG_WITH_REGIONS = [
   startDateFilter,
   endDateFilter,
   grantNumberFilter,
@@ -66,3 +66,9 @@ export const LANDING_FILTER_CONFIG_WITH_REGIONS = [
   topicsFilter,
   ttaTypeFilter,
 ];
+
+// sort both by display prop
+LANDING_BASE_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));
+LANDING_FILTER_CONFIG_WITH_REGIONS.sort((a, b) => a.display.localeCompare(b.display));
+
+export { LANDING_BASE_FILTER_CONFIG, LANDING_FILTER_CONFIG_WITH_REGIONS };

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -13,11 +13,14 @@ export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) => [
   topicsFilter,
 ];
 
-export const TTAHISTORY_FILTER_CONFIG = [
+const TTAHISTORY_FILTER_CONFIG = [
   startDateFilter,
   endDateFilter,
   myReportsFilter,
   specialistRoleFilter,
 ];
+
+TTAHISTORY_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));
+export { TTAHISTORY_FILTER_CONFIG };
 
 export const GOALS_OBJECTIVES_FILTER_KEY = 'goals-objectives-filters';

--- a/frontend/src/pages/RecipientSearch/constants.js
+++ b/frontend/src/pages/RecipientSearch/constants.js
@@ -2,7 +2,12 @@
 import { regionFilter } from '../../components/filter/activityReportFilters';
 import { groupsFilter } from '../../components/filter/grantFilters';
 
-export const RECIPIENT_SEARCH_FILTER_CONFIG = [
+const RECIPIENT_SEARCH_FILTER_CONFIG = [
   groupsFilter,
   regionFilter,
 ];
+
+// sort by display prop
+RECIPIENT_SEARCH_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));
+
+export { RECIPIENT_SEARCH_FILTER_CONFIG };

--- a/frontend/src/pages/RegionalDashboard/constants.js
+++ b/frontend/src/pages/RegionalDashboard/constants.js
@@ -23,7 +23,7 @@ import {
 
 import { groupsFilter } from '../../components/filter/grantFilters';
 
-export const DASHBOARD_FILTER_CONFIG = [
+const DASHBOARD_FILTER_CONFIG = [
   startDateFilter,
   endDateFilter,
   deliveryMethodFilter,
@@ -45,3 +45,8 @@ export const DASHBOARD_FILTER_CONFIG = [
   topicsFilter,
   ttaTypeFilter,
 ];
+
+// sort by display prop
+DASHBOARD_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));
+
+export { DASHBOARD_FILTER_CONFIG };

--- a/frontend/src/pages/RegionalGoalDashboard/constants.js
+++ b/frontend/src/pages/RegionalGoalDashboard/constants.js
@@ -18,7 +18,7 @@ import {
   ttaTypeFilter,
 } from '../../components/filter/activityReportFilters';
 
-export const DASHBOARD_FILTER_CONFIG = [
+const DASHBOARD_FILTER_CONFIG = [
   startDateFilter,
   endDateFilter,
   grantNumberFilter,
@@ -36,3 +36,8 @@ export const DASHBOARD_FILTER_CONFIG = [
   topicsFilter,
   ttaTypeFilter,
 ];
+
+// sort by display prop
+DASHBOARD_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));
+
+export { DASHBOARD_FILTER_CONFIG };

--- a/frontend/src/pages/ResourcesDashboard/constants.js
+++ b/frontend/src/pages/ResourcesDashboard/constants.js
@@ -19,7 +19,7 @@ import {
   ttaTypeFilter,
 } from '../../components/filter/activityReportFilters';
 
-export const RESOURCES_DASHBOARD_FILTER_CONFIG = [
+const RESOURCES_DASHBOARD_FILTER_CONFIG = [
   startDateFilter,
   endDateFilter,
   grantNumberFilter,
@@ -38,3 +38,7 @@ export const RESOURCES_DASHBOARD_FILTER_CONFIG = [
   topicsFilter,
   ttaTypeFilter,
 ];
+
+RESOURCES_DASHBOARD_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));
+
+export { RESOURCES_DASHBOARD_FILTER_CONFIG };


### PR DESCRIPTION
## Description of change

- Change the default language for when there are no public groups created yet
- Auto-alphabetize all the filter options throughout the site.

## How to test
Confirm that the my groups section says "No one in your region has created a public group." when there are no public groups in your region yet.

Confirm that the filters on the landing page & the regional dashboard are alphabetized.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
