### PR TITLE
[TTAHUB-2268] log all unknown errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,9 @@ commands:
       smtp_password:
         description: "SMTP password"
         type: env_var_name
+      suppress_error_logging:
+        description: "Stop logging of non-sequelize errors to the db"
+        type: env_var_name
     steps:
       - run:
           name: Login with service account
@@ -201,6 +204,7 @@ commands:
               --var SMTP_SECURE=${<< parameters.smtp_secure >>} \
               --var SMTP_IGNORE_TLS=${<< parameters.smtp_ignore_tls >>} \
               --var FROM_EMAIL_ADDRESS=${<< parameters.from_email_address >>}
+              --var SUPPRESS_ERROR_LOGGING=${<< parameters.suppress_error_logging >>}
       # - run:
       #     name: Push maintenance application
       #     command: |
@@ -650,6 +654,7 @@ jobs:
                 from_email_address: FROM_EMAIL_ADDRESS
                 smtp_user: SMTP_USER
                 smtp_password: SMTP_PASSWORD
+                suppress_error_logging: SUPPRESS_ERROR_LOGGING
             - run:
                 name: Migrate database
                 command: |
@@ -698,6 +703,7 @@ jobs:
                 from_email_address: FROM_EMAIL_ADDRESS
                 smtp_user: SMTP_USER
                 smtp_password: SMTP_PASSWORD
+                suppress_error_logging: SUPPRESS_ERROR_LOGGING
             - run:
                 name: Migrate database
                 command: |
@@ -746,6 +752,7 @@ jobs:
                 from_email_address: FROM_EMAIL_ADDRESS
                 smtp_user: SMTP_USER
                 smtp_password: SMTP_PASSWORD
+                suppress_error_logging: SUPPRESS_ERROR_LOGGING
             - run:
                 name: Run database migrations
                 command: |
@@ -792,6 +799,7 @@ jobs:
                 from_email_address: FROM_EMAIL_ADDRESS
                 smtp_user: SMTP_USER
                 smtp_password: SMTP_PASSWORD
+                suppress_error_logging: SUPPRESS_ERROR_LOGGING
             - run:
                 name: Run database migrations
                 command: |

--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,7 @@ IGNORE_CACHE=false
 
 # Should be passed as header named X-API-KEY
 SIMILARITY_API_KEY=secret
+
+# This is the flag to control if all errors will be logged to the RequestErrors table
+# or only ones thrown by sequelize.
+SUPPRESS_ERROR_LOGGING=false

--- a/deployment_config/dev_vars.yml
+++ b/deployment_config/dev_vars.yml
@@ -13,3 +13,4 @@ REDIRECT_URI_HOST: https://tta-smarthub-dev.app.cloud.gov
 TTA_SMART_HUB_URI: https://tta-smarthub-dev.app.cloud.gov
 CLAMAV_ENDPOINT: https://clamapi-ttahub-dev.apps.internal:9443
 SEND_NOTIFICATIONS: "true"
+SUPPRESS_ERROR_LOGGING: "false"

--- a/deployment_config/prod_vars.yml
+++ b/deployment_config/prod_vars.yml
@@ -13,3 +13,4 @@ REDIRECT_URI_HOST: https://ttahub.ohs.acf.hhs.gov
 TTA_SMART_HUB_URI: https://ttahub.ohs.acf.hhs.gov
 CLAMAV_ENDPOINT: https://clamapi-ttahub-prod.apps.internal:9443
 SEND_NOTIFICATIONS: "true"
+SUPPRESS_ERROR_LOGGING: "false"

--- a/deployment_config/sandbox_vars.yml
+++ b/deployment_config/sandbox_vars.yml
@@ -13,3 +13,4 @@ REDIRECT_URI_HOST: https://tta-smarthub-sandbox.app.cloud.gov
 TTA_SMART_HUB_URI: https://tta-smarthub-sandbox.app.cloud.gov
 CLAMAV_ENDPOINT: https://clamapi-ttahub-dev.apps.internal:9443
 SEND_NOTIFICATIONS: "true"
+SUPPRESS_ERROR_LOGGING: "false"

--- a/deployment_config/staging_vars.yml
+++ b/deployment_config/staging_vars.yml
@@ -13,3 +13,4 @@ REDIRECT_URI_HOST: https://tta-smarthub-staging.app.cloud.gov
 TTA_SMART_HUB_URI: https://tta-smarthub-staging.app.cloud.gov
 CLAMAV_ENDPOINT: https://clamapi-ttahub-dev.apps.internal:9443
 SEND_NOTIFICATIONS: "true"
+SUPPRESS_ERROR_LOGGING: "false"

