### PR TITLE
[TTAHUB-2150] Sorting sessions

### DIFF
--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { TRAINING_REPORT_STATUSES as TRS } from '@ttahub/common';
 import SCOPES from '../middleware/scopeConstants';
 import { auditLogger } from '../logger';
-import db from '../models';
+import db, { sequelize } from '../models';
 import {
   EventShape,
   CreateEventRequest,
@@ -191,7 +191,16 @@ async function findEventHelperBlob({
       {
         model: SessionReportPilot,
         as: 'sessionReports',
-        order: [['data.startDate', 'ASC'], ['data.title', 'ASC']],
+        separate: true, // This is required to order the joined table results.
+        attributes: [
+          'id',
+          'eventId',
+          'data',
+          'createdAt',
+          'updatedAt',
+          [sequelize.fn('COALESCE', 'data.startDate', 'data.sessionName', 'createdAt'), 'sortByValue'],
+        ],
+        order: [['sortByValue', 'ASC']],
       },
     ],
     where,

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -98,8 +98,17 @@ async function findEventHelper(where, plural = false): Promise<EventShape | Even
     include: [
       {
         model: SessionReportPilot,
+        attributes: [
+          'id',
+          'eventId',
+          'data',
+          'createdAt',
+          'updatedAt',
+          [sequelize.literal('Date(CASE WHEN "SessionReportPilot".data->>\'startDate\' = \'\' THEN NULL ELSE "SessionReportPilot".data->>\'startDate\' END)'), 'startDate'],
+        ],
         as: 'sessionReports',
-        order: [['data.startDate', 'ASC'], ['data.title', 'ASC']],
+        separate: true, // This is required to order the joined table results.
+        order: [['startDate', 'ASC'], ['data.sessionName', 'ASC'], ['createdAt', 'ASC']],
       },
     ],
   };
@@ -198,9 +207,9 @@ async function findEventHelperBlob({
           'data',
           'createdAt',
           'updatedAt',
-          [sequelize.fn('COALESCE', 'data.startDate', 'data.sessionName', 'createdAt'), 'sortByValue'],
+          [sequelize.literal('Date(CASE WHEN "SessionReportPilot".data->>\'startDate\' = \'\' THEN NULL ELSE "SessionReportPilot".data->>\'startDate\' END)'), 'startDate'],
         ],
-        order: [['sortByValue', 'ASC']],
+        order: [['startDate', 'ASC'], ['data.sessionName', 'ASC'], ['createdAt', 'ASC']],
       },
     ],
     where,

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -104,7 +104,8 @@ async function findEventHelper(where, plural = false): Promise<EventShape | Even
           'data',
           'createdAt',
           'updatedAt',
-          [sequelize.literal('Date(CASE WHEN "SessionReportPilot".data->>\'startDate\' = \'\' THEN NULL ELSE "SessionReportPilot".data->>\'startDate\' END)'), 'startDate'],
+          // eslint-disable-next-line @typescript-eslint/quotes
+          [sequelize.literal(`Date(NULLIF("SessionReportPilot".data->>'startDate',''))`), 'startDate'],
         ],
         as: 'sessionReports',
         separate: true, // This is required to order the joined table results.
@@ -207,7 +208,8 @@ async function findEventHelperBlob({
           'data',
           'createdAt',
           'updatedAt',
-          [sequelize.literal('Date(CASE WHEN "SessionReportPilot".data->>\'startDate\' = \'\' THEN NULL ELSE "SessionReportPilot".data->>\'startDate\' END)'), 'startDate'],
+          // eslint-disable-next-line @typescript-eslint/quotes
+          [sequelize.literal(`Date(NULLIF("SessionReportPilot".data->>'startDate',''))`), 'startDate'],
         ],
         order: [['startDate', 'ASC'], ['data.sessionName', 'ASC'], ['createdAt', 'ASC']],
       },

--- a/src/services/sessionReports.test.js
+++ b/src/services/sessionReports.test.js
@@ -8,7 +8,9 @@ import {
   findSessionsByEventId,
   updateSession,
   getPossibleSessionParticipants,
+  findSessionHelper,
 } from './sessionReports';
