### PR TITLE
[TTAHUB-2064] Show not started and suspended as options for TR when TR is not started

### DIFF
--- a/frontend/src/pages/TrainingReportForm/pages/__tests__/completeEvent.js
+++ b/frontend/src/pages/TrainingReportForm/pages/__tests__/completeEvent.js
@@ -91,7 +91,7 @@ describe('completeEvent', () => {
       expect(statusSelect).toHaveValue('Complete');
     });
 
-    it('not started is an option when there are no sessions', async () => {
+    it('not started and suspended are options when there are no sessions', async () => {
       fetchMock.getOnce(sessionsUrl, []);
 
       act(() => {
@@ -105,7 +105,10 @@ describe('completeEvent', () => {
 
       // but there should be no select
       const statusSelect = screen.queryByRole('combobox', { name: /status/i });
-      expect(statusSelect).toBeNull();
+      expect(statusSelect).not.toBeNull();
+      const options = screen.queryAllByRole('option');
+      const optionTexts = options.map((option) => option.textContent);
+      expect(optionTexts).toEqual(['Not started', 'Suspended']);
     });
 
     it('handles an error fetching sessions', async () => {
@@ -122,9 +125,11 @@ describe('completeEvent', () => {
       const status = await screen.findByText('Not started');
       expect(status).toBeInTheDocument();
 
-      // but there should be no select
       const statusSelect = screen.queryByRole('combobox', { name: /status/i });
-      expect(statusSelect).toBeNull();
+      expect(statusSelect).not.toBeNull();
+      const options = screen.queryAllByRole('option');
+      const optionTexts = options.map((option) => option.textContent);
+      expect(optionTexts).toEqual(['Not started', 'Suspended']);
     });
 
     it('calls onUpdatePage when the back button is clicked', async () => {
@@ -170,9 +175,11 @@ describe('completeEvent', () => {
       const status = await screen.findByText('Not started');
       expect(status).toBeInTheDocument();
 
-      // there should be no select
       const statusSelect = screen.queryByRole('combobox', { name: /status/i });
-      expect(statusSelect).toBeNull();
+      expect(statusSelect).not.toBeNull();
+      const options = screen.queryAllByRole('option');
+      const optionTexts = options.map((option) => option.textContent);
+      expect(optionTexts).toEqual(['Not started', 'Suspended']);
 
       const submitButton = await screen.findByRole('button', { name: /submit/i });
       act(() => {

--- a/frontend/src/pages/TrainingReportForm/pages/completeEvent.js
+++ b/frontend/src/pages/TrainingReportForm/pages/completeEvent.js
@@ -4,6 +4,7 @@ import { useFormContext } from 'react-hook-form';
 import { ErrorMessage as ReactHookFormError } from '@hookform/error-message';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
+import { useHistory } from 'react-router-dom';
 import {
   Alert, Button, Table, Dropdown, ErrorMessage,
 } from '@trussworks/react-uswds';
@@ -41,8 +42,9 @@ const CompleteEvent = ({
   const [error, updateError] = useState();
   const [sessions, setSessions] = useState();
   const [showSubmissionError, setShowSubmissionError] = useState(false);
-
   const [showError, setShowError] = useState(false);
+
+  const history = useHistory();
 
   // we store this in state and not the form data because we don't want to
   // automatically update the form object when the user changes the status dropdown
@@ -138,6 +140,24 @@ const CompleteEvent = ({
       <option key="event-status-dropdown-option-suspended">Suspended</option>,
     ];
   }
+
+  const SubmitButton = () => {
+    const onSuspend = async () => {
+      await onSaveForm(updatedStatus);
+      const newPath = '/training-reports/suspended';
+      history.push(newPath);
+    };
+
+    if (isOwner && updatedStatus === 'Suspended') {
+      return (<Button id="submit-event" className="margin-right-1" type="button" disabled={isAppLoading} onClick={onSuspend}>Suspend event</Button>);
+    }
+
+    if (isOwner) {
+      return (<Button id="submit-event" className="margin-right-1" type="button" disabled={isAppLoading} onClick={onFormSubmit}>Submit event</Button>);
+    }
+
+    return null;
+  };
 
   return (
     <div className="padding-x-1">
@@ -256,7 +276,7 @@ const CompleteEvent = ({
 
       <DraftAlert />
       <div className="display-flex">
-        { isOwner && (<Button id="submit-event" className="margin-right-1" type="button" disabled={isAppLoading} onClick={onFormSubmit}>Submit event</Button>)}
+        <SubmitButton />
         <Button id="save-draft" className="usa-button--outline" type="button" disabled={isAppLoading} onClick={() => onSaveForm(updatedStatus)}>Save draft</Button>
         <Button id="back-button" outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(position - 1); }}>Back</Button>
       </div>

--- a/frontend/src/pages/TrainingReportForm/pages/completeEvent.js
+++ b/frontend/src/pages/TrainingReportForm/pages/completeEvent.js
@@ -126,11 +126,18 @@ const CompleteEvent = ({
     return null;
   }
 
-  const options = [
+  let options = [
     <option key="event-status-dropdown-option-in-progress">In progress</option>,
     <option key="event-status-dropdown-option-suspended">Suspended</option>,
     <option key="event-status-dropdown-option-complete">Complete</option>,
   ];
+
+  if (!sessions.length) {
+    options = [
+      <option key="event-status-dropdown-option-not-started">Not started</option>,
+      <option key="event-status-dropdown-option-suspended">Suspended</option>,
+    ];
+  }
 
   return (
     <div className="padding-x-1">
@@ -152,7 +159,7 @@ const CompleteEvent = ({
         {sessions.length}
       </ReadOnlyField>
 
-      { (sessions.length === 0 || !isOwner) && (
+      { (!isOwner) && (
         <>
           <ReadOnlyField label="Event status" name="status">
             {updatedStatus}
@@ -189,26 +196,26 @@ const CompleteEvent = ({
               ))}
             </tbody>
           </Table>
-          { isOwner && (
-          <div className="margin-top-4">
-            <FormItem
-              label="Event status"
-              name="status"
-              required
-            >
-              <Dropdown
-                label="Event status"
-                name="status"
-                id="status"
-                value={updatedStatus}
-                onChange={(e) => setUpdatedStatus(e.target.value)}
-              >
-                {options}
-              </Dropdown>
-            </FormItem>
-          </div>
-          )}
         </>
+      )}
+      { isOwner && (
+      <div className="margin-top-4">
+        <FormItem
+          label="Event status"
+          name="status"
+          required
+        >
+          <Dropdown
+            label="Event status"
+            name="status"
+            id="status"
+            value={updatedStatus}
+            onChange={(e) => setUpdatedStatus(e.target.value)}
+          >
+            {options}
+          </Dropdown>
+        </FormItem>
+      </div>
       )}
 
       {showSubmissionError && (

--- a/frontend/src/pages/TrainingReports/components/EventCard.js
+++ b/frontend/src/pages/TrainingReports/components/EventCard.js
@@ -31,12 +31,14 @@ function EventCard({
   const isOwnerOrPoc = isOwner || isPoc;
   const isOwnerOrCollaborator = isOwner || isCollaborator;
 
+  const isNotComplete = data.status !== TRAINING_REPORT_STATUSES.COMPLETE;
+
   const isNotCompleteOrSuspended = ![
     TRAINING_REPORT_STATUSES.COMPLETE,
     TRAINING_REPORT_STATUSES.SUSPENDED,
   ].includes(data.status);
 
-  const canEditEvent = isNotCompleteOrSuspended && isOwnerOrPoc;
+  const canEditEvent = (isNotCompleteOrSuspended && isOwnerOrPoc) || (isNotComplete && isOwner);
   const canCreateSession = isNotCompleteOrSuspended && isOwnerOrCollaborator;
   const menuItems = [];
 


### PR DESCRIPTION
## Description of change

Training reports did not allow statuses to be changed if in the "not started" status. The ask is now to allow you to "suspend" them from the "not started" state.

## How to test

Confirm that you can move a "not started" TR to "suspended"

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2064

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
