### PR TITLE
[TTAHUB-1561] Goals have incorrect onApprovedAr value

### DIFF
--- a/src/migrations/2023080309391234-update-goal-on-approved-ar-value.js
+++ b/src/migrations/2023080309391234-update-goal-on-approved-ar-value.js
@@ -1,0 +1,32 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+
+      await queryInterface.sequelize.query(`
+        UPDATE "Goals"
+        SET "onApprovedAR" = NOT "onApprovedAR"
+        WHERE "id" IN (
+        SELECT
+            g.id
+        FROM "Goals" g
+        JOIN "ActivityReportGoals" ar
+        ON g.id = ar."goalId"
+        JOIN "ActivityReports" a
+        ON ar."activityReportId" = a.id
+        group by 1
+        having g."onApprovedAR" != ('approved' = ANY (array_agg(DISTINCT a."calculatedStatus"::text)))
+      )
+        `, { transaction });
+    });
+  },
+
+  down: async () => {
+    // it doesn't make sense to roll this back to bad data.
+  },
+};


### PR DESCRIPTION
## Description of change

This script fixes the goals with the incorrect value for onApprovedAr.

## How to test

Run the below script before you run db:migrate:

{code}
-- Detects onApproved AR goal mismatches.
-- IE: No approved reports but field is true.
--     Or field is false and has approved reports.
SELECT
    g.id /*, 
    g."onApprovedAR" AS isGoalApproved, 
    'approved' = ANY (array_agg(DISTINCT a."calculatedStatus"::text)) AS hasApprovedReport,
    (array_agg(DISTINCT a."id")) AS reportIds, 
    (array_agg(DISTINCT a."createdAt")) AS createdAt, 
    count(a.id) AS reportIdCount*/
FROM "Goals" g
JOIN "ActivityReportGoals" ar
ON g.id = ar."goalId"
JOIN "ActivityReports" a
ON ar."activityReportId" = a.id
group by 1
having g."onApprovedAR" != ('approved' = ANY (array_agg(DISTINCT a."calculatedStatus"::text))) 
{code}

Run the migration then the above script again you should no longer have any values.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1561


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
