### PR TITLE
[TTAHUB-2253] Make sure to re-trigger prompt validation

### DIFF
--- a/frontend/src/components/Navigator/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/ActivityReportNavigator.js
@@ -11,7 +11,7 @@ import moment from 'moment';
 import {
   IN_PROGRESS, COMPLETE,
 } from './constants';
-import { OBJECTIVE_RESOURCES, validateGoals } from '../../pages/ActivityReport/Pages/components/goalValidator';
+import { OBJECTIVE_RESOURCES, validateGoals, validatePrompts } from '../../pages/ActivityReport/Pages/components/goalValidator';
 import { saveGoalsForReport, saveObjectivesForReport } from '../../fetchers/activityReports';
 import GoalFormContext from '../../GoalFormContext';
 import { validateObjectives } from '../../pages/ActivityReport/Pages/components/objectiveValidator';
@@ -139,6 +139,7 @@ const ActivityReportNavigator = ({
     watch,
     errors,
     reset,
+    trigger,
   } = hookForm;
 
   // A new form page is being shown so we need to reset `react-hook-form` so validations are
@@ -542,6 +543,8 @@ const ActivityReportNavigator = ({
       objectives,
       regionId: formData.regionId,
     };
+
+    await validatePrompts(promptTitles, trigger);
 
     // validate goals will check the form and set errors
     // where appropriate

--- a/frontend/src/pages/ActivityReport/Pages/__tests__/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/__tests__/goalsObjectives.js
@@ -11,7 +11,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import join from 'url-join';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import goalsObjectives, { validatePrompts } from '../goalsObjectives';
+import goalsObjectives from '../goalsObjectives';
 import NetworkContext from '../../../../NetworkContext';
 import GoalFormContext from '../../../../GoalFormContext';
 
@@ -478,36 +478,6 @@ describe('goals objectives', () => {
       expect(await screen.findByRole('link', { name: /http:\/\/test1\.gov/i })).toBeVisible();
       expect(await screen.findByRole('link', { name: /http:\/\/test2\.gov/i })).toBeVisible();
       expect(await screen.findByRole('link', { name: /http:\/\/test3\.gov/i })).toBeVisible();
-    });
-  });
-
-  describe('validatePrompts', () => {
-    it('returns true if no prompts', async () => {
-      const trigger = jest.fn(() => true);
-      const prompts = [];
-      const result = await validatePrompts(prompts, trigger);
-      expect(result).toBeTruthy();
-    });
-
-    it('returns true if prompts are undefined', async () => {
-      const trigger = jest.fn(() => true);
-      const prompts = undefined;
-      const result = await validatePrompts(prompts, trigger);
-      expect(result).toBeTruthy();
-    });
-
-    it('returns the result of trigger when true', async () => {
-      const trigger = jest.fn(() => true);
-      const prompts = [{ trigger: 'trigger', prompt: 'prompt' }];
-      const result = await validatePrompts(prompts, trigger);
-      expect(result).toBeTruthy();
-    });
-
-    it('returns the result of trigger when false', async () => {
-      const trigger = jest.fn(() => false);
-      const prompts = [{ trigger: 'trigger', prompt: 'prompt' }];
-      const result = await validatePrompts(prompts, trigger);
-      expect(result).toBeFalsy();
     });
   });
 });

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/goalValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/goalValidator.js
@@ -9,6 +9,7 @@ import {
   OBJECTIVE_TITLE,
   OBJECTIVE_TTA,
   OBJECTIVE_RESOURCES,
+  validatePrompts,
 } from '../goalValidator';
 import {
   GOAL_NAME_ERROR,
@@ -181,6 +182,36 @@ describe('validateGoals', () => {
         const result = unfinishedGoals(goals);
         expect(result).toEqual(false);
       });
+    });
+  });
+
+  describe('validatePrompts', () => {
+    it('returns true if no prompts', async () => {
+      const trigger = jest.fn(() => true);
+      const prompts = [];
+      const result = await validatePrompts(prompts, trigger);
+      expect(result).toBeTruthy();
+    });
+
+    it('returns true if prompts are undefined', async () => {
+      const trigger = jest.fn(() => true);
+      const prompts = undefined;
+      const result = await validatePrompts(prompts, trigger);
+      expect(result).toBeTruthy();
+    });
+
+    it('returns the result of trigger when true', async () => {
+      const trigger = jest.fn(() => true);
+      const prompts = [{ trigger: 'trigger', prompt: 'prompt' }];
+      const result = await validatePrompts(prompts, trigger);
+      expect(result).toBeTruthy();
+    });
+
+    it('returns the result of trigger when false', async () => {
+      const trigger = jest.fn(() => false);
+      const prompts = [{ trigger: 'trigger', prompt: 'prompt' }];
+      const result = await validatePrompts(prompts, trigger);
+      expect(result).toBeFalsy();
     });
   });
 

--- a/frontend/src/pages/ActivityReport/Pages/components/goalValidator.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/goalValidator.js
@@ -78,3 +78,15 @@ export const validateGoals = (goals, setError = () => {}) => {
   }
   return true;
 };
+
+export const validatePrompts = async (promptTitles, trigger) => {
+  // attempt to validate prompts
+  if (promptTitles && promptTitles.length) {
+    const outputs = await Promise.all((promptTitles.map((title) => trigger(title.fieldName))));
+    if (outputs.some((output) => output === false)) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -12,7 +12,7 @@ import { Link } from 'react-router-dom';
 import GoalPicker from './components/GoalPicker';
 import { IN_PROGRESS } from '../../../components/Navigator/constants';
 import { getGoals, setGoalAsActivelyEdited } from '../../../fetchers/activityReports';
-import { validateGoals } from './components/goalValidator';
+import { validateGoals, validatePrompts } from './components/goalValidator';
 import RecipientReviewSection from './components/RecipientReviewSection';
 import OtherEntityReviewSection from './components/OtherEntityReviewSection';
 import { validateObjectives } from './components/objectiveValidator';
@@ -27,18 +27,6 @@ import { getGoalTemplates } from '../../../fetchers/goalTemplates';
 import NavigatorButtons from '../../../components/Navigator/components/NavigatorButtons';
 
 const GOALS_AND_OBJECTIVES_PAGE_STATE_IDENTIFIER = '2';
-
-export const validatePrompts = async (promptTitles, trigger) => {
-  // attempt to validate prompts
-  if (promptTitles && promptTitles.length) {
-    const outputs = await Promise.all((promptTitles.map((title) => trigger(title.fieldName))));
-    if (outputs.some((output) => output === false)) {
-      return false;
-    }
-  }
-
-  return true;
-};
 
 const GoalsObjectives = ({
   reportId,


### PR DESCRIPTION
## Description of change

Trigger FEI goal validation before saving a goal, even if the blur event has not fired

## How to test

Attempt to save an FEI goal with three root causes. You should not be able to.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2253


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
