### PR TITLE
[TTAHUB-2494] Fix resource links reducer error

### DIFF
--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -476,6 +476,7 @@ const reduceRelationThroughActivityReportObjectives = (
   join,
   relation,
   exists = {},
+  uniqueBy = 'id',
 ) => {
   const existingRelation = exists[relation] || [];
   return uniqBy([
@@ -486,7 +487,7 @@ const reduceRelationThroughActivityReportObjectives = (
         .map((t) => t[relation].dataValues)
         .filter((t) => t)
       : []),
-  ], (e) => e.id);
+  ], (e) => e[uniqueBy]);
 };
 
 export function reduceObjectivesForActivityReport(newObjectives, currentObjectives = []) {
@@ -518,6 +519,7 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
         'activityReportObjectiveResources',
         'resource',
         exists,
+        'value',
       );
 
       exists.topics = reduceRelationThroughActivityReportObjectives(
@@ -594,6 +596,8 @@ export function reduceObjectivesForActivityReport(newObjectives, currentObjectiv
         objective,
         'activityReportObjectiveResources',
         'resource',
+        {},
+        'value',
       ),
       files: objective.activityReportObjectives
       && objective.activityReportObjectives.length > 0


### PR DESCRIPTION
## Description of change
Another error introduced by my recent refactor; resource links reduced for an objective don't have a "id" but instead use a value

## How to test
Add two resource links to an activity report objective, leave, and then return. Both resource links should be present.

## Issue(s)
* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2494


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
