### PR TITLE
[TTAHUB-2017] fix form data loading

### DIFF
--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -2238,6 +2238,10 @@ export async function createOrUpdateGoalsForActivityReport(goals, reportId) {
   // both model.update() and model.set() + model.save() do NOT update the updatedAt field
   // even if you explicitly set it in the update or save to the current new Date()
   // hence the raw query above
+  //
+  // note also that if we are able to spend some time refactoring
+  // the usage of react-hook-form on the frontend AR report, we'd likely
+  // not have to worry about this, it's just a little bit disjointed right now
   return getGoalsForReport(activityReportId);
 }
 

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -2232,6 +2232,12 @@ export async function createOrUpdateGoalsForActivityReport(goals, reportId) {
   const activityReportId = parseInt(reportId, DECIMAL_BASE);
   const report = await ActivityReport.findByPk(activityReportId);
   await saveGoalsForReport(goals, report);
+  // updating the goals is updating the report, sorry everyone
+  await sequelize.query(`UPDATE "ActivityReports" SET "updatedAt" = '${new Date().toISOString()}' WHERE id = ${activityReportId}`);
+  // note that for some reason (probably sequelize automagic)
+  // both model.update() and model.set() + model.save() do NOT update the updatedAt field
+  // even if you explicitly set it in the update or save to the current new Date()
+  // hence the raw query above
   return getGoalsForReport(activityReportId);
 }
 


### PR DESCRIPTION
## Description of change

I'm unsure if it's due to recent changes or has always been an issue, but "Save Draft" on the goals & objectives page does not actually update the Activity Report but only the goals, objectives, and associated join tables and metadata tables. This leads to a quandary on the front end. 

When a report is loaded, the local storage data is compared to the "updatedAt" timestamp returned from the model. If the local storage timestamp is newer, then it overwrites fields from the database, and vice versa. 

However, given this case, the AR is never going to be newer if you save, add a goal and objective, save draft and then leave the AR entirely, since you never updated the report data after saving draft goals. This PR updates the "updatedAt" column on the AR every time the goals and objectives are updated.

## How to test

To see bug:
1) Create an AR
2) Select an existing goal and objective
3) Save draft
4) Without clicking "Save goal" or anything else on the AR, click the "Activity reports" link on the side nav.
5) Return to your report, and the goals & objectives section.

With this fix in place, you'll see the goal & objective you selected. Otherwise, the section will be empty.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2017


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
