### PR TITLE
[TTAHUB-2155] Check goal name before we attempt to trim()

### DIFF
--- a/src/services/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/services/goalServices/getGoalsByActivityRecipient.test.js
@@ -752,17 +752,20 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[1].grantNumbers.length).toBe(1);
       expect(goalRowsx[1].grantNumbers[0]).toBe('12345');
 
-      // Goal 3 Objectives.
+      // Get objective 4.
       expect(goalRowsx[1].objectives.length).toBe(2);
-      expect(goalRowsx[1].objectives[0].title).toBe('objective 4');
-      expect(goalRowsx[1].objectives[0].endDate).toBe('09/01/2020');
-      expect(goalRowsx[1].objectives[0].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[1].objectives[0].status).toEqual(OBJECTIVE_STATUS.COMPLETE);
+      const objecitve4 = goalRowsx[1].objectives.find((o) => o.title === 'objective 4');
+      expect(objecitve4.title).toBe('objective 4');
+      expect(objecitve4.endDate).toBe('09/01/2020');
+      expect(objecitve4.reasons).toEqual(['COVID-19 response', 'Complaint']);
+      expect(objecitve4.status).toEqual(OBJECTIVE_STATUS.COMPLETE);
 
-      expect(goalRowsx[1].objectives[1].title).toBe('objective 3');
-      expect(goalRowsx[1].objectives[1].endDate).toBe('09/01/2020');
-      expect(goalRowsx[1].objectives[1].reasons).toEqual(['COVID-19 response', 'Complaint']);
-      expect(goalRowsx[1].objectives[1].status).toEqual(OBJECTIVE_STATUS.NOT_STARTED);
+      // Get objective 3.
+      const objecitve3 = goalRowsx[1].objectives.find((o) => o.title === 'objective 3');
+      expect(objecitve3.title).toBe('objective 3');
+      expect(objecitve3.endDate).toBe('09/01/2020');
+      expect(objecitve3.reasons).toEqual(['COVID-19 response', 'Complaint']);
+      expect(objecitve3.status).toEqual(OBJECTIVE_STATUS.NOT_STARTED);
 
       // Goal 2.
       expect(moment(goalRowsx[2].createdOn).format('YYYY-MM-DD')).toBe('2021-02-15');

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -461,7 +461,7 @@ describe('saveGoalsForReport (more tests)', () => {
     });
 
     const goalIdsToDestroy = goalsToDestroy.map((g) => g.id);
-;
+
     await Objective.destroy({
       where: {
         goalId: goalIdsToDestroy,

--- a/src/services/goalServices/saveGoalForReport.test.js
+++ b/src/services/goalServices/saveGoalForReport.test.js
@@ -1347,7 +1347,7 @@ describe('saveGoalsForReport (more tests)', () => {
 
     const defaultGoals = [
       {
-        name: '',
+        name: undefined,
         isActivelyBeingEditing: true,
         endDate: '',
         objectives: [],
@@ -1366,7 +1366,7 @@ describe('saveGoalsForReport (more tests)', () => {
     });
 
     expect(afterReportGoals.length).toBe(1);
-    expect(afterReportGoals[0].name).toBe('');
+    expect(afterReportGoals[0].name).toBe(null);
 
     const afterGoals = await Goal.findAll({
       where: {
@@ -1375,6 +1375,6 @@ describe('saveGoalsForReport (more tests)', () => {
     });
 
     expect(afterGoals.length).toBe(1);
-    expect(afterGoals[0].name).toBe('');
+    expect(afterGoals[0].name).toBe(null);
   });
 });

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1983,7 +1983,7 @@ export async function saveGoalsForReport(goals, report) {
       if (!newOrUpdatedGoal) {
         newOrUpdatedGoal = await Goal.create({
           createdVia: 'activityReport',
-          name: goal.name.trim(),
+          name: goal.name ? goal.name.trim() : '',
           grantId,
           ...fields,
           status,

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1972,7 +1972,7 @@ export async function saveGoalsForReport(goals, report) {
       if (!newOrUpdatedGoal) {
         newOrUpdatedGoal = await Goal.findOne({
           where: {
-            name: goal.name.trim(),
+            name: goal.name ? goal.name.trim() : '',
             grantId,
             status: { [Op.not]: GOAL_STATUS.CLOSED },
           },
@@ -1996,7 +1996,7 @@ export async function saveGoalsForReport(goals, report) {
         }
 
         if (fields.name !== newOrUpdatedGoal.name) {
-          newOrUpdatedGoal.set({ name: fields.name.trim() });
+          newOrUpdatedGoal.set({ name: fields.name ? fields.name.trim() : '' });
         }
 
         if (endDate && endDate !== 'Invalid date' && endDate !== newOrUpdatedGoal.endDate) {

--- a/src/services/goals.js
+++ b/src/services/goals.js
@@ -1995,8 +1995,8 @@ export async function saveGoalsForReport(goals, report) {
           newOrUpdatedGoal.set({ source });
         }
 
-        if (fields.name !== newOrUpdatedGoal.name) {
-          newOrUpdatedGoal.set({ name: fields.name ? fields.name.trim() : '' });
+        if (fields.name !== newOrUpdatedGoal.name && fields.name) {
+          newOrUpdatedGoal.set({ name: fields.name.trim() });
         }
 
         if (endDate && endDate !== 'Invalid date' && endDate !== newOrUpdatedGoal.endDate) {

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -172,9 +172,9 @@ test.describe('Activity Report', () => {
     await page.getByRole('button', { name: 'Goals and objectives not started' }).click();
 
     // create the first goal
-    await page.getByTestId('label').locator('div').filter({ hasText: '- Select -' }).nth(2)
-      .click();
-    await page.locator('#react-select-15-option-0').getByText('Create new goal').click();
+
+    await page.getByLabel(/Select recipient's goal/i).click();
+    await page.keyboard.press('Enter');
     await page.getByTestId('textarea').click();
     await page.getByTestId('textarea').fill('g1');
     await page.getByRole('button', { name: 'Save goal' }).click();
@@ -721,9 +721,8 @@ test.describe('Activity Report', () => {
     await page.getByRole('button', { name: 'Goals and objectives not started' }).click();
 
     // create the goal
-    await page.getByTestId('label').locator('div').filter({ hasText: '- Select -' }).nth(2)
-      .click();
-    await page.locator('#react-select-15-option-0').getByText('Create new goal').click();
+    await page.getByLabel(/Select recipient's goal/i).click();
+    await page.keyboard.press('Enter');
     await page.getByTestId('textarea').click();
     await page.getByTestId('textarea').fill('g1');
     await page.getByRole('button', { name: 'Save goal' }).click();


### PR DESCRIPTION
## Description of change

This change checks that we have a goal name before we trim it.

## How to test

**Steps to reproduce, e.g. on Staging:**
**NOTE:** Use the network tab to see the error before the code change.
    1. create a new report
    2. select a recipient
    3. click "Save and Continue"
    4. navigate back to the Activity Report Summary by clicking the navigator link
    5. click "Save draft"
    6. note the error appears
    7. Also check completing, submitting, and approving the report

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2155

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
