### PR TITLE
[TTAHUB-2220] TR goal: POC credited for "entered by", current user credited for "linker"

### DIFF
--- a/src/models/hooks/eventReportPilot.js
+++ b/src/models/hooks/eventReportPilot.js
@@ -122,10 +122,6 @@ const updateGoalText = async (sequelize, instance, options) => {
     return;
   }
 
-  if (current.goal === previous.goal) {
-    return;
-  }
-
   // Get all SessionReportPilot instances for this event.
   const sessions = await sequelize.models.SessionReportPilot.findAll({
     where: {
@@ -138,6 +134,7 @@ const updateGoalText = async (sequelize, instance, options) => {
     sequelize,
     session,
     options,
+    instance,
   )));
 
   // Disallow goal name propagation if any session on this event has been completed,

--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -439,7 +439,7 @@ describe('createGoalsForSessionRecipientsIfNecessary hook', () => {
         Goal: { create: jest.fn(() => ({ id: 4 })), findOne: jest.fn(() => null) },
         SessionReportPilot: { findByPk: jest.fn(() => mockInstance), findOne: jest.fn(() => null) },
         CollaboratorType: { findOne: jest.fn(() => ({ id: 1 })) },
-        GoalCollaborator: { findAll: jest.fn(() => []), create: jest.fn() },
+        GoalCollaborator: { findAll: jest.fn(() => []), create: jest.fn(), update: jest.fn() },
       },
     };
 
@@ -460,9 +460,10 @@ describe('createGoalsForSessionRecipientsIfNecessary hook', () => {
       { transaction: {} },
     );
     expect(mockSequelize.models.EventReportPilotGoal.create).toHaveBeenCalled();
-    expect(mockSequelize.models.CollaboratorType.findOne).toHaveBeenCalled();
+    expect(mockSequelize.models.CollaboratorType.findOne).toHaveBeenCalledTimes(2);
     expect(mockSequelize.models.GoalCollaborator.findAll).toHaveBeenCalledTimes(1);
-    expect(mockSequelize.models.GoalCollaborator.create).toHaveBeenCalledTimes(2);
+    expect(mockSequelize.models.GoalCollaborator.create).toHaveBeenCalledTimes(0);
+    expect(mockSequelize.models.GoalCollaborator.update).toHaveBeenCalledTimes(0);
   });
 
   it('does not create a new goal if one already exists', async () => {

--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -438,6 +438,8 @@ describe('createGoalsForSessionRecipientsIfNecessary hook', () => {
         EventReportPilotGoal: { create: jest.fn(), findOne: jest.fn(() => null) },
         Goal: { create: jest.fn(() => ({ id: 4 })), findOne: jest.fn(() => null) },
         SessionReportPilot: { findByPk: jest.fn(() => mockInstance), findOne: jest.fn(() => null) },
+        CollaboratorType: { findOne: jest.fn(() => ({ id: 1 })) },
+        GoalCollaborator: { findAll: jest.fn(() => []), create: jest.fn() },
       },
     };
 
@@ -458,6 +460,9 @@ describe('createGoalsForSessionRecipientsIfNecessary hook', () => {
       { transaction: {} },
     );
     expect(mockSequelize.models.EventReportPilotGoal.create).toHaveBeenCalled();
+    expect(mockSequelize.models.CollaboratorType.findOne).toHaveBeenCalled();
+    expect(mockSequelize.models.GoalCollaborator.findAll).toHaveBeenCalledTimes(1);
+    expect(mockSequelize.models.GoalCollaborator.create).toHaveBeenCalledTimes(2);
   });
 
   it('does not create a new goal if one already exists', async () => {


### PR DESCRIPTION
## Description of change

Augment the hook in SessionReportPilot that is responsible for creating a Goal for each session recipient. The hook now also updates the GoalCollaborators table.

## How to test

- Create an event with goal text.
- Create a session with any number of recipients.
- Check the GoalCollaborators table and ensure there are two rows per goalId. One for Creator (POC) and one for Linked (logged in user).

- Change the POC to a different value. It should update the GoalCollaborators entries with the new value.
- Change the POC to an empty value. It should update the GoalCollaborators entries by setting userId to your logged in userId where collaboratorTypeId = 1 (creator).


## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2220


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
