### PR TITLE
[TTAHUB-2174] Unhandled rejection error: (reading 'roles')

### DIFF
--- a/src/policies/recipient.js
+++ b/src/policies/recipient.js
@@ -23,7 +23,7 @@ export default class Recipient {
   }
 
   canMergeGoals() {
-    if (this.canView() && this.user.roles.map((r) => r.name).includes('TTAC')) {
+    if (this.canView() && this.user?.roles?.some((r) => r.name === 'TTAC')) {
       return true;
     }
 

--- a/src/routes/admin/user.js
+++ b/src/routes/admin/user.js
@@ -47,7 +47,7 @@ export async function createUserRoles(requestUser, userId) {
   });
 
   const currentRoles = currentUserRoles.map((r) => r.get('fullName'));
-  const newRoles = requestUser.roles.map((r) => r.fullName);
+  const newRoles = requestUser?.roles?.map((r) => r.fullName) || [];
 
   const rolesToRemove = currentRoles.filter((r) => !newRoles.includes(r));
   const rolesToCreate = newRoles.filter((r) => !currentRoles.includes(r));

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -126,7 +126,7 @@ async function saveReportCollaborators(activityReportId, collaborators) {
 
   if (updatedReportCollaborators && updatedReportCollaborators.length > 0) {
     // eslint-disable-next-line max-len
-    await Promise.all(updatedReportCollaborators.map((collaborator) => Promise.all(collaborator.user.roles.map(async (role) => CollaboratorRole.findOrCreate({
+    await Promise.all(updatedReportCollaborators.map((collaborator) => Promise.all((collaborator?.user?.roles || []).map(async (role) => CollaboratorRole.findOrCreate({
       where: {
         activityReportCollaboratorId: collaborator.id,
         roleId: role.id,


### PR DESCRIPTION
## Description of change

Not a lot of information to work with here, but I think we can narrow down this error to just a few spots:

```bash
…/activityReportCollaborator.js │   30:27 │         const roles = this.roles && this.roles.length
…/activityReportCollaborator.js │   31:17 │           ? this.roles : this.user.roles;
…Start-TTADP/src/models/user.js │   84:48 │         return generateFullName(this.name, this.roles);
…rc/services/activityReports.js │  129:101│     await Promise.all(updatedReportCollaborators.map((collaborator) => Promise.all(collaborator.user.roles.map(async (role) => CollaboratorRole.findOrCreate({
…TTADP/src/routes/admin/user.js │   50:31 │   const newRoles = requestUser.roles.map((r) => r.fullName);
…TADP/src/policies/recipient.js │   26:36 │     if (this.canView() && this.user.roles.map((r) => r.name).includes('TTAC')) {
```

It looks like everywhere else `.roles` is accessed is either a test, a migration, or somewhere in the frontend.

Of the above shown, not all of them make sense or could be causing the error. Of the ones that made sense to me, they have been wrapped in bubblewrap.


## How to test

I wish I knew!

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2174


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
