### PR TITLE
Fix bug when updating existing goal sources

### DIFF
--- a/src/migrations/20240129221712-change-training-event-goal-source.js
+++ b/src/migrations/20240129221712-change-training-event-goal-source.js
@@ -1,5 +1,4 @@
-const { GOAL_SOURCES } = require('@ttahub/common');
-const { prepMigration, dropAndRecreateEnum } = require('../lib/migration');
+const { prepMigration } = require('../lib/migration');
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
@@ -8,28 +7,63 @@ module.exports = {
       const sessionSig = __filename;
       await prepMigration(queryInterface, transaction, sessionSig);
 
-      // Goals.
-      await dropAndRecreateEnum(
-        queryInterface,
-        transaction,
-        'enum_Goals_source',
-        'Goals',
-        'source',
-        GOAL_SOURCES,
-        'text',
-        false,
+      /* Goals */
+      // Add new enum value (Can't use transaction here).
+      await queryInterface.sequelize.query(`
+      DO $$ BEGIN
+        ALTER TYPE "enum_Goals_source" ADD VALUE 'Training event';
+      EXCEPTION
+        WHEN duplicate_object THEN null;
+      END $$;
+    `);
+
+      // Update to new enum value.
+      await queryInterface.sequelize.query(
+        `UPDATE "Goals"
+            SET "source" = 'Training event'::"enum_Goals_source"
+          WHERE "source" = 'Training event follow-up'::"enum_Goals_source";`,
+        { transaction },
       );
 
-      // ActivityReportGoals.
-      await dropAndRecreateEnum(
-        queryInterface,
-        transaction,
-        'enum_ActivityReportGoals_source',
-        'ActivityReportGoals',
-        'source',
-        GOAL_SOURCES,
-        'text',
-        false,
+      // Remove enum value.
+      await queryInterface.sequelize.query(
+        `DELETE FROM pg_enum
+            WHERE enumlabel = 'Training event follow-up'
+              AND enumtypid = (
+                SELECT oid
+                FROM pg_type
+                WHERE typname = 'enum_Goals_source'
+              );`,
+        { transaction },
+      );
+
+      /* ActivityReportGoals */
+      // Add new enum value (Can't use transaction here).
+      await queryInterface.sequelize.query(`
+      DO $$ BEGIN
+        ALTER TYPE "enum_ActivityReportGoals_source" ADD VALUE 'Training event';
+      EXCEPTION
+        WHEN duplicate_object THEN null;
+      END $$;
+    `);
+      // Update to new enum value.
+      await queryInterface.sequelize.query(
+        `UPDATE "ActivityReportGoals"
+            SET "source" = 'Training event'::"enum_ActivityReportGoals_source"
+          WHERE "source" = 'Training event follow-up'::"enum_ActivityReportGoals_source";`,
+        { transaction },
+      );
+
+      // Remove enum value.
+      await queryInterface.sequelize.query(
+        `DELETE FROM pg_enum
+            WHERE enumlabel = 'Training event follow-up'
+              AND enumtypid = (
+                SELECT oid
+                FROM pg_type
+                WHERE typname = 'enum_ActivityReportGoals_source'
+              );`,
+        { transaction },
       );
     });
   },

