### PR TITLE
[TTAHUB-1927] Check if group exists before deleting

### DIFF
--- a/frontend/src/pages/AccountManagement/components/MyGroup.js
+++ b/frontend/src/pages/AccountManagement/components/MyGroup.js
@@ -58,7 +58,6 @@ export default function MyGroup({
                   setError('There was an error deleting your group');
                 } finally {
                   setIsAppLoading(false);
-                  modalRef.current.toggleModal(false);
                 }
               }}
             >

--- a/frontend/src/pages/AccountManagement/components/MyGroup.js
+++ b/frontend/src/pages/AccountManagement/components/MyGroup.js
@@ -19,9 +19,13 @@ export default function MyGroup({
   const { isAppLoading, setIsAppLoading } = useContext(AppLoadingContext);
 
   const onDelete = async (groupId) => {
-    await deleteGroup(groupId);
-    const updatedGroups = await fetchGroups();
-    setMyGroups(updatedGroups);
+    try {
+      await deleteGroup(groupId);
+    } finally {
+      // Regardless, get the updated list of groups.
+      const updatedGroups = await fetchGroups();
+      setMyGroups(updatedGroups);
+    }
   };
 
   return (
@@ -54,6 +58,7 @@ export default function MyGroup({
                   setError('There was an error deleting your group');
                 } finally {
                   setIsAppLoading(false);
+                  modalRef.current.toggleModal(false);
                 }
               }}
             >

--- a/src/routes/groups/handlers.test.js
+++ b/src/routes/groups/handlers.test.js
@@ -351,6 +351,26 @@ describe('Groups Handlers', () => {
       expect(res.json).toHaveBeenCalledWith(groupResponse);
     });
 
+    it('should return 200 if the group no longer exists', async () => {
+      const req = {
+        params: {
+          groupId: 1,
+        },
+      };
+      const res = {
+        json: jest.fn(),
+        sendStatus: jest.fn(),
+        status: jest.fn(() => ({ json: jest.fn() })),
+      };
+      Group.findOne.mockReturnValue(null);
+      const userId = 1;
+      const groupResponse = 1;
+      currentUserId.mockReturnValueOnce(userId);
+      destroyGroup.mockReturnValue(groupResponse);
+      await deleteGroup(req, res);
+      expect(res.status).toHaveBeenCalledWith(httpCodes.OK);
+    });
+
     it('should return 403 if the user does not own the group', async () => {
       const req = {
         params: {

--- a/src/routes/groups/handlers.ts
+++ b/src/routes/groups/handlers.ts
@@ -173,6 +173,12 @@ export async function deleteGroup(req: Request, res: Response) {
       attribtes: ['userId', 'id'],
     });
 
+    // We should check that the group exists before we attempt to delete it.
+    if (!existingGroup) {
+      res.status(httpCodes.OK).json({});
+      return;
+    }
+
     const policy = new GroupPolicy({ id: userId, permissions: [] }, [], existingGroup);
     if (!policy.ownsGroup()) {
       res.sendStatus(httpCodes.FORBIDDEN);


### PR DESCRIPTION
## Description of change

I was able to reproduce the exact error message locally if the group being deleted no longer existed. The thinking is that Patrice  might have already deleted the group in another tab. Then when she attempted to delete it from the old tab it no longer existed and threw an error. The code has been updated to first verify the group exists before deleting it.

## How to test

- Attempt to delete a group that no longer exists (via db delete). You should no longer get an error message.
- Deleting groups should work as it did before.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1927


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
