### PR TITLE
[TTAHUB-2143] Add copy URL and print to PDF buttons to TR

### DIFF
--- a/frontend/src/components/ApprovedReportSpecialButtons.js
+++ b/frontend/src/components/ApprovedReportSpecialButtons.js
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Grid, ModalToggleButton } from '@trussworks/react-uswds';
+import { canUnlockReports } from '../permissions';
+import PrintToPdf from './PrintToPDF';
+
+export default function ApprovedReportSpecialButtons({
+  UnlockModal,
+  modalRef,
+  user,
+  showUnlockReports,
+}) {
+  const [successfullyCopiedClipboard, setSuccessfullyCopiedClipboard] = useState(false);
+  const [somethingWentWrongWithClipboard, setSomethingWentWrongWithClipboard] = useState(false);
+
+  async function handleCopyUrl() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setSuccessfullyCopiedClipboard(true);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      setSomethingWentWrongWithClipboard(true);
+    }
+  }
+
+  return (
+    <>
+      {successfullyCopiedClipboard ? (
+        <div className="usa-alert usa-alert--success margin-bottom-2 no-print">
+          <div className="usa-alert__body">
+            <p className="usa-alert__text">Successfully copied URL</p>
+          </div>
+        </div>
+      ) : null}
+      {somethingWentWrongWithClipboard
+        ? (
+          <div className="usa-alert usa-alert--warning no-print">
+            <div className="usa-alert__body">
+              <p className="usa-alert__text">
+                Sorry, something went wrong copying that url.
+                {window.location.href && (
+                  <>
+                    {' '}
+                    Here it is
+                    {window.location.href}
+                  </>
+                )}
+              </p>
+            </div>
+          </div>
+        )
+        : null}
+      <Grid row>
+        {navigator && navigator.clipboard
+          ? <button id="approved-url" type="button" className="usa-button no-print" disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false} onClick={handleCopyUrl}>Copy URL Link</button>
+          : null}
+        <PrintToPdf
+          id="approved-print"
+          disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false}
+        />
+        {showUnlockReports && user && user.permissions && canUnlockReports(user)
+          ? <ModalToggleButton type="button" className="usa-button usa-button--outline no-print" modalRef={modalRef} opener>Unlock report</ModalToggleButton>
+          : null}
+      </Grid>
+      {showUnlockReports && <UnlockModal /> }
+    </>
+  );
+}
+
+ApprovedReportSpecialButtons.propTypes = {
+  UnlockModal: PropTypes.node,
+  user: PropTypes.shape({
+    permissions: PropTypes.arrayOf(PropTypes.string),
+  }),
+  modalRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape(),
+  ]),
+  showUnlockReports: PropTypes.bool,
+};
+
+ApprovedReportSpecialButtons.defaultProps = {
+  UnlockModal: <></>,
+  modalRef: null,
+  showUnlockReports: false,
+  user: null,
+};

--- a/frontend/src/components/BackLink.js
+++ b/frontend/src/components/BackLink.js
@@ -11,8 +11,8 @@ export default function BackLink({
 }) {
   return (
     <>
-      <FontAwesomeIcon className={`margin-right-1 ${iconClasses}`} data-testid="back-link-icon" color={colors.ttahubMediumBlue} icon={faArrowLeft} />
-      <Link className={`ttahub-back-link text-ttahub-blue margin-bottom-2 display-inline-block ${linkClasses}`} to={to}>{children}</Link>
+      <FontAwesomeIcon className={`margin-right-1 no-print ${iconClasses}`} data-testid="back-link-icon" color={colors.ttahubMediumBlue} icon={faArrowLeft} />
+      <Link className={`no-print ttahub-back-link text-ttahub-blue margin-bottom-2 display-inline-block ${linkClasses}`} to={to}>{children}</Link>
     </>
   );
 }

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -1,12 +1,10 @@
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { Grid, ModalToggleButton } from '@trussworks/react-uswds';
 import { Redirect } from 'react-router-dom';
 import moment from 'moment-timezone';
 import { Helmet } from 'react-helmet';
 import { getReport, unlockReport } from '../../fetchers/activityReports';
