### PR TITLE
[TTAHUB-2086] Fix bug with grant number filter on RTR

### DIFF
--- a/frontend/src/components/GoalCards/GoalDataController.js
+++ b/frontend/src/components/GoalCards/GoalDataController.js
@@ -132,7 +132,7 @@ function GoalDataController({
           <Graph data={data.statuses} loading={loading} />
         </Grid>
       </Grid>
-      <FilterContext.Provider value={{ filterKey: GOALS_OBJECTIVES_FILTER_KEY }}>
+      <FilterContext.Provider value={{ filterKey: GOALS_OBJECTIVES_FILTER_KEY(recipientId) }}>
         <GoalsTable
           recipientId={recipientId}
           regionId={regionId}

--- a/frontend/src/components/filter/__tests__/goalFilters.js
+++ b/frontend/src/components/filter/__tests__/goalFilters.js
@@ -110,6 +110,8 @@ describe('goalFilters', () => {
       number: 'number',
     }]);
 
+    const grantFilterWithNoPossibleGrantsYet = grantNumberFilter([]);
+
     it('renders correctly', async () => {
       renderFilter(() => grantFilter.renderInput('1', 'test', ['number'], () => {}));
       const grantNumberInput = await screen.findByLabelText('Select grant numbers to filter by');
@@ -122,6 +124,14 @@ describe('goalFilters', () => {
       ]);
 
       expect(q).toBe('number EHS');
+    });
+
+    it('displays the correct values with no possible grants', async () => {
+      const q = grantFilterWithNoPossibleGrantsYet.displayQuery([
+        'number',
+      ]);
+
+      expect(q).toBe('number');
     });
 
     it('calls onApply', async () => {

--- a/frontend/src/components/filter/goalFilters.js
+++ b/frontend/src/components/filter/goalFilters.js
@@ -96,9 +96,15 @@ export const grantNumberFilter = (possibleGrants) => ({
   conditions: FILTER_CONDITIONS,
   defaultValues: EMPTY_MULTI_SELECT,
   displayQuery: (query) => {
-    const toDisplay = query.map(
-      (q) => possibleGrants.find((g) => g.number === q).numberWithProgramTypes,
-    );
+    const toDisplay = query.map((q) => {
+      const grant = possibleGrants.find((g) => g.number === q);
+      if (grant) {
+        return grant.numberWithProgramTypes;
+      }
+
+      return q;
+    });
+
     return handleArrayQuery(toDisplay);
   },
   renderInput: (id, condition, query, onApplyQuery) => (

--- a/frontend/src/pages/RecipientRecord/index.js
+++ b/frontend/src/pages/RecipientRecord/index.js
@@ -196,7 +196,10 @@ export default function RecipientRecord({ match, hasAlerts }) {
                 </Link>
               )}
             >
-              <FilterContext.Provider value={{ filterKey: GOALS_OBJECTIVES_FILTER_KEY }}>
+              <FilterContext.Provider value={{
+                filterKey: GOALS_OBJECTIVES_FILTER_KEY(recipientId),
+              }}
+              >
                 <PrintGoals
                   recipientId={recipientId}
                   regionId={regionId}

--- a/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/GoalsObjectives.js
@@ -18,7 +18,7 @@ export default function GoalsObjectives({
   const showNewGoals = location.state && location.state.ids && location.state.ids.length > 0;
 
   const [filters, setFilters] = useSessionFiltersAndReflectInUrl(
-    GOALS_OBJECTIVES_FILTER_KEY,
+    GOALS_OBJECTIVES_FILTER_KEY(recipientId),
     [],
   );
 

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/PrintGoals.js
@@ -88,7 +88,7 @@ describe('PrintGoals', () => {
 
     render(
       <Router history={memoryHistory}>
-        <FilterContext.Provider value={{ filterKey: GOALS_OBJECTIVES_FILTER_KEY }}>
+        <FilterContext.Provider value={{ filterKey: GOALS_OBJECTIVES_FILTER_KEY(RECIPIENT_ID) }}>
           <UserContext.Provider value={{ user }}>
             <PrintGoals
               location={location}

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -23,4 +23,4 @@ const TTAHISTORY_FILTER_CONFIG = [
 TTAHISTORY_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));
 export { TTAHISTORY_FILTER_CONFIG };
 
-export const GOALS_OBJECTIVES_FILTER_KEY = 'goals-objectives-filters';
+export const GOALS_OBJECTIVES_FILTER_KEY = (recipientId) => `goals-objectives-filters-${recipientId}`;


### PR DESCRIPTION
## Description of change

Fixes a bug where a filtering a recipient's data by a grant number that either doesn't exist for them or hasn't been loaded yet returns a white screen of death.

Also fixed the key used by session storage - since it wasn't recipient specific, a grant for one recipient could be loaded for another, which I believe is how the bug happens.

## How to test

On your local machine, visit a URL like this, with nonsense in the grantNumber.in filter:
http://localhost:3000/recipient-tta-records/564/region/3/goals-objectives?grantNumber.in[]=ASDF

It should not white screen. Select a grant for that recipient that does exist, and, as long as that works, visit another recipient's RTTAPA page that you haven't visited in the session yet. Confirm that no out-of-scope grant number filters are loaded

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2086


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
