### PR TITLE
[TTAHUB-1632] Topics performance increase using IN

### DIFF
--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -1145,11 +1145,11 @@ describe('filtersToScopes', () => {
       // Reports.
       includedReport1 = await ActivityReport.create({
         ...draftReport,
-        topics: ['test', 'test 2'],
+        topics: ['Topic 1', 'Topic 2'],
       });
       includedReport2 = await ActivityReport.create({
         ...draftReport,
-        topics: ['a test', 'another topic'],
+        topics: ['Topic 1', 'Topic 3'],
       });
       excludedReport = await ActivityReport.create({ ...draftReport, topics: ['another topic'] });
       possibleIds = [
@@ -1205,11 +1205,11 @@ describe('filtersToScopes', () => {
 
       // Topic.
       topic1 = await Topic.create({
-        name: 'Library Books',
+        name: 'Topic 4',
       });
 
       topic2 = await Topic.create({
-        name: 'Construction Tools',
+        name: 'Topic 2',
       });
 
       // ARO topic.
@@ -1281,19 +1281,19 @@ describe('filtersToScopes', () => {
       });
     });
 
-    it('includes topic with a partial match', async () => {
-      const filters = { 'topic.in': ['tes'] };
+    it('includes topics with a match', async () => {
+      const filters = { 'topic.in': ['Topic 3'] };
       const { activityReport: scope } = await filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
       });
-      expect(found.length).toBe(2);
+      expect(found.length).toBe(1);
       expect(found.map((f) => f.id))
-        .toEqual(expect.arrayContaining([includedReport1.id, includedReport2.id]));
+        .toEqual(expect.arrayContaining([includedReport2.id]));
     });
 
-    it('includes aro topic with a partial match', async () => {
-      const filters = { 'topic.in': ['books'] };
+    it('includes aro topic with a match', async () => {
+      const filters = { 'topic.in': ['Topic 4'] };
       const { activityReport: scope } = await filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -1303,8 +1303,8 @@ describe('filtersToScopes', () => {
         .toEqual(expect.arrayContaining([includedReport1.id]));
     });
 
-    it('includes aro topic and topic with a partial match', async () => {
-      const filters = { 'topic.in': ['tes', 'a test'] };
+    it('includes aro topic and topic with a match', async () => {
+      const filters = { 'topic.in': ['Topic 2'] };
       const { activityReport: scope } = await filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -1314,8 +1314,8 @@ describe('filtersToScopes', () => {
         .toEqual(expect.arrayContaining([includedReport1.id, includedReport2.id]));
     });
 
-    it('excludes topics that do not partial match', async () => {
-      const filters = { 'topic.nin': ['tes'] };
+    it('excludes topics that do not match', async () => {
+      const filters = { 'topic.nin': ['Topic 1'] };
       const { activityReport: scope } = await filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -1325,8 +1325,8 @@ describe('filtersToScopes', () => {
         .toEqual(expect.arrayContaining([excludedReport.id, globallyExcludedReport.id]));
     });
 
-    it('excludes aro topics that do not partial match', async () => {
-      const filters = { 'topic.nin': ['books'] };
+    it('excludes aro topics that do not match', async () => {
+      const filters = { 'topic.nin': ['Topic 4'] };
       const { activityReport: scope } = await filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -1339,8 +1339,8 @@ describe('filtersToScopes', () => {
           globallyExcludedReport.id]));
     });
 
-    it('excludes aro topic and topics that do not partial match', async () => {
-      const filters = { 'topic.nin': ['a test', 'books'] };
+    it('excludes aro topic and topics that do not match', async () => {
+      const filters = { 'topic.nin': ['Topic 3', 'Topic 4'] };
       const { activityReport: scope } = await filtersToScopes(filters);
       const found = await ActivityReport.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },


### PR DESCRIPTION
## Description of change

We are currently doing partial matches on Topics for both the AR and ARO. I don't think we need this as the topics are selected from a set list and not a text field. This seems to speed up the overall filter, when testing locally for all topics both in and nin went from 9 sec to 3 sec. Although perf will vary from env to env.

## How to test

Test the topics filter and make sure it still works as expected with a perf increase.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1632


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