-import { canUnlockReports } from '../../permissions';
 import Modal from '../../components/Modal';
 import Container from '../../components/Container';
 import {
@@ -14,16 +12,15 @@ import {
   LOCAL_STORAGE_ADDITIONAL_DATA_KEY,
   LOCAL_STORAGE_EDITABLE_KEY,
 } from '../../Constants';
-import PrintToPdf from '../../components/PrintToPDF';
 import './index.scss';
 import ApprovedReportV1 from './components/ApprovedReportV1';
 import ApprovedReportV2 from './components/ApprovedReportV2';
+import ApprovedReportSpecialButtons from '../../components/ApprovedReportSpecialButtons';
 
 export default function ApprovedActivityReport({ match, user }) {
   const [notAuthorized, setNotAuthorized] = useState(false);
   const [somethingWentWrong, setSomethingWentWrong] = useState(false);
-  const [successfullyCopiedClipboard, setSuccessfullyCopiedClipboard] = useState(false);
-  const [somethingWentWrongWithClipboard, setSomethingWentWrongWithClipboard] = useState(false);
+
   const [justUnlocked, updatedJustUnlocked] = useState(false);
 
   const [report, setReport] = useState({
@@ -101,17 +98,6 @@ export default function ApprovedActivityReport({ match, user }) {
     fetchReport();
   }, [match.params.activityReportId, user]);
 
-  async function handleCopyUrl() {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      setSuccessfullyCopiedClipboard(true);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-      setSomethingWentWrongWithClipboard(true);
-    }
-  }
-
   if (notAuthorized) {
     return (
       <>
@@ -173,6 +159,31 @@ export default function ApprovedActivityReport({ match, user }) {
     updatedJustUnlocked(true);
   };
 
+  const UnlockModal = () => (
+    <Modal
+      modalRef={modalRef}
+      onOk={() => onUnlock()}
+      modalId="UnlockReportModal"
+      title="Unlock Activity Report"
+      okButtonText="Unlock"
+      okButtonAriaLabel="Unlock approved report will redirect to activity report page."
+    >
+      <>
+        Are you sure you want to unlock this activity report?
+        <br />
+        <br />
+        The report status will be set to
+        {' '}
+        <b>NEEDS ACTION</b>
+        {' '}
+        and
+        {' '}
+        <br />
+        must be re-submitted for approval.
+      </>
+    </Modal>
+  );
+
   const timezone = moment.tz.guess();
   const time = moment().tz(timezone).format('MM/DD/YYYY [at] h:mm a z');
   const message = {
@@ -194,66 +205,13 @@ export default function ApprovedActivityReport({ match, user }) {
           {startDate}
         </title>
       </Helmet>
-      {successfullyCopiedClipboard ? (
-        <div className="usa-alert usa-alert--success margin-bottom-2 no-print">
-          <div className="usa-alert__body">
-            <p className="usa-alert__text">Successfully copied URL</p>
-          </div>
-        </div>
-      ) : null}
-      {somethingWentWrongWithClipboard
-        ? (
-          <div className="usa-alert usa-alert--warning no-print">
-            <div className="usa-alert__body">
-              <p className="usa-alert__text">
-                Sorry, something went wrong copying that url.
-                {window.location.href && (
-                  <>
-                    {' '}
-                    Here it is
-                    {window.location.href}
-                  </>
-                )}
-              </p>
-            </div>
-          </div>
-        )
-        : null}
-      <Grid row>
-        {navigator && navigator.clipboard
-          ? <button id="approved-url" type="button" className="usa-button no-print" disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false} onClick={handleCopyUrl}>Copy URL Link</button>
-          : null}
-        <PrintToPdf
-          id="approved-print"
-          disabled={modalRef && modalRef.current ? modalRef.current.modalIsOpen : false}
-        />
-        {user && user.permissions && canUnlockReports(user)
-          ? <ModalToggleButton type="button" className="usa-button usa-button--outline no-print" modalRef={modalRef} opener>Unlock report</ModalToggleButton>
-          : null}
-      </Grid>
-      <Modal
+      <ApprovedReportSpecialButtons
         modalRef={modalRef}
-        onOk={() => onUnlock()}
-        modalId="UnlockReportModal"
-        title="Unlock Activity Report"
-        okButtonText="Unlock"
-        okButtonAriaLabel="Unlock approved report will redirect to activity report page."
-      >
-        <>
-          Are you sure you want to unlock this activity report?
-          <br />
-          <br />
-          The report status will be set to
-          {' '}
-          <b>NEEDS ACTION</b>
-          {' '}
-          and
-          {' '}
-          <br />
-          must be re-submitted for approval.
-        </>
-      </Modal>
-      {ReportComponent()}
+        UnlockModal={UnlockModal}
+        user={user}
+        showUnlockReports
+      />
+      <ReportComponent />
     </>
   );
 }

--- a/frontend/src/pages/ViewTrainingReport/__tests__/index.js
+++ b/frontend/src/pages/ViewTrainingReport/__tests__/index.js
@@ -205,6 +205,23 @@ describe('ViewTrainingReport', () => {
     expect(screen.getByText('Planning')).toBeInTheDocument();
   });
 
+  it('renders the necessary buttons', async () => {
+    global.navigator.clipboard = jest.fn();
+    global.navigator.clipboard.writeText = jest.fn(() => Promise.resolve());
+
+    fetchMock.getOnce('/api/events/id/1', mockEvent());
+
+    fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
+    fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
+
+    act(() => {
+      renderTrainingReport();
+    });
+
+    expect(await screen.findByRole('button', { name: 'Copy URL Link' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Print to PDF' })).toBeInTheDocument();
+  });
+
   it('handles an error fetching event', async () => {
     fetchMock.getOnce('/api/events/id/1', 500);
 

--- a/frontend/src/pages/ViewTrainingReport/index.css
+++ b/frontend/src/pages/ViewTrainingReport/index.css
@@ -1,0 +1,28 @@
+/** some basic print styles so we don't generate an enormous PDF */
+
+@media print {
+    .ttahub-completed-training-report-container * {
+        font-size: 12pt;
+    }
+
+    .ttahub-completed-training-report-container h1 {
+        font-size: 24pt;
+        margin: 0;
+    }
+
+    .ttahub-completed-training-report-container h2 {
+        font-size: 18pt;
+    }
+
+    .ttahub-completed-training-report-container h3 {
+        font-size: 14pt;
+    }
+
+    .ttahub-completed-training-report-container > div {
+        padding: 0 !important;
+    }
+
+    .ttahub-read-only-content-section {
+        page-break-inside: avoid;
+    }
+}

--- a/frontend/src/pages/ViewTrainingReport/index.js
+++ b/frontend/src/pages/ViewTrainingReport/index.js
@@ -13,6 +13,8 @@ import AppLoadingContext from '../../AppLoadingContext';
 import BackLink from '../../components/BackLink';
 import Container from '../../components/Container';
 import ReadOnlyContent from '../../components/ReadOnlyContent';
+import ApprovedReportSpecialButtons from '../../components/ApprovedReportSpecialButtons';
+import './index.css';
 
 const formatNextSteps = (nextSteps, heading, striped) => {
   const data = nextSteps.reduce((acc, step, index) => ({
@@ -185,21 +187,19 @@ export default function ViewTrainingReport({ match }) {
       <BackLink to={backLinkUrl}>
         Back to Training Reports
       </BackLink>
-      <Container className="margin-top-2 maxw-tablet-lg">
+      <ApprovedReportSpecialButtons />
+      <Container className="margin-top-2 maxw-tablet-lg ttahub-completed-training-report-container">
         { error && (
         <Alert type="error">
           {error}
         </Alert>
         )}
         <h1 className="landing">{pageTitle}</h1>
-
         <ReadOnlyContent
           title="Event"
           sections={eventSummary}
         />
-
         { sessions }
-
       </Container>
     </>
   );


### PR DESCRIPTION
## Description of change
Add the "Copy URL Link" and "Print to PDF" buttons to the TR.
I added only rudimentary print stylings here since there was no mock-up provided or special view requested.

## How to test
Confirm the buttons appear on the "completed" TR view and that they function as expected. 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2143


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
