### PR TITLE
update strictness of goal merge eligibility

### DIFF
--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -2394,6 +2394,190 @@ export async function destroyGoal(goalIds) {
 }
 
 /**
+ * @param {goals[]} include .activityReportGoals
+ * @returns {
+*  reportId: countOfGoalsOnReport,
+* }
+*/
+export const getReportCountForGoals = (goals) => goals.reduce((acc, goal) => {
+  (goal.activityReportGoals || []).forEach((arg) => {
+    if (!acc[arg.activityReportId]) {
+      acc[arg.activityReportId] = 0;
+    }
+    acc[arg.activityReportId] += 1;
+  });
+
+  return acc;
+}, {});
+
+const fieldMappingForDeduplication = {
+  name: 'name',
+  source: 'source',
+  status: 'status',
+  responsesForComparison: 'responsesForComparison',
+};
+
+/**
+*
+* key is activityReportid, value is count of goals on that report
+* @param {{ number: number }} countObject
+*/
+// eslint-disable-next-line max-len
+export const hasMultipleGoalsOnSameActivityReport = (countObject) => Object.values(countObject).some((c) => c > 1);
+
+/**
+*
+* similarity response is an array of objects with the following structure:
+* {
+     "id": number,
+     "name": string,
+     "matches": [{
+       "id": number,
+       "name": string,
+       "grantId": number,
+       "similarity": float,
+     }]
+  }
+*
+* @param {[]} similarityResponse
+* @returns {
+*  goals: [{
+*    name: string,
+*    source: string,
+*    status: string,
+*    responsesForComparison: string,
+*    ids: number[],
+*  }],
+*  ids: number[]
+* }[]
+*/
+export async function getGoalIdsBySimilarity(similarityResponse = []) {
+  // convert the response to a group of IDs
+  const goalIdGroups = similarityResponse.map((matchedGoals) => {
+    const { id, matches } = matchedGoals;
+    return uniq([id, ...matches.map((match) => match.id)]);
+  });
+
+  // convert the ids to a big old database query
+  const goalGroups = await Promise.all(goalIdGroups.map((group) => Goal.findAll({
+    attributes: ['id', 'status', 'name', 'source', 'goalTemplateId', 'grantId'],
+    where: {
+      [Op.or]: [
+        {
+          id: group,
+          '$"goalTemplate"."creationMethod"$': {
+            [Op.ne]: CREATION_METHOD.CURATED,
+          },
+        },
+        {
+          id: group,
+          '$"goalTemplate"."creationMethod"$': {
+            [Op.eq]: CREATION_METHOD.CURATED,
+          },
+          status: {
+            [Op.not]: GOAL_STATUS.CLOSED,
+          },
+        },
+      ],
+    },
+    include: [
+      {
+        model: ActivityReportGoal,
+        as: 'activityReportGoals',
+        attributes: ['goalId', 'activityReportId'],
+        required: false,
+      },
+      {
+        model: Grant,
+        as: 'grant',
+        required: true,
+        attributes: ['id', 'status'],
+      },
+      {
+        model: GoalFieldResponse,
+        as: 'responses',
+        required: false,
+        attributes: ['response', 'goalId'],
+      },
+      {
+        model: GoalTemplate,
+        as: 'goalTemplate',
+        required: false,
+        attributes: ['id', 'creationMethod'],
+      },
+    ],
+  })));
+
+  const uniqueGrantIds = uniq(goalGroups.map((group) => group.map((goal) => goal.grantId)).flat());
+
+  const grants = await Grant.findAll({
+    where: {
+      [Op.or]: [
+        { id: uniqueGrantIds },
+        { oldGrantId: uniqueGrantIds },
+      ],
+      status: 'Active',
+    },
+    attributes: ['id', 'oldGrantId', 'status'],
+  });
+
+  const grantLookup = {};
+  grants.forEach((grant) => {
+    grantLookup[grant.id] = grant.id;
+    if (grant.oldGrantId) {
+      grantLookup[grant.oldGrantId] = grant.id;
+    }
+  });
+
+  // filter out goal groups that include multiple goals on the same report
+  const filteredGoalGroups = goalGroups.filter((group) => {
+    // eslint-disable-next-line max-len
+    const uniqueFieldResponses = uniq(group.map((goal) => goal.responses.map((response) => response.response)).flat(2));
+
+    if (uniqueFieldResponses.length > 2) {
+      return false;
+    }
+    const reportCount = getReportCountForGoals(group);
+
+    return !hasMultipleGoalsOnSameActivityReport(reportCount);
+  });
+
+  const goalGroupsDeduplicated = filteredGoalGroups.map((group) => group
+    .reduce((previous, current) => {
+      if (!grantLookup[current.grantId]) {
+        return previous;
+      }
+
+      // see if we can find an existing goal
+      const existingGoal = findOrFailExistingGoal(current, previous, fieldMappingForDeduplication);
+      // if we found an existing goal,
+      // we'll add the current goal's ID to the existing goal's ID array
+      if (existingGoal) {
+        existingGoal.ids.push(current.id);
+        return previous;
+      }
+
+      return [
+        ...previous,
+        {
+          name: current.name,
+          source: current.source,
+          status: current.status,
+          responsesForComparison: responsesForComparison(current),
+          ids: [current.id],
+        },
+      ];
+    }, []));
+
+  const groupsWithMoreThanOneGoal = goalGroupsDeduplicated.filter((group) => group.length > 1);
+
+  return groupsWithMoreThanOneGoal.map((gg) => ({
+    ids: uniq(gg.map((g) => g.ids).flat()),
+    goals: gg,
+  }));
+}
+
+/**
  * Given a list of goal statuses, determine the final status
  * based on the criteria provided by OHS. Intended only
  * to be used for merge goals
@@ -2535,6 +2719,14 @@ export function determineFinalGoalValues(selectedGoals, finalGoal) {
  * @param {number[]} selectedGoalIds
  */
 export async function mergeGoals(finalGoalId, selectedGoalIds) {
+  // first thing we do is test elibility
+  // in case something weird got into a URL on the frontend
+  const mockResponse = [{ id: finalGoalId, matches: selectedGoalIds.map((id) => ({ id })) }];
+  const elibilityGroup = await getGoalIdsBySimilarity(mockResponse);
+  if (!elibilityGroup.length) {
+    throw new Error('Cannot merge: goals ineligible for merge');
+  }
+
   // create a new goal from "finalGoalId"
   // - update selectedGoalIds to point to newGoalId
   // - i.e. { parentGoalId: newGoalId }
@@ -2684,13 +2876,16 @@ export async function mergeGoals(finalGoalId, selectedGoalIds) {
     }
 
     // copy the goal resources
-    g.goalResources.forEach((gr) => {
-      updatesToRelatedModels.push(GoalResource.create({
-        goalId: grantToGoalDictionary[
-          grantsWithReplacementsDictionary[g.grantId]
-        ],
-        resourceId: gr.resourceId,
-      }, { individualHooks: true }));
+    g.goalResources.forEach(async (gr) => {
+      updatesToRelatedModels.push(GoalResource.findOrCreate({
+        where: {
+          goalId: grantToGoalDictionary[
+            grantsWithReplacementsDictionary[g.grantId]
+          ],
+          resourceId: gr.resourceId,
+        },
+        individualHooks: true,
+      }));
     });
 
     // copy the goal field responses
@@ -2911,143 +3106,4 @@ export async function createMultiRecipientGoalsFromAdmin(data) {
     grantsForWhomGoalAlreadyExists: [],
     grantsForWhichGoalWillBeCreated: [],
   };
-}
-
-const fieldMappingForDeduplication = {
-  name: 'name',
-  source: 'source',
-  status: 'status',
-  responsesForComparison: 'responsesForComparison',
-};
-
-/**
- *
- * similarity response is an array of objects with the following structure:
- * {
-      "id": number,
-      "name": string,
-      "matches": [{
-        "id": number,
-        "name": string,
-        "grantId": number,
-        "similarity": float,
-      }]
-   }
- *
- * @param {[]} similarityResponse
- * @returns {
- *  goals: [{
- *    name: string,
- *    source: string,
- *    status: string,
- *    responsesForComparison: string,
- *    ids: number[],
- *  }],
- *  ids: number[]
- * }[]
- */
-export async function getGoalIdsBySimilarity(similarityResponse = []) {
-  // convert the response to a group of IDs
-  const goalIdGroups = similarityResponse.map((matchedGoals) => {
-    const { id, matches } = matchedGoals;
-    return uniq([id, ...matches.map((match) => match.id)]);
-  });
-
-  // convert the ids to a big old database query
-  const goalGroups = await Promise.all(goalIdGroups.map((group) => Goal.findAll({
-    attributes: ['id', 'status', 'name', 'source', 'goalTemplateId', 'grantId'],
-    where: {
-      [Op.or]: [
-        {
-          id: group,
-          '$"goalTemplate"."creationMethod"$': {
-            [Op.ne]: CREATION_METHOD.CURATED,
-          },
-        },
-        {
-          id: group,
-          '$"goalTemplate"."creationMethod"$': {
-            [Op.eq]: CREATION_METHOD.CURATED,
-          },
-          status: {
-            [Op.not]: GOAL_STATUS.CLOSED,
-          },
-        },
-      ],
-    },
-    include: [
-      {
-        model: Grant,
-        as: 'grant',
-        required: true,
-        attributes: ['id', 'status'],
-      },
-      {
-        model: GoalFieldResponse,
-        as: 'responses',
-        required: false,
-        attributes: ['response', 'goalId'],
-      },
-      {
-        model: GoalTemplate,
-        as: 'goalTemplate',
-        required: false,
-        attributes: ['id', 'creationMethod'],
-      },
-    ],
-  })));
-
-  const uniqueGrantIds = uniq(goalGroups.map((group) => group.map((goal) => goal.grantId)).flat());
-
-  const grants = await Grant.findAll({
-    where: {
-      [Op.or]: [
-        { id: uniqueGrantIds },
-        { oldGrantId: uniqueGrantIds },
-      ],
-      status: 'Active',
-    },
-    attributes: ['id', 'oldGrantId', 'status'],
-  });
-
-  const grantLookup = {};
-  grants.forEach((grant) => {
-    grantLookup[grant.id] = grant.id;
-    if (grant.oldGrantId) {
-      grantLookup[grant.oldGrantId] = grant.id;
-    }
-  });
-
-  const goalGroupsDeduplicated = goalGroups.map((group) => group
-    .reduce((previous, current) => {
-      if (!grantLookup[current.grantId]) {
-        return previous;
-      }
-
-      // see if we can find an existing goal
-      const existingGoal = findOrFailExistingGoal(current, previous, fieldMappingForDeduplication);
-      // if we found an existing goal,
-      // we'll add the current goal's ID to the existing goal's ID array
-      if (existingGoal) {
-        existingGoal.ids.push(current.id);
-        return previous;
-      }
-
-      return [
-        ...previous,
-        {
-          name: current.name,
-          source: current.source,
-          status: current.status,
-          responsesForComparison: responsesForComparison(current),
-          ids: [current.id],
-        },
-      ];
-    }, []));
-
-  const groupsWithMoreThanOneGoal = goalGroupsDeduplicated.filter((group) => group.length > 1);
-  return groupsWithMoreThanOneGoal.map((gg) => ({
-    ids: uniq(gg.map((g) => g.ids).flat()),
-    goals: gg,
-  }));
 }


### PR DESCRIPTION
## Description of change

- Only allow goals that don't appear on the same activity report to be eligible for merge
- Only allow goals that would have less than 3 goal field responses to be merged
- Don't double create goal resource links

## How to test

Check that the code accomplishes these three things

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
