### PR TITLE
[TTAHUB-1863] Fix url validation

### DIFF
--- a/frontend/src/components/GoalForm/__tests__/constants.js
+++ b/frontend/src/components/GoalForm/__tests__/constants.js
@@ -1,8 +1,40 @@
-import { validateListOfResources, FORM_FIELD_DEFAULT_ERRORS, FORM_FIELD_INDEXES } from '../constants';
+import {
+  validateListOfResources,
+  FORM_FIELD_DEFAULT_ERRORS,
+  FORM_FIELD_INDEXES,
+  objectivesWithValidResourcesOnly,
+} from '../constants';
 
 describe('form constants', () => {
   it('the amount of form fields and the amount of default errors should match', () => {
     expect(Object.keys(FORM_FIELD_INDEXES).length).toBe(FORM_FIELD_DEFAULT_ERRORS.length);
+  });
+});
+
+describe('objectivesWithValidResourcesOnly', () => {
+  it('strips invalid resources', () => {
+    const objectives = [
+      {
+        resources: [
+          { value: 'https://www.google.com' },
+          { value: 'not a valid url' },
+          { value: 'https://www.google.com' },
+          { value: 'https://www.google.com ' },
+          { value: ' https://www.google.com' },
+        ],
+      },
+    ];
+
+    expect(objectivesWithValidResourcesOnly(objectives)).toEqual([
+      {
+        resources: [
+          { value: 'https://www.google.com' },
+          { value: 'https://www.google.com' },
+          { value: 'https://www.google.com' },
+          { value: 'https://www.google.com' },
+        ],
+      },
+    ]);
   });
 });
 

--- a/frontend/src/components/GoalForm/constants.js
+++ b/frontend/src/components/GoalForm/constants.js
@@ -24,7 +24,9 @@ export const objectivesWithValidResourcesOnly = (objectives) => {
 
   return objectives.map((objective) => ({
     ...objective,
-    resources: objective.resources.filter((resource) => isValidResourceUrl(resource.value)),
+    resources: objective.resources
+      .map((r) => ({ ...r, value: r.value.trim() }))
+      .filter((resource) => isValidResourceUrl(resource.value)),
   }));
 };
 

--- a/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.oe.js
+++ b/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.oe.js
@@ -101,7 +101,7 @@ const initialData = {
     topics: [{}],
     title: 'test',
     ttaProvided: 'test',
-    resources: ['http://www.test.com'],
+    resources: [{ value: 'http://www.test.com' }],
   }],
   goalPrompts: ['test-prompt', 'test-prompt-error'],
   'test-prompt': ['test'],

--- a/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.recipient.js
+++ b/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.recipient.js
@@ -102,7 +102,7 @@ const initialData = {
       topics: [{}],
       title: 'test',
       ttaProvided: 'test',
-      resources: ['http://www.test.com'],
+      resources: [{ value: 'http://www.test.com' }],
     },
   ],
   objectivesWithoutGoals: [],


### PR DESCRIPTION
## Description of change

An error in the way we validated URLs is fixed - a trailing spaces on an objective URL resource meant that it would be marked invalid and disappear on users. This fixes that by trimming the string before validating it and sending it to the backend, meaning that a trimmed string will be return and the user will never notice the disappearing string

## How to test

On an AR, enter an otherwise valid URL with a space at the end and hit "save goal." On this branch, you will see the URL persist as you might expect. On main, the URL disappears.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1863


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
