### PR TITLE
[TTAHUB-1818] Update form data properly on save

### DIFF
--- a/frontend/src/components/Navigator/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/ActivityReportNavigator.js
@@ -5,6 +5,7 @@ import React, {
   useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import { FormProvider, useForm } from 'react-hook-form';
 import moment from 'moment';
 import {
@@ -137,7 +138,14 @@ const ActivityReportNavigator = ({
     setError,
     watch,
     errors,
+    reset,
   } = hookForm;
+
+  // A new form page is being shown so we need to reset `react-hook-form` so validations are
+  // reset and the proper values are placed inside inputs
+  useDeepCompareEffect(() => {
+    reset(formData);
+  }, [currentPage, reset, formData]);
 
   const pageState = watch('pageState');
   const selectedGoals = watch('goals');

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -34,6 +34,11 @@ describe('ActivityReport', () => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
     fetchMock.get('/api/users/collaborators?region=1', []);
     fetchMock.get('/api/activity-reports/approvers?region=1', []);
+    fetchMock.get('/api/feeds/item?tag=ttahub-topic', `<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <title>Whats New</title>
+    <link rel="alternate" href="https://acf-ohs.atlassian.net/wiki" />
+    <subtitle>Confluence Syndication Feed</subtitle>
+    <id>https://acf-ohs.atlassian.net/wiki</id></feed>`);
   });
 
   it('handles failures to download a report', async () => {
@@ -479,5 +484,399 @@ describe('ActivityReport', () => {
       // we don't expect form controls
       expect(document.querySelector('textarea[name="goalName"]')).toBeNull();
     });
+  });
+
+  it('you can add a goal and objective and add a file after saving', async () => {
+    const data = formData();
+    fetchMock.get('/api/topic', [{ id: 64, name: 'Communication' }]);
+    fetchMock.get('/api/activity-reports/goals?grantIds=12539', []);
+    fetchMock.get('/api/goal-templates?grantIds=12539', []);
+    fetchMock.put('/api/activity-reports/1/goals/edit?goalIds=37504', {});
+    fetchMock.get('/api/activity-reports/1', {
+      ...data,
+      activityRecipientType: 'recipient',
+      activityRecipients: [
+        {
+          id: 12539,
+          activityRecipientId: 12539,
+          name: 'Barton LLC - 04bear012539  - EHS, HS',
+        },
+      ],
+      objectivesWithoutGoals: [],
+      goalsAndObjectives: [{
+        activityReportGoals: [
+          {
+            isActivelyEdited: true,
+          },
+        ],
+        value: 'a5252c25-fbc6-41cc-a655-24fabac34873',
+        number: false,
+        label: 'Create new goal',
+        objectives: [
+          {
+            title: 'sdfgsdfg',
+            topics: [
+              {
+                id: 64,
+                name: 'Communication',
+              },
+            ],
+            resources: [],
+            files: [],
+            ttaProvided: '<p>sdgfsdfg</p>\n',
+            status: 'Not Started',
+            label: 'Create a new objective',
+          },
+        ],
+        name: 'Create new goal',
+        goalNumber: '',
+        id: 'new',
+        isNew: true,
+        endDate: '',
+        onApprovedAR: false,
+        grantIds: [
+          11606,
+        ],
+        goalIds: [],
+        oldGrantIds: [],
+        status: 'Draft',
+        isRttapa: null,
+        isCurated: false,
+      }],
+    });
+
+    act(() => renderActivityReport(1, 'goals-objectives', false, 1));
+
+    await screen.findByRole('heading', { name: 'Goals and objectives' });
+
+    // assert that the file upload is visible
+    let message = await screen.findByText('Add a TTA objective and save as draft to upload resources.');
+    expect(message).toBeInTheDocument();
+
+    let radios = document.querySelector('.ttahub-objective-files input[type="radio"]');
+    expect(radios).toBeNull();
+
+    fetchMock.put('/api/activity-reports/1', {
+      id: 23786,
+      userId: 355,
+      lastUpdatedById: 355,
+      ECLKCResourcesUsed: [],
+      nonECLKCResourcesUsed: [],
+      additionalNotes: null,
+      numberOfParticipants: null,
+      deliveryMethod: null,
+      version: 2,
+      duration: null,
+      endDate: null,
+      startDate: null,
+      activityRecipientType: 'recipient',
+      activityRecipients: [
+        {
+          id: 12539,
+          activityRecipientId: 12539,
+          name: 'Barton LLC - 04bear012539  - EHS, HS',
+        },
+      ],
+      requester: null,
+      targetPopulations: [],
+      virtualDeliveryType: null,
+      reason: [],
+      participants: [],
+      topics: [],
+      programTypes: null,
+      context: '',
+      pageState: {
+        1: 'In progress', 2: 'Complete', 3: 'Not started', 4: 'Not started',
+      },
+      regionId: 1,
+      submissionStatus: 'draft',
+      calculatedStatus: 'draft',
+      ttaType: [],
+      submittedDate: null,
+      updatedAt: '2023-06-21T17:54:15.844Z',
+      approvedAt: null,
+      creatorRole: 'Central Office',
+      createdAt: '2023-06-21T17:43:50.905Z',
+      legacyId: null,
+      objectivesWithGoals: [],
+      author: {},
+      files: [],
+      activityReportCollaborators: [],
+      specialistNextSteps: [{ completeDate: null, note: '', id: 130888 }],
+      recipientNextSteps: [{ completeDate: null, note: '', id: 130887 }],
+      approvers: [],
+      displayId: 'R01-AR-23786',
+      goalsAndObjectives: [{
+        id: 37504,
+        name: 'New goal',
+        status: 'Draft',
+        timeframe: null,
+        isFromSmartsheetTtaPlan: null,
+        endDate: '',
+        closeSuspendReason: null,
+        closeSuspendContext: null,
+        grantId: 10431,
+        goalTemplateId: null,
+        previousStatus: null,
+        onAR: true,
+        onApprovedAR: false,
+        isRttapa: null,
+        firstNotStartedAt: null,
+        lastNotStartedAt: null,
+        firstInProgressAt: null,
+        lastInProgressAt: null,
+        firstCeasedSuspendedAt: null,
+        lastCeasedSuspendedAt: null,
+        firstClosedAt: null,
+        lastClosedAt: null,
+        firstCompletedAt: null,
+        lastCompletedAt: null,
+        createdVia: 'activityReport',
+        rtrOrder: 1,
+        source: null,
+        createdAt: '2023-06-21T17:54:16.543Z',
+        updatedAt: '2023-06-21T17:54:16.812Z',
+        isCurated: null,
+        prompts: [],
+        activityReportGoals: [{
+          endDate: null, id: 76212, activityReportId: 23786, goalId: 37504, isRttapa: null, name: 'New goal', status: 'Draft', timeframe: null, closeSuspendReason: null, closeSuspendContext: null, source: null, isActivelyEdited: false, createdAt: '2023-06-21T17:54:16.699Z', updatedAt: '2023-06-21T17:54:16.699Z',
+        }],
+        grant: {},
+        objectives: [{
+          id: 95299,
+          otherEntityId: null,
+          goalId: 37504,
+          title: 'ASDF',
+          status: 'Not Started',
+          objectiveTemplateId: null,
+          onAR: true,
+          onApprovedAR: false,
+          createdVia: 'activityReport',
+          firstNotStartedAt: '2023-06-21T17:54:16.916Z',
+          lastNotStartedAt: '2023-06-21T17:54:16.916Z',
+          firstInProgressAt: null,
+          lastInProgressAt: null,
+          firstSuspendedAt: null,
+          lastSuspendedAt: null,
+          firstCompleteAt: null,
+          lastCompleteAt: null,
+          rtrOrder: 1,
+          createdAt: '2023-06-21T17:54:16.916Z',
+          updatedAt: '2023-06-21T17:54:17.269Z',
+          activityReportObjectives: [{
+            id: 104904,
+            activityReportId: 23786,
+            objectiveId: 95299,
+            arOrder: 1,
+            title: 'ASDF',
+            status: 'Not Started',
+            ttaProvided: '<p>ASDF</p>\n',
+            createdAt: '2023-06-21T17:54:17.172Z',
+            updatedAt: '2023-06-21T17:54:17.207Z',
+            activityReportObjectiveTopics: [{
+              id: 13747,
+              activityReportObjectiveId: 104904,
+              topicId: 64,
+              createdAt: '2023-06-21T17:54:17.428Z',
+              updatedAt: '2023-06-21T17:54:17.428Z',
+              topic: {
+                id: 64, name: 'Communication', mapsTo: null, createdAt: '2022-03-18T21:27:37.915Z', updatedAt: '2022-03-18T21:27:37.915Z', deletedAt: null,
+              },
+            }],
+            activityReportObjectiveFiles: [],
+            activityReportObjectiveResources: [],
+          }],
+          topics: [{
+            id: 64, name: 'Communication', mapsTo: null, createdAt: '2022-03-18T21:27:37.915Z', updatedAt: '2022-03-18T21:27:37.915Z', deletedAt: null,
+          }],
+          resources: [],
+          files: [],
+          value: 95299,
+          ids: [95299],
+          ttaProvided: '<p>ASDF</p>\n',
+          isNew: false,
+          arOrder: 1,
+        }],
+        goalNumbers: ['G-37504'],
+        goalIds: [37504],
+        grants: [{ }],
+        grantIds: [10431],
+        isNew: false,
+      }],
+      objectivesWithoutGoals: [],
+    });
+
+    expect(fetchMock.called('/api/activity-reports/1', { method: 'PUT' })).toBe(false);
+    const saveGoal = await screen.findByRole('button', { name: /save goal/i });
+    act(() => {
+      userEvent.click(saveGoal);
+    });
+
+    const errors = document.querySelectorAll('.usa-error-message');
+    expect(errors.length).toBe(0);
+
+    await waitFor(() => {
+      expect(fetchMock.called('/api/activity-reports/1', { method: 'PUT' })).toBe(true);
+    });
+
+    const actions = await screen.findByRole('button', { name: /actions for goal/i });
+    act(() => {
+      userEvent.click(actions);
+    });
+
+    fetchMock.get('/api/goals?reportId=1&goalIds=37504', [{
+      endDate: '',
+      status: 'Draft',
+      value: 37504,
+      label: 'dfghgh',
+      id: 37504,
+      name: 'dfghgh',
+      grant: {
+        programTypes: [],
+        name: 'Dooley and Sons - 02bear011606 ',
+        numberWithProgramTypes: '02bear011606 ',
+        recipientInfo: 'Dooley and Sons - 02bear011606 - 757',
+        id: 11606,
+        number: '02bear011606',
+        annualFundingMonth: 'January',
+        cdi: false,
+        status: 'Active',
+        grantSpecialistName: 'Marian Daugherty',
+        grantSpecialistEmail: 'Effie.McCullough@gmail.com',
+        programSpecialistName: 'Eddie Denesik DDS',
+        programSpecialistEmail: 'Darryl_Kunde7@yahoo.com',
+        stateCode: 'RI',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2024-12-31T00:00:00.000Z',
+        inactivationDate: null,
+        inactivationReason: null,
+        recipientId: 757,
+        oldGrantId: 8609,
+        deleted: false,
+        createdAt: '2021-03-16T01:20:44.754Z',
+        updatedAt: '2022-09-28T15:03:28.488Z',
+        regionId: 1,
+        recipient: {
+          id: 757, uei: 'GAKEGQ34K338', name: 'Dooley and Sons', recipientType: 'Private/Public Non-Profit (Non-CAA) (e.g., church or non-profit hospital)', deleted: false, createdAt: '2021-03-16T01:20:43.530Z', updatedAt: '2022-09-28T15:03:26.279Z',
+        },
+      },
+      objectives: [{
+        id: 95300,
+        label: 'dfghdfgh',
+        title: 'dfghdfgh',
+        status: 'Not Started',
+        goalId: 37505,
+        resources: [],
+        activityReportObjectives: [{ ttaProvided: '<p>dfgh</p>\n' }],
+        files: [],
+        topics: [{
+          id: 62,
+          name: 'CLASS: Instructional Support',
+          mapsTo: null,
+          createdAt: '2022-03-18T21:27:37.915Z',
+          updatedAt: '2022-03-18T21:27:37.915Z',
+          deletedAt: null,
+          ObjectiveTopic: {
+            id: 16251, objectiveId: 95300, topicId: 62, onAR: true, onApprovedAR: false, createdAt: '2023-06-21T18:13:19.936Z', updatedAt: '2023-06-21T18:13:20.312Z',
+          },
+        }],
+        activityReports: [{
+          displayId: 'R01-AR-23788',
+          endDate: null,
+          startDate: null,
+          submittedDate: null,
+          lastSaved: '06/21/2023',
+          creatorNameWithRole: ', CO',
+          sortedTopics: [],
+          creatorName: ', CO',
+          id: 23788,
+          legacyId: null,
+          userId: 355,
+          lastUpdatedById: 355,
+          ECLKCResourcesUsed: [],
+          nonECLKCResourcesUsed: [],
+          additionalNotes: null,
+          numberOfParticipants: null,
+          deliveryMethod: null,
+          version: 2,
+          duration: null,
+          activityRecipientType: 'recipient',
+          requester: null,
+          targetPopulations: [],
+          virtualDeliveryType: null,
+          reason: [],
+          participants: [],
+          topics: [],
+          programTypes: null,
+          context: '',
+          pageState: {
+            1: 'In progress', 2: 'In progress', 3: 'Not started', 4: 'Not started',
+          },
+          regionId: 1,
+          submissionStatus: 'draft',
+          calculatedStatus: 'draft',
+          ttaType: [],
+          updatedAt: '2023-06-21T18:14:42.989Z',
+          approvedAt: null,
+          imported: null,
+          creatorRole: 'Central Office',
+          createdAt: '2023-06-21T18:06:00.221Z',
+          ActivityReportObjective: {
+            id: 104905, activityReportId: 23788, objectiveId: 95300, arOrder: 1, title: 'dfghdfgh', status: 'Not Started', ttaProvided: '<p>dfgh</p>\n', createdAt: '2023-06-21T18:13:20.063Z', updatedAt: '2023-06-21T18:13:20.094Z',
+          },
+        }],
+        value: 95300,
+        ids: [95300],
+        recipientIds: [],
+        isNew: false,
+      }],
+      prompts: [],
+      goalNumbers: ['G-37505'],
+      goalIds: [37505],
+      grants: [{
+        id: 11606,
+        number: '02bear011606',
+        annualFundingMonth: 'January',
+        cdi: false,
+        status: 'Active',
+        grantSpecialistName: 'Marian Daugherty',
+        grantSpecialistEmail: 'Effie.McCullough@gmail.com',
+        programSpecialistName: 'Eddie Denesik DDS',
+        programSpecialistEmail: 'Darryl_Kunde7@yahoo.com',
+        stateCode: 'RI',
+        startDate: '2020-01-01T00:00:00.000Z',
+        endDate: '2024-12-31T00:00:00.000Z',
+        inactivationDate: null,
+        inactivationReason: null,
+        recipientId: 757,
+        oldGrantId: 8609,
+        deleted: false,
+        createdAt: '2021-03-16T01:20:44.754Z',
+        updatedAt: '2022-09-28T15:03:28.488Z',
+        regionId: 1,
+        recipient: {
+          id: 757, uei: 'GAKEGQ34K338', name: 'Dooley and Sons', recipientType: 'Private/Public Non-Profit (Non-CAA) (e.g., church or non-profit hospital)', deleted: false, createdAt: '2021-03-16T01:20:43.530Z', updatedAt: '2022-09-28T15:03:26.279Z',
+        },
+        numberWithProgramTypes: '02bear011606 ',
+        name: 'Dooley and Sons - 02bear011606 ',
+        goalId: 37505,
+      }],
+      grantIds: [11606],
+      isNew: false,
+    }]);
+
+    const edit = await screen.findByRole('button', { name: /edit/i });
+    act(() => {
+      userEvent.click(edit);
+    });
+
+    message = screen.queryByText('Add a TTA objective and save as draft to upload resources.');
+    expect(message).toBeNull();
+
+    const didYouUse = await screen.findByText(/Did you use any TTA resources/i);
+    expect(didYouUse).toBeInTheDocument();
+
+    radios = document.querySelector('.ttahub-objective-files input[type="radio"]');
+    expect(radios).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Description of change

a useEffect was removed that needed to be there. We keep the activity report form data in two places: react state and the useForm context. At some point, we should refactor that - the react state is unnecessary - but for now, I've reverted the useEffect change I made previously

## How to test

This issue was exposed because saving a goal wasn't sufficient to remove the "Add a TTA objective and save as draft to upload resources" message. To confirm that this is resolved, create a recipient report, add a new goal and objective, save goal, then edit the goal. The warning message should be gone and you should be able to upload a file

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1818


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
