### PR TITLE
[TTAHUB-2275] Allow changing of end date

### DIFF
--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -2007,10 +2007,10 @@ export async function saveGoalsForReport(goals, report) {
         if (fields.name !== newOrUpdatedGoal.name && fields.name) {
           newOrUpdatedGoal.set({ name: fields.name.trim() });
         }
+      }
 
-        if (endDate && endDate !== 'Invalid date' && endDate !== newOrUpdatedGoal.endDate) {
-          newOrUpdatedGoal.set({ endDate });
-        }
+      if (endDate && endDate !== 'Invalid date' && endDate !== newOrUpdatedGoal.endDate) {
+        newOrUpdatedGoal.set({ endDate });
       }
 
       if (status && status !== newOrUpdatedGoal.status) {


### PR DESCRIPTION
## Description of change

It looks like there is code in the "saveGoalsForReport" which silently failed to update the anticipated close date on a reused goal (if that goal was already on an approved AR)

Since the UI allows it, we should allow it to change (closed and suspended goals don't appear on the AR)

## How to test

Test that you can update the anticipated close date **on an AR** for a reused goal that's been on an approved report.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2275


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
