### PR TITLE
[No ticket] Update "empty" events messaging

### DIFF
--- a/frontend/src/pages/TrainingReports/components/EventCards.js
+++ b/frontend/src/pages/TrainingReports/components/EventCards.js
@@ -1,25 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { eventPropTypes, EVENT_STATUS } from '../constants';
+import { eventPropTypes } from '../constants';
 import EventCard from './EventCard';
 
-const translateEventStatus = (status) => {
-  switch (status) {
-    case EVENT_STATUS.NOT_STARTED:
-      return 'You have no events with a “not started” status.';
-    case EVENT_STATUS.IN_PROGRESS:
-      return 'You have no events in progress.';
-    case EVENT_STATUS.COMPLETE:
-      return 'You have no completed events.';
-    case EVENT_STATUS.SUSPENDED:
-      return 'You have no suspended events.';
-    default:
-      return 'You have no events.';
-  }
-};
 function EventCards({
   events,
-  eventType,
   onRemoveSession,
 }) {
   return (
@@ -33,7 +18,7 @@ function EventCards({
               onRemoveSession={onRemoveSession}
             />
           ))
-          : <p className="usa-prose text-bold margin-y-0 padding-2">{translateEventStatus(eventType)}</p>
+          : <p className="usa-prose text-bold margin-y-0 padding-2">There are no events.</p>
         }
     </div>
   );
@@ -41,7 +26,6 @@ function EventCards({
 
 EventCards.propTypes = {
   events: PropTypes.arrayOf(PropTypes.shape(eventPropTypes)).isRequired,
-  eventType: PropTypes.string.isRequired,
   onRemoveSession: PropTypes.func.isRequired,
 };
 export default EventCards;

--- a/frontend/src/pages/TrainingReports/components/__tests__/EventCards.js
+++ b/frontend/src/pages/TrainingReports/components/__tests__/EventCards.js
@@ -109,27 +109,27 @@ describe('EventCards', () => {
 
   it('renders correctly if there are no not started events', () => {
     renderEventCards([], EVENT_STATUS.NOT_STARTED);
-    expect(screen.getByText('You have no events with a “not started” status.')).toBeInTheDocument();
+    expect(screen.getByText('There are no events.')).toBeInTheDocument();
   });
 
   it('renders correctly if there are no complete events', () => {
     renderEventCards([], EVENT_STATUS.COMPLETE);
-    expect(screen.getByText('You have no completed events.')).toBeInTheDocument();
+    expect(screen.getByText('There are no events.')).toBeInTheDocument();
   });
 
   it('renders correctly if there are no suspended events', () => {
     renderEventCards([], EVENT_STATUS.SUSPENDED);
-    expect(screen.getByText('You have no suspended events.')).toBeInTheDocument();
+    expect(screen.getByText('There are no events.')).toBeInTheDocument();
   });
 
   it('renders correctly if there are no in progress events', () => {
     renderEventCards([], EVENT_STATUS.IN_PROGRESS);
-    expect(screen.getByText('You have no events in progress.')).toBeInTheDocument();
+    expect(screen.getByText('There are no events.')).toBeInTheDocument();
   });
 
   it('renders correctly if there are no in unknown events', () => {
     renderEventCards([], 'blah');
-    expect(screen.getByText('You have no events.')).toBeInTheDocument();
+    expect(screen.getByText('There are no events.')).toBeInTheDocument();
   });
 
   it('collaborator can edit reports they collaborate on and view reports in their region', () => {


### PR DESCRIPTION
## Description of change

During a demo with Patrice, she asked if we could change the "empty" state messaging for the training reports landing. 

## How to test

Confirm that all statuses say "There are no events."

## Issue(s)


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
