### PR TITLE
[TTAHUB-1910] Warn about losing objective

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/GoalPicker.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { uniqBy } from 'lodash';
 import PropTypes from 'prop-types';
-import { Label } from '@trussworks/react-uswds';
+import { Label, Button } from '@trussworks/react-uswds';
 import { useFormContext, useWatch, useController } from 'react-hook-form';
 import Select from 'react-select';
 import { getTopics } from '../../../../fetchers/topics';
@@ -14,6 +14,7 @@ import selectOptionsReset from '../../../../components/selectOptionsReset';
 import { validateGoals } from './goalValidator';
 import './GoalPicker.css';
 import GoalForm from './GoalForm';
+import Modal from '../../../../components/VanillaModal';
 
 export const newGoal = (grantIds) => ({
   value: uuidv4(),
@@ -55,6 +56,9 @@ const GoalPicker = ({
   const selectedGoals = useWatch({ name: 'goals' });
   const activityRecipients = watch('activityRecipients');
   const isMultiRecipientReport = activityRecipients && activityRecipients.length > 1;
+
+  const modalRef = useRef();
+  const [selectedGoal, setSelectedGoal] = useState(null);
 
   const { selectedIds, selectedNames } = (selectedGoals || []).reduce((acc, goal) => {
     const { id, name } = goal;
@@ -122,10 +126,8 @@ const GoalPicker = ({
     )),
   ];
 
-  const onSelectGoal = async (goal) => {
-    setValue('goalForEditing.objectives', []);
+  const onChangeGoal = async (goal) => {
     onChange(goal);
-
     if (goal.isCurated) {
       const prompts = await getGoalTemplatePrompts(goal.goalTemplateId, goal.goalIds);
       if (prompts) {
@@ -141,10 +143,58 @@ const GoalPicker = ({
     if (goal.goalIds) {
       setDatePickerKey(`DPKEY-${goal.goalIds.join('-')}`);
     }
+
+    setSelectedGoal(null);
+  };
+
+  const onKeep = async () => {
+    const savedObjectives = goalForEditing.objectives.map((o) => ({ ...o }));
+    onChangeGoal(selectedGoal);
+    setValue('goalForEditing.objectives', savedObjectives);
+    modalRef.current.toggleModal();
+  };
+
+  const onRemove = async () => {
+    setValue('goalForEditing.objectives', []);
+    onChangeGoal(selectedGoal);
+    modalRef.current.toggleModal();
+  };
+
+  const onSelectGoal = async (goal) => {
+    const objectivesLength = (() => {
+      if (goalForEditing) {
+        return goalForEditing.objectives.length;
+      }
+      return 0;
+    })();
+
+    if (objectivesLength && modalRef.current) {
+      setSelectedGoal(goal);
+      modalRef.current.toggleModal();
+      return;
+    }
+
+    setValue('goalForEditing.objectives', []);
+    onChangeGoal(goal);
   };
 
   return (
     <>
+      <Modal
+        modalRef={modalRef}
+        heading="You have selected a different goal."
+      >
+        <p>Do you want to keep the current objective summary information or remove it?</p>
+        <Button
+          type="button"
+          className="margin-right-1"
+          onClick={onKeep}
+          data-focus="true"
+        >
+          Keep objective
+        </Button>
+        <Button type="button" onClick={onRemove} unstyled>Remove objective</Button>
+      </Modal>
       <div className="margin-top-3 position-relative">
         <Label>
           Select recipient&apos;s goal

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -784,4 +784,51 @@ test.describe('Activity Report', () => {
     await expect(page.getByText('g1 o1 tta', { exact: true })).not.toBeVisible();
     await expect(page.getByText('g1 o1 tta', { exact: true })).not.toBeVisible();
   });
+
+  test('allows preservation of objectives', async ({ page }) => {
+    await page.goto('http://localhost:3000/');
+
+    await page.getByRole('link', { name: 'Activity Reports' }).click();
+    await page.getByRole('button', { name: '+ New Activity Report' }).click();
+
+    // add a recipient
+    await page.getByRole('group', { name: 'Was this activity for a recipient or other entity? *' }).locator('label').filter({ hasText: 'Recipient' }).click();
+
+    await page.locator('#activityRecipients div').filter({ hasText: '- Select -' }).nth(1).click();
+    await page.keyboard.press('Enter'); 
+ 
+    // visit the goals & objectives page
+    await page.getByRole('button', { name: 'Goals and objectives Not Started' }).click();
+
+    await page.waitForNavigation({ waitUntil: 'networkidle' })
+
+    // create the goal
+    await page.getByTestId('label').click();
+    await page.keyboard.press('Enter');
+    await page.getByTestId('textarea').fill('Test goal for preserving objectives');
+
+    // create the objective
+    await page.locator('.css-125guah-control > .css-g1d714-ValueContainer').click();
+    await page.keyboard.press('Enter');
+    await page.getByLabel('TTA objective *').click();
+    await page.getByLabel('TTA objective *').fill('Test objective for preserving objectives');
+    await page.locator('.css-125guah-control > .css-g1d714-ValueContainer').click();
+    await page.keyboard.press('Enter');
+    
+    await blur(page);
+    await page.getByRole('textbox', { name: 'TTA provided for objective' }).locator('div').nth(2).click();
+    await page.keyboard.type('An unlikely statement');
+    
+    // save draft
+    await blur(page)  
+    await page.getByRole('button', { name: 'Save draft' }).click();
+    await page.waitForNavigation({ waitUntil: 'networkidle' })
+
+    await page.getByTestId('form').locator('div').filter({ hasText: 'Create new goal' }).nth(3).click();
+    await page.locator('#react-select-13-option-1').getByText('(FEI) The recipient will eliminate and/or reduce underenrollment as part of the ').click();
+    await page.getByRole('button', { name: 'Keep objective' }).click();
+    await blur(page);
+  
+    expect(page.getByRole('textbox', { name: 'TTA provided for objective' }).getByText('An unlikely statement')).toBeVisible();
+  });
 });

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -796,11 +796,13 @@ test.describe('Activity Report', () => {
 
     await page.locator('#activityRecipients div').filter({ hasText: '- Select -' }).nth(1).click();
     await page.keyboard.press('Enter'); 
+
+    const p = page.waitForURL('**/goals-objectives');
  
     // visit the goals & objectives page
     await page.getByRole('button', { name: 'Goals and objectives Not Started' }).click();
 
-    await page.waitForNavigation({ waitUntil: 'networkidle' })
+    await p;    
 
     // create the goal
     await page.getByTestId('label').click();
@@ -820,9 +822,11 @@ test.describe('Activity Report', () => {
     await page.keyboard.type('An unlikely statement');
     
     // save draft
-    await blur(page)  
+    await blur(page);
+    const p2 = page.waitForResponse('/api/activity-reports/goals');
     await page.getByRole('button', { name: 'Save draft' }).click();
-    await page.waitForNavigation({ waitUntil: 'networkidle' })
+
+    await p2;
 
     await page.getByTestId('form').locator('div').filter({ hasText: 'Create new goal' }).nth(3).click();
     await page.locator('#react-select-13-option-1').getByText('(FEI) The recipient will eliminate and/or reduce underenrollment as part of the ').click();


### PR DESCRIPTION
## Description of change

If you've entered an objective under one goal on an AR and go to change the goal, you'd previously lose that objective automatically. This PR adds a modal that prompts "are you sure you'd like to Lose Everything?" You may then choose whether or not you'd like to lose everything.

## How to test

Consult Jira for details w/mockup. Confirm that you can change goals on an AR given three different cases.
1) You haven't entered any objectives. You change the goal without seeing the modal.
2) You've entered an objective. You want to keep it, so you change the goal and select "Keep objective." The objective should be kept.
3)  You've entered an objective. You want it out of here, so you change the goal and select "Remove objective." The objective should be gone.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1910


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
