### PR TITLE
[TTAHUB-1952] Performance enhancement and add back table

### DIFF
--- a/frontend/src/pages/ResourcesDashboard/__tests__/index.js
+++ b/frontend/src/pages/ResourcesDashboard/__tests__/index.js
@@ -11,7 +11,6 @@ import {
   render,
   screen,
   fireEvent,
-  waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';

--- a/frontend/src/pages/ResourcesDashboard/__tests__/index.js
+++ b/frontend/src/pages/ResourcesDashboard/__tests__/index.js
@@ -11,6 +11,7 @@ import {
   render,
   screen,
   fireEvent,
+  waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
@@ -297,6 +298,18 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/177/i)).toBeInTheDocument();
     expect(screen.getByText(/262/i)).toBeInTheDocument();
 
+    // Resources Associated Default.
+    expect(screen.getByText(/Resources associated with topics on Activity Reports/i)).toBeInTheDocument();
+    expect(screen.getByText(/Oct-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nov-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dec-22/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/https:\/\/official1\.gov/i)).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /66/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /773/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /88/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /99/i })).toBeInTheDocument();
+
     // Add region filter.
     let open = await screen.findByRole('button', { name: /open filters for this page/i });
     act(() => userEvent.click(open));
@@ -328,14 +341,25 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/819 of 1,365/i)).toBeInTheDocument();
 
     expect(await screen.findByText(/148/i)).toBeVisible();
-    expect(screen.getAllByText(/^[ \t]*recipients reached[ \t]*$/i)[0]).toBeInTheDocument();
+    expect(await screen.getAllByText(/^[ \t]*recipients reached[ \t]*$/i)[0]).toBeInTheDocument();
     expect(await screen.findByText(/665/i)).toBeVisible();
-    expect(screen.getAllByText(/^[ \t]*participants reached[ \t]*$/i)[0]).toBeInTheDocument();
+    expect(await screen.getAllByText(/^[ \t]*participants reached[ \t]*$/i)[0]).toBeInTheDocument();
 
     // Reason Use.
     expect(screen.getByText(/Jan-22/i)).toBeInTheDocument();
     expect(screen.getByText(/test2.gov/i)).toBeInTheDocument();
 
+    // Resources Region 1.
+    expect(screen.getByText(/Resources associated with topics on Activity Reports/i)).toBeInTheDocument();
+    expect(screen.getByText(/Oct-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nov-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dec-22/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/https:\/\/official2\.gov/i)).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /111/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /222/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /333/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /444/i })).toBeInTheDocument();
     // Remove filter.
     open = await screen.findByRole('button', { name: /open filters for this page/i });
     act(() => userEvent.click(open));
@@ -367,6 +391,18 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/177/i)).toBeInTheDocument();
     expect(screen.getByText(/262/i)).toBeInTheDocument();
 
+    // Resources Associated Default.
+    expect(screen.getByText(/Resources associated with topics on Activity Reports/i)).toBeInTheDocument();
+    expect(screen.getByText(/Oct-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nov-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dec-22/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/https:\/\/official1\.gov/)).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /66/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /773/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /88/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /99/i })).toBeInTheDocument();
+
     // Add region filter test pill remove.
     open = await screen.findByRole('button', { name: /open filters for this page/i });
     act(() => userEvent.click(open));
@@ -393,14 +429,26 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/818 of 365/i)).toBeInTheDocument();
 
     expect(await screen.findByText(/148/i)).toBeVisible();
-    expect(screen.getAllByText(/^[ \t]*recipients reached[ \t]*$/i)[0]).toBeInTheDocument();
+    expect(await screen.getAllByText(/^[ \t]*recipients reached[ \t]*$/i)[0]).toBeInTheDocument();
     expect(await screen.findByText(/565/i)).toBeVisible();
-    expect(screen.getAllByText(/^[ \t]*participants reached[ \t]*$/i)[0]).toBeInTheDocument();
+    expect(await screen.getAllByText(/^[ \t]*participants reached[ \t]*$/i)[0]).toBeInTheDocument();
 
     // Resource Use.
     expect(screen.getByText(/Jan-22/i)).toBeInTheDocument();
     expect(screen.getByText(/test3.gov/i)).toBeInTheDocument();
     expect(screen.getByText(/19/i)).toBeInTheDocument();
