### PR TITLE
Fix session file upload permissions

### DIFF
--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -126,6 +126,10 @@ export default class EventReport {
     return this.isAdmin() || this.isAuthor() || this.isCollaborator() || this.isPoc();
   }
 
+  canUploadFile() {
+    return this.canEditSession();
+  }
+
   canDeleteSession() {
     return this.canEditSession();
   }

--- a/src/policies/event.test.js
+++ b/src/policies/event.test.js
@@ -166,6 +166,49 @@ describe('Event Report policies', () => {
     });
   });
 
+  describe('canUploadFile', () => {
+    it('is true if the user is an admin', () => {
+      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const policy = new EventReport(admin, eventRegion1);
+      expect(policy.canUploadFile()).toBe(true);
+    });
+
+    it('is true if the user is the author', () => {
+      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const policy = new EventReport(authorRegion1, eventRegion1);
+      expect(policy.canUploadFile()).toBe(true);
+    });
+
+    it('is true if the user is a collaborator', () => {
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1,
+        regionId: 1,
+        collaboratorIds: [authorRegion1Collaborator.id],
+      });
+      const policy = new EventReport(authorRegion1Collaborator, eventRegion1);
+      expect(policy.canUploadFile()).toBe(true);
+    });
+
+    it('is true if the user is a POC', () => {
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1,
+        regionId: 1,
+        pocIds: [authorRegion1Collaborator.id],
+      });
+      const policy = new EventReport(authorRegion1Collaborator, eventRegion1);
+      expect(policy.canUploadFile()).toBe(true);
+    });
+
+    it('is false otherwise', () => {
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1,
+        regionId: 1,
+      });
+      const policy = new EventReport(authorRegion2, eventRegion1);
+      expect(policy.canUploadFile()).toBe(false);
+    });
+  });
+
   describe('canEditSession', () => {
     it('is true if the user is an admin', () => {
       const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -143,7 +143,7 @@ const deleteHandler = async (req, res) => {
 
       const eventPolicy = new EventPolicy(user, event);
 
-      if (!eventPolicy.canUpdate()) {
+      if (!eventPolicy.canUploadFile()) {
         res.sendStatus(403);
         return;
       }
@@ -362,7 +362,7 @@ const uploadHandler = async (req, res) => {
 
       const eventPolicy = new EventPolicy(user, event);
 
-      if (!eventPolicy.canUpdate()) {
+      if (!eventPolicy.canUploadFile()) {
         return res.sendStatus(403);
       }
 

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -25,7 +25,6 @@ import * as s3Queue from '../../services/s3Queue';
 
 jest.mock('bull');
 jest.mock('../../policies/activityReport');
-jest.mock('../../policies/event');
 jest.mock('../../policies/user');
 jest.mock('../../policies/objective');
 jest.mock('../../services/accessValidation', () => ({

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -21,11 +21,12 @@ import ObjectivePolicy from '../../policies/objective';
 import * as Files from '../../services/files';
 import { validateUserAuthForAdmin } from '../../services/accessValidation';
 import { generateRedisConfig } from '../../lib/queue';
-// import { s3Queue } from '../../services/s3Queue';
 import * as s3Queue from '../../services/s3Queue';
+import EventReport from '../../policies/event';
 
 jest.mock('bull');
 jest.mock('../../policies/activityReport');
+jest.mock('../../policies/event');
 jest.mock('../../policies/user');
 jest.mock('../../policies/objective');
 jest.mock('../../services/accessValidation', () => ({
@@ -425,6 +426,36 @@ describe('File Upload', () => {
         .field('objectiveId', objective.dataValues.id)
         .attach('file', `${__dirname}/testfiles/testfile.pdf`)
         .expect(403)
+        .then(() => {
+          expect(uploadFile).not.toHaveBeenCalled();
+        });
+    });
+
+    it('tests an unauthorized event report file upload', async () => {
+      validateUserAuthForAdmin.mockResolvedValue(false);
+      EventReport.mockImplementation(() => ({
+        canUploadFile: () => false,
+      }));
+      await request(app)
+        .post('/api/files')
+        .field('eventSessionId', objective.dataValues.id)
+        .attach('file', `${__dirname}/testfiles/testfile.pdf`)
+        .expect(403)
+        .then(() => {
+          expect(uploadFile).not.toHaveBeenCalled();
+        });
+    });
+
+    it('allows an authorized event report file upload', async () => {
+      validateUserAuthForAdmin.mockResolvedValue(false);
+      EventReport.mockImplementation(() => ({
+        canUploadFile: () => true,
+      }));
+      await request(app)
+        .post('/api/files')
+        .field('eventSessionId', objective.dataValues.id)
+        .attach('file', `${__dirname}/testfiles/testfile.pdf`)
+        .expect(200)
         .then(() => {
           expect(uploadFile).not.toHaveBeenCalled();
         });

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -22,7 +22,6 @@ import * as Files from '../../services/files';
 import { validateUserAuthForAdmin } from '../../services/accessValidation';
 import { generateRedisConfig } from '../../lib/queue';
 import * as s3Queue from '../../services/s3Queue';
-import EventReport from '../../policies/event';
 
 jest.mock('bull');
 jest.mock('../../policies/activityReport');
@@ -426,36 +425,6 @@ describe('File Upload', () => {
         .field('objectiveId', objective.dataValues.id)
         .attach('file', `${__dirname}/testfiles/testfile.pdf`)
         .expect(403)
-        .then(() => {
-          expect(uploadFile).not.toHaveBeenCalled();
-        });
-    });
-
-    it('tests an unauthorized event report file upload', async () => {
-      validateUserAuthForAdmin.mockResolvedValue(false);
-      EventReport.mockImplementation(() => ({
-        canUploadFile: () => false,
-      }));
-      await request(app)
-        .post('/api/files')
-        .field('eventSessionId', objective.dataValues.id)
-        .attach('file', `${__dirname}/testfiles/testfile.pdf`)
-        .expect(403)
-        .then(() => {
-          expect(uploadFile).not.toHaveBeenCalled();
-        });
-    });
-
-    it('allows an authorized event report file upload', async () => {
-      validateUserAuthForAdmin.mockResolvedValue(false);
-      EventReport.mockImplementation(() => ({
-        canUploadFile: () => true,
-      }));
-      await request(app)
-        .post('/api/files')
-        .field('eventSessionId', objective.dataValues.id)
-        .attach('file', `${__dirname}/testfiles/testfile.pdf`)
-        .expect(200)
         .then(() => {
           expect(uploadFile).not.toHaveBeenCalled();
         });


### PR DESCRIPTION
## Description of change

It looks like I missed a permission rename when they were revamped a few weeks ago. Events now have an explicit "can upload files" permission used in the file uploader

## How to test

Confirm that you can upload a file to a session

## Issue(s)


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
