### PR TITLE
[TTAHUB-2119] Fix FEI root cause name

### DIFF
--- a/src/migrations/20230920131223-fix-other-ece-fei-root-cause.js
+++ b/src/migrations/20230920131223-fix-other-ece-fei-root-cause.js
@@ -1,0 +1,76 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+
+      await queryInterface.sequelize.query(`
+        -- Update Other ECE Care Options root causes for fei.
+        with ids as (
+            SELECT
+            argfr.id
+            FROM "Grants" gr
+            JOIN "Goals" goal
+                ON gr.id = goal."grantId"
+            JOIN "ActivityReportGoals" arg
+                ON goal."id" = arg."goalId"
+            JOIN "ActivityReportGoalFieldResponses" argfr
+                ON arg.id = argfr."activityReportGoalId"
+            WHERE "number" IN ('06CH010745', '06HP000265', '06HP000473'))
+            UPDATE "ActivityReportGoalFieldResponses"
+                SET "response" = '{Other ECE Care Options}'
+            WHERE "id" IN (SELECT "id" FROM "ids");
+
+            with ids as (
+                SELECT
+                gfr.id
+                FROM "Grants" gr
+                JOIN "Goals" goal
+                    ON gr.id = goal."grantId"
+                JOIN "GoalFieldResponses" gfr
+                    ON goal.id = gfr."goalId"
+                    WHERE "number" IN ('06CH010745', '06HP000265', '06HP000473'))
+                UPDATE "GoalFieldResponses"
+                        SET "response" = '{Other ECE Care Options}'
+                WHERE "id" IN (SELECT "id" FROM "ids");
+
+            -- Update Workforce, Other ECE Care Options root causes for fei.
+            with ids as (
+                SELECT
+                argfr.id
+                FROM "Grants" gr
+                JOIN "Goals" goal
+                    ON gr.id = goal."grantId"
+                JOIN "ActivityReportGoals" arg
+                    ON goal."id" = arg."goalId"
+                JOIN "ActivityReportGoalFieldResponses" argfr
+                    ON arg.id = argfr."activityReportGoalId"
+                WHERE "number" IN ('06CH011414'))
+                UPDATE "ActivityReportGoalFieldResponses"
+                    SET "response" = '{Workforce, Other ECE Care Options}'
+                WHERE "id" IN (SELECT "id" FROM "ids");
+
+                with ids as (
+                    SELECT
+                    gfr.id
+                    FROM "Grants" gr
+                    JOIN "Goals" goal
+                        ON gr.id = goal."grantId"
+                    JOIN "GoalFieldResponses" gfr
+                        ON goal.id = gfr."goalId"
+                        WHERE "number" IN ('06CH011414'))
+                    UPDATE "GoalFieldResponses"
+                            SET "response" = '{Workforce, Other ECE Care Options}'
+                    WHERE "id" IN (SELECT "id" FROM "ids");
+              `, { transaction });
+    });
+  },
+
+  down: async () => {
+  },
+};


### PR DESCRIPTION
## Description of change

The last script to update the FEI root cause for a handful of region 6 goals changed the name to an invalid value. This sets it to the correct value.

'**Other ECE Options**' should be '**Other ECE Care Options**'.


## How to test

1. Run the migration
2. Verify that for the recipient '**Rolling Plains Management Corporation**' the FEI goal has the root cause: '**Other ECE Care Options**'.
3. Verify that for the recipient '**Washita Valley Community Action Council**' the FEI goal has the root cause: '**Workforce, Other ECE Care Options**'.

both should be region 6.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2119


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
