### PR TITLE
Use Group UX Change

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -292,7 +292,7 @@ const ActivitySummary = ({
         {
           activityRecipientType === 'recipient' && !showGroupInfo && groups.length > 0
            && (
-           <div className="margin-top-1">
+           <div className="smart-hub-activity-summary-use-group margin-top-1">
              <Checkbox
                id="use-group"
                label="Use group"

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -292,7 +292,7 @@ const ActivitySummary = ({
         {
           activityRecipientType === 'recipient' && !showGroupInfo && groups.length > 0
            && (
-           <div className="margin-top-2">
+           <div className="margin-top-1">
              <Checkbox
                id="use-group"
                label="Use group"

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.scss
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.scss
@@ -2,6 +2,6 @@
     margin-top: 0;
  }
 
- .smart-hub-activity-summary .smart-hub--report-checkbox {
+ .smart-hub-activity-summary .smart-hub-activity-summary-use-group .smart-hub--report-checkbox {
     margin-top: 0px;
  }

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.scss
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.scss
@@ -1,3 +1,7 @@
 .smart-hub-activity-summary .smart-hub-activity-summary-group-info {
     margin-top: 0;
  }
+
+ .smart-hub-activity-summary .smart-hub--report-checkbox {
+    margin-top: 0px;
+ }


### PR DESCRIPTION
## Description of change

Kelly pointed out we want 8px above the use group check box not 16px.

## How to test

Visually inspect the activity summary page make sure we only have 8px above the checkbox.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
