### PR TITLE
[TTAHUB-1923] update "save session" to "save draft"

### DIFF
--- a/frontend/src/pages/SessionForm/__tests__/index.js
+++ b/frontend/src/pages/SessionForm/__tests__/index.js
@@ -123,7 +123,7 @@ describe('SessionReportForm', () => {
     expect(screen.getByText(/Regional\/National Training Report/i)).toBeInTheDocument();
 
     fetchMock.put(url, { eventId: 1 });
-    const saveSession = screen.getByText(/Save Session/i);
+    const saveSession = screen.getByText(/Save draft/i);
     userEvent.click(saveSession);
     await waitFor(() => expect(fetchMock.called(url, { method: 'put' })).toBe(true));
   });
@@ -144,7 +144,7 @@ describe('SessionReportForm', () => {
     expect(screen.getByText(/Regional\/National Training Report/i)).toBeInTheDocument();
 
     fetchMock.put(url, 500);
-    const saveSession = screen.getByText(/Save Session/i);
+    const saveSession = screen.getByText(/Save draft/i);
     userEvent.click(saveSession);
     await waitFor(() => expect(fetchMock.called(url, { method: 'put' })).toBe(true));
     expect(screen.getByText(/There was an error saving the session/i)).toBeInTheDocument();

--- a/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
@@ -262,7 +262,7 @@ describe('sessionSummary', () => {
         userEvent.selectOptions(supportType, 'Planning');
       });
 
-      const saveDraftButton = await screen.findByRole('button', { name: /save session/i });
+      const saveDraftButton = await screen.findByRole('button', { name: /save draft/i });
       userEvent.click(saveDraftButton);
       expect(onSaveDraft).toHaveBeenCalled();
     });

--- a/frontend/src/pages/SessionForm/pages/nextSteps.js
+++ b/frontend/src/pages/SessionForm/pages/nextSteps.js
@@ -81,7 +81,7 @@ export default {
       <Alert />
       <div className="display-flex">
         <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>
-        <Button id={`${path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save session</Button>
+        <Button id={`${path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save draft</Button>
         <Button id={`${path}-back`} outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(position - 1); }}>Back</Button>
       </div>
     </div>

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -268,7 +268,7 @@ export default {
       <Alert />
       <div className="display-flex">
         <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>
-        <Button id={`${path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save session</Button>
+        <Button id={`${path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save draft</Button>
         <Button id={`${path}-back`} outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(position - 1); }}>Back</Button>
       </div>
     </div>

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -579,7 +579,7 @@ export default {
       <Alert />
       <div className="display-flex">
         <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>
-        <Button id={`${path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save session</Button>
+        <Button id={`${path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save draft</Button>
       </div>
     </div>
   ),


### PR DESCRIPTION
## Description of change

From the Jira "There is inconsistency on the "Save draft" buttons in the Session form. In the design, they had said "Save session", but it's better to be consistent and use "Save draft" on both forms."

Updated the session form to use "save draft" instead of "save session" for the appropriate button text.

## How to test

Ensure that the session form still works as expected (save draft, etc)

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1923


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