+
+    // Resources Region 2.
+    expect(screen.getByText(/Resources associated with topics on Activity Reports/i)).toBeInTheDocument();
+    expect(screen.getByText(/Oct-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nov-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dec-22/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/https:\/\/official3\.gov/i)).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /333/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /444/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /555/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /666/i })).toBeInTheDocument();
 
     // Test filter updates from region pill remove.
     let removePill = await screen.findByRole('button', { name: /this button removes the filter: region is 2/i });
@@ -453,14 +501,26 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/818 of 365/i)).toBeInTheDocument();
 
     expect(await screen.findByText(/148/i)).toBeVisible();
-    expect(screen.getAllByText(/^[ \t]*recipients reached[ \t]*$/i)[0]).toBeInTheDocument();
+    expect(await screen.getAllByText(/^[ \t]*recipients reached[ \t]*$/i)[0]).toBeInTheDocument();
     expect(await screen.findByText(/565/i)).toBeVisible();
-    expect(screen.getAllByText(/^[ \t]*participants reached[ \t]*$/i)[0]).toBeInTheDocument();
+    expect(await screen.getAllByText(/^[ \t]*participants reached[ \t]*$/i)[0]).toBeInTheDocument();
 
     // Resource Use.
     expect(screen.getByText(/Jan-22/i)).toBeInTheDocument();
     expect(screen.getByText(/test3.gov/i)).toBeInTheDocument();
     expect(screen.getByText(/19/i)).toBeInTheDocument();
+
+    // Resources Region 2.
+    expect(screen.getByText(/Resources associated with topics on Activity Reports/i)).toBeInTheDocument();
+    expect(screen.getByText(/Oct-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nov-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dec-22/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/https:\/\/official3\.gov/i)).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /333/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /444/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /555/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /666/i })).toBeInTheDocument();
 
     // Test remove non-region filter pill.
     removePill = await screen.findByRole('button', { name: /this button removes the filter: report id contains 123/i });
