### PR TITLE
Fix language issue on approved reports on prod

### DIFF
--- a/frontend/src/pages/ApprovedActivityReport/helpers.js
+++ b/frontend/src/pages/ApprovedActivityReport/helpers.js
@@ -49,7 +49,7 @@ export function renderData(heading, data) {
 }
 
 export function formatSimpleArray(arr) {
-  return arr.sort().join(', ');
+  return arr ? arr.sort().join(', ') : '';
 }
 
 export function mapAttachments(attachments) {

--- a/frontend/src/pages/ApprovedActivityReport/index.js
+++ b/frontend/src/pages/ApprovedActivityReport/index.js
@@ -55,6 +55,7 @@ export default function ApprovedActivityReport({ match, user }) {
     startDate: '',
     creatorNotes: '',
     ttaType: ['Training'],
+    language: [],
   });
 
   const modalRef = useRef();


### PR DESCRIPTION
## Description of change

We found a bug where the formatSimpleArray() function on approved reports wasn't checking for null value.
This fixes the issue by adding a check.

## How to test

View any approved v2 report that doesn't have language set.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
