### PR TITLE
[TTAHUB-2031] Remove EHS-CCP from filters

### DIFF
--- a/frontend/src/components/filter/FilterProgramType.js
+++ b/frontend/src/components/filter/FilterProgramType.js
@@ -2,7 +2,7 @@ import React from 'react';
 import FilterSelect from './FilterSelect';
 import { filterSelectProps } from './props';
 
-const PROGRAM_TYPE_OPTIONS = ['EHS', 'HS', 'EHS-CCP'].map((label, value) => ({ value, label }));
+const PROGRAM_TYPE_OPTIONS = ['EHS', 'HS'].map((label, value) => ({ value, label }));
 
 export default function FilterProgramType({
   onApply,


### PR DESCRIPTION
## Description of change

We want to temporarily remove the EHC-CCP from the program types filter.

## How to test

This should no longer be an option on the Activity Report, Regional Dashboard, Regional Goal Dashboard, Resources Dashboard.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2031


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
