### PR TITLE
switch goals to left join

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -1185,6 +1185,7 @@ async function getDownloadableActivityReports(where, separate = true) {
           include: [{
             model: Goal,
             as: 'goal',
+            required: false,
           },
           ],
           attributes: ['id', 'title', 'status'],


### PR DESCRIPTION
## Description of change

Switch getDownloadableActivityReports to use a left join for Goals because Other entities have objectives but not Goals. Currently it's an inner join that makes the title blank, which in turn throws an error at https://github.com/HHS/Head-Start-TTADP/blob/main/src/lib/transform.js#L223 if the CSV export contains an AR with Other entities in it.

## How to test

Export a CSV containing an AR with an Other entity in it to see if it generates and error.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2352


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
