### PR TITLE
[No-ticket] Change to force SSL on environments with newer versions of Postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ parameters:
     default: "kw-staging-smtp"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "kw-staging-smtp"
+    default: "change-to-force-ssl"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/config/config.js
+++ b/config/config.js
@@ -9,9 +9,6 @@ module.exports = {
     port: (process.env.POSTGRES_PORT || 5432),
     dialect: 'postgres',
     minifyAliases: true,
-    dialectOptions: {
-      ssl: true,
-    },
   },
   test: {
     username: process.env.POSTGRES_USERNAME,
@@ -22,10 +19,6 @@ module.exports = {
     dialect: 'postgres',
     logging: false,
     minifyAliases: true,
-    ssl: true,
-    dialectOptions: {
-      ssl: true,
-    },
   },
   production: {
     use_env_variable: 'DATABASE_URL',
@@ -36,5 +29,8 @@ module.exports = {
     port: (process.env.POSTGRES_PORT || 5432),
     dialect: 'postgres',
     minifyAliases: true,
+    dialectOptions: {
+      ssl: true,
+    },
   },
 };

--- a/config/config.js
+++ b/config/config.js
@@ -20,6 +20,16 @@ module.exports = {
     logging: false,
     minifyAliases: true,
   },
+  dss: {
+    use_env_variable: 'DATABASE_URL',
+    username: process.env.POSTGRES_USERNAME,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+    host: process.env.POSTGRES_HOST,
+    port: (process.env.POSTGRES_PORT || 5432),
+    dialect: 'postgres',
+    minifyAliases: true,
+  },
   production: {
     use_env_variable: 'DATABASE_URL',
     username: process.env.POSTGRES_USERNAME,

--- a/config/config.js
+++ b/config/config.js
@@ -9,6 +9,9 @@ module.exports = {
     port: (process.env.POSTGRES_PORT || 5432),
     dialect: 'postgres',
     minifyAliases: true,
+    dialectOptions: {
+      ssl: true,
+    },
   },
   test: {
     username: process.env.POSTGRES_USERNAME,
@@ -19,6 +22,10 @@ module.exports = {
     dialect: 'postgres',
     logging: false,
     minifyAliases: true,
+    ssl: true,
+    dialectOptions: {
+      ssl: true,
+    },
   },
   production: {
     use_env_variable: 'DATABASE_URL',

--- a/docker-compose.dss.yml
+++ b/docker-compose.dss.yml
@@ -13,7 +13,7 @@ services:
       - db
     environment:
       - POSTGRES_HOST=postgres_docker
-      - NODE_ENV=production
+      - NODE_ENV=development
       - POSTGRES_USERNAME=postgres
       - POSTGRES_PASSWORD=secretpass
       - POSTGRES_DB=ttasmarthub

--- a/docker-compose.dss.yml
+++ b/docker-compose.dss.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ".:/app:rw"
   db:
-    image: postgres:12.4
+    image: postgres:15.4
     container_name: postgres_docker
     environment:
       POSTGRES_USER: postgres

--- a/docker-compose.dss.yml
+++ b/docker-compose.dss.yml
@@ -13,7 +13,7 @@ services:
       - db
     environment:
       - POSTGRES_HOST=postgres_docker
-      - NODE_ENV=development
+      - NODE_ENV=test
       - POSTGRES_USERNAME=postgres
       - POSTGRES_PASSWORD=secretpass
       - POSTGRES_DB=ttasmarthub

--- a/docker-compose.dss.yml
+++ b/docker-compose.dss.yml
@@ -13,7 +13,7 @@ services:
       - db
     environment:
       - POSTGRES_HOST=postgres_docker
-      - NODE_ENV=test
+      - NODE_ENV=dss
       - POSTGRES_USERNAME=postgres
       - POSTGRES_PASSWORD=secretpass
       - POSTGRES_DB=ttasmarthub

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -32,7 +32,7 @@ services:
     networks:
       - ttadp-test
   test-db:
-    image: postgres:12.4
+    image: postgres:15.4
     container_name: test-db
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - SPEC_URL=swagger/index.yaml
   db:
-    image: postgres:12.4
+    image: postgres:15.4
     container_name: postgres_docker
     env_file: .env
     ports:

--- a/src/app.js
+++ b/src/app.js
@@ -45,7 +45,7 @@ const app = express();
 const oauth2CallbackPath = '/oauth2-client/login/oauth2/code/';
 let index;
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'dss') {
   index = fs.readFileSync(path.join(__dirname, '../client', 'index.html')).toString();
 }
 
@@ -75,7 +75,7 @@ app.use((req, res, next) => {
   cspMiddleware(req, res, next);
 });
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'dss') {
   app.use('/index.html', serveIndex);
   app.use(express.static(path.join(__dirname, '../client'), { index: false }));
 }
@@ -104,7 +104,7 @@ app.get(oauth2CallbackPath, cookieSession, async (req, res) => {
   }
 });
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'dss') {
   app.use('*', serveIndex);
 }
 

--- a/src/middleware/testingOnlyMiddleware.ts
+++ b/src/middleware/testingOnlyMiddleware.ts
@@ -1,6 +1,6 @@
 export const isTestingOrCI = () => {
   const isLocal = process.env.NODE_ENV === 'development'
-    || process.env.NODE_ENV === 'test';
+    || process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'dss';
   const isCI = process.env.CI !== undefined
     && process.env.CI !== null;
 


### PR DESCRIPTION
## Description of change

See acf-head-start-eng slack channel for details, but essentially we now need to force postgres to use SSL. This change makes that happen.

## How to test

CI & deploy passes. Change is deployed to sandbox, so site functionality can be tested there

## Issue(s)


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
