### PR TITLE
[TTAHUB-2053] Add ability to edit root cause on RTR for goals on draft reports

### DIFF
--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -44,6 +44,7 @@ export default function Form({
   topicOptions,
   isOnApprovedReport,
   isOnReport,
+  isCurated,
   status,
   datePickerKey,
   fetchError,
@@ -96,6 +97,16 @@ export default function Form({
   const formTitle = goalNumbers && goalNumbers.length ? `Goal ${goalNumbers.join(', ')}` : 'Recipient TTA goal';
 
   const showAlert = isOnReport && status !== 'Closed';
+
+  const isCuratedOnDraftReport = (isCurated && isOnReport && !isOnApprovedReport);
+
+  const showNewObjectiveButton = (() => {
+    if (isCuratedOnDraftReport) {
+      return false;
+    }
+
+    return (status !== 'Closed' && userCanEdit);
+  })();
 
   return (
     <div className="ttahub-create-goals-form">
@@ -162,7 +173,7 @@ export default function Form({
           error={errors[FORM_FIELD_INDEXES.GOAL_SOURCES]}
           isOnReport={isOnApprovedReport}
           goalStatus={status}
-          userCanEdit={userCanEdit}
+          userCanEdit={userCanEdit && !isCuratedOnDraftReport}
           validateGoalSource={validateGoalSource}
         />
       </FeatureFlag>
@@ -176,7 +187,7 @@ export default function Form({
         key={datePickerKey}
         isLoading={isAppLoading}
         goalStatus={status}
-        userCanEdit={userCanEdit}
+        userCanEdit={userCanEdit && !isCuratedOnDraftReport}
       />
 
       { objectives.map((objective, i) => (
@@ -198,7 +209,7 @@ export default function Form({
         />
       ))}
 
-      { (status !== 'Closed' && userCanEdit) && (
+      { (showNewObjectiveButton) && (
         <div className="margin-top-4">
           {errors[FORM_FIELD_INDEXES.OBJECTIVES_EMPTY]}
           <PlusButton onClick={onAddNewObjectiveClick} text="Add new objective" />
@@ -209,6 +220,7 @@ export default function Form({
 }
 
 Form.propTypes = {
+  isCurated: PropTypes.bool.isRequired,
   isOnReport: PropTypes.bool.isRequired,
   isOnApprovedReport: PropTypes.bool.isRequired,
   errors: PropTypes.arrayOf(

--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -44,7 +44,6 @@ export default function Form({
   topicOptions,
   isOnApprovedReport,
   isOnReport,
-  isCurated,
   status,
   datePickerKey,
   fetchError,
@@ -98,15 +97,7 @@ export default function Form({
 
   const showAlert = isOnReport && status !== 'Closed';
 
-  const isCuratedOnDraftReport = (isCurated && isOnReport && !isOnApprovedReport);
-
-  const showNewObjectiveButton = (() => {
-    if (isCuratedOnDraftReport) {
-      return false;
-    }
-
-    return (status !== 'Closed' && userCanEdit);
-  })();
+  const showNewObjectiveButton = (() => (status !== 'Closed' && userCanEdit))();
 
   return (
     <div className="ttahub-create-goals-form">
@@ -173,7 +164,7 @@ export default function Form({
           error={errors[FORM_FIELD_INDEXES.GOAL_SOURCES]}
           isOnReport={isOnApprovedReport}
           goalStatus={status}
-          userCanEdit={userCanEdit && !isCuratedOnDraftReport}
+          userCanEdit={userCanEdit}
           validateGoalSource={validateGoalSource}
         />
       </FeatureFlag>
@@ -187,7 +178,7 @@ export default function Form({
         key={datePickerKey}
         isLoading={isAppLoading}
         goalStatus={status}
-        userCanEdit={userCanEdit && !isCuratedOnDraftReport}
+        userCanEdit={userCanEdit}
       />
 
       { objectives.map((objective, i) => (
@@ -220,7 +211,6 @@ export default function Form({
 }
 
 Form.propTypes = {
-  isCurated: PropTypes.bool.isRequired,
   isOnReport: PropTypes.bool.isRequired,
   isOnApprovedReport: PropTypes.bool.isRequired,
   errors: PropTypes.arrayOf(

--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -901,6 +901,8 @@ describe('create goal', () => {
       isRttapa: 'No',
       prompts: [],
       sources: [],
+      onAnyReport: true,
+      onApprovedAR: false,
       grants: [{
         id: 1,
         number: '1',

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -72,6 +72,7 @@ export default function GoalForm({
     objectives: [],
     id: 'new',
     onApprovedAR: false,
+    onAnyReport: false,
     prompts: [],
     isCurated: false,
     source: '',
@@ -96,6 +97,7 @@ export default function GoalForm({
   const [goalTemplateId, setGoalTemplateId] = useState(goalDefaults.goalTemplateId);
   const [selectedGrants, setSelectedGrants] = useState(goalDefaults.grants);
   const [goalOnApprovedAR, setGoalOnApprovedReport] = useState(goalDefaults.onApprovedAR);
+  const [goalOnAnyReport, setGoalOnAnyReport] = useState(goalDefaults.onAnyReport);
 
   // we need to set this key to get the component to re-render (uncontrolled input)
   const [datePickerKey, setDatePickerKey] = useState('DPK-00');
@@ -124,10 +126,6 @@ export default function GoalForm({
       ),
   ).length > 0, [regionId, user.permissions]);
 
-  const isOnReport = useMemo(() => objectives.some(
-    (objective) => objective.activityReports && objective.activityReports.length > 0,
-  ), [objectives]);
-
   // we can access the params as the third arg returned by useUrlParamState
   // (if we need it)
   const [ids, setIds] = useUrlParamState('id[]');
@@ -149,6 +147,7 @@ export default function GoalForm({
         setSelectedGrants(formatGrantsFromApi(goal.grants ? goal.grants : [goal.grant]));
         setGoalNumbers(goal.goalNumbers);
         setGoalOnApprovedReport(goal.onApprovedAR);
+        setGoalOnAnyReport(goal.onAnyReport);
         setIsCurated(goal.isCurated);
         setGoalTemplateId(goal.goalTemplateId);
         setSource(goal.source || '');
@@ -949,8 +948,9 @@ export default function GoalForm({
               setObjectiveError={setObjectiveError}
               clearEmptyObjectiveError={clearEmptyObjectiveError}
               topicOptions={topicOptions}
-              isOnReport={isOnReport}
+              isOnReport={goalOnAnyReport}
               isOnApprovedReport={goalOnApprovedAR}
+              isCurated={isCurated}
               status={status || 'Needs status'}
               goalNumbers={goalNumbers}
               onUploadFiles={onUploadFiles}

--- a/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert } from '@trussworks/react-uswds';
+
+const SomeGoalsHaveNoPromptResponse = ({ promptsMissingResponses }) => (
+  <Alert validation noIcon slim type="error">
+    <strong>Some goals are incomplete</strong>
+    <br />
+    Please check the Recipient TTA Record and complete the missing fields.
+    <ul>
+      {promptsMissingResponses.map((prompt) => (
+        <li key={prompt}>
+          {prompt}
+        </li>
+      ))}
+    </ul>
+  </Alert>
+);
+
+SomeGoalsHaveNoPromptResponse.propTypes = {
+  promptsMissingResponses: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default SomeGoalsHaveNoPromptResponse;

--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
@@ -44,7 +44,10 @@ const RenderReview = ({
 }) => {
   const hookForm = useForm({
     mode: 'onChange',
-    defaultValues: { ...formData },
+    defaultValues: {
+      goalsAndObjectives: [],
+      ...formData,
+    },
   });
 
   return (
@@ -87,6 +90,7 @@ const renderReview = (
   calculatedStatus = REPORT_STATUSES.DRAFT,
   formData = {
     additionalNotes: '',
+    goalsAndObjectives: [],
   },
   onSubmit = jest.fn(),
   onReview = jest.fn(),
@@ -210,7 +214,7 @@ describe('ReviewSubmit', () => {
       const isApprover = false;
       const isPendingApprover = false;
       const calculatedStatus = REPORT_STATUSES.DRAFT;
-      const formData = { additionalNotes: '' };
+      const formData = { additionalNotes: '', goalsAndObjectives: [] };
       const onSubmit = jest.fn();
       const onReview = jest.fn();
       const onResetToDraft = jest.fn();

--- a/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
@@ -37,6 +37,7 @@ describe('convertGoalsToFormData', () => {
         id: 2,
         grantIds: [1, 2, 3],
         source: '',
+        prompts: [],
         objectives: [],
         activityReportGoals: [
           { id: 2, isActivelyEdited: false },
@@ -47,6 +48,7 @@ describe('convertGoalsToFormData', () => {
     expect(goalForEditing).toEqual({
       id: 1,
       source: '',
+      prompts: [],
       grantIds: [1, 2, 3],
       objectives: [],
       activityReportGoals: [
@@ -65,6 +67,7 @@ describe('convertGoalsToFormData', () => {
               isActivelyEdited: true,
             },
           ],
+          prompts: [],
         },
         {
           id: 2,
@@ -74,6 +77,7 @@ describe('convertGoalsToFormData', () => {
               isActivelyEdited: true,
             },
           ],
+          prompts: [],
         },
       ],
       [1, 2, 3],
@@ -91,6 +95,7 @@ describe('convertGoalsToFormData', () => {
           },
         ],
         source: '',
+        prompts: [],
       },
     ]);
 
@@ -104,6 +109,7 @@ describe('convertGoalsToFormData', () => {
           isActivelyEdited: true,
         },
       ],
+      prompts: [],
     });
   });
   it('returns an empty goalForEditing if no activityreportgoal has isActivelyEditing: true', () => {
@@ -117,6 +123,7 @@ describe('convertGoalsToFormData', () => {
               isActivelyEdited: false,
             },
           ],
+          prompts: [],
         },
         {
           id: 2,
@@ -126,6 +133,7 @@ describe('convertGoalsToFormData', () => {
               isActivelyEdited: false,
             },
           ],
+          prompts: [],
         },
       ],
       [1, 2, 3],
@@ -137,6 +145,7 @@ describe('convertGoalsToFormData', () => {
         id: 1,
         grantIds: [1, 2, 3],
         source: '',
+        prompts: [],
         activityReportGoals: [
           {
             id: 1,
@@ -147,6 +156,7 @@ describe('convertGoalsToFormData', () => {
       {
         id: 2,
         source: '',
+        prompts: [],
         grantIds: [1, 2, 3],
         activityReportGoals: [
           {
@@ -178,11 +188,13 @@ describe('convertGoalsToFormData', () => {
         id: 1,
         grantIds: [1, 2, 3],
         source: '',
+        prompts: [],
       },
       {
         id: 2,
         grantIds: [1, 2, 3],
         source: '',
+        prompts: [],
       },
     ]);
 
@@ -225,6 +237,7 @@ describe('convertGoalsToFormData', () => {
           },
         ],
         source: '',
+        prompts: [],
       },
       {
         id: 2,
@@ -236,6 +249,7 @@ describe('convertGoalsToFormData', () => {
           },
         ],
         source: '',
+        prompts: [],
       },
     ]);
 

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -217,11 +217,17 @@ describe('ActivityReport', () => {
     });
 
     it('displays review submit save alert', async () => {
-      renderActivityReport('new', 'review');
-      fetchMock.post('/api/activity-reports', formData);
+      const data = formData();
+      fetchMock.get('/api/activity-reports/1', {
+        ...data,
+        approvers: [],
+      });
+
+      renderActivityReport('1', 'review');
+      fetchMock.put('/api/activity-reports/1', formData());
       const button = await screen.findByRole('button', { name: 'Save Draft' });
       userEvent.click(button);
-      await waitFor(() => expect(fetchMock.called('/api/activity-reports')).toBeTruthy());
+      await waitFor(() => expect(fetchMock.called('/api/activity-reports/1', { method: 'put' })).toBeTruthy());
       expect(await screen.findByText(/draft saved on/i)).toBeVisible();
     });
 

--- a/frontend/src/pages/ActivityReport/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/formDataHelpers.js
@@ -71,7 +71,7 @@ export const findWhatsChanged = (object, base) => {
 
           return true;
         })(),
-        // no multigrant/multirecipient reports should have prompts
+        // no multigrant/multirecipient reports should have prompts or source
         prompts: grantIds.length < 2 ? goal.prompts : [],
         source: grantIds.length < 2 ? goal.source : '',
       }));
@@ -129,6 +129,7 @@ export const convertGoalsToFormData = (
       grantIds,
       objectives: goal.objectives,
       source: grantIds.length < 2 ? goal.source : '',
+      prompts: grantIds.length < 2 ? goal.prompts : [],
     };
   } else {
     // otherwise we add it to the list of goals, formatting it with the correct
@@ -137,6 +138,7 @@ export const convertGoalsToFormData = (
       ...goal,
       grantIds,
       source: grantIds.length < 2 ? goal.source : '',
+      prompts: grantIds.length < 2 ? goal.prompts : [],
     });
   }
 

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -545,7 +545,19 @@ function reducePrompts(forReport, newPrompts = [], promptsToReduce = []) {
               ...(currentPrompt.reportResponse || []),
             ],
           );
+
+          if (
+            existingPrompt.allGoalsHavePromptResponse
+            && (
+              (currentPrompt.response || []).length || (currentPrompt.reportResponse || []).length
+            )
+          ) {
+            existingPrompt.allGoalsHavePromptResponse = true;
+          } else {
+            existingPrompt.allGoalsHavePromptResponse = false;
+          }
         }
+
         return previousPrompts;
       }
 
@@ -558,6 +570,7 @@ function reducePrompts(forReport, newPrompts = [], promptsToReduce = []) {
         fieldType: currentPrompt.fieldType,
         options: currentPrompt.options,
         validations: currentPrompt.validations,
+        allGoalsHavePromptResponse: false,
       };
 
       if (forReport) {
@@ -568,6 +581,10 @@ function reducePrompts(forReport, newPrompts = [], promptsToReduce = []) {
           ],
         );
         newPrompt.reportResponse = (currentPrompt.reportResponse || []);
+
+        if (newPrompt.response.length || newPrompt.reportResponse.length) {
+          newPrompt.allGoalsHavePromptResponse = true;
+        }
       }
 
       if (!forReport) {

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -7,6 +7,7 @@ import {
   Program,
   sequelize,
   Goal,
+  GoalTemplate,
   ActivityReport,
   Objective,
   ActivityRecipient,
@@ -19,6 +20,7 @@ import {
   RECIPIENTS_PER_PAGE,
   GOALS_PER_PAGE,
   GOAL_STATUS,
+  CREATION_METHOD,
 } from '../constants';
 import filtersToScopes from '../scopes';
 import orderGoalsBy from '../lib/orderGoalsBy';
@@ -428,6 +430,7 @@ export async function getGoalsByActivityRecipient(
       { onApprovedAR: true },
       { isFromSmartsheetTtaPlan: true },
       { createdVia: 'rtr' },
+      { '$"goalTemplate"."creationMethod"$': CREATION_METHOD.CURATED },
     ],
     [Op.and]: scopes,
   };
@@ -452,10 +455,17 @@ export async function getGoalsByActivityRecipient(
       'onApprovedAR',
       'isRttapa',
       'source',
+      'goalTemplateId',
       [sequelize.literal('CASE WHEN COALESCE("Goal"."status",\'\')  = \'\' OR "Goal"."status" = \'Needs Status\' THEN 1 WHEN "Goal"."status" = \'Draft\' THEN 2 WHEN "Goal"."status" = \'Not Started\' THEN 3 WHEN "Goal"."status" = \'In Progress\' THEN 4 WHEN "Goal"."status" = \'Closed\' THEN 5 WHEN "Goal"."status" = \'Suspended\' THEN 6 ELSE 7 END'), 'status_sort'],
     ],
     where: goalWhere,
     include: [
+      {
+        model: GoalTemplate,
+        as: 'goalTemplate',
+        attributes: ['creationMethod', 'id'],
+        required: false,
+      },
       {
         model: Grant,
         as: 'grant',

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -26,7 +26,7 @@ import {
 } from './recipient';
 import filtersToScopes from '../scopes';
 import SCOPES from '../middleware/scopeConstants';
-import { GOAL_STATUS, OBJECTIVE_STATUS } from '../constants';
+import { OBJECTIVE_STATUS } from '../constants';
 import { createReport, destroyReport } from '../testUtils';
 
 describe('Recipient DB service', () => {


### PR DESCRIPTION
## Description of change
- For a single recipient report, adding a root cause to the FEI goal can be done as before, uninterrupted on an AR.
- Multiple recipient reports now allow the editing of the FEI goal from the RTR as soon as it is added to a report and that report is saved. If you've added an FEI goal to an multi-recipient AR, and you attempt to submit that report before you've added root causes to all the goals, you'll see a message alongside the "incomplete pages" alert telling you to go to the RTR for these recipients

## How to test
- Create a single recipient report for a user without the FEI goal.  You should be able to set a root cause without issue.
- For a multi-grant report: Attempt to do the same. Confirm that you can't set a root cause on a multi-grant report, that you can't submit until you've set those root causes, and that you can find and set them on the RTR. 

I would also appreciate a moment's consideration - is there some weird consequence of the changes I've made that I am not thinking of?

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2053


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
