### PR TITLE
[TTAHUB-2120] Mark test FEI goals deleted

### DIFF
--- a/src/migrations/20231027150000-remove-test-fei-goals.js
+++ b/src/migrations/20231027150000-remove-test-fei-goals.js
@@ -45,7 +45,7 @@ module.exports = {
     });
   },
 
-  down: async () => {
+  down: async (queryInterface) => {
     await queryInterface.sequelize.transaction(async (transaction) => {
       const sessionSig = __filename;
       await prepMigration(queryInterface, transaction, sessionSig);

--- a/src/migrations/20231027150000-remove-test-fei-goals.js
+++ b/src/migrations/20231027150000-remove-test-fei-goals.js
@@ -1,0 +1,86 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+
+      await queryInterface.sequelize.query(`
+      -- Some test FEI goals were created for region 6 grants that weren't supposed to have them
+
+      -- PROCESS:
+      -- Mark objectives deletedAt
+      -- Mark goals deletedAt
+
+      CREATE TEMP TABLE goals_for_deletion
+      AS
+      SELECT * FROM (
+        VALUES -- sorted and deduped
+        (51072),
+        (51322),
+        (51326),
+        (51327),
+        (51330),
+        (51331)
+      ) AS data(gid)
+      ;
+
+      UPDATE "Objectives"
+      SET "deletedAt" = NOW()
+      FROM goals_for_deletion
+      WHERE "goalId" = gid
+      ;
+
+      UPDATE "Goals"
+      SET "deletedAt" = NOW()
+      FROM goals_for_deletion
+      WHERE id = gid
+      ;
+      
+      `, { transaction });
+    });
+  },
+
+  down: async () => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+
+      await queryInterface.sequelize.query(`
+      -- REVERSE PROCESS:
+      -- Unmark objectives deletedAt
+      -- Unmark goals deletedAt
+
+      CREATE TEMP TABLE goals_for_deletion
+      AS
+      SELECT * FROM (
+        VALUES -- sorted and deduped
+        (51072),
+        (51322),
+        (51326),
+        (51327),
+        (51330),
+        (51331)
+      ) AS data(gid)
+      ;
+
+      UPDATE "Objectives"
+      SET "deletedAt" = NULL
+      FROM goals_for_deletion
+      WHERE "goalId" = gid
+      ;
+
+      UPDATE "Goals"
+      SET "deletedAt" = NULL
+      FROM goals_for_deletion
+      WHERE id = gid
+      ;
+      
+      `, { transaction });
+    });
+  },
+};

--- a/src/migrations/20231027150000-remove-test-fei-goals.js
+++ b/src/migrations/20231027150000-remove-test-fei-goals.js
@@ -45,7 +45,7 @@ module.exports = {
     });
   },
 
-  down: async (queryInterface) => {
+  async down(queryInterface) {
     await queryInterface.sequelize.transaction(async (transaction) => {
       const sessionSig = __filename;
       await prepMigration(queryInterface, transaction, sessionSig);


### PR DESCRIPTION
## Description of change

Marks some test FEI Goals and associated Objectives to be 'deletedAt' the time of migration so they drop out of visibility

## How to test

The goals and objectives should disappear. E.g. on grant 06CH012163, there should no longer be an FEI goal visible. There should also be no Objectives left visible with the title `hghgh`

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2120


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
