### PR TITLE
[TTAHUB-2265] Log the callstack in Kibana

### DIFF
--- a/src/lib/apiErrorHandler.js
+++ b/src/lib/apiErrorHandler.js
@@ -36,7 +36,12 @@ export const handleError = async (req, res, error, logContext) => {
   }
   if (error instanceof Sequelize.Error) {
     await handleSequelizeError(req, res, error, logContext);
+  } else if (error?.stack) {
+    // Log with call stack.
+    logger.error(`${logContext.namespace} - UNEXPECTED ERROR - Call Stack: ${error.stack}`);
+    res.status(INTERNAL_SERVER_ERROR).end();
   } else {
+    // Log without call stack.
     logger.error(`${logContext.namespace} - UNEXPECTED ERROR - ${error}`);
     res.status(INTERNAL_SERVER_ERROR).end();
   }


### PR DESCRIPTION
## Description of change

Log the callstack in Kibana so we see what line the error occured on.

**NOTE:** I tried the solution in this thread without any luck.
https://stackoverflow.com/questions/51630896/winston-not-displaying-error-details

## How to test

Throw an exception on the BE handler and check the server log to see the error message and callstack.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2265


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