--- a/src/migrations/20240129221712-change-training-event-goal-source.js
+++ b/src/migrations/20240129221712-change-training-event-goal-source.js
@@ -17,6 +17,14 @@ module.exports = {
       END $$;
     `);
 
+      await queryInterface.sequelize.query(`
+    DO $$ BEGIN
+      ALTER TYPE "enum_Goals_source" ADD VALUE 'Training event follow-up';
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+
       // Update to new enum value.
       await queryInterface.sequelize.query(
         `UPDATE "Goals"
@@ -46,6 +54,14 @@ module.exports = {
         WHEN duplicate_object THEN null;
       END $$;
     `);
+
+      await queryInterface.sequelize.query(`
+    DO $$ BEGIN
+      ALTER TYPE "enum_ActivityReportGoals_source" ADD VALUE 'Training event follow-up';
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
       // Update to new enum value.
       await queryInterface.sequelize.query(
         `UPDATE "ActivityReportGoals"

--- a/src/migrations/20240129221712-change-training-event-goal-source.js
+++ b/src/migrations/20240129221712-change-training-event-goal-source.js
@@ -1,4 +1,5 @@
-const { prepMigration } = require('../lib/migration');
+const { GOAL_SOURCES } = require('@ttahub/common');
+const { prepMigration, dropAndRecreateEnum } = require('../lib/migration');
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
@@ -7,79 +8,64 @@ module.exports = {
       const sessionSig = __filename;
       await prepMigration(queryInterface, transaction, sessionSig);
 
-      /* Goals */
-      // Add new enum value (Can't use transaction here).
-      await queryInterface.sequelize.query(`
-      DO $$ BEGIN
-        ALTER TYPE "enum_Goals_source" ADD VALUE 'Training event';
-      EXCEPTION
-        WHEN duplicate_object THEN null;
-      END $$;
-    `);
+      // Goals.
+      await dropAndRecreateEnum(
+        queryInterface,
+        transaction,
+        'enum_Goals_source',
+        'Goals',
+        'source',
+        [...GOAL_SOURCES, 'Training event follow-up'],
+        'text',
+        false,
+      );
 
-      await queryInterface.sequelize.query(`
-    DO $$ BEGIN
-      ALTER TYPE "enum_Goals_source" ADD VALUE 'Training event follow-up';
-    EXCEPTION
-      WHEN duplicate_object THEN null;
-    END $$;
-  `);
-
-      // Update to new enum value.
       await queryInterface.sequelize.query(
         `UPDATE "Goals"
-            SET "source" = 'Training event'::"enum_Goals_source"
-          WHERE "source" = 'Training event follow-up'::"enum_Goals_source";`,
+          SET source = 'Training event'::"enum_Goals_source"
+        WHERE source = 'Training event follow-up'::"enum_Goals_source";`,
         { transaction },
       );
 
-      // Remove enum value.
-      await queryInterface.sequelize.query(
-        `DELETE FROM pg_enum
-            WHERE enumlabel = 'Training event follow-up'
-              AND enumtypid = (
-                SELECT oid
-                FROM pg_type
-                WHERE typname = 'enum_Goals_source'
-              );`,
-        { transaction },
+      await dropAndRecreateEnum(
+        queryInterface,
+        transaction,
+        'enum_Goals_source',
+        'Goals',
+        'source',
+        GOAL_SOURCES,
+        'text',
+        false,
       );
 
-      /* ActivityReportGoals */
-      // Add new enum value (Can't use transaction here).
-      await queryInterface.sequelize.query(`
-      DO $$ BEGIN
-        ALTER TYPE "enum_ActivityReportGoals_source" ADD VALUE 'Training event';
-      EXCEPTION
-        WHEN duplicate_object THEN null;
-      END $$;
-    `);
+      // ActivityReportGoals.
+      await dropAndRecreateEnum(
+        queryInterface,
+        transaction,
+        'enum_ActivityReportGoals_source',
+        'ActivityReportGoals',
+        'source',
+        [...GOAL_SOURCES, 'Training event follow-up'],
+        'text',
+        false,
+      );
 
-      await queryInterface.sequelize.query(`
-    DO $$ BEGIN
-      ALTER TYPE "enum_ActivityReportGoals_source" ADD VALUE 'Training event follow-up';
-    EXCEPTION
-      WHEN duplicate_object THEN null;
-    END $$;
-  `);
-      // Update to new enum value.
       await queryInterface.sequelize.query(
         `UPDATE "ActivityReportGoals"
-            SET "source" = 'Training event'::"enum_ActivityReportGoals_source"
-          WHERE "source" = 'Training event follow-up'::"enum_ActivityReportGoals_source";`,
+          SET source = 'Training event'::"enum_ActivityReportGoals_source"
+        WHERE source = 'Training event follow-up'::"enum_ActivityReportGoals_source";`,
         { transaction },
       );
 
-      // Remove enum value.
-      await queryInterface.sequelize.query(
-        `DELETE FROM pg_enum
-            WHERE enumlabel = 'Training event follow-up'
-              AND enumtypid = (
-                SELECT oid
-                FROM pg_type
-                WHERE typname = 'enum_ActivityReportGoals_source'
-              );`,
-        { transaction },
+      await dropAndRecreateEnum(
+        queryInterface,
+        transaction,
+        'enum_ActivityReportGoals_source',
+        'ActivityReportGoals',
+        'source',
+        GOAL_SOURCES,
+        'text',
+        false,
       );
     });
   },


### PR DESCRIPTION
## Description of change

The migration modified by this PR has not run successfully on prod. The issue is because we already have goals and arg's using the source we are changing. This PR updates the way we handle this to first add the new ENUM switch it over and remove the old value.

**NOTE:** Verified that this migration has NOT run yet by querying SequelizeMeta table on latest prod db.
SELECT * FROM "SequelizeMeta" where "name" = '20240129221712-change-training-event-goal-source.js'

## How to test
- We should have the same number of Goals and Activity Report goals set with a  source value before and after.
- On a prod database run the migration make sure any goal source in the Goals or ActivityReportGoals that was using 'Training event follow-up' is now using 'Training event'. 

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
