### PR TITLE
Limit AR Groups

### DIFF
--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -362,7 +362,7 @@ export async function getGroups(req, res) {
   try {
     // Get groups for shared users and region.
     // TODO: Add a optional check for shared users.
-    const groups = await groupsByRegion(regionNumber);
+    const groups = await groupsByRegion(regionNumber, userId);
 
     res.json(groups);
   } catch (error) {

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -39,7 +39,6 @@ interface GroupResponse {
 }
 
 export async function groupsByRegion(region: number, userId?: number): Promise<GroupResponse[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let where: WhereOptions = {
     '$grants.regionId$': { [Op.eq]: region },
   };

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -38,7 +38,7 @@ interface GroupResponse {
   isPublic: boolean;
 }
 
-export async function groupsByRegion(region: number, userId: number): Promise<GroupResponse[]> {
+export async function groupsByRegion(region: number, userId?: number): Promise<GroupResponse[]> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let where: any = {
     '$grants.regionId$': { [Op.eq]: region },

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -38,16 +38,29 @@ interface GroupResponse {
   isPublic: boolean;
 }
 
-export async function groupsByRegion(region: number): Promise<GroupResponse[]> {
+export async function groupsByRegion(region: number, userId: number): Promise<GroupResponse[]> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let where: any = {
+    '$grants.regionId$': { [Op.eq]: region },
+  };
+
+  if (userId) {
+    where = {
+      ...where,
+      [Op.or]: [
+        { userId },
+        { isPublic: true },
+      ],
+    };
+  }
+
   return Group.findAll({
     attributes: [
       'id',
       'name',
       'userId',
     ],
-    where: {
-      '$grants.regionId$': { [Op.eq]: region },
-    },
+    where,
     include: [
       {
         attributes: [

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -1,4 +1,4 @@
-import { Op } from 'sequelize';
+import { Op, WhereOptions } from 'sequelize';
 import db from '../models';
 
 const {
@@ -40,7 +40,7 @@ interface GroupResponse {
 
 export async function groupsByRegion(region: number, userId?: number): Promise<GroupResponse[]> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let where: any = {
+  let where: WhereOptions = {
     '$grants.regionId$': { [Op.eq]: region },
   };
 


### PR DESCRIPTION
## Description of change

We need to limit what groups are returned to the AR (public vs private) not just region.

**NOTE:** This code will be replaced by Garrett's re-write and is a place holder for now.

## How to test

Make sure when you are creating a recipient AR and use the 'use group' check box. You can ONLY see groups that are public or created by the user and private.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
