### PR TITLE
[TTAHUB-2379] Update required fields on communication log

### DIFF
--- a/frontend/src/components/ControlledDatePicker.js
+++ b/frontend/src/components/ControlledDatePicker.js
@@ -21,6 +21,7 @@ export default function ControlledDatePicker({
   isStartDate,
   inputId,
   endDate,
+  required,
 }) {
   /**
    * we don't want to compute these fields multiple times if we don't have to,
@@ -114,6 +115,7 @@ export default function ControlledDatePicker({
       minDate={min.datePicker}
       maxDate={max.datePicker}
       onBlur={(e) => handleOnBlur(e)}
+      required={required}
     />
   );
 }
@@ -132,6 +134,7 @@ ControlledDatePicker.propTypes = {
   setEndDate: PropTypes.func,
   inputId: PropTypes.string.isRequired,
   endDate: PropTypes.string,
+  required: PropTypes.bool,
 };
 
 ControlledDatePicker.defaultProps = {
@@ -140,5 +143,6 @@ ControlledDatePicker.defaultProps = {
   endDate: '',
   isStartDate: false,
   setEndDate: () => {},
+  required: true,
   value: '',
 };

--- a/frontend/src/hooks/useCompleteSectionOnVisit.js
+++ b/frontend/src/hooks/useCompleteSectionOnVisit.js
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+/**
+ * This needs to be accompanied by a hidden input within the form
+ * with the name `visitedField` <input type="hidden" ref={register()} name={visitedField} />
+ * @param {string} visitedField
+ */
+export default function useCompleteSectionOnVisit(visitedField) {
+  const { watch, setValue } = useFormContext();
+  const visitedRef = useRef(false);
+  const pageVisited = watch(visitedField);
+
+  useEffect(() => {
+    /**
+       * this is some weirdness, I admit...
+       * I want to replicate the behavior of the
+       * page in the activity report form (not started until you visit it,
+       * complete one you do), but also use the page state hooks that I
+       * wrote for the session & training forms
+       */
+
+    if (!pageVisited && !visitedRef.current) {
+      visitedRef.current = true;
+      setValue(visitedField, true);
+    }
+  }, [pageVisited, setValue, visitedField]);
+}

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -181,7 +181,7 @@ export default function NextStepsRepeater({
                   name={`${name}[${index}].completeDate`}
                   value={item.completeDate}
                   dataTestId={`${name === 'specialistNextSteps' ? 'specialist' : 'recipient'}StepCompleteDate-input`}
-                  required={false}
+                  required={required}
                 />
               </div>
             </FormGroup>

--- a/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/NextStepsRepeater.js
@@ -19,6 +19,7 @@ export default function NextStepsRepeater({
   name,
   ariaName,
   recipientType,
+  required,
 }) {
   const [heights, setHeights] = useState([]);
 
@@ -95,6 +96,13 @@ export default function NextStepsRepeater({
     ? `When does the ${recipientLabel} anticipate completing step ${index + 1}?`
     : `When do you anticipate completing step ${index + 1}?`);
 
+  const textareaRegister = (() => {
+    if (required) {
+      return register({ required: 'Enter a next step' });
+    }
+    return register();
+  })();
+
   return (
     <>
       <div className="ttahub-next-steps-repeater">
@@ -109,7 +117,7 @@ export default function NextStepsRepeater({
                 htmlFor={`${stepType}-next-step-${index + 1}`}
               >
                 {`Step ${index + 1}`}
-                <Req />
+                {required && (<Req />)}
               </Label>
               {(errors[name]
                 && errors[name][index] && errors[name][index].note)
@@ -124,11 +132,11 @@ export default function NextStepsRepeater({
                   className="height-10 minh-5 smart-hub--text-area__resize-vertical"
                   name={`${name}[${index}].note`}
                   defaultValue={item.note}
-                  inputRef={register({ required: 'Enter a next step' })}
+                  inputRef={textareaRegister}
                   data-testid={`${name === 'specialistNextSteps' ? 'specialist' : 'recipient'}NextSteps-input`}
                   style={{ height: !heights[index] ? `${DEFAULT_STEP_HEIGHT}px` : heights[index] }}
                   onChange={(e) => onStepTextChanged(e, index)}
-                  required
+                  required={required}
                 />
                 {canDelete ? (
                   <Button
@@ -157,7 +165,7 @@ export default function NextStepsRepeater({
                 htmlFor={`${stepType}-next-step-date-${index + 1}`}
               >
                 {dateLabel(index)}
-                <Req announce />
+                {required && (<Req announce />)}
               </Label>
               {(errors[name] && errors[name][index]
                   && errors[name][index].completeDate)
@@ -173,6 +181,7 @@ export default function NextStepsRepeater({
                   name={`${name}[${index}].completeDate`}
                   value={item.completeDate}
                   dataTestId={`${name === 'specialistNextSteps' ? 'specialist' : 'recipient'}StepCompleteDate-input`}
+                  required={false}
                 />
               </div>
             </FormGroup>
@@ -194,8 +203,10 @@ NextStepsRepeater.propTypes = {
   name: PropTypes.string.isRequired,
   ariaName: PropTypes.string.isRequired,
   recipientType: PropTypes.string,
+  required: PropTypes.bool,
 };
 
 NextStepsRepeater.defaultProps = {
   recipientType: '',
+  required: true,
 };

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
@@ -128,7 +128,6 @@ describe('CommunicationLogForm', () => {
       /Select a communication method/i,
       /enter duration/i,
       /Select a purpose of communication/i,
-      /Select a result of communication/i,
     ].map(async (message) => {
       expect(await screen.findByText(message)).toBeInTheDocument();
     }));

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/constants.js
@@ -11,7 +11,6 @@ const defaultLogValues = {
   duration: '',
   method: '',
   purpose: '',
-  result: '',
 };
 
 const defaultAttachmentValues = {

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
@@ -144,14 +144,14 @@ const Log = ({ datePickerKey }) => {
       </div>
       <div className="margin-top-2">
         <FormItem
-          label="Result "
+          label="Result"
           name="result"
+          required={false}
         >
           <Dropdown
-            required
             id="result"
             name="result"
-            inputRef={register({ required: 'Select a result of communication' })}
+            inputRef={register()}
           >
             {COMMUNICATION_RESULTS.map((option) => (
               <option key={`resultOptions${option}`}>{option}</option>

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
@@ -152,8 +152,9 @@ const Log = ({ datePickerKey }) => {
             id="result"
             name="result"
             inputRef={register()}
+            defaultValue=""
           >
-            <option disabled hidden value="">Select one</option>
+            <option value="" disabled hidden>Select one</option>
             {COMMUNICATION_RESULTS.map((option) => (
               <option key={`resultOptions${option}`}>{option}</option>
             ))}

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
@@ -153,6 +153,7 @@ const Log = ({ datePickerKey }) => {
             name="result"
             inputRef={register()}
           >
+            <option disabled hidden value="">Select one</option>
             {COMMUNICATION_RESULTS.map((option) => (
               <option key={`resultOptions${option}`}>{option}</option>
             ))}

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/nextSteps.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/nextSteps.js
@@ -1,43 +1,55 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useFormContext } from 'react-hook-form';
 import {
   Button,
   Fieldset,
 } from '@trussworks/react-uswds';
+import { pageComplete } from '../constants';
 import IndicatesRequiredField from '../../../../../components/IndicatesRequiredField';
-import { nextStepsFields } from '../constants';
 import NextStepsRepeater from '../../../../ActivityReport/Pages/components/NextStepsRepeater';
-import { isPageComplete } from '../../../../SessionForm/pages/nextSteps';
+import useCompleteSectionOnVisit from '../../../../../hooks/useCompleteSectionOnVisit';
 
-const NextSteps = () => (
-  <>
-    <Helmet>
-      <title>Next steps</title>
-    </Helmet>
-    <IndicatesRequiredField />
-    <Fieldset id="specialist-field-set" className="smart-hub--report-legend margin-top-4" legend="Specialist&apos;s next steps">
-      <NextStepsRepeater
-        id="specialist-next-steps-repeater-id"
-        name="specialistNextSteps"
-        ariaName="Specialist Next Steps"
-      />
-    </Fieldset>
-    <Fieldset id="recipient-field-set" className="smart-hub--report-legend margin-top-3" legend={'Recipient\'s next steps'}>
-      <NextStepsRepeater
-        id="recipient-next-steps-repeater-id"
-        name="recipientNextSteps"
-        ariaName={'Recipient\'s next steps'}
-        recipientType="recipient"
-      />
-    </Fieldset>
-  </>
-);
-
-const fields = Object.keys(nextStepsFields);
 const path = 'next-steps';
+const visitedField = `pageVisited-${path}`;
+const fields = [visitedField];
 const position = 3;
 
+const NextSteps = () => {
+  const { register } = useFormContext();
+
+  useCompleteSectionOnVisit(visitedField);
+
+  return (
+    <>
+      <Helmet>
+        <title>Next steps</title>
+      </Helmet>
+      <IndicatesRequiredField />
+      <input type="hidden" ref={register()} name={visitedField} />
+      <Fieldset id="specialist-field-set" className="smart-hub--report-legend margin-top-4" legend="Specialist&apos;s next steps">
+        <NextStepsRepeater
+          id="specialist-next-steps-repeater-id"
+          name="specialistNextSteps"
+          ariaName="Specialist Next Steps"
+          required={false}
+        />
+      </Fieldset>
+      <Fieldset id="recipient-field-set" className="smart-hub--report-legend margin-top-3" legend={'Recipient\'s next steps'}>
+        <NextStepsRepeater
+          id="recipient-next-steps-repeater-id"
+          name="recipientNextSteps"
+          ariaName={'Recipient\'s next steps'}
+          recipientType="recipient"
+          required={false}
+        />
+      </Fieldset>
+    </>
+  );
+};
+
 const ReviewSection = () => <><h2>Event summary</h2></>;
+export const isPageComplete = (hookForm) => pageComplete(hookForm, fields);
 
 export default {
   position,

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/supportingAttachments.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/supportingAttachments.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Helmet } from 'react-helmet';
@@ -12,6 +12,7 @@ import {
 import { pageComplete } from '../constants';
 import ReportFileUploader from '../../../../../components/FileUploader/ReportFileUploader';
 import { deleteLogFile } from '../../../../../fetchers/File';
+import useCompleteSectionOnVisit from '../../../../../hooks/useCompleteSectionOnVisit';
 
 const path = 'supporting-attachments';
 const position = 2;
@@ -20,23 +21,9 @@ const fields = [visitedField];
 
 const SupportingAttachments = ({ reportId }) => {
   const [fileError, setFileError] = useState();
-  const { watch, register, setValue } = useFormContext();
-  const visitedRef = useRef(false);
-  const pageVisited = watch(visitedField);
+  const { register } = useFormContext();
 
-  useEffect(() => {
-    /**
-     * this is some weirdness, I admit...
-     * I want to replicate the behavior of the
-     * page in the activity report form (not started until you visit it,
-     * complete one you do), but also use the page state hooks that I
-     * wrote for the session & training forms
-     */
-    if (!pageVisited && !visitedRef.current) {
-      visitedRef.current = true;
-      setValue(visitedField, true);
-    }
-  }, [pageVisited, setValue]);
+  useCompleteSectionOnVisit(visitedField);
 
   return (
     <>

--- a/frontend/src/pages/RecipientRecord/pages/ViewCommunicationLog/components/DisplayNextSteps.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewCommunicationLog/components/DisplayNextSteps.js
@@ -2,8 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReadOnlyField from '../../../../../components/ReadOnlyField';
 
-export default function DisplayNextSteps({ title, steps }) {
+export const skipDisplaySteps = (steps) => {
   if (!steps || !steps.length) {
+    return true;
+  }
+
+  return steps.every((step) => !step.note && !step.completeDate);
+};
+
+export default function DisplayNextSteps({ title, steps }) {
+  if (skipDisplaySteps(steps)) {
     return null;
   }
 
@@ -11,7 +19,7 @@ export default function DisplayNextSteps({ title, steps }) {
     <>
       <h3>{title}</h3>
       {steps.map(((step, index) => (
-        <div key={`${title}${step}`}>
+        <div key={`${title}${step.note}`}>
           <ReadOnlyField
             label={`Step ${index + 1}`}
           >

--- a/frontend/src/pages/RecipientRecord/pages/ViewCommunicationLog/components/__tests__/DisplayNextSteps.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewCommunicationLog/components/__tests__/DisplayNextSteps.js
@@ -1,8 +1,42 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import DisplayNextSteps from '../DisplayNextSteps';
+import { render, act, screen } from '@testing-library/react';
+import DisplayNextSteps, { skipDisplaySteps } from '../DisplayNextSteps';
 
 describe('DisplayNextSteps', () => {
+  describe('skipDisplaySteps', () => {
+    it('should return true if steps array is empty or not provided', () => {
+      expect(skipDisplaySteps()).toBe(true);
+      expect(skipDisplaySteps([])).toBe(true);
+    });
+
+    it('should return true if all steps do not have a note and completeDate', () => {
+      expect(skipDisplaySteps([
+        { note: '', completeDate: '' },
+        { note: null, completeDate: null },
+      ])).toBe(true);
+    });
+
+    it('should return false if some steps have a note or completeDate', () => {
+      expect(skipDisplaySteps([
+        { note: 'Note 1', completeDate: '' },
+        { note: '', completeDate: '2022-01-01' },
+      ])).toBe(false);
+    });
+
+    it('should return false if all steps have a note or completeDate', () => {
+      expect(skipDisplaySteps([
+        {
+          note: 'First step',
+          completeDate: '2022-01-01',
+        },
+        {
+          note: 'second step',
+          completeDate: '2022-01-02',
+        },
+      ])).toBe(false);
+    });
+  });
+
   const title = 'Next Steps';
   const steps = [
     {
@@ -16,7 +50,8 @@ describe('DisplayNextSteps', () => {
   ];
 
   it('renders the component with title and steps', () => {
-    const { getByText } = render(<DisplayNextSteps title={title} steps={steps} />);
+    const { getByText } = screen;
+    act(() => render(<DisplayNextSteps title={title} steps={steps} />));
 
     expect(getByText(title)).toBeInTheDocument();
     expect(getByText('Step 1')).toBeInTheDocument();

--- a/frontend/src/pages/RecipientRecord/pages/ViewCommunicationLog/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewCommunicationLog/index.js
@@ -96,14 +96,16 @@ export default function ViewCommunicationLog({ match, recipientName }) {
         >
           {log.data.result}
         </ReadOnlyField>
-        <p className="usa-prose margin-bottom-0 text-bold">Supporting attachments</p>
-        {log.files.map((file) => (
-          <p className="usa-prose margin-top-0 margin-bottom-0">
-            <a href={file.url.url}>
-              {file.originalFileName}
-            </a>
-          </p>
-        ))}
+        <>
+          <p className="usa-prose margin-bottom-0 text-bold">Supporting attachments</p>
+          {log.files.map((file) => (
+            <p className="usa-prose margin-top-0 margin-bottom-0">
+              <a href={file.url.url}>
+                {file.originalFileName}
+              </a>
+            </p>
+          ))}
+        </>
 
         <DisplayNextSteps
           title="Specialist's next steps"

--- a/frontend/src/widgets/RttapaUpdates.js
+++ b/frontend/src/widgets/RttapaUpdates.js
@@ -42,7 +42,11 @@ export default function RttapaUpdates({
             <tbody>
               {logs.map((log) => (
                 <tr key={`logrow${log.id}`}>
-                  <td data-label="Date">{log.data ? log.data.communicationDate : ''}</td>
+                  <td data-label="Date">
+                    <Link to={`/recipient-tta-records/${recipientId}/region/${regionId}/communication/${log.id}/view`}>
+                      {log.data ? log.data.communicationDate : ''}
+                    </Link>
+                  </td>
                   <td data-label="Purpose">{log.data ? log.data.purpose : ''}</td>
                   <td data-label="Result">{log.data ? log.data.result : ''}</td>
                 </tr>


### PR DESCRIPTION
## Description of change
- Result and next steps should not be required. (This means the next steps component, also used in other forms, should accept a "required" parameter)
- The RTTAPA updates table should link to the log entry in the same way the communication log does

## How to test
Confirm the above are resolved. Note I left the validation "onBlur" for the dates just in case someone tries to type "cactus" or "never" in there, but the form can be saved with any value.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2379


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
