### PR TITLE
[NO-TICKET] Fix bugs with goal source

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -14,7 +14,6 @@ import { DATE_DISPLAY_FORMAT } from '../../Constants';
 import { reasonsToMonitor } from '../../pages/ActivityReport/constants';
 import ObjectiveCard from './ObjectiveCard';
 import ObjectiveButton from './components/ObjectiveButton';
-import TooltipList from '../TooltipList';
 import './GoalCard.scss';
 import colors from '../../colors';
 import { goalPropTypes } from './constants';
@@ -38,7 +37,6 @@ function GoalCard({
     goalStatus,
     createdOn,
     goalText,
-    goalTopics,
     objectiveCount,
     reasons,
     objectives,
@@ -145,9 +143,9 @@ function GoalCard({
             {determineFlagStatus()}
           </p>
         </div>
-        <div className="ttahub-goal-card__goal-column ttahub-goal-card__goal-column__goal-topics padding-right-3">
-          <p className="usa-prose text-bold margin-y-0">Topics</p>
-          <TooltipList list={goalTopics} cardType="goal" listType="topics" />
+        <div className="ttahub-goal-card__goal-column ttahub-goal-card__goal-column__goal-source padding-right-3">
+          <p className="usa-prose text-bold margin-y-0">Goal source</p>
+          <p className="usa-prose margin-y-0">{goal.source}</p>
         </div>
         <div className="ttahub-goal-card__goal-column ttahub-goal-card__goal-column__created-on padding-right-3">
           <p className="usa-prose text-bold  margin-y-0">Created on</p>

--- a/frontend/src/components/GoalCards/__tests__/GoalCard.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCard.js
@@ -15,6 +15,7 @@ describe('GoalCard', () => {
     reasons: ['Reason 1', 'Reason 2'],
     objectiveCount: 1,
     goalNumbers: ['G-1'],
+    source: 'The inferno',
     objectives: [
       {
         id: 1,
@@ -71,6 +72,13 @@ describe('GoalCard', () => {
   it('shows the checkbox by default', () => {
     renderGoalCard();
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('shows goal source', () => {
+    renderGoalCard();
+
+    expect(screen.getByText(/goal source/i)).toBeInTheDocument();
+    expect(screen.getByText(/The inferno/i)).toBeInTheDocument();
   });
 
   it('hides the checkbox when hideCheckbox is true', () => {

--- a/src/services/goalServices/goals.test.js
+++ b/src/services/goalServices/goals.test.js
@@ -1,4 +1,3 @@
-// import { Op } from 'sequelize';
 import {
   saveGoalsForReport, goalsForGrants,
 } from '../goals';

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1347,9 +1347,10 @@ export async function goalsForGrants(grantIds) {
       'status',
       'onApprovedAR',
       'endDate',
+      'source',
       [sequelize.fn('BOOL_OR', sequelize.literal(`"goalTemplate"."creationMethod" = '${CREATION_METHOD.CURATED}'`)), 'isCurated'],
     ],
-    group: ['"Goal"."name"', '"Goal"."status"', '"Goal"."endDate"', '"Goal"."onApprovedAR"'],
+    group: ['"Goal"."name"', '"Goal"."status"', '"Goal"."endDate"', '"Goal"."onApprovedAR"', '"Goal"."source"'],
     where: {
       '$grant.id$': ids,
       status: {

--- a/tests/api/activityReport.spec.ts
+++ b/tests/api/activityReport.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import Joi from 'joi';
+import { root, validateSchema } from './common';
+
+test.describe('get /activity-reports/goals', () => {
+  test('200', async ({ request }) => {
+    const response = await request.get(`${root}/activity-reports/goals?grantIds=1`,  { headers: { 'playwright-user-id': '1' } });
+    const goalForGrant = Joi.object({
+      grantIds: Joi.array().items(Joi.number()).required(),
+      goalIds: Joi.array().items(Joi.number()).required(),
+      oldGrantIds: Joi.array().items(Joi.any()).required(),
+      created: Joi.any().required(),
+      goalTemplateId: Joi.number().required(),
+      name: Joi.string().required(),
+      status: Joi.string().required(),
+      onApprovedAR: Joi.boolean().required(),
+      endDate: Joi.any().required(),
+      source: Joi.string(),
+      isCurated: Joi.boolean().required(),
+    });
+    expect(response.status()).toBe(200);
+
+    const schema = Joi.array().items(goalForGrant);
+
+    await validateSchema(response, schema, expect);
+  });
+});
+

--- a/tests/api/activityReport.spec.ts
+++ b/tests/api/activityReport.spec.ts
@@ -15,7 +15,7 @@ test.describe('get /activity-reports/goals', () => {
       status: Joi.string().required(),
       onApprovedAR: Joi.boolean().required(),
       endDate: Joi.any().required(),
-      source: Joi.string(),
+      source: Joi.any(),
       isCurated: Joi.boolean().required(),
     });
     expect(response.status()).toBe(200);

--- a/tests/api/users.spec.ts
+++ b/tests/api/users.spec.ts
@@ -1,11 +1,6 @@
 import { test, expect } from '@playwright/test';
 import Joi from 'joi';
-import { validate } from 'uuid';
 import { root, validateSchema } from './common';
-
-test('get /users/collaborators', async ({ request }) => {
-  
-});
 
 test.describe('get /users/collaborators', () => {
   test('no region - 403 case', async ({ request }) => {


### PR DESCRIPTION
## Description of change
There are two bugs with the goal source.
- Goal source should be on the goals cards view of the RTR instead of topics. 
- When you've picked a grant and first visit the goals & objectives page, if you select an existing goal with a goal source, it should populate the already selected goal source. Goal source was missing from the "goalForGrants" api response.

## How to test
Confirm the two issues above are fixed.

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
