### PR TITLE
Specify buildpacks as URLS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "TTAHUB-1027/try-zap-latest"
+    default: "fix-deploys"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "al-ttahub-519-grant-personnel"

--- a/maintenance_page/manifest.yml
+++ b/maintenance_page/manifest.yml
@@ -2,5 +2,5 @@
 applications:
   - name: tta-smarthub-maintenance-page-((env))
     buildpacks:
-      - staticfile_buildpack
+      - https://github.com/cloudfoundry/staticfile-buildpack
     memory: 64M

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: tta-smarthub-((env))
     buildpacks:
-      - nodejs_buildpack
+      - https://github.com/cloudfoundry/nodejs-buildpack
     env:
       AUTH_BASE: ((AUTH_BASE))
       AUTH_CLIENT_ID: ((AUTH_CLIENT_ID))


### PR DESCRIPTION
## Description of change

Specify buildpack as URLs to unlock deploys and get around slug/stack mismatch in Cloud Foundry.

- [Slack thread with details](https://adhoc.slack.com/archives/C017Z3PC6MS/p1688560182670759)

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
