### PR TITLE
Update create goals error message

### DIFF
--- a/src/goalServices/goals.alt.test.js
+++ b/src/goalServices/goals.alt.test.js
@@ -198,7 +198,7 @@ describe('Goals DB service', () => {
       });
       expect(response).toEqual({
         isError: true,
-        message: `Goal name already exists for grants ${grant.id}`,
+        message: `Goal name already exists for grants ${grant.number}`,
         grantsForWhomGoalAlreadyExists: [grant.id],
       });
     });

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -3198,7 +3198,17 @@ export async function createMultiRecipientGoalsFromAdmin(data) {
 
   if (!isError && grantIds.length > 0) {
     goalsForNameCheck = await Goal.findAll({
-      attributes: ['id', 'grantId'],
+      attributes: [
+        'id',
+        'grantId',
+      ],
+      include: [
+        {
+          model: Grant,
+          attributes: ['number'],
+          as: 'grant',
+        },
+      ],
       where: {
         grantId: grantIds,
         name,
@@ -3210,7 +3220,7 @@ export async function createMultiRecipientGoalsFromAdmin(data) {
 
   if (goalsForNameCheck.length) {
     isError = true;
-    message = `Goal name already exists for grants ${goalsForNameCheck.map((g) => g.grantId).join(', ')}`;
+    message = `Goal name already exists for grants ${goalsForNameCheck.map((g) => g.grant.number).join(', ')}`;
   }
 
   if (isError) {


### PR DESCRIPTION
## Description of change
Helping with a support request, I learned the message displayed on the admin when bulk creating a goal is unhelpful. It displays the _grant id_ but what is needed is the **grant number**.

## How to test
Using prod or transformed data, attempt to create a multi-recipient goal via the admin. If you pick any substantial group and then pick the FEI goal, it is likely you will see an error message. This message will say "Goal name already exists for grants" and then list the numbers not the ID

## Issue(s)
No ticket

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
