### PR TITLE
[TTAHUB-1981] Admins should be able to see all training reports

### DIFF
--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -61,6 +61,8 @@ export default class EventReport {
     const viablePermissions = this.permissions.filter((p) => [
       SCOPES.READ_TRAINING_REPORTS,
       SCOPES.READ_WRITE_TRAINING_REPORTS,
+      SCOPES.READ_REPORTS,
+      SCOPES.READ_WRITE_REPORTS,
     ].includes(p.scopeId));
 
     return viablePermissions.map((p) => Number(p.regionId));

--- a/src/routes/events/handlers.js
+++ b/src/routes/events/handlers.js
@@ -45,6 +45,7 @@ export const getByStatus = async (req, res) => {
       null,
       false,
       scopes,
+      auth.isAdmin(),
     );
 
     return res.status(httpCodes.OK).send(events);

--- a/src/routes/events/handlers.test.js
+++ b/src/routes/events/handlers.test.js
@@ -333,6 +333,7 @@ describe('event handlers', () => {
         {
           session: { userId: 1 },
           params: { status: 'not-started' },
+          query: { regionId: 99_999 },
         },
         mockResponse,
       );

--- a/src/routes/events/handlers.test.js
+++ b/src/routes/events/handlers.test.js
@@ -302,12 +302,9 @@ describe('event handlers', () => {
     });
 
     it('handles errors', async () => {
-      EventReport.mockImplementationOnce(() => ({
-        canDelete: () => true,
-      }));
       findEventById.mockRejectedValueOnce(new Error('error'));
       await deleteHandler(
-        { session: { userId: 1 }, params: { eventId: mockEvent.id } },
+        { session: { userId: 1 }, params: { eventId: mockEvent.id }, query: {} },
         mockResponse,
       );
       expect(mockResponse.status).toHaveBeenCalledWith(500);
@@ -316,6 +313,9 @@ describe('event handlers', () => {
 
   describe('getByStatus', () => {
     it('works', async () => {
+      EventReport.mockImplementationOnce(() => ({
+        isAdmin: () => false,
+      }));
       findEventsByStatus.mockResolvedValueOnce([mockEvent]);
       await getByStatus(
         {
@@ -328,6 +328,9 @@ describe('event handlers', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(200);
     });
     it('handles errors', async () => {
+      EventReport.mockImplementationOnce(() => ({
+        isAdmin: () => false,
+      }));
       findEventsByStatus.mockRejectedValueOnce(new Error('error'));
       await getByStatus(
         {

--- a/src/services/event.test.js
+++ b/src/services/event.test.js
@@ -196,6 +196,23 @@ describe('event service', () => {
       await destroyEvent(created4.id);
     });
 
+    it('shows all if user is admin', async () => {
+      const created = await createAnEventWithStatus(98_900, TRS.NOT_STARTED);
+      const found = await findEventsByStatus(
+        TRS.NOT_STARTED,
+        [],
+        98_989,
+        null,
+        false,
+        { ownerId: 98_900 },
+        true, // isAdmin?
+      );
+
+      expect(found.length).toBe(1);
+      expect(found[0].data).toHaveProperty('status', TRS.NOT_STARTED);
+      await destroyEvent(created.id);
+    });
+
     it('findEventsByStatus sort order', async () => {
       // eventId is used for sorting, then startDate
       const e1 = await createAnEventWithData(11_111, { eventId: 'C', startDate: '2020-01-02', status: TRS.NOT_STARTED });

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -296,7 +296,10 @@ export async function findEventsByRegionId(id: number): Promise<EventShape[] | n
  * @param userId
  * @returns
  */
-export async function filterEventsByStatus(events: EventShape[], status: string, userId: number) : Promise<EventShape[]> {
+export async function filterEventsByStatus(events: EventShape[], status: string, userId: number, isAdmin = false) : Promise<EventShape[]> {
+  // do not filter if admin
+  if (isAdmin) return events;
+
   switch (status) {
     case TRS.NOT_STARTED:
     case null:
@@ -358,7 +361,15 @@ export async function filterEventsByStatus(events: EventShape[], status: string,
   }
 }
 
-export async function findEventsByStatus(status: string, readableRegions: number[], userId: number, fallbackValue = undefined, allowNull = false, scopes = undefined): Promise<EventShape[] | null> {
+export async function findEventsByStatus(
+  status: string,
+  readableRegions: number[],
+  userId: number,
+  fallbackValue = undefined,
+  allowNull = false,
+  scopes = undefined,
+  isAdmin = false,
+): Promise<EventShape[] | null> {
   const events = await findEventHelperBlob({
     key: 'status',
     value: status,
@@ -368,7 +379,7 @@ export async function findEventsByStatus(status: string, readableRegions: number
     scopes,
   }) as EventShape[];
 
-  const es = await filterEventsByStatus(events, status, userId);
+  const es = await filterEventsByStatus(events, status, userId, isAdmin);
   return es;
 }
 


### PR DESCRIPTION
## Description of change

With this change, admins will be able to **view** all training reports, regardless of status. 

Note that they will still need to a regional permission (READ_REPORTS, READ_WRITE_REPORTS, READ_TRAINING_REPORTS, or READ_WRITE_TRAINING_REPORTS) to see the reports. This differs from the acceptance criteria but I didn't want to worry about the interaction with the filters, etc

## How to test

Import fresh events, of which you are not the owner. Log in as an admin. You should see the not started events.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1981


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
