### PR TITLE
[TTAHUB-2367] Fix FEI Root Cause local storage bug

### DIFF
--- a/src/models/hooks/goalFieldResponse.js
+++ b/src/models/hooks/goalFieldResponse.js
@@ -72,7 +72,9 @@ const syncActivityReportGoalFieldResponses = async (sequelize, instance, options
       // Get a list of activity report ids from idsToUpdate.
       const activityReportIds = idsToUpdate.map((item) => item.activityReportGoal.activityReportId);
       // We need to update the AR createdAt so we don't pull from outdated local storage.
-      await sequelize.query(`UPDATE "ActivityReports" SET "updatedAt" = '${new Date().toISOString()}' WHERE id IN (${activityReportIds.join(',')})`);
+      if (activityReportIds.length > 0) {
+        await sequelize.query(`UPDATE "ActivityReports" SET "updatedAt" = '${new Date().toISOString()}' WHERE id IN (${activityReportIds.join(',')})`);
+      }
     }
   }
 };

--- a/src/models/hooks/goalFieldResponse.js
+++ b/src/models/hooks/goalFieldResponse.js
@@ -40,12 +40,12 @@ const syncActivityReportGoalFieldResponses = async (sequelize, instance, options
       // Get ids to update (sequelize update doesn't support joins...)
       const idsToUpdate = await sequelize.models.ActivityReportGoalFieldResponse.findAll(
         {
-          attributes: ['id'],
+          attributes: ['id', 'activityReportGoalId'],
           where: {
             goalTemplateFieldPromptId,
           },
           include: {
-            attributes: [],
+            attributes: ['id', 'activityReportId'],
             required: true,
             model: sequelize.models.ActivityReportGoal,
             as: 'activityReportGoal',
@@ -68,6 +68,11 @@ const syncActivityReportGoalFieldResponses = async (sequelize, instance, options
           },
         },
       );
+
+      // Get a list of activity report ids from idsToUpdate.
+      const activityReportIds = idsToUpdate.map((item) => item.activityReportGoal.activityReportId);
+      // We need to update the AR createdAt so we don't pull from outdated local storage.
+      await sequelize.query(`UPDATE "ActivityReports" SET "updatedAt" = '${new Date().toISOString()}' WHERE id IN (${activityReportIds.join(',')})`);
     }
   }
 };

--- a/src/models/hooks/goalFieldResponse.test.js
+++ b/src/models/hooks/goalFieldResponse.test.js
@@ -280,6 +280,10 @@ describe('goalFieldResponseHooks', () => {
 
       // HOOK: Change goal response to trigger hook.
       goalFieldResponse.response = ['Updated Activity Report Goal Response'];
+
+      // Get the current time using moment.
+      const beforeGoalFieldResponseUpdate = new Date();
+
       await GoalFieldResponse.update(
         { response: ['Updated Goal Field Response'] },
         {
@@ -305,6 +309,30 @@ describe('goalFieldResponseHooks', () => {
       // Assert updated values.
       expect(goalFieldResponse.response).toEqual(['Updated Goal Field Response']);
       expect(activityReportGoalFieldResponse.response).toEqual(goalFieldResponse.response);
+
+      // Get the activity report associated with activityReportGoalFieldResponse.
+      const activityReportUpdatedAt = await ActivityReport.findOne({
+        where: {
+          id: report.id,
+        },
+      });
+
+      // Assert update date.
+      expect(activityReportUpdatedAt).not.toBeNull();
+      const activityReportUpdatedAtDate = new Date(activityReportUpdatedAt.updatedAt);
+      expect(activityReportUpdatedAtDate >= beforeGoalFieldResponseUpdate).toBeTruthy();
+
+      // Get report not to update.
+      const activityReportNotUpdatedAt = await ActivityReport.findOne({
+        where: {
+          id: reportNotToUpdate.id,
+        },
+      });
+
+      // Assert we didn't update anything we weren't supposed to.
+      expect(activityReportNotUpdatedAt).not.toBeNull();
+      const activityReportNotUpdatedAtDate = new Date(activityReportNotUpdatedAt.updatedAt);
+      expect(activityReportNotUpdatedAtDate < beforeGoalFieldResponseUpdate).toBeTruthy();
 
       // Assert no updated values.
       goalFieldResponseNotToUpdate = await GoalFieldResponse.findOne({


### PR DESCRIPTION
## Description of change

A bug was found during the demo of TTAHUB-23767. When updating FEI root cause on an activity report, we would properly 
propagate the root cause to all other reports and goals. However because the AR '**updatedAt**' was NOT changed. The local storage thought it had a more recent copy of the report and overwrote it.

## How to test

- Review the code.

**AR Test:**
1. Create two AR's using the same FEI goal.
2. Update the FEI on one of the AR's and save.
3. Verify both AR's have the set FEI.
4. Verify the Goal in RTR has the set FEI from the AR.
5. Check both AR's in the db to make sure they have the same **updatedAt** date.

**RTR Test:**
1. Create two AR's using the same FEI goal.
2. Update the FEI from the RTR.
3. Verify both AR's have the RTR set FEI.
4. Verify the RTR FEI value stuck on the goal.
5. Check both AR's in the db to make sure they have the same **updatedAt** date.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2367


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
