### PR TITLE
[TTAHUB-2145] Fix links in resource table

### DIFF
--- a/frontend/src/widgets/HorizontalTableWidget.js
+++ b/frontend/src/widgets/HorizontalTableWidget.js
@@ -98,7 +98,7 @@ export default function HorizontalTableWidget(
                   {
                     r.isUrl
                       ? (
-                        <a href={r.heading} target="_blank" rel="noreferrer" title={r.heading}>
+                        <a href={r.link} target="_blank" rel="noreferrer">
                           {r.heading}
                         </a>
                       )

--- a/frontend/src/widgets/ResourceUse.js
+++ b/frontend/src/widgets/ResourceUse.js
@@ -15,7 +15,7 @@ function ResourceUse({ data, loading }) {
       <HorizontalTableWidget
         id="resourceUse"
         headers={data.headers}
-        data={data.resources.map((d) => ({ ...d, heading: d.title || d.heading }))}
+        data={data.resources.map((d) => ({ ...d, heading: d.title || d.heading, link: d.heading }))}
         firstHeading="Resource URL"
       />
     </WidgetContainer>

--- a/frontend/src/widgets/__tests__/ResourceUse.js
+++ b/frontend/src/widgets/__tests__/ResourceUse.js
@@ -107,7 +107,9 @@ describe('Resource Use Widget', () => {
     expect(screen.getByText(/Feb-22/i)).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /total/i })).toBeInTheDocument();
 
-    expect(screen.getByRole('link', { name: /eclkc Sample Title Test/i })).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /eclkc Sample Title Test/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://eclkc.ohs.acf.hhs.gov/school-readiness/effective-practice-guides/effective-practice-guides');
     expect(screen.getByRole('cell', { name: /17/i })).toBeInTheDocument();
     expect(screen.getByRole('cell', { name: /18/i })).toBeInTheDocument();
     expect(screen.getByRole('cell', { name: /19/i })).toBeInTheDocument();

--- a/frontend/src/widgets/__tests__/ResourcesAssociatedWithTopics.js
+++ b/frontend/src/widgets/__tests__/ResourcesAssociatedWithTopics.js
@@ -18,6 +18,7 @@ const emptyData = {
 const mockData = {
   headers: ['Jan-22', 'Feb-22', 'Mar-22'],
   topics: [{
+    link: 'https://official.gov',
     heading: 'https://official.gov',
     isUrl: true,
     data: [
@@ -46,6 +47,7 @@ const mockSortData = {
   headers: ['Feb-22'],
   topics: [
     {
+      link: 'https://secondrow.gov',
       heading: 'https://secondrow.gov',
       isUrl: true,
       data: [
@@ -60,6 +62,7 @@ const mockSortData = {
       ],
     },
     {
+      link: 'https://firstrow.gov',
       heading: 'https://firstrow.gov',
       isUrl: true,
       data: [


### PR DESCRIPTION
## Description of change

The resource dashboard will display the title of an ECLKC resource if it's been fetched by the API. There was an error in the markup that was putting the title as both the text content of the link and as the `href`, which means dead links in the table.

## How to test

Confirm with recent prod data on the Resource Dashboard -> Resource Use table that resources with human readable titles also have valid link destinations.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2145


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
