### PR TITLE
Fix 2 bugs with TR goal

### DIFF
--- a/frontend/src/pages/SessionForm/__tests__/index.js
+++ b/frontend/src/pages/SessionForm/__tests__/index.js
@@ -188,6 +188,11 @@ describe('SessionReportForm', () => {
         2: COMPLETE,
         3: COMPLETE,
       },
+      event: {
+        data: {
+          goal: 'test goal',
+        },
+      },
       sessionName: 'Test session',
       duration: 1,
       context: '', // context missing
@@ -243,6 +248,11 @@ describe('SessionReportForm', () => {
         2: COMPLETE,
         3: COMPLETE,
       },
+      event: {
+        data: {
+          goal: 'test goal',
+        },
+      },
       sessionName: 'Test session',
       duration: 1,
       context: '', // context missing
@@ -279,7 +289,7 @@ describe('SessionReportForm', () => {
 
     expect(await screen.findByText(/Status must be complete to submit session/i)).toBeInTheDocument();
   });
-  it('will submit if every page & the status is complete', async () => {
+  it('will submit if every page & the status & the event goal is complete', async () => {
     const url = join(sessionsUrl, 'id', '1');
     const formData = {
       eventId: 1,
@@ -287,6 +297,11 @@ describe('SessionReportForm', () => {
       id: 1,
       ownerId: 1,
       eventName: 'Test event',
+      event: {
+        data: {
+          goal: 'test goal',
+        },
+      },
       status: 'In progress',
       pageState: {
         1: IN_PROGRESS,
@@ -339,6 +354,76 @@ describe('SessionReportForm', () => {
 
     await waitFor(() => expect(fetchMock.called(url, { method: 'PUT' })).toBe(true));
   });
+
+  it('will not submit if the event\'s goal is not complete', async () => {
+    const url = join(sessionsUrl, 'id', '1');
+    const formData = {
+      eventId: 1,
+      eventDisplayId: 'R-EVENT-123',
+      event: {
+        data: {
+          goal: '',
+          eventId: 'R-EVENT-123',
+        },
+      },
+      id: 1,
+      ownerId: 1,
+      eventName: 'Test event',
+      status: 'In progress',
+      pageState: {
+        1: IN_PROGRESS,
+        2: COMPLETE,
+        3: COMPLETE,
+        4: COMPLETE,
+      },
+      'pageVisited-supporting-attachments': true,
+      sessionName: 'Test session',
+      endDate: '01/01/2024',
+      startDate: '01/01/2024',
+      duration: 1,
+      context: 'asasfdsafasdfsdaf',
+      objective: 'test objective',
+      objectiveTopics: ['topic'],
+      objectiveTrainers: ['DTL'],
+      objectiveResources: [],
+      files: [],
+      objectiveSupportType: SUPPORT_TYPES[1],
+      regionId: 1,
+      participants: [1],
+      recipients: [1],
+      deliveryMethod: 'In-person',
+      numberOfParticipants: 1,
+      ttaProvided: 'oH YEAH',
+      specialistNextSteps: [{ note: 'A', completeDate: '01/01/2024' }],
+      recipientNextSteps: [{ note: 'B', completeDate: '01/01/2024' }],
+      language: ['English'],
+    };
+
+    fetchMock.get(url, formData);
+
+    act(() => {
+      renderSessionForm('1', 'complete-session', '1');
+    });
+
+    await waitFor(() => expect(fetchMock.called(url, { method: 'get' })).toBe(true));
+
+    const statusSelect = await screen.findByRole('combobox', { name: /status/i });
+    act(() => {
+      userEvent.selectOptions(statusSelect, 'Complete');
+    });
+
+    await waitFor(() => expect(fetchMock.called(url, { method: 'get' })).toBe(true));
+    fetchMock.put(url, formData);
+    const submit = screen.getByRole('button', { name: /Submit/i });
+    act(() => {
+      userEvent.click(submit);
+    });
+
+    await waitFor(() => expect(fetchMock.called(url, { method: 'PUT' })).not.toBe(true));
+
+    expect(await screen.findByText(/Vision and goal for/i)).toBeInTheDocument();
+  });
+
   it('redirects if session is complete', async () => {
     const url = join(sessionsUrl, 'id', '1');
     const formData = {

--- a/frontend/src/pages/SessionForm/pages/__tests__/completeSession.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/completeSession.js
@@ -24,6 +24,9 @@ describe('completeSession', () => {
       pageState: defaultPageState,
       event: {
         ownerId: 1,
+        data: {
+          goal: 'This is a goal',
+        },
       },
     };
 

--- a/frontend/src/pages/SessionForm/pages/completeSession.js
+++ b/frontend/src/pages/SessionForm/pages/completeSession.js
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { EVENT_REPORT_STATUSES } from '@ttahub/common';
 import { useFormContext } from 'react-hook-form';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import {
@@ -10,6 +11,7 @@ import FormItem from '../../../components/FormItem';
 import useTrainingReportRole from '../../../hooks/useTrainingReportRole';
 import UserContext from '../../../UserContext';
 import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
+import { getEventIdSlug } from '../../TrainingReportForm/constants';
 
 const position = 5;
 const path = 'complete-session';
@@ -49,6 +51,21 @@ const CompleteSession = ({
   const onFormSubmit = async () => {
     if (updatedStatus !== 'Complete') {
       setError('status', { message: 'Status must be complete to submit session' });
+      return;
+    }
+
+    if (!formData.event.data.goal) {
+      const eventId = getEventIdSlug(formData.event.data.eventId);
+      setError('status', {
+        message: (
+          <span>
+            Vision and goal for
+            {' '}
+            <Link to={`/training-report/${eventId}/vision-goal`}>{formData.event.data.eventId}</Link>
+            {' '}
+            must be completed before completing session
+          </span>),
+      });
       return;
     }
 
@@ -140,7 +157,12 @@ const CompleteSession = ({
 CompleteSession.propTypes = {
   DraftAlert: PropTypes.node.isRequired,
   formData: PropTypes.shape({
-    event: PropTypes.shape({}),
+    event: PropTypes.shape({
+      data: PropTypes.shape({
+        eventId: PropTypes.string,
+        goal: PropTypes.string,
+      }),
+    }),
     id: PropTypes.number,
     status: PropTypes.string,
     pageState: PropTypes.shape({

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -1527,17 +1527,31 @@ export async function goalsForGrants(grantIds) {
       'onApprovedAR',
       'endDate',
       'source',
+      'createdVia',
       [sequelize.fn('BOOL_OR', sequelize.literal(`"goalTemplate"."creationMethod" = '${CREATION_METHOD.CURATED}'`)), 'isCurated'],
     ],
-    group: ['"Goal"."name"', '"Goal"."status"', '"Goal"."endDate"', '"Goal"."onApprovedAR"', '"Goal"."source"'],
+    group: ['"Goal"."name"', '"Goal"."status"', '"Goal"."endDate"', '"Goal"."onApprovedAR"', '"Goal"."source"', '"Goal"."createdVia"'],
     where: {
+      name: {
+        [Op.ne]: '', // exclude "blank" goals
+      },
       '$grant.id$': ids,
       status: {
-        [Op.or]: [
-          { [Op.notIn]: ['Closed', 'Suspended'] },
-          { [Op.is]: null },
-        ],
+        [Op.notIn]: ['Closed', 'Suspended'],
       },
+      [Op.or]: [
+        {
+          createdVia: {
+            [Op.not]: 'tr',
+          },
+        },
+        {
+          createdVia: 'tr',
+          status: {
+            [Op.not]: 'Draft',
+          },
+        },
+      ],
     },
     include: [
       {


### PR DESCRIPTION
## Description of change
When testing #1947, I found two bugs that I think should be fixed.

1) Draft TR goals were available for selection on the AR. I adjusted the goalsForGrants query to meet the original criteria.
2) I thought of a problematic scenario where a session was completed before the goal was, locking the UI. A support ticket waiting to happen. I added an error state to our session completion so that such a thing would be disallowed.

## How to test

- Confirm that draft TR goals can't be selected on an AR, only "In Progress" goals
- Attempt to complete a session when the "goal" isn't filled out on the parent training report. You should be unable to.

## Issue(s)

There's no ticket for this


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
