### PR TITLE
[TTAHUB-1677] Allow adding approvers when report is "needs action"

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
@@ -41,10 +41,9 @@ const NeedsAction = ({
       setShowCreatorRoleError(true);
     } else if (!hasIncompletePages) {
       await onSubmit({
-        approvers: approverStatusList,
         additionalNotes: creatorNotes,
-        approverUserIds: approvers.map((a) => a.user.id),
         creatorRole: submitCR,
+        approvers,
       });
 
       // if successful, we should redirect to

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/NeedsAction.js
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types';
 import {
   FormGroup, Button, Fieldset, Dropdown, ErrorMessage,
 } from '@trussworks/react-uswds';
+import { useFormContext } from 'react-hook-form';
 import { useHistory } from 'react-router';
 import RichEditor from '../../../../../components/RichEditor';
+import ApproverSelect from './components/ApproverSelect';
 import FormItem from '../../../../../components/FormItem';
 import ApproverStatusList from '../../components/ApproverStatusList';
 import DisplayApproverNotes from '../../components/DisplayApproverNotes';
@@ -21,6 +23,7 @@ const NeedsAction = ({
   creatorRole,
   displayId,
   reportId,
+  availableApprovers,
 }) => {
   const hasIncompletePages = incompletePages.length > 0;
   const { user } = useContext(UserContext);
@@ -29,6 +32,9 @@ const NeedsAction = ({
   const [creatorNotes, setCreatorNotes] = useState(additionalNotes);
   const [showCreatorRoleError, setShowCreatorRoleError] = useState(false);
   const history = useHistory();
+  const { watch } = useFormContext();
+
+  const approvers = watch('approvers');
 
   const submit = async () => {
     if (!submitCR) {
@@ -37,6 +43,7 @@ const NeedsAction = ({
       await onSubmit({
         approvers: approverStatusList,
         additionalNotes: creatorNotes,
+        approverUserIds: approvers.map((a) => a.user.id),
         creatorRole: submitCR,
       });
 
@@ -70,7 +77,8 @@ const NeedsAction = ({
           !userHasOneRole
             ? (
               <>
-                <span className="text-bold">Creator role</span>
+                { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+                <label htmlFor="creatorRole" className="text-bold">Creator role</label>
                 <span className="smart-hub--form-required"> (Required)</span>
                 <FormGroup error={showCreatorRoleError}>
                   <Fieldset>
@@ -122,6 +130,23 @@ const NeedsAction = ({
       {hasIncompletePages && <IncompletePages incompletePages={incompletePages} />}
       <div className="margin-top-3">
         <ApproverStatusList approverStatus={approverStatusList} />
+      </div>
+      <div className="margin-top-3">
+        <FormItem
+          label="Add additional approvers"
+          name="approvers"
+          htmlFor="approvers"
+        >
+          <ApproverSelect
+            name="approvers"
+            valueProperty="user.id"
+            labelProperty="user.fullName"
+            options={availableApprovers.map((a) => ({ value: a.id, label: a.name }))}
+            lockExistingValues
+          />
+        </FormItem>
+      </div>
+      <div className="margin-top-3">
         <Button className="margin-bottom-4" onClick={submit}>Update report</Button>
       </div>
     </>
@@ -135,6 +160,10 @@ NeedsAction.propTypes = {
   approverStatusList: PropTypes.arrayOf(PropTypes.shape({
     approver: PropTypes.string,
     status: PropTypes.string,
+  })).isRequired,
+  availableApprovers: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
   })).isRequired,
   creatorRole: PropTypes.string,
   displayId: PropTypes.string.isRequired,

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/index.js
@@ -138,6 +138,7 @@ const Submitter = ({
               creatorRole={creatorRole}
               displayId={displayId}
               reportId={id}
+              availableApprovers={availableApprovers}
             />
           )}
         {approved

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -464,7 +464,6 @@ function ActivityReport({
             ...data,
             ECLKCResourcesUsed: data.ECLKCResourcesUsed.map((r) => (r.value)),
             nonECLKCResourcesUsed: data.nonECLKCResourcesUsed.map((r) => (r.value)),
-
             regionId: formData.regionId,
             approverUserIds: approverIds,
             version: 2,


### PR DESCRIPTION
## Description of change

Allow adding approvers when report is needs action

## How to test

Use user impersonation to create a report, then set the report as needs action as the approver.
As the creator, confirm you can add an additional user.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1677


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
