### PR TITLE
[TTAHUB-2288] Fix ActivityReportGoalFieldResponse update bug

### DIFF
--- a/src/models/hooks/goalFieldResponse.js
+++ b/src/models/hooks/goalFieldResponse.js
@@ -36,19 +36,36 @@ const syncActivityReportGoalFieldResponses = async (sequelize, instance, options
     && changed.includes('response')) {
       // Update all ActivityReportGoalFieldResponses with this goalId and promptId.
       const { goalId, goalTemplateFieldPromptId } = instance;
-      await sequelize.models.ActivityReportGoalFieldResponse.update(
-        { response: instance.response },
+
+      // Get ids to update (sequelize update doesn't support joins...)
+      const idsToUpdate = await sequelize.models.ActivityReportGoalFieldResponse.findAll(
         {
+          attributes: ['id'],
           where: {
             goalTemplateFieldPromptId,
           },
-          includes: {
+          include: {
+            attributes: [],
+            required: true,
             model: sequelize.models.ActivityReportGoal,
+            as: 'activityReportGoal',
             where: {
               goalId,
             },
           },
+        },
+      );
 
+      // Get ids to update.
+      const ids = idsToUpdate.map((item) => item.id);
+
+      // Perform the update.
+      await sequelize.models.ActivityReportGoalFieldResponse.update(
+        { response: instance.response },
+        {
+          where: {
+            id: ids,
+          },
         },
       );
     }


### PR DESCRIPTION
## Description of change

We found an awesome bug that updates all values in 'ActivityReportGoalFieldResponse'. This occurs when a FEI Root cause is changed on a goal that is not on an approved report. This updates all values in the 'ActivityReportGoalFieldResponse' (for every goal).

Apparently sequelize doesn't support joins on updates so it updates everything 🤷‍♂️ (it also doesn't complain)

## How to test

- Review code.
- Update an FEI Goal's root cause that is linked to a non-approved report. Check the database and make sure the GoalFieldResponse and ActivityReportGoalFieldResponse are ONLY changed for your goal and ar.

Steps to Reproduce:
1. Edit any FEI goal that is not on a approved report
2. Change the FEI root causes and save
3. Verify the GoalFieldResponse  and ActivityReportGoalFieldResponse  are in sync and no other rows have been updated in either table


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2288


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
