### PR TITLE
[TTAHUB-2159] Fix overlapping filters on the TR page

### DIFF
--- a/frontend/src/pages/TrainingReports/components/EventCards.js
+++ b/frontend/src/pages/TrainingReports/components/EventCards.js
@@ -9,7 +9,7 @@ function EventCards({
   onDeleteEvent,
 }) {
   return (
-    <div className="padding-x-3 padding-y-2">
+    <div className="padding-x-3 padding-y-2 position-relative z-0">
       {
         events && events.length > 0
           ? events.map((event, index, arr) => (


### PR DESCRIPTION
## Description of change

Fix the filter menu appearing behind the event cards on the TR landing page

## before

![before](https://github.com/HHS/Head-Start-TTADP/assets/3288586/b77fb91f-dd2b-4db9-9f80-b0e8c2dbdd22)

## after

![after](https://github.com/HHS/Head-Start-TTADP/assets/3288586/39f77647-7c76-4bc4-b4dd-88af2945c041)

## How to test

Confirm the filters no longer overlap

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2159


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
