### PR TITLE
[TTAHUB-2300] Display which program a CFO belongs to on the leadership widget

### DIFF
--- a/src/models/programPersonnel.js
+++ b/src/models/programPersonnel.js
@@ -97,6 +97,14 @@ export default (sequelize, DataTypes) => {
         const { programType } = program;
 
         if (role.toLowerCase() === 'cfo') {
+          if (programType && programType.toLowerCase() === 'ehs') {
+            return 'Chief Financial Officer for Early Head Start';
+          }
+
+          if (programType && programType.toLowerCase() === 'hs') {
+            return 'Chief Financial Officer for Head Start';
+          }
+
           return 'Chief Financial Officer';
         }
 
@@ -105,7 +113,7 @@ export default (sequelize, DataTypes) => {
             return 'Director for Early Head Start';
           }
 
-          if (programType.toLowerCase() === 'hs') {
+          if (programType && programType.toLowerCase() === 'hs') {
             return 'Director for Head Start';
           }
 

--- a/src/models/tests/programPersonnel.test.js
+++ b/src/models/tests/programPersonnel.test.js
@@ -11,8 +11,24 @@ describe('ProgramPersonnel', () => {
   let grant;
   let recipient;
   let program;
+  let ehsProgram;
+  let weirdProgram;
   let baseProgramPersonnel;
   let programPersonnel;
+
+  const BASE_PERSONNEL = {
+    role: GRANT_PERSONNEL_ROLES[0],
+    active: false,
+    prefix: 'Mr.',
+    firstName: 'John',
+    lastName: 'Doe',
+    suffix: 'Jr.',
+    title: 'Director',
+    email: 'john.doe@test.gov',
+    effectiveDate: '2023-01-01',
+    mapsTo: null,
+  };
+
   beforeAll(async () => {
     // Recipient.
     recipient = await Recipient.create({
@@ -44,20 +60,33 @@ describe('ProgramPersonnel', () => {
       endDate: '2025',
     });
 
+    ehsProgram = await Program.create({
+      id: faker.datatype.number({ min: 10000, max: 100000 }),
+      grantId: grant.id,
+      name: 'Sample Program Personnel ehs',
+      programType: 'EHS',
+      startYear: '2023',
+      status: 'active',
+      startDate: '2023',
+      endDate: '2025',
+    });
+
+    weirdProgram = await Program.create({
+      id: faker.datatype.number({ min: 10000, max: 100000 }),
+      grantId: grant.id,
+      name: 'Sample Program Personnel weird',
+      programType: 'something-weird',
+      startYear: '2023',
+      status: 'active',
+      startDate: '2023',
+      endDate: '2025',
+    });
+
     // Grant Personnel.
     baseProgramPersonnel = await ProgramPersonnel.create({
+      ...BASE_PERSONNEL,
       grantId: grant.id,
       programId: program.id,
-      role: GRANT_PERSONNEL_ROLES[0],
-      active: false,
-      prefix: 'Mr.',
-      firstName: 'John',
-      lastName: 'Doe',
-      suffix: 'Jr.',
-      title: 'Director',
-      email: 'john.doe@test.gov',
-      effectiveDate: '2023-01-01',
-      mapsTo: null,
     });
 
     // Grant Personnel.
@@ -83,16 +112,11 @@ describe('ProgramPersonnel', () => {
         grantId: grant.id,
       },
     });
-    await ProgramPersonnel.destroy({
-      where: {
-        grantId: grant.id,
-      },
-    });
 
     // Delete Program.
     await Program.destroy({
       where: {
-        id: program.id,
+        id: [program.id, ehsProgram.id, weirdProgram.id],
       },
     });
 
@@ -206,5 +230,47 @@ describe('ProgramPersonnel', () => {
 
     // Assert there are two program personnel.
     expect(grant.programPersonnel.length).toBe(2);
+  });
+
+  it('returns the correct data for CFO', async () => {
+    await ProgramPersonnel.bulkCreate([
+      {
+        ...BASE_PERSONNEL,
+        role: 'cfo',
+        programId: program.id,
+        grantId: grant.id,
+      }, {
+        ...BASE_PERSONNEL,
+        role: 'cfo',
+        programId: ehsProgram.id,
+        grantId: grant.id,
+      },
+      {
+        ...BASE_PERSONNEL,
+        role: 'cfo',
+        programId: weirdProgram.id,
+        grantId: grant.id,
+      }]);
+
+    const personnel = await ProgramPersonnel.findAll({
+      where: {
+        role: 'cfo',
+        grantId: grant.id,
+      },
+      include: [
+        {
+          model: Program,
+          as: 'program',
+        },
+      ],
+    });
+
+    expect(personnel.length).toBe(3);
+
+    const fullRoles = personnel.map((p) => p.fullRole);
+
+    expect(fullRoles).toContain('Chief Financial Officer for Head Start');
+    expect(fullRoles).toContain('Chief Financial Officer for Early Head Start');
+    expect(fullRoles).toContain('Chief Financial Officer');
   });
 });


### PR DESCRIPTION
## Description of change
Display the program type if leadership is CFO on the recipient profile/leadership widget

## How to test
- Load a prod dataset and visit /recipient-tta-records/4707/region/5/profile
- You will see that the CFO now says "CFO for early head start" or "CFO for head start" depending on the associated program

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2300


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
