### PR TITLE
[TTAHUB-1865] Fix bug with rolling up objective topics

### DIFF
--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -858,12 +858,15 @@ describe('Recipient DB service', () => {
       expect(goalsForRecord.allGoalIds.length).toBe(2);
 
       const goal = goalsForRecord.goalRows[0];
-      expect(goal.goalTopics.length).toBe(4); // all topics, including the floating AR topic
-      expect(goal.reasons.length).toBe(1); // the random one we created
+
+      expect(goal.goalTopics.length).toBe(4);
+      expect(goal.goalTopics.sort()).toEqual(topics.map((t) => t.name).sort());
+      expect(goal.reasons.length).toBe(1);
 
       expect(goal.objectives.length).toBe(1);
       const objective = goal.objectives[0];
-      expect(objective.topics.length).toBe(3); // the ones derived from the ObjectiveTopics link
+      expect(objective.topics.length).toBe(4);
+      expect(objective.topics.sort()).toEqual(topics.map((t) => t.name).sort());
       expect(objective.activityReports.length).toBe(1);
     });
   });

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -858,9 +858,6 @@ describe('Recipient DB service', () => {
       expect(goalsForRecord.allGoalIds.length).toBe(2);
 
       const goal = goalsForRecord.goalRows[0];
-
-      expect(goal.goalTopics.length).toBe(4);
-      expect(goal.goalTopics.sort()).toEqual(topics.map((t) => t.name).sort());
       expect(goal.reasons.length).toBe(1);
 
       expect(goal.objectives.length).toBe(1);


### PR DESCRIPTION
## Description of change
This is the second attempt at a fix for this. The bug involves how we were creating a list of topics. Right now, the UI expect topics from the activity reports (an array of strings) and the topics table (objects like ```{ id: 1, name: "A topic"}```. 

When we de-duplicate a goal, we also de-duplicate the objectives within that goal (each time a goal is added). We were iterating over the topics and standardizing them to a matching array of strings. However, with rolled-up goals, the second time we iterated over an objective's topics, we were iterating over an array of strings and essentially wiping it out.

This change fixes it. I also adjusted the test to ensure the fidelity of the topics returned to the UI.

## How to test

With a recent data extract from prod loaded up, visit the following link: /recipient-tta-records/678/region/6/goals-objectives

There is a rolled up goal with the numbers G-37171 & G-17703. The first objective "ECS will identify how the areas of social/emotional, communication and problem solving skills for children have been strengthened and identify areas of support needed" should have 3 topics present.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1865


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
