### PR TITLE
Handle nth level merging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ parameters:
     default: "fix-broken-deploy-config"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "jp/2259/similarity-node-service"
+    default: "mb/TTAHUB-2337/handle-nth-level-merging"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -2637,17 +2637,7 @@ export async function mergeObjectiveFromGoal(objective, parentGoalId) {
   objective.activityReportObjectives.forEach((aro) => {
     updatesToRelatedModels.push(
       ActivityReportObjective.update({
-        originalObjectiveId: aro.objectiveId,
-      }, {
-        where: {
-          id: aro.id,
-          originalObjectiveId: null,
-        },
-        individualHooks: true,
-      }),
-    );
-    updatesToRelatedModels.push(
-      ActivityReportObjective.update({
+        originalObjectiveId: sequelize.fn('COALESCE', sequelize.col('originalObjectiveId'), aro.objectiveId),
         objectiveId: newObjective.id,
       }, {
         where: {
@@ -2872,16 +2862,10 @@ export async function mergeGoals(finalGoalId, selectedGoalIds) {
   selectedGoals.forEach((g) => {
     // update the activity report goal
     if (g.activityReportGoals.length) {
+      // originalGoalId: g.id,
       updatesToRelatedModels.push(ActivityReportGoal.update(
         {
-          originalGoalId: g.id,
-        },
-        {
-          where: { id: g.activityReportGoals.map((arg) => arg.id), originalGoalId: null },
-        },
-      ));
-      updatesToRelatedModels.push(ActivityReportGoal.update(
-        {
+          originalGoalId: sequelize.fn('COALESCE', sequelize.col('originalGoalId'), g.id),
           goalId: grantToGoalDictionary[
             grantsWithReplacementsDictionary[g.grantId]
           ],

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -2637,8 +2637,18 @@ export async function mergeObjectiveFromGoal(objective, parentGoalId) {
   objective.activityReportObjectives.forEach((aro) => {
     updatesToRelatedModels.push(
       ActivityReportObjective.update({
-        objectiveId: newObjective.id,
         originalObjectiveId: aro.objectiveId,
+      }, {
+        where: {
+          id: aro.id,
+          originalObjectiveId: null,
+        },
+        individualHooks: true,
+      }),
+    );
+    updatesToRelatedModels.push(
+      ActivityReportObjective.update({
+        objectiveId: newObjective.id,
       }, {
         where: {
           id: aro.id,
@@ -2865,6 +2875,13 @@ export async function mergeGoals(finalGoalId, selectedGoalIds) {
       updatesToRelatedModels.push(ActivityReportGoal.update(
         {
           originalGoalId: g.id,
+        },
+        {
+          where: { id: g.activityReportGoals.map((arg) => arg.id), originalGoalId: null },
+        },
+      ));
+      updatesToRelatedModels.push(ActivityReportGoal.update(
+        {
           goalId: grantToGoalDictionary[
             grantsWithReplacementsDictionary[g.grantId]
           ],

--- a/src/routes/goals/handlers.js
+++ b/src/routes/goals/handlers.js
@@ -269,7 +269,7 @@ export async function getSimilarGoalsForRecipient(req, res) {
     const { result } = await similarGoalsForRecipient(recipientId, true);
 
     const ids = Array.from((result || []).reduce((acc, resp) => {
-      const goals = resp.matches.map((match) => match.id);
+      const goals = (resp.matches || []).map((match) => match.id);
       goals.forEach((goal) => acc.add(goal));
 
       return acc;


### PR DESCRIPTION
## Description of change

For merge goals, we want to preserve the value in "originalGoalId" and "originalObjectiveId" in the case where a merged ActivityReportGoal or ActivityReportObjective is merged again.

This preserves the lineage more directly.

## How to test

Merge a merged goal and verify in the database that the ARG and ARO have their original values for the columns above. You probably want to record the value before merging for ease of verification.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2337


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
