### PR TITLE
[TTAHUB-2367] Change logic for updating fei responses on approved reports

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
+++ b/frontend/src/pages/ApprovedActivityReport/components/ApprovedReportV2.js
@@ -149,7 +149,7 @@ function calculateGoalsAndObjectives(report) {
       if (prompts && prompts.length) {
         const promptData = {};
         prompts.forEach((prompt) => {
-          promptData[prompt.title] = prompt.response.join(', ');
+          promptData[prompt.title] = prompt.reportResponse.join(', ');
         });
         goalSection.data = { ...goalSection.data, ...promptData };
       }

--- a/src/models/hooks/goalFieldResponse.js
+++ b/src/models/hooks/goalFieldResponse.js
@@ -1,3 +1,5 @@
+import { Op } from 'sequelize';
+
 const autoPopulateOnAR = (sequelize, instance, options) => {
   // eslint-disable-next-line no-prototype-builtins
   if (instance.onAR === undefined
@@ -43,16 +45,29 @@ const syncActivityReportGoalFieldResponses = async (sequelize, instance, options
         where: {
           goalTemplateFieldPromptId,
         },
-        include: {
+        include: [{
           attributes: ['id', 'activityReportId'],
           required: true,
           model: sequelize.models.ActivityReportGoal,
           as: 'activityReportGoal',
           where: {
             goalId,
-            onApprovedAR: false, // Only update ActivityReportGoalFieldResponses on unapproved ARs.
           },
+          include: [
+            {
+              attributes: ['id', 'calculatedStatus'],
+              required: true,
+              model: sequelize.models.ActivityReport,
+              as: 'activityReport',
+              where: {
+                calculatedStatus: {
+                  [Op.ne]: 'approved', // Only update ActivityReportGoalFieldResponses on unapproved ARs.
+                },
+              },
+            },
+          ],
         },
+        ],
       },
     );
 

--- a/src/services/goalTemplates.ts
+++ b/src/services/goalTemplates.ts
@@ -311,9 +311,9 @@ export async function setFieldPromptForCuratedTemplate(
         { response },
         {
           where: {
+            // GoalFieldResponses should always be updated regardless of on approved ar.
             goalTemplateFieldPromptId: promptId,
             goalId: goalIdsToUpdate,
-            onApprovedAR: false,
           },
           individualHooks: true,
         },


### PR DESCRIPTION
## Description of change

Currently we do NOT update FEI responses if its linked to an approved AR. 

This code change does two things:
1. **GoalFieldResponses** are ALWAYS updated regardless of onApproved report status.
2. **ActivityReportGoalFieldResponses** are ONLY updated if they are not linked to an approved report (cached as of the time of approval) all others are updated.

## How to test

- Review the code.

**Test:** 
1. Create a approved report using an FEI goal
2. Create an unapproved report using an FEI goal (using a different response than step 1)
3. Check the approved report is should still have its unique response
4. Edit the FEI goal make sure its set to the response of the unapproved goal
5. Update the response from the fei goal to something new
6. verify it was changed on the unapproved and goal
7. verify it was NOT changed on the approved report


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2367


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