@@ -486,6 +546,19 @@ describe('Resources Dashboard page', () => {
     expect(screen.getByText(/test1.gov/i)).toBeInTheDocument();
     expect(screen.getByText(/177/i)).toBeInTheDocument();
     expect(screen.getByText(/262/i)).toBeInTheDocument();
+
+    // Resources Associated Default.
+    expect(screen.getByText(/Resources associated with topics on Activity Reports/i)).toBeInTheDocument();
+    expect(screen.getByText(/Topics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Oct-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nov-22/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dec-22/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/https:\/\/official1\.gov/i)).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /66/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /773/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /88/i })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: /99/i })).toBeInTheDocument();
   });
 
   it('handles errors by displaying an error message', async () => {

--- a/frontend/src/pages/ResourcesDashboard/index.js
+++ b/frontend/src/pages/ResourcesDashboard/index.js
@@ -24,6 +24,7 @@ import { fetchResourceData } from '../../fetchers/Resources';
 import UserContext from '../../UserContext';
 import { RESOURCES_DASHBOARD_FILTER_CONFIG } from './constants';
 import RegionPermissionModal from '../../components/RegionPermissionModal';
+import ResourcesAssociatedWithTopics from '../../widgets/ResourcesAssociatedWithTopics';
 
 const defaultDate = formatDateRange({
   forDateTime: true,
@@ -41,6 +42,7 @@ export default function ResourcesDashboard() {
   const [isLoading, setIsLoading] = useState(false);
   const [resourcesData, setResourcesData] = useState({});
   const [error, updateError] = useState();
+  const [resetPagination, setResetPagination] = useState(false);
   const hasCentralOffice = useMemo(() => (
     user && user.homeRegionId && user.homeRegionId === 14
   ), [user]);
@@ -85,6 +87,7 @@ export default function ResourcesDashboard() {
 
   const setFilters = useCallback((newFilters) => {
     setFiltersInHook(newFilters);
+    setResetPagination(true);
   }, [setFiltersInHook]);
 
   // Remove Filters.
@@ -190,6 +193,12 @@ export default function ResourcesDashboard() {
         <ResourceUse
           data={resourcesData.resourcesUse}
           loading={isLoading}
+        />
+        <ResourcesAssociatedWithTopics
+          data={resourcesData.topicUse}
+          loading={isLoading}
+          resetPagination={resetPagination}
+          setResetPagination={setResetPagination}
         />
       </>
     </div>

--- a/src/services/dashboards/resource.js
+++ b/src/services/dashboards/resource.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { Sequelize, Op } from 'sequelize';
 import { REPORT_STATUSES } from '@ttahub/common';
 import {
@@ -335,16 +336,16 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
   const dbData = {
     allReports: null,
     // viaReport: null,
-    viaSpecialistNextSteps: null,
-    viaRecipientNextSteps: null,
+    // viaSpecialistNextSteps: null,
+    // viaRecipientNextSteps: null,
     viaObjectives: null,
     viaGoals: null,
   };
   [
     dbData.allReports,
     // dbData.viaReport,
-    dbData.viaSpecialistNextSteps,
-    dbData.viaRecipientNextSteps,
+    // dbData.viaSpecialistNextSteps,
+    // dbData.viaRecipientNextSteps,
     dbData.viaObjectives,
     dbData.viaGoals,
   ] = await Promise.all([
@@ -499,6 +500,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       raw: true,
     }),
     */
+    /*
     await ActivityReport.findAll({
       attributes: [
         'id',
@@ -697,6 +699,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       ],
       raw: true,
     }),
+    */
     await ActivityReport.findAll({
       attributes: [
         'id',
@@ -991,10 +994,12 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
   let reportsMap = mergeInResources(new Map(), dbData.viaReport);
   delete dbData.viaReport;
   */
+  /*
   reportsMap = mergeInResources(reportsMap, dbData.viaSpecialistNextSteps);
   delete dbData.viaSpecialistNextSteps;
   reportsMap = mergeInResources(reportsMap, dbData.viaRecipientNextSteps);
   delete dbData.viaRecipientNextSteps;
+  */
   reportsMap = mergeInResources(reportsMap, dbData.viaObjectives);
   delete dbData.viaObjectives;
   reportsMap = mergeInResources(reportsMap, dbData.viaGoals);

--- a/src/services/dashboards/resource.js
+++ b/src/services/dashboards/resource.js
@@ -334,7 +334,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
   // Query Database for all Resources within the scope.
   const dbData = {
     allReports: null,
-    viaReport: null,
+    // viaReport: null,
     viaSpecialistNextSteps: null,
     viaRecipientNextSteps: null,
     viaObjectives: null,
@@ -342,7 +342,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
   };
   [
     dbData.allReports,
-    dbData.viaReport,
+    // dbData.viaReport,
     dbData.viaSpecialistNextSteps,
     dbData.viaRecipientNextSteps,
     dbData.viaObjectives,
@@ -383,6 +383,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
+            createdAt: { [Op.gt]: '2022-12-01' },
           },
         ],
       },
@@ -404,6 +405,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       ],
       raw: true,
     }),
+    /*
     await ActivityReport.findAll({
       attributes: [
         'id',
@@ -496,6 +498,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
       ],
       raw: true,
     }),
+    */
     await ActivityReport.findAll({
       attributes: [
         'id',
@@ -558,6 +561,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
+            createdAt: { [Op.gt]: '2022-12-01' },
           },
         ],
       },
@@ -656,6 +660,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
+            createdAt: { [Op.gt]: '2022-12-01' },
           },
         ],
       },
@@ -763,6 +768,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
+            createdAt: { [Op.gt]: '2022-12-01' },
           },
           {
             [Op.or]: [
@@ -900,6 +906,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
+            createdAt: { [Op.gt]: '2022-12-01' },
           },
           {
             [Op.or]: [
@@ -980,8 +987,10 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
 
   let reportsMap = mergeInResources(new Map(), dbData.allReports);
   delete dbData.allReports;
-  reportsMap = mergeInResources(reportsMap, dbData.viaReport);
+  /*
+  let reportsMap = mergeInResources(new Map(), dbData.viaReport);
   delete dbData.viaReport;
+  */
   reportsMap = mergeInResources(reportsMap, dbData.viaSpecialistNextSteps);
   delete dbData.viaSpecialistNextSteps;
   reportsMap = mergeInResources(reportsMap, dbData.viaRecipientNextSteps);

--- a/src/services/dashboards/resource.js
+++ b/src/services/dashboards/resource.js
@@ -332,6 +332,8 @@ const switchToTopicCentric = (input) => {
 
 // collect all resource data from the db filtered via the scopes
 export async function resourceData(scopes, skipResources = false, skipTopics = false) {
+  // Date to retrieve report data from.
+  const reportCreatedAtDate = '2022-12-01';
   // Query Database for all Resources within the scope.
   const dbData = {
     allReports: null,
@@ -384,7 +386,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
-            createdAt: { [Op.gt]: '2022-12-01' },
+            createdAt: { [Op.gt]: reportCreatedAtDate },
           },
         ],
       },
@@ -563,7 +565,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
-            createdAt: { [Op.gt]: '2022-12-01' },
+            createdAt: { [Op.gt]: reportCreatedAtDate },
           },
         ],
       },
@@ -662,7 +664,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
-            createdAt: { [Op.gt]: '2022-12-01' },
+            createdAt: { [Op.gt]: reportCreatedAtDate },
           },
         ],
       },
