### PR TITLE
Make sure permissions match across TRs

### DIFF
--- a/frontend/src/pages/ViewTrainingReport/__tests__/index.js
+++ b/frontend/src/pages/ViewTrainingReport/__tests__/index.js
@@ -213,6 +213,14 @@ describe('ViewTrainingReport', () => {
     expect(await screen.findByText('Sorry, something went wrong')).toBeInTheDocument();
   });
 
+  it('handles a permissions error', async () => {
+    fetchMock.getOnce('/api/events/id/1', 403);
+
+    renderTrainingReport();
+
+    expect(await screen.findByText('You do not have permission to view this page')).toBeInTheDocument();
+  });
+
   it('handles an error fetching collaborators', async () => {
     fetchMock.getOnce('/api/events/id/1', mockEvent());
 

--- a/frontend/src/pages/ViewTrainingReport/index.js
+++ b/frontend/src/pages/ViewTrainingReport/index.js
@@ -28,6 +28,8 @@ const formatNextSteps = (nextSteps, heading, striped) => {
   };
 };
 
+const FORBIDDEN = 403;
+
 export default function ViewTrainingReport({ match }) {
   const [event, setEvent] = useState(null);
   const [error, setError] = useState(null);
@@ -43,8 +45,14 @@ export default function ViewTrainingReport({ match }) {
         const e = await eventById(match.params.trainingReportId);
         setEvent(e);
       } catch (err) {
+        let message = 'Sorry, something went wrong';
         setEvent({});
-        setError('Sorry, something went wrong');
+
+        if (err && err.status === FORBIDDEN) {
+          message = 'You do not have permission to view this page';
+        }
+
+        setError(message);
       } finally {
         setIsAppLoading(false);
       }

--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -21,6 +21,8 @@ export default class EventReport {
     return !!this.permissions.find((p) => [
       SCOPES.READ_TRAINING_REPORTS,
       SCOPES.READ_WRITE_TRAINING_REPORTS,
+      SCOPES.READ_REPORTS,
+      SCOPES.READ_WRITE_REPORTS,
     ].includes(p.scopeId) && p.regionId === this.eventReport.regionId);
   }
 

--- a/src/routes/events/handlers.js
+++ b/src/routes/events/handlers.js
@@ -97,7 +97,7 @@ export const getHandler = async (req, res) => {
     const auth = await getEventAuthorization(req, res, event);
 
     if (!auth.canRead() && !auth.isPoc()) {
-      return res.sendStatus(403);
+      return res.sendStatus(httpCodes.FORBIDDEN);
     }
 
     return res.status(httpCodes.OK).send(event);


### PR DESCRIPTION
## Description of change

"View training reports" had a bug - if you have permissions to view the training reports **or**  activity reports in a given region, you should be able to see the read only view of a TR. The landing page was displaying the correct reports, but clicking on the report to view it generated an error.

## How to test

Confirm that a user who can read activity reports in a given region, has the TR feature flag, but does not have the READ_TRAINING_REPORTS permission in that same region can view a TR in that region. 

For example:
User X has
- READ_REPORTS in region 3
- training_reports feature flag

But does not have READ_TRAINING_REPORTS in region 3

They should be see a Region 3 TR report on their landing page AND have the permissions to view it

## Issue(s)


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
