### PR TITLE
[TTAHUB-2146] Don't Re-Throw in ES

### DIFF
--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -32,10 +32,7 @@ import db, {
 } from '../../models';
 import { createReport, destroyReport, createGrant } from '../../testUtils';
 import {
-  getClient,
   deleteIndex,
-  createIndex,
-  addIndexDocument,
 } from '../../lib/awsElasticSearch/index';
 import { findOrCreateResources, processActivityReportForResourcesById } from '../../services/resource';
 import { createActivityReportObjectiveFileMetaData } from '../../services/files';


### PR DESCRIPTION
## Description of change

We found out after the fact that throwing exceptions from worker processes has a negative impact on the queue. To help mitigate this issue and because we are not currently using ES, lets not re-throw exceptions from the common ES processes.

**NOTE:** The processes create index and bulk index are only called from the createAwsElasticSearchIndexes script and should still re-throw.

## How to test

- Review all code make sure we are NOT throwing exceptions from processes.
- Test creating, updating, and deleting a AR and ensure we are still performing the operation but not throwing.
- Run the YARN **createAwsElasticSearchIndexes** job to make sure it still works.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2146


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
