### PR TITLE
[TTAHUB-2255] Multi-line SQL queries mess up logging aggregator Kibana and NewRelic

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,5 +1,10 @@
 require('dotenv').config();
 
+const singleLineLogger = (
+  queryString,
+  queryObject,
+) => console.log(queryString.replace(/\n/g, '\\n')); // eslint-disable-line no-console
+
 module.exports = {
   development: {
     username: process.env.POSTGRES_USERNAME,
@@ -8,6 +13,8 @@ module.exports = {
     host: (process.env.POSTGRES_HOST || 'localhost'),
     port: (process.env.POSTGRES_PORT || 5432),
     dialect: 'postgres',
+    logging: singleLineLogger,
+    logQueryParameters: true,
     minifyAliases: true,
   },
   test: {
@@ -28,6 +35,7 @@ module.exports = {
     host: process.env.POSTGRES_HOST,
     port: (process.env.POSTGRES_PORT || 5432),
     dialect: 'postgres',
+    logging: singleLineLogger,
     minifyAliases: true,
   },
   production: {
@@ -38,6 +46,7 @@ module.exports = {
     host: process.env.POSTGRES_HOST,
     port: (process.env.POSTGRES_PORT || 5432),
     dialect: 'postgres',
+    logging: singleLineLogger,
     minifyAliases: true,
     dialectOptions: {
       ssl: true,

--- a/config/config.js
+++ b/config/config.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 
 const singleLineLogger = (
   queryString,
-  queryObject,
 ) => console.log(queryString.replace(/\n/g, '\\n')); // eslint-disable-line no-console
 
 module.exports = {


### PR DESCRIPTION
## Description of change
By default, sql queries are logged to the terminal. when the query contains a new line the log aggregator treats newlines as separate logs. This change makes queries a single line


## How to test
click around on the site and see that all queries in the log are a single line

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2255


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
