### PR TITLE
Honor no send with TR notifications

### DIFF
--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -426,6 +426,13 @@ export const sendTrainingReportNotification = async (job, transport = defaultTra
     debugMessage,
   } = data;
 
+  const toEmails = filterAndDeduplicateEmails([emailTo]);
+
+  if (toEmails.length === 0) {
+    logger.info(`Did not send ${job.name} notification for ${job.data.report.displayId || job.data.report.id} preferences are not set or marked as "no-send"`);
+    return null;
+  }
+
   logger.debug(debugMessage);
 
   if (SEND_NOTIFICATIONS === 'true' && !CI) {
@@ -442,7 +449,7 @@ export const sendTrainingReportNotification = async (job, transport = defaultTra
     return email.send({
       template: path.resolve(emailTemplatePath, templatePath),
       message: {
-        to: emailTo,
+        to: toEmails,
       },
       locals: data,
     });

--- a/src/lib/mailer/index.test.js
+++ b/src/lib/mailer/index.test.js
@@ -365,6 +365,25 @@ describe('mailer tests', () => {
       );
       expect(message.text).toContain('/asdf/');
     });
+    it('Honors no send', async () => {
+      process.env.SEND_NOTIFICATIONS = true;
+      process.env.CI = '';
+      const data = {
+        emailTo: [`no-send_${mockNewCollaborator.email}`],
+        templatePath: 'tr_session_completed',
+        debugMessage: 'Congrats dude',
+        displayId: 'TR-04-1235',
+        reportPath: '/asdf/',
+        report: {
+          id: 1,
+          displayId: 'mockReport-1',
+        },
+      };
+      const email = await sendTrainingReportNotification({
+        data,
+      }, jsonTransport);
+      expect(email).toBeNull();
+    });
     it('Tests that emails are not sent without SEND_NOTIFICATIONS', async () => {
       process.env.SEND_NOTIFICATIONS = false;
       const data = {


### PR DESCRIPTION
## Description of change

Check for "no-send" prefix before sending a TR notification

## How to test


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2296


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
