### PR TITLE
Shorten websocket interval, display websockets on all pages of form

### DIFF
--- a/frontend/src/hooks/useSocket.js
+++ b/frontend/src/hooks/useSocket.js
@@ -8,6 +8,8 @@ import {
 } from 'react';
 import useInterval from '@use-it/interval';
 
+const THIRTY_SECONDS = 30000;
+
 const WS_URL = process.env.REACT_APP_WEBSOCKET_URL || '';
 
 export function publishLocation(socket, socketPath, user, lastSaveTime) {
@@ -23,7 +25,7 @@ export function publishLocation(socket, socketPath, user, lastSaveTime) {
 }
 
 export function usePublishWebsocketLocationOnInterval(
-  socket, socketPath, user, lastSaveTime, interval,
+  socket, socketPath, user, lastSaveTime, interval = THIRTY_SECONDS,
 ) {
   useInterval(() => publishLocation(socket, socketPath, user, lastSaveTime), interval);
 }

--- a/frontend/src/pages/SessionForm/index.js
+++ b/frontend/src/pages/SessionForm/index.js
@@ -23,7 +23,7 @@ import AppLoadingContext from '../../AppLoadingContext';
 import { isValidResourceUrl } from '../../components/GoalForm/constants';
 
 // websocket publish location interval
-const INTERVAL_DELAY = 30000; // THIRTY SECONDS
+const INTERVAL_DELAY = 10000; // TEN SECONDS
 
 /**
    * this is just a simple handler to "flatten"
@@ -106,12 +106,12 @@ export default function SessionForm({ match }) {
   } = useSocket(user);
 
   useEffect(() => {
-    if (!trainingReportId || !currentPage || !sessionId) {
+    if (!trainingReportId || !sessionId) {
       return;
     }
-    const newPath = `/training-report/${trainingReportId}/session/${sessionId}/${currentPage}`;
+    const newPath = `/training-report/${trainingReportId}/session/${sessionId}`;
     setSocketPath(newPath);
-  }, [currentPage, sessionId, setSocketPath, trainingReportId]);
+  }, [sessionId, setSocketPath, trainingReportId]);
 
   usePublishWebsocketLocationOnInterval(socket, socketPath, user, lastSaveTime, INTERVAL_DELAY);
 

--- a/frontend/src/pages/TrainingReportForm/index.js
+++ b/frontend/src/pages/TrainingReportForm/index.js
@@ -27,7 +27,7 @@ import AppLoadingContext from '../../AppLoadingContext';
 import useHookFormPageState from '../../hooks/useHookFormPageState';
 
 // websocket publish location interval
-const INTERVAL_DELAY = 30000; // THIRTY SECONDS
+const INTERVAL_DELAY = 10000; // TEN SECONDS
 
 /**
  * this is just a simple handler to "flatten"
@@ -134,10 +134,10 @@ export default function TrainingReportForm({ match }) {
   } = useSocket(user);
 
   useEffect(() => {
-    if (!trainingReportId || !currentPage) {
+    if (!trainingReportId) {
       return;
     }
-    const newPath = `/training-reports/${trainingReportId}/${currentPage}`;
+    const newPath = `/training-reports/${trainingReportId}}`;
     setSocketPath(newPath);
   }, [currentPage, setSocketPath, trainingReportId]);
 


### PR DESCRIPTION
## Description of change

This change applies only to the training report form and the session form. Because of the single column storage approach, multiple people working on the form at the same time is worse than on the activity report.

This change:
- Shortens the websocket interval to 10 seconds from 30
- Publishes the warning if any user is inside ANY page of the form, rather than just the same page

## How to test

Websocket event still fires, behaves as above (you can test solo by removing the logic that excludes the active user from displaying in the SocketAlert component)

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
