### PR TITLE
[TTAHUB-2494] Fix for activity report approvers

### DIFF
--- a/src/models/hooks/activityReportApprover.js
+++ b/src/models/hooks/activityReportApprover.js
@@ -41,6 +41,12 @@ const updateReportStatus = async (sequelize, instance) => {
       submissionStatus: REPORT_STATUSES.SUBMITTED,
     },
   });
+
+  // we only update any of the report status fields if the report is submitted
+  if (!report) {
+    return;
+  }
+
   // We allow users to create approvers before submitting the report. Calculated
   // status should only exist for submitted reports.
 

--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -161,8 +161,15 @@ export default class ActivityReport {
     return approverUserIds.includes(this.user.id);
   }
 
+  // This is a helper function to determine if the report is in a state where it can be edited
   reportHasEditableStatus() {
+    // if the report is in draft
     return this.activityReport.submissionStatus === REPORT_STATUSES.DRAFT
-      || this.activityReport.calculatedStatus === REPORT_STATUSES.NEEDS_ACTION;
+    // or if it's been marked as needs action
+      || this.activityReport.calculatedStatus === REPORT_STATUSES.NEEDS_ACTION || (
+    // or if it's submitted and the calculated status is not submitted for some reason
+      this.activityReport.submissionStatus === REPORT_STATUSES.SUBMITTED
+        && this.activityReport.calculatedStatus !== REPORT_STATUSES.SUBMITTED
+    );
   }
 }

--- a/src/policies/activityReport.js
+++ b/src/policies/activityReport.js
@@ -163,13 +163,18 @@ export default class ActivityReport {
 
   // This is a helper function to determine if the report is in a state where it can be edited
   reportHasEditableStatus() {
-    // if the report is in draft
-    return this.activityReport.submissionStatus === REPORT_STATUSES.DRAFT
-    // or if it's been marked as needs action
-      || this.activityReport.calculatedStatus === REPORT_STATUSES.NEEDS_ACTION || (
-    // or if it's submitted and the calculated status is not submitted for some reason
-      this.activityReport.submissionStatus === REPORT_STATUSES.SUBMITTED
-        && this.activityReport.calculatedStatus !== REPORT_STATUSES.SUBMITTED
-    );
+    // if the report is in draft, it's editable
+    if (this.activityReport.submissionStatus === REPORT_STATUSES.DRAFT
+      || this.activityReport.calculatedStatus === REPORT_STATUSES.DRAFT) {
+      return true;
+    }
+
+    // if the report is in needs action, it's editable,
+    // regardless of whether the report is submitted
+    if (this.activityReport.calculatedStatus === REPORT_STATUSES.NEEDS_ACTION) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/services/activityReportApprovers.js
+++ b/src/services/activityReportApprovers.js
@@ -6,7 +6,12 @@ import { ActivityReportApprover, User } from '../models';
  * @param {*} values - object containing Approver properties to create or update
  */
 export async function upsertApprover(values) {
-  const { activityReportId, userId, status } = values;
+  const {
+    activityReportId,
+    userId,
+    status,
+    note,
+  } = values;
 
   let approver = await ActivityReportApprover.findOne({
     where: {
@@ -23,11 +28,11 @@ export async function upsertApprover(values) {
     approver.changed('updatedAt', true);
     approver.set('updatedAt', new Date());
 
-    if (approver.status) {
+    if (status) {
       approver.set('status', status);
     }
 
-    if (approver.note) {
+    if (note) {
       approver.set('note', values.note);
     }
 

--- a/src/services/activityReportApprovers.js
+++ b/src/services/activityReportApprovers.js
@@ -95,8 +95,6 @@ export async function syncApprovers(activityReportId, userIds = []) {
     await Promise.all(destroyPromises);
   }
 
-  console.log({ userIds });
-
   // Create or restore approvers
   if (userIds.length > 0) {
     const upsertApproverPromises = userIds.map(async (userId) => upsertApprover({


### PR DESCRIPTION
## Description of change
We (I) removed the upserts from the approval process (big mistake?)
In doing so, there was one straight up mistake and one thing that we missed.

## How to test
1/25/24 prod dataset is on keybase. Impersonate the user listed in the Jira ticket and submit report 39409.
Clear local storage; refresh the page

You will see that the report is **actually submitted**

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2494


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
