### PR TITLE
[TTAHUB-1693] Apply fix for end date

### DIFF
--- a/frontend/src/components/filter/activityReportFilters.js
+++ b/frontend/src/components/filter/activityReportFilters.js
@@ -108,9 +108,11 @@ export const endDateFilter = {
   conditions: DATE_CONDITIONS,
   defaultValues: defaultDateValues,
   displayQuery: (query) => {
-    if (query.includes('-')) {
+    // we need to handle array vs string case here
+    const smushed = fixQueryWhetherStringOrArray(query);
+    if (smushed.includes('-')) {
       return formatDateRange({
-        string: query,
+        string: smushed,
         withSpaces: false,
       });
     }

--- a/tests/e2e/activity-reports.spec.ts
+++ b/tests/e2e/activity-reports.spec.ts
@@ -11,7 +11,12 @@ const openFilters = async (page: Page, condition: string, value: string) => {
 test.describe('activity reports landing page', () => {
   test('properly displays start date in filter', async ({ page }) => {
     await page.goto('http://localhost:3000/activity-reports?region.in[]=1&startDate.in[]=2023%2F04%2F04-2023%2F05%2F04');
-  
+    await page.waitForTimeout(5000);
+    expect(page.getByText('04/04/2023-05/04/2023')).toBeTruthy();
+  });
+
+  test('properly displays end date in filter', async ({ page }) => {
+    await page.goto('http://localhost:3000/activity-reports?region.in[]=1&endDate.in[]=2023%2F04%2F04-2023%2F05%2F04');
     await page.waitForTimeout(5000);
     expect(page.getByText('04/04/2023-05/04/2023')).toBeTruthy();
   });


### PR DESCRIPTION
## Description of change

This was a fix that @thewatermethod had applied for the start date. We just need it also for the end date.

## How to test

On the regional dashboard add a filter for 'end date' 'is' 'ytd' paste it in slack and click the link. Notice the date filter is applied incorrectly.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1693


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
