### PR TITLE
[TTAHUB-2164] Updates to session form when session is completed

### DIFF
--- a/frontend/src/pages/SessionForm/__tests__/index.js
+++ b/frontend/src/pages/SessionForm/__tests__/index.js
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
+import { TRAINING_REPORT_STATUSES } from '@ttahub/common';
 import SessionForm from '..';
 import UserContext from '../../../UserContext';
 import AppLoadingContext from '../../../AppLoadingContext';
@@ -34,6 +35,7 @@ describe('SessionReportForm', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
     fetchMock.reset();
 
     // the basic app before stuff
@@ -75,6 +77,7 @@ describe('SessionReportForm', () => {
   });
 
   it('fetches existing session report form', async () => {
+    jest.useFakeTimers();
     const url = join(sessionsUrl, 'id', '1');
 
     fetchMock.get(
@@ -86,7 +89,6 @@ describe('SessionReportForm', () => {
     });
 
     await waitFor(() => expect(fetchMock.called(url)).toBe(true));
-
     jest.advanceTimersByTime(30000);
 
     expect(screen.getByText(/Training report - Session/i)).toBeInTheDocument();
@@ -331,5 +333,49 @@ describe('SessionReportForm', () => {
     });
 
     await waitFor(() => expect(fetchMock.called(url, { method: 'PUT' })).toBe(true));
+  });
+  it('redirects if session is complete', async () => {
+    const url = join(sessionsUrl, 'id', '1');
+    const formData = {
+      eventId: 1,
+      eventDisplayId: 'R-EVENT',
+      id: 1,
+      ownerId: 1,
+      eventName: 'Test event',
+      status: TRAINING_REPORT_STATUSES.COMPLETE,
+      pageState: {
+        1: IN_PROGRESS,
+        2: COMPLETE,
+        3: COMPLETE,
+      },
+      sessionName: 'Test session',
+      endDate: '01/01/2024',
+      startDate: '01/01/2024',
+      duration: 1,
+      context: 'asasfdsafasdfsdaf',
+      objective: 'test objective',
+      objectiveTopics: ['topic'],
+      objectiveTrainers: ['DTL'],
+      objectiveResources: [],
+      files: [],
+      objectiveSupportType: 'Planning',
+      regionId: 1,
+      participants: [1],
+      recipients: [1],
+      deliveryMethod: 'In-person',
+      numberOfParticipants: 1,
+      ttaProvided: 'oH YEAH',
+      specialistNextSteps: [{ note: 'A', completeDate: '01/01/2024' }],
+      recipientNextSteps: [{ note: 'B', completeDate: '01/01/2024' }],
+    };
+
+    fetchMock.get(url, formData);
+
+    act(() => {
+      renderSessionForm('1', 'complete-session', '1');
+    });
+
+    await waitFor(() => expect(fetchMock.called(url, { method: 'get' })).toBe(true));
+    expect(history.location.pathname).toBe('/training-report/view/1');
   });
 });

--- a/frontend/src/pages/SessionForm/index.js
+++ b/frontend/src/pages/SessionForm/index.js
@@ -10,6 +10,7 @@ import { Helmet } from 'react-helmet';
 import { Alert, Grid } from '@trussworks/react-uswds';
 import { useHistory, Redirect } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
+import { TRAINING_REPORT_STATUSES } from '@ttahub/common';
 import useSocket, { usePublishWebsocketLocationOnInterval } from '../../hooks/useSocket';
 import useHookFormPageState from '../../hooks/useHookFormPageState';
 import { defaultValues } from './constants';
@@ -265,6 +266,12 @@ export default function SessionForm({ match }) {
 
   if (!reportFetched) {
     return null;
+  }
+
+  if (reportFetched && formData.status === TRAINING_REPORT_STATUSES.COMPLETE) {
+    return (
+      <Redirect to={`/training-report/view/${trainingReportId}`} />
+    );
   }
 
   return (

--- a/frontend/src/pages/TrainingReports/components/SessionCard.js
+++ b/frontend/src/pages/TrainingReports/components/SessionCard.js
@@ -57,6 +57,8 @@ function SessionCard({
     }
   };
 
+  const statusIsComplete = status === TRAINING_REPORT_STATUSES.COMPLETE;
+
   const displaySessionStatus = getSessionDisplayStatusText();
 
   const getSessionStatusIcon = (() => {
@@ -94,7 +96,7 @@ function SessionCard({
             {sessionName}
           </p>
           {
-            isWriteable
+            isWriteable && !statusIsComplete
               ? (
                 <div className="padding-bottom-2 padding-top-1 desktop:padding-y-0">
                   <Link to={`/training-report/${eventId}/session/${session.id}/session-summary`} className="margin-right-4">

--- a/frontend/src/pages/TrainingReports/components/__tests__/SessionCard.js
+++ b/frontend/src/pages/TrainingReports/components/__tests__/SessionCard.js
@@ -46,10 +46,17 @@ describe('SessionCard', () => {
     expect(screen.getByText(/in progress/i)).toBeInTheDocument();
   });
 
-  it('hides edit link', () => {
+  it('hides edit link based on permissions', () => {
     renderSessionCard(defaultSession, false);
     expect(screen.getByText('This is my session title')).toBeInTheDocument();
     expect(screen.queryByText(/edit session/i)).not.toBeInTheDocument();
+  });
+
+  it('hides edit link if session is complete', () => {
+    renderSessionCard({ id: 1, data: { ...defaultSession.data, status: 'Complete' } });
+    expect(screen.getByText('This is my session title')).toBeInTheDocument();
+    expect(screen.queryByText(/edit session/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/delete session/i)).not.toBeInTheDocument();
   });
 
   it('shows the edit link with the correct permissions', () => {

--- a/tests/e2e/training-report.spec.ts
+++ b/tests/e2e/training-report.spec.ts
@@ -81,16 +81,20 @@ test('can fill out and complete a training and session report', async ({ page })
   await page.getByLabel('When does the recipient anticipate completing step 1? *').fill('07/03/2023');
   await page.getByRole('button', { name: 'Save and continue' }).click();
 
-  // complete session
-  await page.getByTestId('dropdown').selectOption('Complete');
+  await page.goto('http://localhost:3000/');
+  await page.getByRole('link', { name: 'Training Reports' }).click();
+  await page.getByRole('link', { name: 'In progress' }).click();
 
   // edit session and save changes
-  await page.getByRole('button', { name: 'Submit session' }).click();
   await page.getByRole('button', { name: 'View sessions for event R01-PD-23-1037' }).click();
   await page.getByRole('link', { name: 'Edit session' }).click();
   await page.getByLabel('Session name *').fill('First session revised');
-  await page.getByRole('button', { name: 'Save and continue' }).click();
-  await page.getByRole('link', { name: 'Back to Training Reports' }).click();
+
+  await page.getByRole('button', { name: 'Complete session Not Started' }).click();
+
+  // complete session 
+  await page.getByTestId('dropdown').selectOption('Complete');
+  await page.getByRole('button', { name: 'Submit session' }).click();
 
   // complete event
   await page.getByTestId('ellipsis-button').click();


### PR DESCRIPTION
## Description of change

**When the session is complete** 
- Hide the "edit" and "delete" buttons from the interface
- Prevent access to the session form

These changes should prevent editing or deleting sessions once it has been completed. I am not locking the backend down at this time at Garrett's (sensible) request, as he is in the middle of rewriting things.

## How to test

- Confirm the above is true
- Confirm regular session operations are good to go

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2164


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