--- a/manifest.yml
+++ b/manifest.yml
@@ -34,6 +34,7 @@ applications:
       SMTP_IGNORE_TLS: ((SMTP_IGNORE_TLS))
       FROM_EMAIL_ADDRESS: ((FROM_EMAIL_ADDRESS))
       NODE_MODULES_CACHE: false
+      SUPPRESS_ERROR_LOGGING: ((SUPPRESS_ERROR_LOGGING))
     services:
       - ttahub-((env))
       - ttahub-redis-((env))

--- a/src/lib/apiErrorHandler.js
+++ b/src/lib/apiErrorHandler.js
@@ -11,7 +11,20 @@ async function logRequestError(req, operation, error, logContext) {
   }
   try {
     const responseBody = typeof error === 'object' && error !== null ? { ...error, errorStack: error?.stack } : error;
-    const requestBody = typeof req.body === 'object' ? { ...req.body } : {};
+    const requestBody = {
+      ...(req.body
+        && typeof req.body === 'object'
+        && Object.keys(req.body).length > 0
+        && { body: req.body }),
+      ...(req.params
+        && typeof req.params === 'object'
+        && Object.keys(req.params).length > 0
+        && { params: req.params }),
+      ...(req.query
+        && typeof req.query === 'object'
+        && Object.keys(req.query).length > 0
+        && { query: req.query }),
+    };
     const requestErrorId = await createRequestError({
       operation,
       uri: req.originalUrl,

--- a/src/lib/apiErrorHandler.test.js
+++ b/src/lib/apiErrorHandler.test.js
@@ -64,7 +64,7 @@ describe('apiErrorHandler', () => {
 
     const requestErrors = await RequestErrors.findAll();
 
-    expect(requestErrors.length).toBe(0);
+    expect(requestErrors.length).not.toBe(0);
   });
 
   it('can handle unexpected error in catch block', async () => {
@@ -75,6 +75,6 @@ describe('apiErrorHandler', () => {
 
     const requestErrors = await RequestErrors.findAll();
 
-    expect(requestErrors.length).toBe(0);
+    expect(requestErrors.length).not.toBe(0);
   });
 });

--- a/src/lib/apiErrorHandler.test.js
+++ b/src/lib/apiErrorHandler.test.js
@@ -75,6 +75,6 @@ describe('apiErrorHandler', () => {
 
     const requestErrors = await RequestErrors.findAll();
 
-    expect(requestErrors.length).not.toBe(0);
+    expect(requestErrors.length).toBe(0);
   });
 });

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -246,7 +246,7 @@ export async function updateLegacyFields(req, res) {
     const savedReport = await createOrUpdate({ imported }, report);
     res.json(savedReport);
   } catch (error) {
-    handleErrors(req, res, error, logContext);
+    await handleErrors(req, res, error, logContext);
   }
 }
 
@@ -268,7 +268,7 @@ export async function getLegacyReport(req, res) {
     }
     res.json(report);
   } catch (error) {
-    handleErrors(req, res, error, logContext);
+    await handleErrors(req, res, error, logContext);
   }
 }
 

--- a/src/routes/externalApi/activityReports/handlers.js
+++ b/src/routes/externalApi/activityReports/handlers.js
@@ -33,6 +33,6 @@ export async function getReportByDisplayId(req, res) {
 
     res.json(ActivityReportsPresenter.render(report));
   } catch (error) {
-    handleErrors(req, res, error, logContext);
+    await handleErrors(req, res, error, logContext);
   }
 }

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -456,7 +456,7 @@ const deleteObjectiveFileHandler = async (req, res) => {
     }
     res.status(204).send();
   } catch (error) {
-    handleErrors(req, res, error, logContext);
+    await handleErrors(req, res, error, logContext);
   }
 };
 
@@ -493,7 +493,7 @@ async function deleteActivityReportObjectiveFile(req, res) {
 
     res.status(204).send();
   } catch (error) {
-    handleErrors(req, res, error, logContext);
+    await handleErrors(req, res, error, logContext);
   }
 }
 

--- a/src/routes/widgets/handlers.js
+++ b/src/routes/widgets/handlers.js
@@ -70,6 +70,6 @@ export async function getWidget(req, res) {
 
     res.json(widgetData);
   } catch (error) {
-    handleErrors(req, res, error, logContext);
+    await handleErrors(req, res, error, logContext);
   }
 }


### PR DESCRIPTION
## Description of change
Now all unknown errors will log to the Request Errors table unless the env SUPPRESS_ERROR_LOGGING is set to true
This should result in missing/lost ttaProvided or similar to be recoverable more often

## How to test
Trigger an error, look in the RequestErrors DB or the admin UI for the logged data

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2268


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
