### PR TITLE
[TTAHUB-1899] Prevent retry on resource url's that exceed max redirects

### DIFF
--- a/src/lib/resource.js
+++ b/src/lib/resource.js
@@ -108,7 +108,11 @@ const getResourceMetaDataJob = async (job) => {
     return ({ status: httpCodes.OK, data: { url: resourceUrl } });
   } catch (error) {
     auditLogger.error(`Resource Queue: Unable to retrieve title for Resource (ID: ${resourceId} URL: ${resourceUrl}), please make sure this is a valid address:`, error);
-    throw Error(error); // We must rethrow the error here to ensure the job is retried.
+    // Determine if max number of redirects has been exceeded if not retry.
+    if (error.code !== 'ERR_FR_TOO_MANY_REDIRECTS') {
+      throw Error(error); // We must rethrow the error here to ensure the job is retried.
+    }
+    return ({ status: httpCodes.BAD_REQUEST, data: { url: resourceUrl } });
   }
 };
 

--- a/src/lib/resource.test.js
+++ b/src/lib/resource.test.js
@@ -132,6 +132,46 @@ describe('resource worker tests', () => {
     expect(mockUpdate).toBeCalledTimes(1);
   });
 
+  it('does not trigger a retry an if eclkc resource throws max retries', async () => {
+    // Mock TITLE get.
+    const maxRequestError = new Error();
+    maxRequestError.response = { status: 500, data: 'Error', code: 'ERR_FR_TOO_MANY_REDIRECTS' };
+    maxRequestError.code = 'ERR_FR_TOO_MANY_REDIRECTS';
+    mockAxios.mockImplementationOnce(() => Promise.reject(maxRequestError));
+
+    // Call the function.
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+
+    // check for bad request response.
+    expect(got.status).toBe(400);
+
+    // Check the data.
+    expect(got).toStrictEqual({ status: 400, data: { url: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+
+    // expect mock axios to have been called once.
+    expect(mockAxios).toBeCalledTimes(1);
+  });
+
+  it('does not trigger a retry an if non-eclkc resource throws max retries', async () => {
+    // Mock TITLE get.
+    const maxRequestError = new Error();
+    maxRequestError.response = { status: 500, data: 'Error', code: 'ERR_FR_TOO_MANY_REDIRECTS' };
+    maxRequestError.code = 'ERR_FR_TOO_MANY_REDIRECTS';
+    mockAxios.mockImplementationOnce(() => Promise.reject(maxRequestError));
+
+    // Call the function.
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'https://test.gov/mental-health' } });
+
+    // check for bad request response.
+    expect(got.status).toBe(400);
+
+    // Check the data.
+    expect(got).toStrictEqual({ status: 400, data: { url: 'https://test.gov/mental-health' } });
+
+    // expect mock axios to have been called once.
+    expect(mockAxios).toBeCalledTimes(1);
+  });
+
   it('tests a clean resource metadata get', async () => {
     // Metadata.
     mockAxios.mockImplementationOnce(() => Promise.resolve({ status: 200, data: metadata }));

--- a/src/lib/resource.test.js
+++ b/src/lib/resource.test.js
@@ -172,6 +172,51 @@ describe('resource worker tests', () => {
     expect(mockAxios).toBeCalledTimes(1);
   });
 
+  it('does not throw an error if eclkc resources returns invalid json', async () => {
+    // Mock JSON get.
+    mockAxios.mockImplementationOnce(() => Promise.resolve({ status: 200, data: 'blah' }));
+    mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
+
+    // Mock HTML get.
+    mockAxios.mockImplementationOnce(() => Promise.resolve(axiosCleanResponse));
+    mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
+
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+    expect(got.status).toBe(200);
+    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov' });
+
+    expect(mockUpdate).toBeCalledTimes(1);
+
+    // Check title scrape update..
+    expect(mockUpdate).toBeCalledWith(
+      {
+        title: 'Head Start | ECLKC',
+      },
+      {
+        individualHooks: false,
+        where: { url: 'http://www.eclkc.ohs.acf.hhs.gov' },
+      },
+    );
+  });
+
+  it('does not throw an error if non-eclkc resources returns invalid html', async () => {
+    // Mock TITLE get.
+    mockAxios.mockImplementationOnce(() => Promise.resolve({ status: 200, data: 'blah' }));
+    mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
+
+    // Call the function.
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'https://test.gov/mental-health' } });
+
+    // check for bad request response.
+    expect(got.status).toBe(200);
+
+    // Check the data.
+    expect(got).toStrictEqual({ status: 200, data: { url: 'https://test.gov/mental-health' } });
+
+    // expect mock axios to have been called once.
+    expect(mockAxios).toBeCalledTimes(1);
+  });
+
   it('tests a clean resource metadata get', async () => {
     // Metadata.
     mockAxios.mockImplementationOnce(() => Promise.resolve({ status: 200, data: metadata }));

--- a/src/services/resourceQueue.js
+++ b/src/services/resourceQueue.js
@@ -6,7 +6,7 @@ import { getResourceMetaDataJob } from '../lib/resource';
 const resourceQueue = newQueue('resource');
 
 const addGetResourceMetadataToQueue = async (id, url) => {
-  const retries = process.env.RESOURCE_METADATA_RETRIES || 3;
+  const retries = process.env.RESOURCE_METADATA_RETRIES || 1;
   const delay = process.env.RESOURCE_METADATA_BACKOFF_DELAY || 10000;
   const backOffOpts = {
     type: 'exponential',

--- a/src/services/resourceQueue.js
+++ b/src/services/resourceQueue.js
@@ -6,7 +6,7 @@ import { getResourceMetaDataJob } from '../lib/resource';
 const resourceQueue = newQueue('resource');
 
 const addGetResourceMetadataToQueue = async (id, url) => {
-  const retries = process.env.RESOURCE_METADATA_RETRIES || 1;
+  const retries = process.env.RESOURCE_METADATA_RETRIES || 2;
   const delay = process.env.RESOURCE_METADATA_BACKOFF_DELAY || 10000;
   const backOffOpts = {
     type: 'exponential',


### PR DESCRIPTION
## Description of change

When running the resource scrape job for a year the redis queue crashed. One of the common failures (and retries) that we saw was that the max number of redirects had been exceeded. This change prevents the job from retrying if this error is encountered.

## How to test

**The following URL causes the redirect issue:** https://mypeers.mangoapps.com/user/document?folder=7116816

1. Make sure this resource does not exist in your db. 
2. With the worker running add it to a report.
3. The worker output should show a failure for ERR_FR_TOO_MANY_REDIRECTS and NOT attempt to retry.
4. Running for a valid resource should still work.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1899


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