+import sessionReportPilot from '../models/sessionReportPilot';
 
 jest.mock('bull');
 
@@ -207,6 +209,45 @@ describe('session reports service', () => {
       expect(participants[0]).toHaveProperty('id');
       expect(participants[0]).toHaveProperty('name');
       expect(participants[0].grants.length).toBe(1);
+    });
+  });
+  describe('findSessionHelper', () => {
+    let createdEvent;
+    let sessionIds;
+    beforeAll(async () => {
+      const eventData = {
+        ownerId: 99_989,
+        regionId: 99_888,
+        pocIds: [99_888],
+        collaboratorIds: [99_888],
+        data: {
+          eventId,
+        },
+      };
+      createdEvent = await createEvent(eventData);
+
+      // Create Sessions.
+      const session1 = await createSession({ eventId: createdEvent.id, data: { startDate: '04/20/2022' } });
+      const session2 = await createSession({ eventId: createdEvent.id, data: { startDate: '01/01/2023' } });
+      const session3 = await createSession({ eventId: createdEvent.id, data: { startDate: '02/10/2022' } });
+      sessionIds = [session1.id, session2.id, session3.id];
+    });
+
+    afterAll(async () => {
+      await sessionReportPilot.destroy({
+        where: {
+          id: sessionIds,
+        },
+      });
+      destroyEvent(createdEvent.id);
+    });
+
+    it('check sessions sort order', async () => {
+      const sessions = await findSessionHelper({ eventId: createdEvent.id }, true);
+      expect(sessions.length).toBe(3);
+      expect(sessions[0].data.startDate).toBe('02/10/2022');
+      expect(sessions[1].data.startDate).toBe('04/20/2022');
+      expect(sessions[2].data.startDate).toBe('01/01/2023');
     });
   });
 });

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -37,7 +37,8 @@ export async function findSessionHelper(where: WhereOptions, plural = false): Pr
       'eventId',
       'data',
       'updatedAt',
-      [sequelize.literal('Date(CASE WHEN "SessionReportPilot".data->>\'startDate\' = \'\' THEN NULL ELSE "SessionReportPilot".data->>\'startDate\' END)'), 'startDate'],
+      // eslint-disable-next-line @typescript-eslint/quotes
+      [sequelize.literal(`Date(NULLIF("SessionReportPilot".data->>'startDate',''))`), 'startDate'],
     ],
     where,
     order: [['startDate', 'ASC']],

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -1,5 +1,5 @@
 import { cast } from 'sequelize';
-import db from '../models';
+import db, { sequelize } from '../models';
 import { SessionReportShape } from './types/sessionReport';
 import { findEventBySmartsheetIdSuffix, findEventByDbId } from './event';
 
@@ -37,8 +37,10 @@ async function findSessionHelper(where: WhereOptions, plural = false): Promise<S
       'eventId',
       'data',
       'updatedAt',
+      [sequelize.literal('Date(CASE WHEN "SessionReportPilot".data->>\'startDate\' = \'\' THEN NULL ELSE "SessionReportPilot".data->>\'startDate\' END)'), 'startDate'],
     ],
     where,
+    order: [['startDate', 'ASC']],
     include: [
       {
         model: db.File,

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -28,7 +28,7 @@ type WhereOptions = {
 };
 
 // eslint-disable-next-line max-len
-async function findSessionHelper(where: WhereOptions, plural = false): Promise<SessionReportShape | SessionReportShape[] | null> {
+export async function findSessionHelper(where: WhereOptions, plural = false): Promise<SessionReportShape | SessionReportShape[] | null> {
   let session;
 
   const query = {


### PR DESCRIPTION
## Description of change

This changes the session sort in 3 locations.

1. TR landing (startDate, sessionName, createdAt)
2. Edit TR > Complete Event > Session List (startDate)
3. TR Landing > View Report (startDate, sessionName, createdAt)

## How to test

See sort specified on TTAHUB-2150.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2150

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