@@ -771,7 +773,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
-            createdAt: { [Op.gt]: '2022-12-01' },
+            createdAt: { [Op.gt]: reportCreatedAtDate },
           },
           {
             [Op.or]: [
@@ -909,7 +911,7 @@ export async function resourceData(scopes, skipResources = false, skipTopics = f
           {
             calculatedStatus: REPORT_STATUSES.APPROVED,
             startDate: { [Op.ne]: null },
-            createdAt: { [Op.gt]: '2022-12-01' },
+            createdAt: { [Op.gt]: reportCreatedAtDate },
           },
           {
             [Op.or]: [

--- a/src/services/dashboards/resource.test.js
+++ b/src/services/dashboards/resource.test.js
@@ -20,6 +20,7 @@ import {
   resourcesDashboardOverview,
   resourceUse,
   resourceDashboard,
+  resourceTopicUse,
 } from './resource';
 import { RESOURCE_DOMAIN } from '../../constants';
 import { processActivityReportObjectiveForResourcesById } from '../resource';
@@ -138,6 +139,7 @@ const regionOneDraftReport = {
   topics: ['Equity', 'ERSEA'],
 };
 
+let grant;
 let goal;
 let objective;
 let activityReportObjectiveOne;
@@ -148,7 +150,7 @@ describe('Resources dashboard', () => {
   beforeAll(async () => {
     await User.findOrCreate({ where: mockUser, individualHooks: true });
     await Recipient.findOrCreate({ where: mockRecipient, individualHooks: true });
-    await Grant.findOrCreate({
+    [grant] = await Grant.findOrCreate({
       where: mockGrant,
       validate: true,
       individualHooks: true,
@@ -457,6 +459,23 @@ describe('Resources dashboard', () => {
     });
   });
 
+  it('resourceTopicUse', async () => {
+    const scopes = await filtersToScopes({ 'region.in': [REGION_ID], 'startDate.win': '2021/01/01-2021/01/31' });
+    const data = await resourceTopicUse(scopes);
+    expect(data).toStrictEqual({
+      headers: ['Jan-21'],
+      topics: [
+        { heading: 'ERSEA', isUrl: false, data: [{ title: 'Jan-21', value: '2' }, { title: 'Total', value: '2' }] },
+        { heading: 'CLASS: Classroom Organization', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+        { heading: 'Coaching', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+        { heading: 'Facilities', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+        { heading: 'Fiscal / Budget', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+        { heading: 'Nutrition', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+        { heading: 'Oral Health', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+      ],
+    });
+  });
+
   it('resourceDashboard', async () => {
     const scopes = await filtersToScopes({ 'region.in': [REGION_ID], 'startDate.win': '2021/01/01-2021/01/31' });
     const data = await resourceDashboard(scopes);
@@ -497,6 +516,18 @@ describe('Resources dashboard', () => {
               { title: 'Total', value: '1' },
             ],
           },
+        ],
+      },
+      topicUse: {
+        headers: ['Jan-21'],
+        topics: [
+          { heading: 'ERSEA', isUrl: false, data: [{ title: 'Jan-21', value: '2' }, { title: 'Total', value: '2' }] },
+          { heading: 'CLASS: Classroom Organization', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+          { heading: 'Coaching', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+          { heading: 'Facilities', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+          { heading: 'Fiscal / Budget', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+          { heading: 'Nutrition', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
+          { heading: 'Oral Health', isUrl: false, data: [{ title: 'Jan-21', value: '1' }, { title: 'Total', value: '1' }] },
         ],
       },
       domainList: [


### PR DESCRIPTION
## Description of change

Two changes here:
- Add back topics resource table.
- Remove unwanted tables and filter reports to speed up performance.

Testing locally saw a increase of 50% from 18 seconds to 9 seconds. Although this still isn't ideal we will move forward with this increase for now. Keep in mind this test was with no date filter and all regions.

## How to test

- Review all code.
- Make sure the resource topics table now shows.
- Run the change before and after note the time diff (comment out the cache.ts)

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1952


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
