### PR TITLE
Implement Amazon SES integration for non-production environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ parameters:
     type: string
   dev_git_branch: # change to feature branch to test deployment
     description: "Name of github branch that will deploy to dev"
-    default: "switch-cflinuxfs4"
+    default: "kw-move-staging-to-ses"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
     default: "switch-cflinuxfs4"

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -347,7 +347,6 @@ export const notifyCollaboratorAssigned = (job, transport = defaultTransport) =>
   return null; // Don't send anything if SEND_NOTIFICATIONS is not 'true'
 };
 
-
 export const collaboratorAssignedNotification = (report, newCollaborators) => {
   // Each collaborator will get an individual notification
   newCollaborators.forEach((collaborator) => {

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -81,11 +81,10 @@ export const frequencyToInterval = (freq) => {
  * @returns {string[]} - A deduplicated and filtered array of email addresses.
  */
 export const filterAndDeduplicateEmails = (emails) => {
-  console.log(emails);
   const filteredEmails = emails.flat()
     .filter((email) => typeof email === 'string' && !email.startsWith('no-send_'))
     .filter((email, index, array) => array.indexOf(email) === index);
-console.log(filteredEmails);
+
   return filteredEmails;
 };
 

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -73,6 +73,21 @@ export const frequencyToInterval = (freq) => {
   return date;
 };
 
+/**
+ * Filters and deduplicates an array of email addresses, removing duplicates
+ * and excluding email addresses that start with 'no-send_'.
+ *
+ * @param {string[]} emails - An array of email addresses to filter and deduplicate.
+ * @returns {string[]} - A deduplicated and filtered array of email addresses.
+ */
+export const filterAndDeduplicateEmails = (emails) => {
+  const filteredEmails = emails
+    .filter((email) => !email.startsWith('no-send_'))
+    .filter((email, index, array) => array.indexOf(email) === index);
+
+  return filteredEmails;
+};
+
 export const onFailedNotification = (job, error) => {
   auditLogger.error(`job ${job.name} failed for report ${job.data.report.displayId} with error ${error}`);
   logEmailNotification(job, false, error);
@@ -134,7 +149,7 @@ export const notifyChangesRequested = (job, transport = defaultTransport) => {
     return email.send({
       template: path.resolve(emailTemplatePath, 'changes_requested_by_manager'),
       message: {
-        to: toEmails,
+        to: filterAndDeduplicateEmails(toEmails),
       },
       locals: {
         managerName: approverName,
@@ -188,7 +203,7 @@ export const notifyReportApproved = (job, transport = defaultTransport) => {
     return email.send({
       template: path.resolve(emailTemplatePath, 'report_approved'),
       message: {
-        to: toEmails,
+        to: filterAndDeduplicateEmails(toEmails),
       },
       locals: {
         reportPath,
@@ -221,7 +236,7 @@ export const notifyRecipientReportApproved = (job, transport = defaultTransport)
     });
     return email.send({
       template: path.resolve(emailTemplatePath, 'recipient_report_approved'),
-      message: { to: addresses },
+      message: { to: filterAndDeduplicateEmails(addresses) },
       locals: { reportPath, displayId, recipientNamesDisplay },
     });
   }
@@ -257,7 +272,7 @@ export const notifyApproverAssigned = (job, transport = defaultTransport) => {
     return email.send({
       template: path.resolve(emailTemplatePath, 'manager_approval_requested'),
       message: {
-        to: [approverEmail],
+        to: filterAndDeduplicateEmails([approverEmail]),
       },
       locals: {
         reportPath,
@@ -298,7 +313,7 @@ export const notifyCollaboratorAssigned = (job, transport = defaultTransport) =>
     return email.send({
       template: path.resolve(emailTemplatePath, 'collaborator_added'),
       message: {
-        to: [newCollaborator.email],
+        to: filterAndDeduplicateEmails([newCollaborator.email]),
       },
       locals: {
         reportPath,
@@ -647,7 +662,7 @@ export const notifyDigest = (job, transport = defaultTransport) => {
     return email.send({
       template: path.resolve(emailTemplatePath, templateType),
       message: {
-        to: [user.email],
+        to: filterAndDeduplicateEmails([user.email]),
       },
       locals: {
         user,
@@ -702,7 +717,7 @@ export const sendEmailVerificationRequestWithToken = (user, token) => {
   return email.send({
     template: path.resolve(emailTemplatePath, 'email_verification'),
     message: {
-      to: [user.email],
+      to: filterAndDeduplicateEmails([user.email]),
     },
     locals: {
       token,

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -81,10 +81,11 @@ export const frequencyToInterval = (freq) => {
  * @returns {string[]} - A deduplicated and filtered array of email addresses.
  */
 export const filterAndDeduplicateEmails = (emails) => {
-  const filteredEmails = emails
-    .filter((email) => !email.startsWith('no-send_'))
+  console.log(emails);
+  const filteredEmails = emails.flat()
+    .filter((email) => typeof email === 'string' && !email.startsWith('no-send_'))
     .filter((email, index, array) => array.indexOf(email) === index);
-
+console.log(filteredEmails);
   return filteredEmails;
 };
 

--- a/src/lib/mailer/index.test.js
+++ b/src/lib/mailer/index.test.js
@@ -14,6 +14,7 @@ import {
   notificationQueue as notificationQueueMock,
   notificationQueue as notificationDigestQueueMock,
   notifyRecipientReportApproved,
+  filterAndDeduplicateEmails,
 } from '.';
 import {
   EMAIL_ACTIONS,
@@ -1049,6 +1050,26 @@ describe('mailer tests', () => {
 
     it('"approved" digest which logs on bad date', async () => {
       await expect(approvedDigest('')).rejects.toThrow();
+    });
+  });
+
+  describe('filterAndDeduplicateEmails', () => {
+    it('should return an array with unique emails when given an array with duplicate emails', () => {
+      const emails = ['test@example.com', 'test@example.com', 'another@example.com'];
+      const result = filterAndDeduplicateEmails(emails);
+      expect(result).toEqual(['test@example.com', 'another@example.com']);
+    });
+
+    it('should return an array without emails starting with "no-send_"', () => {
+      const emails = ['test@example.com', 'test@example.com', 'another@example.com', 'unique@example.com', 'no-send_test@example.com'];
+      const result = filterAndDeduplicateEmails(emails);
+      expect(result).toEqual(['test@example.com', 'another@example.com', 'unique@example.com']);
+    });
+
+    it('should return an empty array when given an empty array', () => {
+      const emails = [];
+      const result = filterAndDeduplicateEmails(emails);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/lib/mailer/index.test.js
+++ b/src/lib/mailer/index.test.js
@@ -295,9 +295,9 @@ describe('mailer tests', () => {
     });
     it('Tests that emails are not sent without SEND_NOTIFICATIONS', async () => {
       process.env.SEND_NOTIFICATIONS = false;
-      await expect(notifyApproverAssigned({
+      expect(notifyApproverAssigned({
         data: { report: mockReport },
-      }, jsonTransport)).resolves.toBeNull();
+      }, jsonTransport)).toBeNull();
     });
   });
   describe('Add Collaborators', () => {
@@ -317,9 +317,9 @@ describe('mailer tests', () => {
     });
     it('Tests that emails are not sent without SEND_NOTIFICATIONS', async () => {
       process.env.SEND_NOTIFICATIONS = false;
-      await expect(notifyCollaboratorAssigned({
+      expect(notifyCollaboratorAssigned({
         data: { report: mockReport, newCollaborator: mockCollaborator1 },
-      }, jsonTransport)).resolves.toBeNull();
+      }, jsonTransport)).toBeNull();
     });
   });
 

--- a/src/tools/processData.js
+++ b/src/tools/processData.js
@@ -79,6 +79,8 @@ const hsesUsers = [
   },
 ];
 
+const generateFakeEmail = () => 'no-send_'.concat(faker.internet.email());
+
 const processHtml = async (input) => {
   if (!input) {
     return input;
@@ -111,7 +113,7 @@ export const convertEmails = (emails) => {
       const foundTransformedUser = transformedUsers.find((user) => user.id === userId);
       return foundTransformedUser ? foundTransformedUser.email : '';
     }
-    return emails.includes('@') ? faker.internet.email() : '';
+    return emails.includes('@') ? generateFakeEmail() : '';
   });
 
   return convertedEmails.join(', ');
@@ -136,7 +138,7 @@ export const convertName = (name, email) => {
     foundTransformedUser = {
       id: foundUser.id,
       name: faker.name.findName(),
-      email: faker.internet.email(),
+      email: generateFakeEmail(),
     };
     transformedUsers.push(foundTransformedUser);
   }
@@ -196,7 +198,7 @@ export const hideUsers = async (userIds) => {
     promises.push(
       user.update({
         hsesUsername: faker.internet.email(),
-        email: faker.internet.email(),
+        email: generateFakeEmail(),
         phoneNumber: faker.phone.phoneNumber(),
         name: faker.name.findName(),
       }, { individualHooks: true }),

--- a/src/tools/processData.test.js
+++ b/src/tools/processData.test.js
@@ -330,13 +330,19 @@ describe('processData', () => {
 
   describe('convertEmails', () => {
     it('handles null emails', async () => {
-      const emails = await convertEmails(null);
+      const emails = convertEmails(null);
       expect(emails).toBe(null);
     });
 
     it('handles emails lacking a @', async () => {
-      const emails = await convertEmails('test,test2@test.com,test3');
+      const emails = convertEmails('test,test2@test.com,test3');
       expect(emails.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)).toBeTruthy();
+    });
+
+    it('should convert a single email address to a transformed email address', () => {
+      const input = 'real@example.com';
+      const output = convertEmails(input);
+      expect(output).toMatch(/^no-send_/);
     });
   });
 


### PR DESCRIPTION
## Description of change
This PR allows to enable AWS SES in the non-production environments by eliminating bounces to fake email addresses. It flags the generated emails with a "no-send_" prefix and filters out these addresses. It also prevents sending to duplicate emails.


## How to test
Verify on locally (while having the latest transformed db snapshot) or on Dev that notifications work as expected, e.g. by adding yourself as a collaborator.

Extra check: Verify there is no record of sending an email to a fake address by looking at the MailerLogs table.
e.g.

`SELECT * FROM "MailerLogs" order by "createdAt" desc LIMIT 10;`

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2100


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
