### PR TITLE
[TTAHUB-2483] Add back url to files

### DIFF
--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -528,13 +528,14 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
         exists,
       );
 
-      exists.files = reduceRelationThroughActivityReportObjectives(
-        objective,
-        'activityReportObjectiveFiles',
-        'file',
-        exists,
-      );
-
+      exists.files = uniqBy([
+        ...exists.files,
+        ...(objective.activityReportObjectives
+          && objective.activityReportObjectives.length > 0
+          ? objective.activityReportObjectives[0].activityReportObjectiveFiles
+            .map((f) => ({ ...f.file.dataValues, url: f.file.url }))
+          : []),
+      ], (e) => e.key);
       return objectives;
     }
 
@@ -587,11 +588,11 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
         'activityReportObjectiveResources',
         'resource',
       ),
-      files: reduceRelationThroughActivityReportObjectives(
-        objective,
-        'activityReportObjectiveFiles',
-        'file',
-      ),
+      files: objective.activityReportObjectives
+      && objective.activityReportObjectives.length > 0
+        ? objective.activityReportObjectives[0].activityReportObjectiveFiles
+          .map((f) => ({ ...f.file.dataValues, url: f.file.url }))
+        : [],
       courses: reduceRelationThroughActivityReportObjectives(
         objective,
         'activityReportObjectiveCourses',


### PR DESCRIPTION
## Description of change

This issue had to do with a required file.url param missing from the returned report. We simply put it back the way it was before.

## How to test

Edit any existing report with objective file attachments there should be no error.

Or edit the report from the JIRA.


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2483


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
