### PR TITLE
[TTAHUB-2316] POC should be able to view training report

### DIFF
--- a/frontend/src/fetchers/__tests__/event.js
+++ b/frontend/src/fetchers/__tests__/event.js
@@ -10,22 +10,31 @@ import {
 import { EVENT_STATUS } from '../../pages/TrainingReports/constants';
 
 describe('eventById', () => {
-  beforeEach(() => {
-    fetchMock.get('/api/events/id/1', {
-      id: 1,
-      name: 'test event',
-    });
-  });
-
   afterEach(() => {
     fetchMock.reset();
   });
 
   it('fetches data from the server with the given id', async () => {
+    fetchMock.get('/api/events/id/1', {
+      id: 1,
+      name: 'test event',
+    });
     const event = await eventById(1);
 
     expect(fetchMock.called()).toBe(true);
     expect(fetchMock.lastUrl()).toBe('/api/events/id/1');
+    expect(event).toEqual({ id: 1, name: 'test event' });
+  });
+
+  it('fetches data from the server with the given id and accepts query param', async () => {
+    fetchMock.get('/api/events/id/1?readOnly=true', {
+      id: 1,
+      name: 'test event',
+    });
+    const event = await eventById(1, true);
+
+    expect(fetchMock.called()).toBe(true);
+    expect(fetchMock.lastUrl()).toBe('/api/events/id/1?readOnly=true');
     expect(event).toEqual({ id: 1, name: 'test event' });
   });
 });

--- a/frontend/src/fetchers/event.js
+++ b/frontend/src/fetchers/event.js
@@ -4,8 +4,12 @@ import { get, put, destroy } from './index';
 
 const eventsUrl = join('/', 'api', 'events');
 
-export const eventById = async (id) => {
-  const res = await get(`/api/events/id/${id}`);
+export const eventById = async (id, readOnly = false) => {
+  let url = `/api/events/id/${id}`;
+  if (readOnly) {
+    url += '?readOnly=true';
+  }
+  const res = await get(url);
   return res.json();
 };
 

--- a/frontend/src/pages/ViewTrainingReport/__tests__/index.js
+++ b/frontend/src/pages/ViewTrainingReport/__tests__/index.js
@@ -127,7 +127,7 @@ describe('ViewTrainingReport', () => {
   });
 
   it('renders a basic report with sessions', async () => {
-    fetchMock.getOnce('/api/events/id/1', mockEvent());
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', mockEvent());
 
     fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
     fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
@@ -209,7 +209,7 @@ describe('ViewTrainingReport', () => {
     global.navigator.clipboard = jest.fn();
     global.navigator.clipboard.writeText = jest.fn(() => Promise.resolve());
 
-    fetchMock.getOnce('/api/events/id/1', mockEvent());
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', mockEvent());
 
     fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
     fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
@@ -223,7 +223,7 @@ describe('ViewTrainingReport', () => {
   });
 
   it('handles an error fetching event', async () => {
-    fetchMock.getOnce('/api/events/id/1', 500);
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', 500);
 
     renderTrainingReport();
 
@@ -231,7 +231,7 @@ describe('ViewTrainingReport', () => {
   });
 
   it('handles a permissions error', async () => {
-    fetchMock.getOnce('/api/events/id/1', 403);
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', 403);
 
     renderTrainingReport();
 
@@ -239,7 +239,7 @@ describe('ViewTrainingReport', () => {
   });
 
   it('handles an error fetching collaborators', async () => {
-    fetchMock.getOnce('/api/events/id/1', mockEvent());
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', mockEvent());
 
     fetchMock.getOnce('/api/users/names?ids=1', 500);
     fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
@@ -250,7 +250,7 @@ describe('ViewTrainingReport', () => {
   });
 
   it('handles an error fetching points of contact', async () => {
-    fetchMock.getOnce('/api/events/id/1', mockEvent());
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', mockEvent());
 
     fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
     fetchMock.getOnce('/api/users/names?ids=2', 500);
@@ -267,7 +267,7 @@ describe('ViewTrainingReport', () => {
       status: 'Complete',
     };
 
-    fetchMock.getOnce('/api/events/id/1', e);
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
 
     fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
     fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
@@ -283,7 +283,7 @@ describe('ViewTrainingReport', () => {
     const e = mockEvent();
     delete e.sessionReports;
 
-    fetchMock.getOnce('/api/events/id/1', e);
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
 
     fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
     fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
@@ -311,7 +311,7 @@ describe('ViewTrainingReport', () => {
       },
     ];
 
-    fetchMock.getOnce('/api/events/id/1', e);
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
 
     fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
     fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);

--- a/frontend/src/pages/ViewTrainingReport/index.js
+++ b/frontend/src/pages/ViewTrainingReport/index.js
@@ -44,7 +44,7 @@ export default function ViewTrainingReport({ match }) {
     async function fetchEvent() {
       try {
         setIsAppLoading(true);
-        const e = await eventById(match.params.trainingReportId);
+        const e = await eventById(match.params.trainingReportId, true);
         setEvent(e);
       } catch (err) {
         let message = 'Sorry, something went wrong';

--- a/src/routes/events/handlers.js
+++ b/src/routes/events/handlers.js
@@ -71,10 +71,12 @@ export const getHandler = async (req, res) => {
       return res.status(httpCodes.BAD_REQUEST).send({ message: 'Must provide a qualifier' });
     }
 
+    const { readOnly } = req.query;
+
     // Check if user is a collaborator.
     const userId = await currentUserId(req, res);
     const scopes = [];
-    if (await userIsPocRegionalCollaborator(userId)) {
+    if (!readOnly && await userIsPocRegionalCollaborator(userId)) {
       scopes.push({ pocIds: { [Op.contains]: [userId] } });
     }
 

--- a/src/routes/events/handlers.test.js
+++ b/src/routes/events/handlers.test.js
@@ -73,42 +73,51 @@ describe('event handlers', () => {
       EventReport.mockImplementation(() => ({
         canRead: () => true,
       }));
-      await getHandler({ params: { eventId: 99_999 } }, mockResponse);
+      await getHandler({ params: { eventId: 99_999 }, query: {} }, mockResponse);
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+    });
+
+    it('returns the event if read only', async () => {
+      findEventBySmartsheetIdSuffix.mockResolvedValue(mockEvent);
+      EventReport.mockImplementation(() => ({
+        canRead: () => true,
+      }));
+      await getHandler({ params: { eventId: 99_999 }, query: { readOnly: true } }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(200);
     });
 
     it('400 when no params', async () => {
-      await getHandler({ params: {} }, mockResponse);
+      await getHandler({ params: {}, query: {} }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(400);
     });
 
     it('404 when not found by eventId', async () => {
       findEventBySmartsheetIdSuffix.mockResolvedValue(null);
-      await getHandler({ params: { eventId: 1 } }, mockResponse);
+      await getHandler({ params: { eventId: 1 }, query: {} }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(404);
     });
 
     it('returns 404 when not found by regionId', async () => {
       findEventsByRegionId.mockResolvedValue(null);
-      await getHandler({ params: { regionId: 1 } }, mockResponse);
+      await getHandler({ params: { regionId: 1 }, query: {} }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(404);
     });
 
     it('returns 404 when not found by ownerId', async () => {
       findEventsByOwnerId.mockResolvedValue(null);
-      await getHandler({ params: { ownerId: 1 } }, mockResponse);
+      await getHandler({ params: { ownerId: 1 }, query: {} }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(404);
     });
 
     it('returns 404 when not found by pocIds', async () => {
       findEventsByPocId.mockResolvedValue(null);
-      await getHandler({ params: { pocIds: 1 } }, mockResponse);
+      await getHandler({ params: { pocIds: 1 }, query: {} }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(404);
     });
 
     it('returns 404 when not found by collaboratorId', async () => {
       findEventsByCollaboratorId.mockResolvedValue(null);
-      await getHandler({ params: { collaboratorId: 1 } }, mockResponse);
+      await getHandler({ params: { collaboratorId: 1 }, query: {} }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(404);
     });
 
@@ -118,7 +127,7 @@ describe('event handlers', () => {
         isPoc: () => false,
       }));
       findEventBySmartsheetIdSuffix.mockResolvedValue(mockEvent);
-      await getHandler({ params: { eventId: 1 } }, mockResponse);
+      await getHandler({ params: { eventId: 1 }, query: {} }, mockResponse);
       expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
     });
   });


### PR DESCRIPTION
## Description of change

Allow query param to be passed into the route fetching events, making it more chill.

## How to test

Reference associated Jira for test case. After the change, specialist in question should be able to view pertinent training report.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2316


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
