### PR TITLE
[NO-TICKET] Fix training report import names and transformers

### DIFF
--- a/frontend/src/pages/TrainingReportForm/index.js
+++ b/frontend/src/pages/TrainingReportForm/index.js
@@ -137,7 +137,7 @@ export default function TrainingReportForm({ match }) {
     if (!trainingReportId) {
       return;
     }
-    const newPath = `/training-reports/${trainingReportId}}`;
+    const newPath = `/training-reports/${trainingReportId}`;
     setSocketPath(newPath);
   }, [currentPage, setSocketPath, trainingReportId]);
 

--- a/src/tools/importSmartSheetEvent.js
+++ b/src/tools/importSmartSheetEvent.js
@@ -13,10 +13,12 @@ import { logger } from '../logger';
 
 // eslint-disable-next-line max-len
 const splitArrayTransformer = (value, splitter = '|') => value.split(splitter).map((item) => item.trim());
+const lowerCaseTransformer = (value) => value.toLowerCase();
 
 const transformers = {
   reasons: splitArrayTransformer,
   targetPopulations: splitArrayTransformer,
+  eventIntendedAudience: lowerCaseTransformer,
 };
 
 const mappings = {

--- a/src/tools/importSmartSheetEvent.js
+++ b/src/tools/importSmartSheetEvent.js
@@ -23,7 +23,7 @@ const mappings = {
   Audience: 'audience',
   Creator: 'creator',
   'Edit Title': 'eventName',
-  'Event Duration/#NC Days of Support': 'eventDuration',
+  'Event Duration/# NC Days of Support': 'trainingType',
   'Event ID': 'eventId',
   'Overall Vision/Goal for the PD Event': 'vision',
   'Reason for Activity': 'reasons',

--- a/src/tools/importSmartSheetEvent.js
+++ b/src/tools/importSmartSheetEvent.js
@@ -20,7 +20,7 @@ const transformers = {
 };
 
 const mappings = {
-  Audience: 'audience',
+  Audience: 'eventIntendedAudience',
   Creator: 'creator',
   'Edit Title': 'eventName',
   'Event Duration/# NC Days of Support': 'trainingType',

--- a/src/tools/importSmartSheetEvent.test.js
+++ b/src/tools/importSmartSheetEvent.test.js
@@ -82,7 +82,7 @@ describe('Import Smart Sheet Events', () => {
         'Full Event Title': 'R01 Reaching More Children and Families',
         eventName: 'Reaching More Children and Families',
         eventOrganizer: 'Regional PD Event (with National Centers)',
-        audience: 'Recipients',
+        eventIntendedAudience: 'Recipients',
         trainingType: 'Series',
         reasons: ['Full Enrollment', 'Change in Scope'],
         targetPopulations: [
@@ -102,7 +102,7 @@ describe('Import Smart Sheet Events', () => {
         'Full Event Title': 'R03 Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective',
         eventName: 'Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective',
         eventOrganizer: 'Regional PD Event (with National Centers)',
-        audience: 'Recipients',
+        eventIntendedAudience: 'Recipients',
         trainingType: 'Series',
         reasons: ['Ongoing Quality Improvement'],
         targetPopulations: ['None'],

--- a/src/tools/importSmartSheetEvent.test.js
+++ b/src/tools/importSmartSheetEvent.test.js
@@ -82,7 +82,7 @@ describe('Import Smart Sheet Events', () => {
         'Full Event Title': 'R01 Reaching More Children and Families',
         eventName: 'Reaching More Children and Families',
         eventOrganizer: 'Regional PD Event (with National Centers)',
-        eventIntendedAudience: 'Recipients',
+        eventIntendedAudience: 'recipients',
         trainingType: 'Series',
         reasons: ['Full Enrollment', 'Change in Scope'],
         targetPopulations: [
@@ -102,7 +102,7 @@ describe('Import Smart Sheet Events', () => {
         'Full Event Title': 'R03 Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective',
         eventName: 'Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective',
         eventOrganizer: 'Regional PD Event (with National Centers)',
-        eventIntendedAudience: 'Recipients',
+        eventIntendedAudience: 'recipients',
         trainingType: 'Series',
         reasons: ['Ongoing Quality Improvement'],
         targetPopulations: ['None'],

--- a/src/tools/importSmartSheetEvent.test.js
+++ b/src/tools/importSmartSheetEvent.test.js
@@ -83,7 +83,7 @@ describe('Import Smart Sheet Events', () => {
         eventName: 'Reaching More Children and Families',
         eventOrganizer: 'Regional PD Event (with National Centers)',
         audience: 'Recipients',
-        'Event Duration/# NC Days of Support': 'Series',
+        trainingType: 'Series',
         reasons: ['Full Enrollment', 'Change in Scope'],
         targetPopulations: [
           'Children/Families affected by traumatic events (select the other reasons for child welfare, disaster, substance use or homelessness)',
@@ -103,7 +103,7 @@ describe('Import Smart Sheet Events', () => {
         eventName: 'Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective',
         eventOrganizer: 'Regional PD Event (with National Centers)',
         audience: 'Recipients',
-        'Event Duration/# NC Days of Support': 'Series',
+        trainingType: 'Series',
         reasons: ['Ongoing Quality Improvement'],
         targetPopulations: ['None'],
         vision: 'Oral Health',


### PR DESCRIPTION
## Description of change

Some small quality of life improvements for the TR to match the import script to the form.
- Import ```audience``` to match ```eventIntendedAudience```. Lowercase the value to match the form choices.
- Fix lookup key for "Event Duration/# NC Days of Support" and map it to ```trainingType``` instead of ```eventDuration```
- Remove a '}' character from the websocket URL (not hurting anything, but shouldn't be there)


## How to test


## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
