### PR TITLE
[TTAHUB-1817] Admins should be able to read approved reports

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/__tests__/index.js
@@ -202,6 +202,8 @@ describe('Activity report print and share view', () => {
       ...report,
       version: null,
     });
+
+    fetchMock.get('/api/activity-reports/5007', 401);
   });
 
   it('renders an activity report in clean view', async () => {
@@ -221,7 +223,7 @@ describe('Activity report print and share view', () => {
   });
 
   it('handles authorization errors', async () => {
-    act(() => renderApprovedActivityReport(4999));
+    act(() => renderApprovedActivityReport(5007));
 
     await waitFor(() => {
       expect(screen.getByText(/sorry, you are not allowed to view this report/i)).toBeInTheDocument();

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -6,7 +6,7 @@ import { Redirect } from 'react-router-dom';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet';
 import { getReport, unlockReport } from '../../fetchers/activityReports';
-import { allRegionsUserHasPermissionTo, canUnlockReports } from '../../permissions';
+import { canUnlockReports } from '../../permissions';
 import Modal from '../../components/Modal';
 import Container from '../../components/Container';
 import {
@@ -76,8 +76,6 @@ export default function ApprovedActivityReport({ match, user }) {
   [report.id]);
 
   useEffect(() => {
-    const allowedRegions = allRegionsUserHasPermissionTo(user);
-
     if (!parseInt(match.params.activityReportId, 10)) {
       setSomethingWentWrong(true);
       return;
@@ -86,14 +84,14 @@ export default function ApprovedActivityReport({ match, user }) {
     async function fetchReport() {
       try {
         const data = await getReport(match.params.activityReportId);
-        if (!allowedRegions.includes(data.regionId)) {
+        // review and submit table
+        setReport(data);
+      } catch (err) {
+        if (err && err.status && (err.status >= 400 && err.status < 500)) {
           setNotAuthorized(true);
           return;
         }
 
-        // review and submit table
-        setReport(data);
-      } catch (err) {
         // eslint-disable-next-line no-console
         console.log(err);
         setSomethingWentWrong(true);

--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -64,7 +64,7 @@ export default class ActivityReport {
     }
 
     if (this.activityReport.calculatedStatus === REPORT_STATUSES.APPROVED) {
-      // TTAHUB-xx: Admins should be allowed to read an approved report.
+      // TTAHUB-1817: Admins should be allowed to read an approved report.
       if (this.isAdmin()) {
         return true;
       }

--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -76,33 +76,42 @@ export default class ActivityReport {
   }
 
   canApproveInRegion() {
+    const regionId = this.activityReport.regionId
+    || (this.activityReport.dataValues && this.activityReport.dataValues.regionId);
+
     const permissions = _.find(
       this.user.permissions,
       (permission) => (
         permission.scopeId === SCOPES.APPROVE_REPORTS
-        && permission.regionId === this.activityReport.regionId),
+        && permission.regionId === regionId),
     );
     return !_.isUndefined(permissions);
   }
 
   canWriteInRegion() {
+    const regionId = this.activityReport.regionId
+    || (this.activityReport.dataValues && this.activityReport.dataValues.regionId);
+
     const permissions = _.find(
       this.user.permissions,
       (permission) => (
         permission.scopeId === SCOPES.READ_WRITE_REPORTS
-        && permission.regionId === this.activityReport.regionId),
+        && permission.regionId === regionId),
     );
     return !_.isUndefined(permissions);
   }
 
   canReadInRegion() {
+    const regionId = this.activityReport.regionId
+    || (this.activityReport.dataValues && this.activityReport.dataValues.regionId);
+
     const permissions = _.find(
       this.user.permissions,
       (permission) => (
         (permission.scopeId === SCOPES.READ_REPORTS
           || permission.scopeId === SCOPES.APPROVE_REPORTS
           || permission.scopeId === SCOPES.READ_WRITE_REPORTS)
-        && permission.regionId === this.activityReport.regionId),
+        && permission.regionId === regionId),
     );
     return !_.isUndefined(permissions);
   }

--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -64,6 +64,11 @@ export default class ActivityReport {
     }
 
     if (this.activityReport.calculatedStatus === REPORT_STATUSES.APPROVED) {
+      // TTAHUB-xx: Admins should be allowed to read an approved report.
+      if (this.isAdmin()) {
+        return true;
+      }
+
       return this.canReadInRegion();
     }
 

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -8,14 +8,24 @@ function activityReport(
   approvers,
   submissionStatus = REPORT_STATUSES.DRAFT,
   calculatedStatus = null,
+  raw = true,
 ) {
-  const report = {
+  const report = raw ? {
     userId: author,
     regionId: 1,
     activityReportCollaborators: [],
     approvers: [],
     submissionStatus,
     calculatedStatus,
+  } : {
+    dataValues: {
+      userId: author,
+      regionId: 1,
+      activityReportCollaborators: [],
+      approvers: [],
+      submissionStatus,
+      calculatedStatus,
+    },
   };
 
   if (activityReportCollaborator) {
@@ -423,6 +433,20 @@ describe('Activity Report policies', () => {
       );
       const policy = new ActivityReport(author, report);
       expect(policy.canDelete()).toBeFalsy();
+    });
+  });
+
+  describe('canReadInRegion', () => {
+    it('works with raw model instance (dataValues)', async () => {
+      const report = activityReport(author.id, null, null, null, null, true);
+      const policy = new ActivityReport(author, report);
+      expect(policy.canReadInRegion()).toBeTruthy();
+    });
+
+    it('works with non-raw model instance', async () => {
+      const report = activityReport(author.id, null, null, null, null, false);
+      const policy = new ActivityReport(author, report);
+      expect(policy.canReadInRegion()).toBeTruthy();
     });
   });
 });

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -349,6 +349,18 @@ describe('Activity Report policies', () => {
         const policy = new ActivityReport(approver, report);
         expect(policy.canGet()).toBeTruthy();
       });
+
+      it('is true for admins', () => {
+        const report = activityReport(
+          author.id,
+          null,
+          null,
+          REPORT_STATUSES.SUBMITTED,
+          REPORT_STATUSES.APPROVED,
+        );
+        const policy = new ActivityReport(admin, report);
+        expect(policy.canGet()).toBeTruthy();
+      });
     });
   });
 

--- a/src/policies/activityReport.test.js
+++ b/src/policies/activityReport.test.js
@@ -323,6 +323,12 @@ describe('Activity Report policies', () => {
         const policy = new ActivityReport(otherUser, report);
         expect(policy.canGet()).toBeFalsy();
       });
+
+      it('is false for an admin with no other permissions to the report', () => {
+        const report = activityReport(author.id);
+        const policy = new ActivityReport(admin, report);
+        expect(policy.canGet()).toBeFalsy();
+      });
     });
 
     describe('for approved reports', () => {

--- a/src/policies/goals.test.js
+++ b/src/policies/goals.test.js
@@ -119,4 +119,23 @@ describe('Goals policies', () => {
       expect(policy.canCreate()).toBe(true);
     });
   });
+
+  describe('canReadInRegion', () => {
+    it('works', async () => {
+      const goal = {};
+      const user = {
+        permissions: [
+          {
+            regionId: 2,
+            scopeId: SCOPES.READ_WRITE_REPORTS,
+          },
+        ],
+      };
+      const regionId = 2;
+
+      const policy = new Goal(user, goal, regionId);
+
+      expect(policy.canReadInRegion(2)).toBe(true);
+    });
+  });
 });

--- a/src/policies/goals.test.js
+++ b/src/policies/goals.test.js
@@ -161,7 +161,7 @@ describe('Goals policies', () => {
       };
 
       const policy = new Goal(user, goal);
-      expect(policy.isOnApprovedActivityReports()).toBe(true);
+      expect(policy.isOnActivityReports()).toBe(true);
     });
   });
 

