### PR TITLE
[TTAHUB-2336] Unify merge goals permissions

### DIFF
--- a/frontend/src/fetchers/__tests__/goals.js
+++ b/frontend/src/fetchers/__tests__/goals.js
@@ -5,9 +5,9 @@ describe('goals fetcher', () => {
   beforeEach(() => fetchMock.reset());
 
   it('merges goals', async () => {
-    fetchMock.post('/api/goals/merge', { res: 'ok' });
+    fetchMock.post('/api/goals/recipient/1/region/2/merge', { res: 'ok' });
 
-    const res = await mergeGoals([1, 2, 3], 4);
+    const res = await mergeGoals([1, 2, 3], 4, 1, 2);
 
     expect(res).toEqual({ res: 'ok' });
   });

--- a/frontend/src/fetchers/goals.js
+++ b/frontend/src/fetchers/goals.js
@@ -48,8 +48,15 @@ export async function deleteGoal(goalIds, regionId) {
   return deleted.json();
 }
 
-export async function mergeGoals(selectedGoalIds, finalGoalId) {
-  const res = await post(join(goalsUrl, 'merge'), {
+export async function mergeGoals(selectedGoalIds, finalGoalId, recipientId, regionId) {
+  const res = await post(join(
+    goalsUrl,
+    'recipient',
+    String(recipientId),
+    'region',
+    String(regionId),
+    'merge',
+  ), {
     selectedGoalIds,
     finalGoalId,
   });

--- a/frontend/src/pages/RecipientRecord/pages/MergeGoals/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/MergeGoals/__tests__/index.js
@@ -267,7 +267,7 @@ describe('Merge goals', () => {
     const label = document.querySelector('.ttahub-final-goal--status .ttahub-final-goal--status-label');
     expect(label.textContent).toBe('In progress');
 
-    const goalsUrl = join('api', 'goals', 'merge');
+    const goalsUrl = join('api', 'goals', 'recipient', String(RECIPIENT_ID), 'region', String(REGION_ID), 'merge');
     fetchMock.post(goalsUrl, [{ id: 1 }, { id: 2 }]);
 
     const openModal = await screen.findByRole('button', { name: 'Merge goals' });
@@ -314,7 +314,7 @@ describe('Merge goals', () => {
     const label = document.querySelector('.ttahub-final-goal--status .ttahub-final-goal--status-label');
     expect(label.textContent).toBe('In progress');
 
-    const goalsUrl = join('api', 'goals', 'merge');
+    const goalsUrl = join('api', 'goals', 'recipient', String(RECIPIENT_ID), 'region', String(REGION_ID), 'merge');
     fetchMock.post(goalsUrl, 500);
 
     const openModal = await screen.findByRole('button', { name: 'Merge goals' });

--- a/frontend/src/pages/RecipientRecord/pages/MergeGoals/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/MergeGoals/index.js
@@ -288,7 +288,12 @@ export default function MergeGoals({
   const onSubmit = async (data) => {
     try {
       setIsAppLoading(true);
-      const mergedGoals = await mergeGoals(data.selectedGoalIds, data.finalGoalId);
+      const mergedGoals = await mergeGoals(
+        data.selectedGoalIds,
+        data.finalGoalId,
+        recipientId,
+        regionId,
+      );
       const goalIds = mergedGoals.map((g) => g.id);
       setIsAppLoading(false);
       history.push(`${backPath}`, { mergedGoals: goalIds });

--- a/similarity_api/src/settings.py
+++ b/similarity_api/src/settings.py
@@ -20,7 +20,7 @@ vcap_credentials = get_postgres_credentials_from_vcap()
 
 DB_USERNAME = os.environ.get("POSTGRES_USERNAME") or (vcap_credentials and vcap_credentials.get('username'))
 DB_PASSWORD = os.environ.get("POSTGRES_PASSWORD") or (vcap_credentials and vcap_credentials.get('password'))
-DB_HOST = os.environ.get("DOCKER_INTERNAL_HOST") or os.environ.get("POSTGRES_HOST") or (vcap_credentials and vcap_credentials.get('host'))
+DB_HOST = 'postgres_docker' #os.environ.get("DOCKER_INTERNAL_HOST") or os.environ.get("POSTGRES_HOST") or (vcap_credentials and vcap_credentials.get('host'))
 DB_NAME = os.environ.get("POSTGRES_DB") or (vcap_credentials and vcap_credentials.get('db_name'))
 PORT = (vcap_credentials and vcap_credentials.get('port')) or 5432
 

--- a/similarity_api/src/settings.py
+++ b/similarity_api/src/settings.py
@@ -20,7 +20,7 @@ vcap_credentials = get_postgres_credentials_from_vcap()
 
 DB_USERNAME = os.environ.get("POSTGRES_USERNAME") or (vcap_credentials and vcap_credentials.get('username'))
 DB_PASSWORD = os.environ.get("POSTGRES_PASSWORD") or (vcap_credentials and vcap_credentials.get('password'))
-DB_HOST = 'postgres_docker' #os.environ.get("DOCKER_INTERNAL_HOST") or os.environ.get("POSTGRES_HOST") or (vcap_credentials and vcap_credentials.get('host'))
+DB_HOST = os.environ.get("DOCKER_INTERNAL_HOST") or os.environ.get("POSTGRES_HOST") or (vcap_credentials and vcap_credentials.get('host'))
 DB_NAME = os.environ.get("POSTGRES_DB") or (vcap_credentials and vcap_credentials.get('db_name'))
 PORT = (vcap_credentials and vcap_credentials.get('port')) or 5432
 

--- a/src/routes/admin/helpers.js
+++ b/src/routes/admin/helpers.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import { readFileSync } from 'fs';
+
+export const bufferFromPath = (path) => readFileSync(path);

--- a/src/routes/admin/trainingReport.js
+++ b/src/routes/admin/trainingReport.js
@@ -1,10 +1,10 @@
 import express from 'express';
 import httpCodes from 'http-codes';
-import { readFileSync } from 'fs';
 import multiparty from 'multiparty';
 import transactionWrapper from '../transactionWrapper';
 import { handleError } from '../../lib/apiErrorHandler';
 import { csvImport } from '../../services/event';
+import { bufferFromPath } from './helpers';
 
 const namespace = 'ADMIN:TRAINING_REPORT';
 const logContext = { namespace };
@@ -26,7 +26,7 @@ export async function importTrainingReport(req, res) {
       }
 
       const file = files.file[0];
-      const buf = readFileSync(file.path);
+      const buf = bufferFromPath(file.path);
       const response = await csvImport(buf);
 
       res.status(httpCodes.OK).json(response);

--- a/src/routes/admin/trainingReport.test.js
+++ b/src/routes/admin/trainingReport.test.js
@@ -1,0 +1,107 @@
+import httpCodes from 'http-codes';
+import multiparty from 'multiparty';
+import { importTrainingReport } from './trainingReport';
+import { handleError } from '../../lib/apiErrorHandler';
+import { csvImport } from '../../services/event';
+import { bufferFromPath } from './helpers';
+
+jest.mock('multiparty', () => ({
+  Form: jest.fn(() => ({
+    parse: jest.fn(),
+  })),
+}));
+
+jest.mock('../../lib/apiErrorHandler', () => ({
+  handleError: jest.fn(),
+}));
+
+jest.mock('../../services/event', () => ({
+  csvImport: jest.fn(),
+}));
+
+jest.mock('./helpers', () => ({
+  bufferFromPath: jest.fn(),
+}));
+
+describe('importTrainingReport', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = {};
+    res = {
+      status: jest.fn(() => ({
+        json: jest.fn(),
+      })),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle error when form parsing fails', async () => {
+    const err = new Error('Form parsing failed');
+    const logContext = { namespace: 'ADMIN:TRAINING_REPORT' };
+
+    multiparty.Form.mockImplementationOnce(() => ({
+      parse: jest.fn((_request, callback) => {
+        callback(err);
+      }),
+    }));
+
+    await importTrainingReport(req, res);
+
+    expect(handleError).toHaveBeenCalledWith(req, res, err, logContext);
+  });
+
+  it('should return error response when file type is invalid', async () => {
+    const headers = { 'content-type': 'application/json' };
+    const files = {
+      file: [
+        {
+          headers,
+          path: '/path/to/file.csv',
+        },
+      ],
+    };
+
+    multiparty.Form.mockImplementationOnce(() => ({
+      parse: jest.fn((_request, callback) => {
+        callback(null, {}, files);
+      }),
+    }));
+
+    await importTrainingReport(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(httpCodes.BAD_REQUEST);
+  });
+
+  it('should import training report successfully', async () => {
+    const headers = { 'content-type': 'text/csv' };
+    const files = {
+      file: [
+        {
+          headers,
+          path: '/path/to/file.csv',
+        },
+      ],
+    };
+    const buf = Buffer.from('csv data');
+    const response = { success: true };
+
+    multiparty.Form.mockImplementationOnce(() => ({
+      parse: jest.fn((_request, callback) => {
+        callback(null, {}, files);
+      }),
+    }));
+
+    bufferFromPath.mockReturnValueOnce(buf);
+    csvImport.mockResolvedValueOnce(response);
+
+    await importTrainingReport(req, res);
+
+    expect(bufferFromPath).toHaveBeenCalledWith('/path/to/file.csv');
+    expect(csvImport).toHaveBeenCalledWith(buf);
+  });
+});

--- a/src/routes/goals/handlers.test.js
+++ b/src/routes/goals/handlers.test.js
@@ -30,6 +30,11 @@ import {
   getGoalIdsBySimilarity,
 } from '../../goalServices/goals';
 import { currentUserId } from '../../services/currentUser';
+import { validateMergeGoalPermissions } from '../recipient/handlers';
+
+jest.mock('../recipient/handlers', () => ({
+  validateMergeGoalPermissions: jest.fn(),
+}));
 
 jest.mock('../../services/users', () => ({
   userById: jest.fn(),
@@ -85,14 +90,7 @@ describe('merge goals', () => {
       },
     };
 
-    goalRegionsById.mockResolvedValue([1]);
-
-    userById.mockResolvedValue({
-      permissions: [{
-        regionId: 1,
-        scopeId: SCOPES.READ_WRITE_REPORTS,
-      }],
-    });
+    validateMergeGoalPermissions.mockResolvedValue(true);
 
     mergeGoals.mockResolvedValue({
       id: 1,
@@ -114,14 +112,7 @@ describe('merge goals', () => {
       },
     };
 
-    goalRegionsById.mockResolvedValue([1]);
-
-    userById.mockResolvedValue({
-      permissions: [{
-        regionId: 1,
-        scopeId: SCOPES.READ_REPORTS,
-      }],
-    });
+    validateMergeGoalPermissions.mockResolvedValue(false);
 
     await mergeGoalHandler(req, mockResponse);
 
@@ -139,15 +130,8 @@ describe('merge goals', () => {
       },
     };
 
-    goalRegionsById.mockResolvedValue([1]);
-    userById.mockResolvedValue({
-      permissions: [{
-        regionId: 1,
-        scopeId: SCOPES.READ_WRITE_REPORTS,
-      }],
-    });
-
-    mergeGoals.mockRejectedValue(new Error('Unauthorized'));
+    validateMergeGoalPermissions.mockResolvedValue(true);
+    mergeGoals.mockRejectedValue(new Error('Big time error'));
 
     await mergeGoalHandler(req, mockResponse);
 

--- a/src/routes/goals/index.js
+++ b/src/routes/goals/index.js
@@ -9,18 +9,23 @@ import {
   getSimilarGoalsForRecipient,
 } from './handlers';
 import transactionWrapper from '../transactionWrapper';
-import { checkIdParam } from '../../middleware/checkIdParamMiddleware';
+import { checkRegionIdParam, checkRecipientIdParam } from '../../middleware/checkIdParamMiddleware';
 
 const router = express.Router();
 router.post('/', transactionWrapper(createGoals));
 router.get('/', transactionWrapper(retrieveGoalsByIds));
 router.get('/:goalId/recipient/:recipientId', transactionWrapper(retrieveGoalByIdAndRecipient));
 router.put('/changeStatus', transactionWrapper(changeGoalStatus));
-router.post('/merge', transactionWrapper(mergeGoalHandler));
+router.post(
+  '/recipient/:recipientId/region/:regionId/merge',
+  checkRegionIdParam,
+  checkRecipientIdParam,
+  transactionWrapper(mergeGoalHandler),
+);
 router.delete('/', transactionWrapper(deleteGoal));
 router.get(
   '/similar/:recipientId',
-  (req, res, next) => checkIdParam(req, res, next, 'recipientId'),
+  checkRecipientIdParam,
   transactionWrapper(getSimilarGoalsForRecipient),
 );
 


### PR DESCRIPTION
## Description of change

Use the same permissions for the merge goals handler as we use for showing the alert with the merge goal candidates on the RTR. As below:

```js
    // can view in region and is a TTAC
    if (this.canView() && this.user.roles.map((r) => r.name).includes('TTAC')) {
      return true;
    }

    // or on recipient reports
    if (this.isOnRecipientsReports) {
      return true;
    }

    return false;
 ```
(or is an admin)


## How to test

If you can see an alert, you can merge goals.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2336


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
