### PR TITLE
[TTAHUB-2170] Update Files: cannot read properties of null (dataValues)

### DIFF
--- a/src/workers/files.js
+++ b/src/workers/files.js
@@ -21,7 +21,12 @@ const KEY_NOT_FOUND = 'File with key not found.';
  */
 const getIdFromKey = async (key) => {
   const file = await File.findOne({ where: { key } });
-  if (!file) throw new Error(KEY_NOT_FOUND);
+  if (!file) {
+    throw Object.assign(
+      new Error(KEY_NOT_FOUND),
+      { key },
+    );
+  }
   return file.dataValues.id;
 };
 
@@ -58,9 +63,8 @@ const processFile = async (key) => {
     });
     await updateFileStatus(key, APPROVED);
   } catch (error) {
-    // If the key couldn't be found, we can't update the status.
     if (error.message === KEY_NOT_FOUND) {
-      throw error;
+      return { status: error.message, data: error.key };
     }
 
     if (error.response && error.response.status === 406) {

--- a/src/workers/files.js
+++ b/src/workers/files.js
@@ -59,7 +59,7 @@ const processFile = async (key) => {
     await updateFileStatus(key, APPROVED);
   } catch (error) {
     // If the key couldn't be found, we can't update the status.
-    if (error.message == KEY_NOT_FOUND) {
+    if (error.message === KEY_NOT_FOUND) {
       throw error;
     }
 

--- a/src/workers/files.js
+++ b/src/workers/files.js
@@ -19,6 +19,7 @@ const {
  */
 const getIdFromKey = async (key) => {
   const file = await File.findOne({ where: { key } });
+  if (!file) throw new Error(`File with key ${key} not found.`);
   return file.dataValues.id;
 };
 

--- a/src/workers/files.test.js
+++ b/src/workers/files.test.js
@@ -64,4 +64,11 @@ describe('File Scanner tests', () => {
     const got = processFile(fileKey);
     await expect(got).rejects.toBe(axiosServerError);
   });
+  it('fails when the key could not be found', async () => {
+    mockFindOne.mockImplementationOnce(() => Promise.resolve(null));
+    const got = processFile(fileKey);
+    await expect(got).rejects.toThrow('File with key not found.');
+    expect(mockFindOne).toBeCalledWith({ where: { key: fileKey } });
+    expect(mockUpdate).not.toBeCalled();
+  });
 });

--- a/src/workers/files.test.js
+++ b/src/workers/files.test.js
@@ -64,10 +64,11 @@ describe('File Scanner tests', () => {
     const got = processFile(fileKey);
     await expect(got).rejects.toBe(axiosServerError);
   });
-  it('fails when the key could not be found', async () => {
+  it('resolves with an error message when the key could not be found', async () => {
     mockFindOne.mockImplementationOnce(() => Promise.resolve(null));
-    const got = processFile(fileKey);
-    await expect(got).rejects.toThrow('File with key not found.');
+    const got = await processFile(fileKey);
+    expect(got).toHaveProperty('status', 'File with key not found.');
+    expect(got).toHaveProperty('data', fileKey);
     expect(mockFindOne).toBeCalledWith({ where: { key: fileKey } });
     expect(mockUpdate).not.toBeCalled();
   });


### PR DESCRIPTION
## Description of change

This one is more straight forward. It seems like we access dataValues in only one spot in this pipeline. We should check the return of `findOne` before accessing `dataValues`. If it is `null`, throw an error to short circuit the `processFile` operation.


## How to test

`files.test.js` has been updated to check for this

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2170


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
