### PR TITLE
[TTAHUB-2172] SERVICE:WIDGETS -TypeError: (reading 'forEach')

### DIFF
--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -40,7 +40,7 @@ export async function countOccurrences(scopes, column, possibilities) {
 
 export function countBySingleKey(data, key, results) {
   // Get counts for each key.
-  data.forEach((point) => {
+  data?.forEach((point) => {
     point[key].forEach((r) => {
       const obj = results.find((e) => e.name === r);
       if (obj) {

--- a/src/widgets/helpers.test.js
+++ b/src/widgets/helpers.test.js
@@ -1,4 +1,4 @@
-import { formatNumber } from './helpers';
+import { countBySingleKey, formatNumber } from './helpers';
 
 describe('Format Number', () => {
   it('renders with correct decimal places and separator', async () => {
@@ -22,5 +22,15 @@ describe('Format Number', () => {
     expect(formatNumber('sdfgdfg', 3)).toBe('0');
 
     expect(formatNumber()).toBe('0');
+  });
+});
+
+describe('countBySingleKey', () => {
+  it('doesn\'t throw when null data (TTAHUB-2172)', async () => {
+    const data = null;
+    const key = 'someKey';
+    const results = [];
+
+    expect(() => countBySingleKey(data, key, results)).not.toThrow();
   });
 });

--- a/src/widgets/topicFrequencyGraph.js
+++ b/src/widgets/topicFrequencyGraph.js
@@ -91,7 +91,7 @@ export async function topicFrequencyGraph(scopes) {
     const allTopics = uniq(report.topics).map((t) => lookUpTopic.get(t));
 
     // Loop all topics array and update totals.
-    allTopics.forEach((topic) => {
+    allTopics?.forEach((topic) => {
       const topicIndex = acc.findIndex((t) => t.topic === topic);
       if (topicIndex !== -1) {
         acc[topicIndex].count += 1;
@@ -207,13 +207,13 @@ export async function topicFrequencyGraphViaGoals(scopes) {
     reportIds: new Set(),
   }));
 
-  topicsAndParticipants.forEach((goalData) => {
+  topicsAndParticipants?.forEach((goalData) => {
     goalData
       .get('topics')?.forEach(({ topic, reportIds }) => {
         const topicResponce = topicsResponse
           .find((t) => t.topic === lookUpTopic.get(topic));
 
-        reportIds.forEach((id) => topicResponce.reportIds.add(id));
+        reportIds?.forEach((id) => topicResponce.reportIds.add(id));
       });
   });
 

--- a/src/widgets/topicFrequencyGraph.test.js
+++ b/src/widgets/topicFrequencyGraph.test.js
@@ -17,7 +17,7 @@ import db, {
   Topic,
 } from '../models';
 import filtersToScopes from '../scopes';
-import { topicFrequencyGraph } from './topicFrequencyGraph';
+import { topicFrequencyGraph, topicFrequencyGraphViaGoals } from './topicFrequencyGraph';
 
 jest.mock('bull');
 
@@ -1101,5 +1101,11 @@ describe('Topics and frequency graph widget', () => {
         count: 0,
       },
     ]);
+  });
+
+  it('doesn\'t throw when likely no results (TTAHUB-2172)', async () => {
+    const query = { 'region.in': [100], 'startDate.win': '2222/01/01-3000/01/01' };
+    const scopes = await filtersToScopes(query);
+    expect(() => topicFrequencyGraph(scopes)).not.toThrow();
   });
 });

--- a/src/widgets/totalHrsAndRecipientGraph.js
+++ b/src/widgets/totalHrsAndRecipientGraph.js
@@ -12,7 +12,7 @@ function addOrUpdateResponse(traceIndex, res, xValue, valueToAdd, month) {
 
   const valueToUse = parseFloat(cleanValue, 10) === 0 ? 0 : parseFloat(cleanValue, 10);
 
-  res.forEach((responseObject, index) => {
+  res?.forEach((responseObject, index) => {
     if (index === traceIndex) {
       if (responseObject.x.includes(xValue)) {
         // Update existing x value.
@@ -111,7 +111,7 @@ export default async function totalHrsAndRecipientGraph(scopes, query) {
 
   const arDates = [];
 
-  reports.forEach((r) => {
+  reports?.forEach((r) => {
     if (r.startDate && r.startDate !== null) {
       // Get X Axis value to use.
       let xValue;

--- a/src/widgets/totalHrsAndRecipientGraph.test.js
+++ b/src/widgets/totalHrsAndRecipientGraph.test.js
@@ -314,4 +314,10 @@ describe('Total Hrs and Recipient Graph widget', () => {
     expect(data[2].x).toEqual(['Nov-21', 'Dec-21', 'Jan-22', 'Feb-22', 'May-23']);
     expect(data[2].y).toStrictEqual([0, 0, 3.2, 0, 0]);
   });
+
+  it('doesn\'t throw when likely no reports found (TTAHUB-2172)', async () => {
+    const query = { 'region.in': [100], 'startDate.win': '2222/01/01-3000/01/01' };
+    const scopes = await filtersToScopes(query);
+    expect(() => totalHrsAndRecipientGraph(scopes, query)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Description of change

Not a lot of information to go off of with this one, so just coalescing wherever I see a `forEach` in the scope of `SERVICE:WIDGETS`.

## How to test

Unclear! Use any and all widgets and ensure the error doesn't appear in the server logs:

`SERVICE:WIDGETS - UNEXPECTED ERROR - TypeError: Cannot read properties of null (reading 'forEach')`

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2172


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
