### PR TITLE
[TTAHUB-1850] Add new permissions to users export

### DIFF
--- a/src/services/activeUsers.js
+++ b/src/services/activeUsers.js
@@ -11,6 +11,12 @@ const arrayFields = [
   'READ_REPORTS regions',
   'APPROVE_REPORTS regions',
   'UNLOCK_APPROVED_REPORTS regions',
+  'READ_TRAINING_REPORTS',
+  'READ_TRAINING_REPORTS regions',
+  'READ_WRITE_TRAINING_REPORTS',
+  'READ_WRITE_TRAINING_REPORTS regions',
+  'POC_TRAINING_REPORTS',
+  'POC_TRAINING_REPORTS regions',
   'Flags',
 ];
 
@@ -111,6 +117,12 @@ SELECT
     array_agg(DISTINCT "ActiveUsers"."regionId") filter (WHERE "ActiveUsers"."scope" = 'READ_REPORTS') AS "READ_REPORTS regions",
     MIN(CASE WHEN "ActiveUsers"."scope" = 'APPROVE_REPORTS' THEN 'Yes' END) AS "APPROVE_REPORTS",
     array_agg(DISTINCT "ActiveUsers"."regionId") filter (WHERE "ActiveUsers"."scope" = 'APPROVE_REPORTS') AS "APPROVE_REPORTS regions",
+    MIN(CASE WHEN "ActiveUsers"."scope" = 'READ_TRAINING_REPORTS' THEN 'Yes' END) AS "READ_TRAINING_REPORTS",
+    array_agg(DISTINCT "ActiveUsers"."regionId") filter (WHERE "ActiveUsers"."scope" = 'READ_TRAINING_REPORTS') AS "READ_TRAINING_REPORTS regions",
+    MIN(CASE WHEN "ActiveUsers"."scope" = 'READ_WRITE_TRAINING_REPORTS' THEN 'Yes' END) AS "READ_WRITE_TRAINING_REPORTS",
+    array_agg(DISTINCT "ActiveUsers"."regionId") filter (WHERE "ActiveUsers"."scope" = 'READ_WRITE_TRAINING_REPORTS') AS "READ_WRITE_TRAINING_REPORTS regions",
+    MIN(CASE WHEN "ActiveUsers"."scope" = 'POC_TRAINING_REPORTS' THEN 'Yes' END) AS "POC_TRAINING_REPORTS",
+    array_agg(DISTINCT "ActiveUsers"."regionId") filter (WHERE "ActiveUsers"."scope" = 'POC_TRAINING_REPORTS') AS "POC_TRAINING_REPORTS regions",
     "ActiveUsers"."flags" AS "Flags"
 FROM
     "ActiveUsers"


### PR DESCRIPTION
## Description of change
Add 6 new columns to the "download users" button in Admin > Users

- READ_WRITE_TRAINING_REPORTS - Yes or blank
- READ_WRITE_TRAINING_REPORTS regions - List of regions with permission
- READ_TRAINING_REPORTS - Yes or blank
- READ_TRAINING_REPORTS regions - List of regions with permission
- POC_TRAINING_REPORTS - Yes or blank
- POC_TRAINING_REPORTS regions - List of regions with permission{}

## How to test

Make sure you have users with those new permissions. Download the CSV of users from the Admin section and confirm that the information is correct.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1850


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
