### PR TITLE
Fix bug with removing recipients

### DIFF
--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -255,6 +255,12 @@ describe('ActivityReport', () => {
         activityRecipients: [{
           activityRecipientId: 1,
         }],
+        goalForEditing: {
+          name: 'goal 3',
+          activityReportGoals: [{ isActivelyEdited: true }],
+          prompts: [],
+          source: '',
+        },
         goals: [
           {
             name: 'goal 1', activityReportGoals: [{ isActivelyEdited: true }], source: '', prompts: [],
@@ -271,60 +277,61 @@ describe('ActivityReport', () => {
         }, {
           activityRecipientId: 1,
         }],
-        goals: [
-          {
-            name: 'goal 1', activityReportGoals: [{ isActivelyEdited: true }], source: '', prompts: [],
-          },
-          {
-            name: 'goal 2', activityReportGoals: [{ isActivelyEdited: false }], prompts: [], source: '',
-          },
-        ],
       };
 
       const changed = findWhatsChanged(young, old);
-      expect(changed).toEqual({
-        activityRecipients: [
-          {
-            activityRecipientId: 2,
-          },
-          {
-            activityRecipientId: 1,
-          },
-        ],
-        goals: [
-          {
-            activityReportGoals: [
-              {
-                isActivelyEdited: true,
-              },
-            ],
-            grantIds: [
-              2,
-              1,
-            ],
-            isActivelyEdited: true,
-            name: 'goal 1',
-            prompts: [],
-            source: '',
-          },
-          {
-            activityReportGoals: [
-              {
-                isActivelyEdited: false,
-              },
-            ],
-            grantIds: [
-              2,
-              1,
-            ],
-            isActivelyEdited: false,
-            name: 'goal 2',
-            prompts: [],
-            source: '',
-          },
-        ],
-        recipientsWhoHaveGoalsThatShouldBeRemoved: [],
-      });
+
+      expect(Object.keys(changed).sort()).toEqual(['activityRecipients', 'goals', 'recipientsWhoHaveGoalsThatShouldBeRemoved']);
+
+      expect(changed.recipientsWhoHaveGoalsThatShouldBeRemoved).toEqual([]);
+      expect(changed.activityRecipients.map((ar) => ar.activityRecipientId)).toEqual([2, 1]);
+      expect(changed.goals).toEqual([
+        {
+          activityReportGoals: [
+            {
+              isActivelyEdited: true,
+            },
+          ],
+          grantIds: [
+            2,
+            1,
+          ],
+          isActivelyEdited: true,
+          name: 'goal 3',
+          prompts: [],
+          source: '',
+        },
+        {
+          activityReportGoals: [
+            {
+              isActivelyEdited: true,
+            },
+          ],
+          grantIds: [
+            2,
+            1,
+          ],
+          isActivelyEdited: false,
+          name: 'goal 1',
+          prompts: [],
+          source: '',
+        },
+        {
+          activityReportGoals: [
+            {
+              isActivelyEdited: false,
+            },
+          ],
+          grantIds: [
+            2,
+            1,
+          ],
+          isActivelyEdited: false,
+          name: 'goal 2',
+          prompts: [],
+          source: '',
+        },
+      ]);
     });
 
     it('displays the creator name', async () => {

--- a/frontend/src/pages/ActivityReport/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/formDataHelpers.js
@@ -50,8 +50,9 @@ export const findWhatsChanged = (object, base) => {
       let currentlyEditing = false;
 
       accumulator.goals = [
+        (base.goalForEditing || null),
         ...(base.goals || []),
-      ].map((goal) => ({
+      ].filter((g) => g).map((goal) => ({
         ...goal,
         grantIds,
         isActivelyEdited: (() => {
@@ -118,10 +119,9 @@ export const convertGoalsToFormData = (
   if (
     // if any of the goals ids are included in the activelyEditedGoals id array
     goal.activityReportGoals
-    && goal.activityReportGoals.some((arGoal) => arGoal.isActivelyEdited
+    && goal.activityReportGoals.some((arGoal) => arGoal.isActivelyEdited)
     && ALLOWED_STATUSES_FOR_GOAL_EDITING.includes(calculatedStatus)
-    && !accumulatedData.goalForEditing)
-  ) {
+    && !accumulatedData.goalForEditing) {
     // we set it as the goal for editing
     // eslint-disable-next-line no-param-reassign
     accumulatedData.goalForEditing = {

--- a/src/models/hooks/activityReportGoalFieldResponse.js
+++ b/src/models/hooks/activityReportGoalFieldResponse.js
@@ -32,7 +32,7 @@ const recalculateOnAR = async (
   instance,
 ) => sequelize.models.GoalFieldResponse.update(
   {
-    onAR: Sequelize.literal(`(
+    onAR: Sequelize.literal(`COALESCE ((
       SELECT
         COUNT(arg.id) > 0 "onAR"
       FROM "Goals" g
@@ -44,7 +44,7 @@ const recalculateOnAR = async (
       AND arg."id" != ${instance.activityReportGoalId}
       AND argfr."goalTemplateFieldPromptId" = ${instance.goalTemplateFieldPromptId}
       GROUP BY TRUE
-    )`),
+    ), FALSE)`),
   },
   {
     where: { goalTemplateFieldPromptId: instance.goalTemplateFieldPromptId },


### PR DESCRIPTION
## Description of change

We saw this bug in standup yesterday. To duplicate in main: 1)On a new AR, add a recipient 2) pick the FEI goal, no need to fill out any fields 3) click activity summary in the left nav to go back and add a second recipient 4) save and continue, you'll get a 500 error.

This PR fixes it. **I understand that the goal does not stay open**. I'd like to fix this bug and log a ticket to fix that one, as it seems to be something in the backend goal service that I don't want to untangle and write a test for before having this fix out there. 

## How to test

See description

## Issue(s)

No ticket for this


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
