### PR TITLE
[TTAHUB-2124] Remove aro topics from version 1 reports

### DIFF
--- a/src/migrations/20240104110924-remove-unwanted-aro-topics.js
+++ b/src/migrations/20240104110924-remove-unwanted-aro-topics.js
@@ -1,0 +1,30 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, _Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      await queryInterface.sequelize.query(
+        `DELETE FROM "ActivityReportObjectiveTopics"
+        WHERE "activityReportObjectiveId" IN (
+            SELECT aro."id"
+            FROM "ActivityReportObjectives" aro
+            INNER JOIN "ActivityReports" ar
+                ON aro."activityReportId" = ar.id
+            WHERE aro.id IN (
+                SELECT ("new_row_data"->'activityReportObjectiveId')::int
+                FROM "ZALActivityReportObjectiveTopics" where "dml_txid" = '00000000-0000-0000-0000-000002266502'
+            )
+            AND ar."version" = 1
+        );`,
+        { transaction },
+      );
+    });
+  },
+
+  down: async () => {},
+};

--- a/src/migrations/20240104110924-remove-unwanted-aro-topics.js
+++ b/src/migrations/20240104110924-remove-unwanted-aro-topics.js
@@ -9,18 +9,15 @@ module.exports = {
       const sessionSig = __filename;
       await prepMigration(queryInterface, transaction, sessionSig);
       await queryInterface.sequelize.query(
-        `DELETE FROM "ActivityReportObjectiveTopics"
-        WHERE "activityReportObjectiveId" IN (
-            SELECT aro."id"
-            FROM "ActivityReportObjectives" aro
-            INNER JOIN "ActivityReports" ar
-                ON aro."activityReportId" = ar.id
-            WHERE aro.id IN (
-                SELECT ("new_row_data"->'activityReportObjectiveId')::int
-                FROM "ZALActivityReportObjectiveTopics" where "dml_txid" = '00000000-0000-0000-0000-000002266502'
-            )
-            AND ar."version" = 1
-        );`,
+        `DELETE FROM  "ActivityReportObjectiveTopics" arot
+        USING "ActivityReportObjectives" aro
+        JOIN "ZALActivityReportObjectiveTopics" zaro
+          ON dml_txid = '00000000-0000-0000-0000-000002266502'
+          AND aro.id = (zaro.new_row_data->>'activityReportObjectiveId')::int
+        JOIN "ActivityReports" ar
+          ON aro."activityReportId" = ar.id
+          AND ar.version = 1
+        WHERE arot."activityReportObjectiveId" = aro.id;`,
         { transaction },
       );
     });


### PR DESCRIPTION
## Description of change

When exporting an older report (id: 10558), we noticed that both the ARO and AR (legacy) level topics were populated. This should not be the case as this report was created and approved before the introduction of ARO's. After some investigation it turns out that the creation of these topics was from a migration file '20220802000000-goal-objective-metadata-caching'. The attached script will delete any ARO topics that were created as a result of this migration on version 1 reports.

## How to test

- Review the migration.
- Make sure you agree with the cleanup (criteria used to determine what we delete).
- Export report 10558 and see the 'Objective 1.1 Topics' field populated in addition to the 'Legacy Topics covered'.
- Run the migration and export the report csv only the legacy topics should be populated.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2124


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
