### PR TITLE
[TTAHUB-2122] distinguish between support and engineer admin functions

### DIFF
--- a/frontend/src/pages/Admin/index.js
+++ b/frontend/src/pages/Admin/index.js
@@ -14,31 +14,36 @@ import Email from './Email';
 function Admin() {
   return (
     <>
-      <h1>Admin UI</h1>
+      <h1>Admin</h1>
+      <h2>Support</h2>
       <div className="margin-bottom-2">
         <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/cdi">
           CDI grants
         </NavLink>
-        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/users">
-          Users
-        </NavLink>
-        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/diag">
-          Diag
-        </NavLink>
         <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/flags">
           Feature flags
-        </NavLink>
-        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/site-alerts">
-          Site alerts
-        </NavLink>
-        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/redis">
-          Redis info
         </NavLink>
         <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/national-centers">
           National centers
         </NavLink>
+        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/site-alerts">
+          Site alerts
+        </NavLink>
+
+        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/users">
+          Users
+        </NavLink>
+      </div>
+      <h2>Engineer only</h2>
+      <div className="margin-bottom-2">
         <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/email">
           Email
+        </NavLink>
+        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/diag">
+          Diag
+        </NavLink>
+        <NavLink activeClassName="usa-button--active" className="usa-button" to="/admin/redis">
+          Redis info
         </NavLink>
       </div>
       <Switch>


### PR DESCRIPTION
## Description of change

Added secondary headings and sub-grouped the admin buttons. Declined to remove the h1 as skipping straight to h2 produces non-semantic HTML, which we do not like.

## How to test

Headings and buttons on the Admin panel appear as the ticket requests

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2122


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
