### PR TITLE
[TTAHUB-1345] properly sort regions in regional permission modal

### DIFF
--- a/frontend/src/components/RegionPermissionModal.js
+++ b/frontend/src/components/RegionPermissionModal.js
@@ -17,10 +17,10 @@ function RegionPermissionModal({
     && f.condition !== 'is not'
     && !userRegions
       .includes(parseInt(f.query, DECIMAL_BASE)))
-    .map((m) => m.query), [filters, userRegions]);
+    .map((m) => Number(m.query)), [filters, userRegions]);
 
   const showMultipleRegions = missingRegions && missingRegions.length > 1 ? 's' : '';
-  const missingRegionsList = missingRegions && missingRegions.length > 0 ? missingRegions.sort().join(', ') : '';
+  const missingRegionsList = missingRegions && missingRegions.length > 0 ? missingRegions.sort((a, b) => a - b).join(', ') : '';
 
   useEffect(() => {
     if (missingRegions

--- a/frontend/src/components/__tests__/RegionPermissionModal.js
+++ b/frontend/src/components/__tests__/RegionPermissionModal.js
@@ -239,12 +239,12 @@ describe('Region Permission Modal', () => {
         id: uuidv4(),
         topic: 'region',
         condition: 'is',
-        query: 4,
+        query: 10,
       },
     ];
 
     render(<PermissionModal filters={filtersToPass} />);
 
-    expect(await screen.findByRole('heading', { name: /you need permission to access regions 3, 4/i, hidden: true })).toBeVisible();
+    expect(await screen.findByRole('heading', { name: /you need permission to access regions 3, 10/i, hidden: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description of change

Reorder regions in regional permission modal numerically instead of treating them as strings

### Before

![before](https://github.com/HHS/Head-Start-TTADP/assets/3288586/138f24ab-8d91-444b-ba86-6180d0498fc9)

### After

![after](https://github.com/HHS/Head-Start-TTADP/assets/3288586/d82d159e-9f40-4fba-a76c-9bdf4c6230cb)


## How to test

Log in as or impersonate a user who is missing access to a region 10 or greater as well as one other (10 & 7 in my example above) 

Visit a link like:
/activity-reports?region.in[]=1&region.in[]=2&region.in[]=3&region.in[]=4&region.in[]=5&region.in[]=6&region.in[]=7&region.in[]=8&region.in[]=9&region.in[]=10&region.in[]=11&region.in[]=12

The regions in the modal should be ordered correctly



## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1345


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
