### PR TITLE
[TTAHUB-2546] Small changes to TR goal deletion - missed from previous PR

### DIFF
--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -451,7 +451,7 @@ describe('createGoalsForSessionRecipientsIfNecessary hook', () => {
         name: 'Increase knowledge about X',
         onAR: true,
         onApprovedAR: false,
-        source: 'Training event',
+        source: 'Training event follow-up',
         status: 'Draft',
         updatedAt: expect.any(Date),
       },
@@ -523,8 +523,8 @@ describe('removeGoalsForSessionRecipientsIfNecessary hook', () => {
       },
     };
     await removeGoalsForSessionRecipientsIfNecessary(mockSequelize, { id: '1' }, mockOptions);
-    expect(mockSequelize.models.EventReportPilotGoal.destroy).toHaveBeenCalled();
-    expect(mockSequelize.models.Goal.destroy).toHaveBeenCalled();
+    expect(mockSequelize.models.EventReportPilotGoal.destroy).not.toHaveBeenCalled();
+    expect(mockSequelize.models.Goal.destroy).not.toHaveBeenCalled();
   });
 
   it('does not remove goals that are used in ARG', async () => {

--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -451,7 +451,7 @@ describe('createGoalsForSessionRecipientsIfNecessary hook', () => {
         name: 'Increase knowledge about X',
         onAR: true,
         onApprovedAR: false,
-        source: 'Training event follow-up',
+        source: 'Training event',
         status: 'Draft',
         updatedAt: expect.any(Date),
       },


### PR DESCRIPTION
## Description of change

This was supposed to be in the last PR, but I forgot to push it. It's a pretty small change and the logic should be simple enough to verify by just looking at it, but please go ahead and test using the steps below if you'd like.

The change:

Don't delete the goal if it is currently in use by another session. In other words, only delete the goal if the session removing this recipient is the ONLY session using this recipient/goal pair.

## How to test

Useful query:

```sql
SELECT e.id AS "ERPG id",
       erp.data->>'goal' as "EventReportPilot.data->>'goal'",
       g.id AS "Goal.id",
       g.name AS "Goal.name",
       g."grantId" AS "Goal.grantId",
       g.status AS "Goal.status",
       g."previousStatus" AS "Goal.previousStatus",
       s.data->>'status' AS "SessionReportPilot.data->>'status'"
FROM "EventReportPilotGoals" as e
LEFT JOIN "EventReportPilots" as erp ON e."eventId" = erp.id
LEFT JOIN "Goals" as g ON e."goalId" = g.id
LEFT JOIN "SessionReportPilots" as s ON e."sessionId" = s.id
WHERE e."goalId" IS NOT NULL;
```

- Session1: add two recipients (they should both get a unique goal created for them):

```bash
 ERPG id | EventReportPilot.data->>'goal' | Goal.id | Goal.name | Goal.grantId | Goal.status | Goal.previousStatus | SessionReportPilot.data->>'status' 
---------+--------------------------------+---------+-----------+--------------+-------------+---------------------+------------------------------------
       1 | asdf                           |       5 | asdf      |           10 | Draft       |                     | In progress
       2 | asdf                           |       6 | asdf      |           18 | Draft       |                     | In progress

```
- Session2: add both of the same recipients, no new goals are created and the result of the query should look exactly the same as above.
- Session2: remove ONE of the recipients, and re-run the query to verify no goals have been deleted because they are in use by that recipient on session1: the result of the query should look exactly the same as above.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2546


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
