### PR TITLE
[TTAHUB-2217] Fix bug with parsing dates on an unchanged report

### DIFF
--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -22,6 +22,7 @@ import {
   recipients,
   mockGoalsAndObjectives,
 } from '../testHelpers';
+import { formatReportWithSaveBeforeConversion } from '..';
 import { HTTPError } from '../../../fetchers';
 
 describe('ActivityReport', () => {
@@ -1126,5 +1127,28 @@ describe('ActivityReport', () => {
 
     radios = document.querySelector('.ttahub-objective-files input[type="radio"]');
     expect(radios).not.toBeNull();
+  });
+});
+
+describe('formatReportWithSaveBeforeConversion', () => {
+  it('properly formats dates', async () => {
+    const reportData = await formatReportWithSaveBeforeConversion(
+      {
+        creatorRole: 'Tiny Lizard',
+        startDate: '10/04/2020',
+        endDate: '10/04/2020',
+      },
+      {
+        creatorRole: 'Tiny Lizard',
+        startDate: '10/04/2020',
+        endDate: '10/04/2020',
+      },
+      {},
+      false,
+      1,
+      [],
+    );
+    expect(reportData.startDate).toBe('10/04/2020');
+    expect(reportData.endDate).toBe('10/04/2020');
   });
 });


### PR DESCRIPTION
## Description of change

Start and end dates were being doubled parsed in some circumstances.

## How to test

On main, steps are basically:
- New report. No need to touch anything other than start or end date.
- Enter 10/04/2023 for start date (or use calendar)
- Enter 10/20/2023 for end date (or use calendar)
- Save and continue
- Without touching anything else, use the side navigation (activity summary in progress) to go back to the activity summary
- You'll see some weird stuff.

But not on this branch

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2217


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
