### PR TITLE
[TTAHUB-2236] Add websocket to goal merge

### DIFF
--- a/frontend/src/components/SocketAlert.js
+++ b/frontend/src/components/SocketAlert.js
@@ -8,7 +8,7 @@ import useArrayWithExpiration from '../hooks/useArrayWithExpiration';
 import './SocketAlert.css';
 
 const THIRTY_SECONDS = 30 * 1000;
-export default function SocketAlert({ store }) {
+export default function SocketAlert({ store, messageSubject }) {
   const [users, { push: pushUser }] = useArrayWithExpiration([], THIRTY_SECONDS);
   const isMobile = useMediaQuery({ maxWidth: 1023 });
 
@@ -35,7 +35,7 @@ export default function SocketAlert({ store }) {
       return `and ${user}`;
     }
     return user;
-  }).join(usersToRender.length < 3 ? ' ' : ', ')} ${usersToRender.length === 1 ? 'is' : 'are'} now also working in this section. Your changes may not be saved.`;
+  }).join(usersToRender.length < 3 ? ' ' : ', ')} ${usersToRender.length === 1 ? 'is' : 'are'} also working ${messageSubject}. Your changes may not be saved.`;
 
   return store && usersToRender.length ? (
     <Sticky className="ttahub-socket-alert margin-bottom-2" top={71} enabled={!isMobile}>
@@ -54,8 +54,10 @@ SocketAlert.propTypes = {
   store: PropTypes.shape({
     user: PropTypes.string,
   }),
+  messageSubject: PropTypes.string,
 };
 
 SocketAlert.defaultProps = {
   store: null,
+  messageSubject: 'in this section',
 };

--- a/frontend/src/components/__tests__/SocketAlert.js
+++ b/frontend/src/components/__tests__/SocketAlert.js
@@ -12,7 +12,7 @@ describe('SocketAlert', () => {
         <SocketAlert store={mockStore} />
       </UserContext.Provider>,
     );
-    expect(screen.getByText(/john is now also working in this section\. your changes may not be saved\./i)).toBeInTheDocument();
+    expect(screen.getByText(/john is also working in this section\. your changes may not be saved\./i)).toBeInTheDocument();
     expect(screen.queryByText('Todd')).not.toBeInTheDocument();
   });
   it('excludes the current user from the list of users', () => {

--- a/frontend/src/pages/RecipientRecord/pages/MergeGoals/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/MergeGoals/index.js
@@ -25,6 +25,9 @@ import FinalGoalCard from './components/FinalGoalCard';
 import AppLoadingContext from '../../../../AppLoadingContext';
 import GoalMergeGuidanceDrawer from './components/GoalMergeGuidanceDrawer';
 import Modal from '../../../../components/VanillaModal';
+import useSocket, { usePublishWebsocketLocationOnInterval } from '../../../../hooks/useSocket';
+import UserContext from '../../../../UserContext';
+import SocketAlert from '../../../../components/SocketAlert';
 
 const OFFSET = 0;
 const SELECT_GOALS_TO_MERGE = 1;
@@ -87,6 +90,8 @@ const stepIndicatorStatus = (position, activePage) => {
   return 'incomplete';
 };
 
+const INTERVAL_DELAY = 2500;
+
 export const navigate = (newPage, setActivePage) => {
   if (!pages.includes(newPage)) {
     return;
@@ -108,6 +113,7 @@ export default function MergeGoals({
   const [goals, setGoals] = useState([]);
   const [activePage, setActivePage] = useState(SELECT_GOALS_TO_MERGE);
   const { setIsAppLoading } = useContext(AppLoadingContext);
+  const { user } = useContext(UserContext);
   const drawerTriggerRef = useRef(null);
   const modalRef = useRef();
 
@@ -124,6 +130,26 @@ export default function MergeGoals({
   const finalGoalId = watch('finalGoalId');
 
   const history = useHistory();
+
+  const {
+    socket,
+    setSocketPath,
+    socketPath,
+    messageStore,
+  } = useSocket(user);
+
+  useEffect(() => {
+    const newPath = `/merge-goals/${new URLSearchParams(location.search).toString()}&recipientId=${recipientId}&regionId=${regionId}`;
+    setSocketPath(newPath);
+  }, [location.search, recipientId, regionId, setSocketPath]);
+
+  usePublishWebsocketLocationOnInterval(
+    socket,
+    socketPath,
+    user,
+    Date.now().toString(),
+    INTERVAL_DELAY,
+  );
 
   useEffect(() => {
     async function fetchGoals() {
@@ -300,7 +326,7 @@ export default function MergeGoals({
   };
 
   return (
-    <div className="padding-top-5">
+    <div className="padding-top-5 position-relative">
       <Link
         className="ttahub-recipient-record--tabs_back-to-search margin-bottom-2 display-inline-block"
         to={backPath}
@@ -309,6 +335,7 @@ export default function MergeGoals({
         {' '}
         {recipientNameWithRegion}
       </Link>
+      <SocketAlert store={messageStore} messageSubject="on this goal merge" />
       <h1 className="ttahub-recipient-record--heading merge-goals page-heading margin-top-0 margin-bottom-3">
         These goals might be duplicates
       </h1>


### PR DESCRIPTION
## Description of change

Add a websocket alert to the goal merge page

## How to test

For testing it may be helpful to comment out the code that excludes the current user from the list.
In ```frontend/src/components/SocketAlert.js``` I change line 26 from:

``` users.map((user) => (user.name)).filter((user) => user !== currentUser),```

to 

```  users.map((user) => (user.name)) ```

Visit the goal merge and your location should be published 2500 ms after you arrive. 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2236


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
