### PR TITLE
Training report cleanup for testing party

### DIFF
--- a/frontend/src/pages/TrainingReports/components/EventCard.scss
+++ b/frontend/src/pages/TrainingReports/components/EventCard.scss
@@ -35,7 +35,7 @@ $min-width-menu-column: 20px;
   display: block;
 }
 
-@container ttahub-event-card (min-width: 640px) {
+@container ttahub-event-card (min-width: 710px) {
   .ttahub-event-card__row {
     display: flex;
     flex-wrap: wrap;
@@ -68,7 +68,7 @@ $min-width-menu-column: 20px;
 
 }
 
-@container ttahub-event-card (min-width: 800px) {
+@container ttahub-event-card (min-width: 980px) {
   .ttahub-event-card__row {
     flex-wrap: no-wrap;
   }

--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -114,7 +114,7 @@ export default class EventReport {
   }
 
   isPoc() {
-    return this.eventReport.pocId.includes(this.user.id);
+    return this.eventReport.pocId && this.eventReport.pocId.includes(this.user.id);
   }
 
   isCollaborator() {

--- a/src/routes/sessionReports/handlers.js
+++ b/src/routes/sessionReports/handlers.js
@@ -42,6 +42,7 @@ export const getHandler = async (req, res) => {
 
     if (id) {
       session = await findSessionById(id);
+      sessionEventId = session.eventId;
     } else if (eventId) {
       sessionEventId = eventId;
       session = await findSessionsByEventId(eventId);

--- a/src/seeders/20230718123611-tr-report.js
+++ b/src/seeders/20230718123611-tr-report.js
@@ -1,0 +1,66 @@
+const { SCOPE_IDS } = require('@ttahub/common');
+
+const {
+  READ_WRITE_TRAINING_REPORTS,
+  COLLABORATOR_TRAINING_REPORTS,
+} = SCOPE_IDS;
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    const readWriteTrainingReports = [
+      {
+        userId: 1,
+        regionId: 1,
+        scopeId: READ_WRITE_TRAINING_REPORTS,
+      },
+      {
+        userId: 5,
+        regionId: 1,
+        scopeId: READ_WRITE_TRAINING_REPORTS,
+      },
+    ];
+
+    const collaboratorTrainingReports = [
+      {
+        userId: 3,
+        regionId: 1,
+        scopeId: COLLABORATOR_TRAINING_REPORTS,
+      },
+    ];
+
+    await queryInterface.bulkInsert('Permissions', readWriteTrainingReports, {});
+    await queryInterface.bulkInsert('Permissions', collaboratorTrainingReports, {});
+
+    await queryInterface.sequelize.query(`
+    -- create a report for cuke    
+    INSERT INTO "EventReportPilots" (
+      "ownerId",
+      "collaboratorIds",
+      "regionId",
+      "data",
+      "imported",
+      "createdAt",
+      "updatedAt"
+    ) VALUES (
+      5,
+      ARRAY[]::INTEGER[],
+      1,
+      CAST('{"Sheet Name":"PD23-24 b. Region 01 PD Plan WITH NCs","eventId":"R01-PD-23-1037","Full Event Title":"R01 Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective","eventName":"Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective","eventOrganizer":"Regional PD Event (with National Centers)","audience":"Recipients","Event Duration/# NC Days of Support":"Series","reasons":["Ongoing Quality Improvement"],"targetPopulations":["None"],"vision":"Oral Health","creator":"cucumber@hogwarts.com"}' AS JSONB),
+      CAST('{"Sheet Name":"PD23-24 b. Region 01 PD Plan WITH NCs","Event ID":"R01-PD-23-1037","Full Event Title":"R01 Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective","Edit Title":"Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective","Event Organizer - Type of Event":"Regional PD Event (with National Centers)","Audience":"Recipients","Event Duration/# NC Days of Support":"Series","Reason for Activity":"Ongoing Quality Improvement","Target Population(s)":"None","Overall Vision/Goal for the PD Event":"Oral Health","Creator":"cucumber@hogwarts.com"}' AS JSONB),
+      NOW(),
+      NOW()
+    );    
+
+    -- give cuke the feature flag
+    UPDATE "Users" SET "flags" = array_append("flags", 'training_reports') WHERE "id" = 5;
+  `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('EventReportPilots', { ownerId: 1 }, {});
+    await queryInterface.bulkDelete('Permissions', { userId: 1, scopeId: READ_WRITE_TRAINING_REPORTS }, {});
+    await queryInterface.bulkDelete('Permissions', { userId: 3, scopeId: COLLABORATOR_TRAINING_REPORTS }, {});
+    await queryInterface.bulkDelete('Permissions', { userId: 5, scopeId: READ_WRITE_TRAINING_REPORTS }, {});
+  },
+};

--- a/src/services/event.test.js
+++ b/src/services/event.test.js
@@ -172,11 +172,11 @@ describe('event service', () => {
 
     it('findEventsByStatus sort order', async () => {
       // eventId is used for sorting, then startDate
-      await createAnEventWithData(11_111, { eventId: 'C', startDate: '2020-01-02' });
-      await createAnEventWithData(11_112, { eventId: 'B', startDate: '2020-01-03' });
-      await createAnEventWithData(11_113, { eventId: 'A', startDate: '2020-01-01' });
+      const e1 = await createAnEventWithData(11_111, { eventId: 'C', startDate: '2020-01-02' });
+      const e2 = await createAnEventWithData(11_112, { eventId: 'B', startDate: '2020-01-03' });
+      const e3 = await createAnEventWithData(11_113, { eventId: 'A', startDate: '2020-01-01' });
 
-      const found = await findEventsByStatus(null, [], null, true);
+      const found = await findEventsByStatus(null, [], null, true, [{ id: [e1.id, e2.id, e3.id] }]);
 
       // expect date to be priority sorted, followed by title:
       expect(found[0].data).toHaveProperty('eventId', 'A');
@@ -188,11 +188,17 @@ describe('event service', () => {
       await destroyEvent(found[2].id);
 
       // when eventId is missing, sort by startDate:
-      await createAnEventWithData(11_111, { startDate: '2020-01-02' });
-      await createAnEventWithData(11_112, { startDate: '2020-01-03' });
-      await createAnEventWithData(11_113, { startDate: '2020-01-01' });
+      const e4 = await createAnEventWithData(11_111, { startDate: '2020-01-02' });
+      const e5 = await createAnEventWithData(11_112, { startDate: '2020-01-03' });
+      const e6 = await createAnEventWithData(11_113, { startDate: '2020-01-01' });
 
-      const found2 = await findEventsByStatus(null, [], null, true);
+      const found2 = await findEventsByStatus(
+        null,
+        [],
+        null,
+        true,
+        [{ id: [e4.id, e5.id, e6.id] }],
+      );
 
       expect(found2[0].data).toHaveProperty('startDate', '2020-01-01');
       expect(found2[1].data).toHaveProperty('startDate', '2020-01-02');
@@ -203,11 +209,17 @@ describe('event service', () => {
       await destroyEvent(found2[2].id);
 
       // when eventId is the same, sort by startDate:
-      await createAnEventWithData(11_111, { eventId: 'A', startDate: '2020-01-02' });
-      await createAnEventWithData(11_112, { eventId: 'A', startDate: '2020-01-03' });
-      await createAnEventWithData(11_113, { eventId: 'A', startDate: '2020-01-01' });
+      const e7 = await createAnEventWithData(11_111, { eventId: 'A', startDate: '2020-01-02' });
+      const e8 = await createAnEventWithData(11_112, { eventId: 'A', startDate: '2020-01-03' });
+      const e9 = await createAnEventWithData(11_113, { eventId: 'A', startDate: '2020-01-01' });
 
-      const found3 = await findEventsByStatus(null, [], null, true);
+      const found3 = await findEventsByStatus(
+        null,
+        [],
+        null,
+        true,
+        [{ id: [e7.id, e8.id, e9.id] }],
+      );
 
       expect(found3[0].data).toHaveProperty('startDate', '2020-01-01');
       expect(found3[1].data).toHaveProperty('startDate', '2020-01-02');


### PR DESCRIPTION
## Description of change

- Putting the event status in a read-only field under certain circumstances meant the submit error message was hidden. This shows it.
- Breakpoints for the event card weren't quite reflecting the content, they have been updated
- There was a possibility for a newly created event to throw an error saving if there was no POC ID set
- getSessionById was missing a variable assignment that threw an error
- Created a seeder (forking this branch to work on an e2e test)

## How to test

Confirm the errors listed above have been resolved.

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
