### PR TITLE
[TTAHUB-1918] Fix for last tta date

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -43,7 +43,7 @@ function GoalCard({
     previousStatus,
   } = goal;
 
-  const lastTTA = useMemo(() => objectives.reduce((prev, curr) => (prev > curr.endDate ? prev : curr.endDate), ''), [objectives]);
+  const lastTTA = useMemo(() => objectives.reduce((prev, curr) => (new Date(prev) > new Date(curr.endDate) ? prev : curr.endDate), ''), [objectives]);
   const history = useHistory();
 
   const goalNumbers = goal.goalNumbers.join(', ');

--- a/frontend/src/components/GoalCards/__tests__/GoalCard.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCard.js
@@ -50,11 +50,11 @@ describe('GoalCard', () => {
     hideGoalOptions: false,
   };
 
-  const renderGoalCard = (props = DEFAULT_PROPS) => {
+  const renderGoalCard = (props = DEFAULT_PROPS, defaultGoal = goal) => {
     render((
       <UserContext.Provider value={{ user: DEFAULT_USER }}>
         <GoalCard
-          goal={goal}
+          goal={defaultGoal}
           recipientId="1"
           regionId="1"
           showCloseSuspendGoalModal={() => {}}
@@ -106,5 +106,41 @@ describe('GoalCard', () => {
   it('can hide the goal options', () => {
     renderGoalCard({ ...DEFAULT_PROPS, hideGoalOptions: true });
     expect(screen.queryByTestId('ellipsis-button')).not.toBeInTheDocument();
+  });
+
+  it('display correct last tta date', () => {
+    const goalsWithMultipleObjectives = {
+      ...goal,
+      objectives: [
+        {
+          id: 1,
+          title: 'Objective 1',
+          arNumber: 'AR-1',
+          ttaProvided: 'TTA 1',
+          endDate: '2023-01-01',
+          reasons: ['Reason 1', 'Reason 2'],
+          status: 'Closed',
+          activityReports: [],
+          grantNumbers: ['G-1'],
+          topics: [],
+        },
+        {
+          id: 2,
+          title: 'Objective 2',
+          arNumber: 'AR-2',
+          ttaProvided: 'TTA 2',
+          endDate: '2022-09-13',
+          reasons: ['Reason 3'],
+          status: 'Closed',
+          activityReports: [],
+          grantNumbers: ['G-2'],
+          topics: [],
+        },
+      ],
+    };
+
+    renderGoalCard({ ...DEFAULT_PROPS }, goalsWithMultipleObjectives);
+    expect(screen.getByText(/last tta/i)).toBeInTheDocument();
+    expect(screen.queryAllByText(/2023-01-01/i).length).toBe(2);
   });
 });


### PR DESCRIPTION
## Description of change

We expect to see the latest objective's end date displayed under the 'Last TTA' column.

## How to test

View one of the goals from the JIRA or any goal with multiple objectives and make sure we correctly display the date.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1918


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [x] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