--- a/src/policies/goals.test.js
+++ b/src/policies/goals.test.js
@@ -138,4 +138,56 @@ describe('Goals policies', () => {
       expect(policy.canReadInRegion(2)).toBe(true);
     });
   });
+
+  describe('isOnActivityReports', () => {
+    it('works', async () => {
+      const goal = {
+        objectives: [
+          {
+            activityReports: [
+              { id: 1, calculatedStatus: REPORT_STATUSES.NEEDS_ACTION },
+            ],
+          },
+        ],
+        grant: { regionId: 2 },
+      };
+      const user = {
+        permissions: [
+          {
+            regionId: 2,
+            scopeId: SCOPES.APPROVE_REPORTS,
+          },
+        ],
+      };
+
+      const policy = new Goal(user, goal);
+      expect(policy.isOnApprovedActivityReports()).toBe(true);
+    });
+  });
+
+  describe('isOnApprovedActivityReports', () => {
+    it('works', async () => {
+      const goal = {
+        objectives: [
+          {
+            activityReports: [
+              { id: 1, calculatedStatus: REPORT_STATUSES.APPROVED },
+            ],
+          },
+        ],
+        grant: { regionId: 2 },
+      };
+      const user = {
+        permissions: [
+          {
+            regionId: 2,
+            scopeId: SCOPES.APPROVE_REPORTS,
+          },
+        ],
+      };
+
+      const policy = new Goal(user, goal);
+      expect(policy.isOnApprovedActivityReports()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Description of change

In a support case it was brought to my attention that an admin user should always be able to read/view an approved activity report.

`regionId` normally exists on `this.activityReport.regionId`, but only when the scope is constructed with a `raw` `ActivityReport` model instance. If a `not raw` instance is given, then `regionId` is at `this.activityReport.dataValues.regionId`. the helpers that check for `this.activityReport.regionId` have been updated to support both possibilities and tests have been written to verify this behavior.

- [x] admins should be able to read approved activity reports in any region
- [x] `regionId` check should be made more robust

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1817


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
