### PR TITLE
[TTAHUB-1848] Cannot close objective on open goal

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1248,7 +1248,9 @@ export async function createOrUpdateGoals(goals) {
         }
 
         await objective.update({
-          title,
+          ...(!objective.dataValues.onApprovedAR
+            && title.trim() !== objective.dataValues.title.trim()
+            && { title }),
           status: objectiveStatus,
           rtrOrder: index + 1,
         }, { individualHooks: true });


### PR DESCRIPTION
## Description of change
Only allow the title to be included in the update when the onApprovedAR is false and the trimmed value of the title is different then the current value.


## How to test
Tawny Hardyman
I went through each recipient I've worked with and sometimes I could close the objectives after the goals were closed. 
Sometimes I couldn't close the objective on an open goal, for example, The Order of the Fishermen Ministry Goal 31918 and Rock-Walworth Goal 44967 are open and will not let me close an objective: the message I receive is "There was an error saving the goal" and "The goals is used on an activity report, so some fields can't be edited." I didn't try to close goal 31918 or 44967 because the objectives are still in progress.
I have about 50 goals with open objectives. If you'd like me to, I could email a list to you of the goals to be opened so I can close the objectives. I'm copying my supervisor, Linda Langosch, on this email chain just to keep her in the loop.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1848


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
