### PR TITLE
[TTAHUB-1936] End date filter not filtering

### DIFF
--- a/src/scopes/activityReport/index.js
+++ b/src/scopes/activityReport/index.js
@@ -125,6 +125,7 @@ export const topicToQuery = {
     bef: (query) => beforeEndDate(query),
     aft: (query) => afterEndDate(query),
     win: (query) => withinEndDate(query),
+    in: (query) => withinEndDate(query),
   },
   otherEntities: {
     in: (query) => withOtherEntities(query),

--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -3028,6 +3028,17 @@ describe('filtersToScopes', () => {
       expect(found.map((f) => f.id))
         .toEqual(expect.arrayContaining([firstReport.id, secondReport.id, thirdReport.id]));
     });
+
+    it('in returns reports with end dates between the two dates', async () => {
+      const filters = { 'endDate.in': '2020/09/01-2020/09/03' };
+      const { activityReport: scope } = await filtersToScopes(filters);
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+      expect(found.length).toBe(3);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([firstReport.id, secondReport.id, thirdReport.id]));
+    });
   });
 
   describe('region id', () => {


### PR DESCRIPTION
## Description of change

We are not currently handling the IN case for endDate filter. I have updated the code to behave the same way as start date.


## How to test

View the AR landing with no filters. Apply the last thirty days filter for end date. The number should change based on your filter.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1651


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
