### PR TITLE
[TTAHUB-1887] Rename RTTAPA tab

### DIFF
--- a/frontend/src/pages/RecipientRecord/components/RecipientTabs.js
+++ b/frontend/src/pages/RecipientRecord/components/RecipientTabs.js
@@ -22,7 +22,7 @@ export default function RecipientTabs({ region, recipientId, backLink }) {
             <NavLink activeClassName={`${linkClass}--active`} className={`${linkClass}`} to={`/recipient-tta-records/${recipientId}/region/${region}/tta-history`}>TTA History</NavLink>
           </li>
           <li className={liClass}>
-            <NavLink activeClassName={`${linkClass}--active`} className={`${linkClass}`} to={`/recipient-tta-records/${recipientId}/region/${region}/goals-objectives`}>Goals & Objectives</NavLink>
+            <NavLink activeClassName={`${linkClass}--active`} className={`${linkClass}`} to={`/recipient-tta-records/${recipientId}/region/${region}/goals-objectives`}>RTTAPA</NavLink>
           </li>
           <FeatureFlag flag="rttapa_form">
             <li className={liClass}>

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -42,7 +42,7 @@ export default function GoalsObjectives({
     <>
       <Helmet>
         <title>
-          Goals and Objectives -
+          RTTAPA Goals and Objectives -
           {' '}
           {recipientName}
         </title>

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -353,7 +353,7 @@ test.describe('Activity Report', () => {
     // click on the previously extracted recipient
     await page.getByRole('link', { name: recipient }).click();
     // navigate to the 'Goals & Objectives page
-    await page.getByRole('link', { name: 'Goals & Objectives' }).click();
+    await page.getByRole('link', { name: 'RTTAPA' }).click();
     // check that previously created goals g1 and g2 are visible
     await expect(page.getByText('g1', { exact: true })).toBeVisible();
     await expect(page.getByText('g2', { exact: true })).toBeVisible();
@@ -588,7 +588,7 @@ test.describe('Activity Report', () => {
     // check first recipient
     await page.getByRole('link', { name: 'Recipient TTA Records' }).click();
     await page.getByRole('link', { name: 'Agency 1.a in region 1, Inc.' }).click();
-    await page.getByRole('link', { name: 'Goals & Objectives' }).click();
+    await page.getByRole('link', { name: 'RTTAPA' }).click();
 
     // confirm goal is in RTR
     await expect(page.getByText('This is a goal for multiple grants')).toBeVisible();

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -596,10 +596,10 @@ test.describe('Activity Report', () => {
     // check second recipient
     await page.getByRole('link', { name: 'Recipient TTA Records' }).click();
     await page.getByRole('link', { name: 'Agency 2 in region 1, Inc.' }).click();
-    await page.getByRole('link', { name: 'Goals & Objectives' }).click();
+    await page.getByRole('link', { name: 'RTTAPA' }).click();
 
     // check page title is updated (formerly TTAHUB-1322.spec.ts)
-    expect(await page.title()).toBe('Goals and Objectives - Agency 2 in region 1, Inc. - TTA Hub');
+    expect(await page.title()).toBe('RTTAPA Goals and Objectives - Agency 2 in region 1, Inc. - TTA Hub');
 
     await expect(page.getByText('This is a goal for multiple grants')).toBeVisible();
     await page.getByRole('button', { name: /View objectives for goal G-(\d)/i }).click();

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -482,7 +482,7 @@ test.describe('Activity Report', () => {
     // navigate to the RTR, select a recipient, and click add new goal
     await page.getByRole('link', { name: 'Recipient TTA Records' }).click();
     await page.getByRole('link', { name: 'Agency 1.a in region 1, Inc.' }).click();
-    await page.getByRole('link', { name: 'Goals & Objectives' }).click();
+    await page.getByRole('link', { name: 'RTTAPA' }).click();
     await page.getByRole('link', { name: 'Add new goals' }).click();
 
     // select recipients

--- a/tests/e2e/recipient-record.spec.ts
+++ b/tests/e2e/recipient-record.spec.ts
@@ -13,7 +13,7 @@ test.describe('Recipient record', () => {
     await page.getByRole('button', { name: /This button removes the filter: Date started is within/i }).click();
 
     // goals and objectives, add a new goal
-    await page.getByRole('link', { name: 'Goals & Objectives' }).click();
+    await page.getByRole('link', { name: 'RTTAPA' }).click();
     await page.getByRole('link', { name: 'Add new goals' }).click();
 
     // save first goal, without an objective


### PR DESCRIPTION
## Description of change

Rename the "Goals & Objectives" tab on the Recipient Record to "RTTAPA"

## How to test

Confirm that the change has been made

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1887


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
