### PR TITLE
[TTAHUB-2157] Allow admins & approvers to delete certain goals

### DIFF
--- a/frontend/src/__tests__/permissions.js
+++ b/frontend/src/__tests__/permissions.js
@@ -4,6 +4,7 @@ import isAdmin, {
   allRegionsUserHasPermissionTo,
   getRegionWithReadWrite,
   hasApproveActivityReport,
+  hasApproveActivityReportInRegion,
 } from '../permissions';
 
 describe('permissions', () => {
@@ -130,6 +131,44 @@ describe('permissions', () => {
         ],
       };
       expect(hasApproveActivityReport(user)).toBeFalsy();
+    });
+  });
+
+  describe('hasApproveActivityReportInRegion', () => {
+    it('returns true if the user has the appropriate permission', () => {
+      const user = {
+        permissions: [
+          {
+            scopeId: 5,
+            regionId: 1,
+          },
+        ],
+      };
+      expect(hasApproveActivityReportInRegion(user, 1)).toBeTruthy();
+    });
+
+    it('returns false if the user does not have the appropriate permission', () => {
+      const user = {
+        permissions: [
+          {
+            scopeId: 2,
+            regionId: 1,
+          },
+        ],
+      };
+      expect(hasApproveActivityReportInRegion(user, 1)).toBeFalsy();
+    });
+
+    it('returns false if the user does not have the appropriate region', () => {
+      const user = {
+        permissions: [
+          {
+            scopeId: 5,
+            regionId: 2,
+          },
+        ],
+      };
+      expect(hasApproveActivityReportInRegion(user, 1)).toBeFalsy();
     });
   });
 

--- a/frontend/src/components/GoalCards/__tests__/GoalCard.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCard.js
@@ -1,10 +1,18 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import join from 'url-join';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SCOPE_IDS } from '@ttahub/common';
+import fetchMock from 'fetch-mock';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
 import GoalCard from '../GoalCard';
 import UserContext from '../../../UserContext';
+import AppLoadingContext from '../../../AppLoadingContext';
 
 describe('GoalCard', () => {
+  afterEach(() => fetchMock.restore());
+  const goalApi = join('/', 'api', 'goals');
   const goal = {
     id: 1,
     ids: [1],
@@ -17,6 +25,7 @@ describe('GoalCard', () => {
     goalNumbers: ['G-1'],
     source: 'The inferno',
     createdVia: 'rtr',
+    onAR: true,
     objectives: [
       {
         id: 1,
@@ -51,23 +60,29 @@ describe('GoalCard', () => {
     hideGoalOptions: false,
   };
 
-  const renderGoalCard = (props = DEFAULT_PROPS, defaultGoal = goal) => {
+  const history = createMemoryHistory();
+
+  const renderGoalCard = (props = DEFAULT_PROPS, defaultGoal = goal, user = DEFAULT_USER) => {
     render((
-      <UserContext.Provider value={{ user: DEFAULT_USER }}>
-        <GoalCard
-          goal={defaultGoal}
-          recipientId="1"
-          regionId="1"
-          showCloseSuspendGoalModal={() => {}}
-          performGoalStatusUpdate={() => {}}
-          handleGoalCheckboxSelect={() => {}}
-          isChecked={false}
-          marginX={3}
-          marginY={2}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-          {...props}
-        />
-      </UserContext.Provider>));
+      <Router history={history}>
+        <AppLoadingContext.Provider value={{ setIsAppLoading: () => {} }}>
+          <UserContext.Provider value={{ user }}>
+            <GoalCard
+              goal={defaultGoal}
+              recipientId="1"
+              regionId="1"
+              showCloseSuspendGoalModal={() => {}}
+              performGoalStatusUpdate={() => {}}
+              handleGoalCheckboxSelect={() => {}}
+              isChecked={false}
+              marginX={3}
+              marginY={2}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+              {...props}
+            />
+          </UserContext.Provider>
+        </AppLoadingContext.Provider>
+      </Router>));
   };
 
   it('shows the checkbox by default', () => {
@@ -88,7 +103,7 @@ describe('GoalCard', () => {
   });
 
   it('shows the goal status as a button by default', () => {
-    renderGoalCard();
+    renderGoalCard({ });
     const status = screen.getByText(/In Progress/i);
     expect(status.tagName).toEqual('BUTTON');
   });
@@ -102,6 +117,209 @@ describe('GoalCard', () => {
   it('shows the goal options by default', () => {
     renderGoalCard();
     expect(screen.getByTestId('ellipsis-button')).toBeInTheDocument();
+  });
+
+  it('shows only one options by default', async () => {
+    renderGoalCard();
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+  });
+
+  it('shows only one options by if the goal is not "draft" or "not started"', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.APPROVE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, onAR: false }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it('shows only one options by if the goal is on AR', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.APPROVE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, goalStatus: 'Draft' }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it('can delete if user is approver and goal is Draft and not on AR', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.APPROVE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, goalStatus: 'Draft', onAR: false }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  it('can delete if user is approver and goal is Not Started and not on AR', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.APPROVE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, goalStatus: 'Not Started', onAR: false }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  it('can delete if user is admin and goal is Draft and not on AR', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.ADMIN,
+          regionId: 14,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, goalStatus: 'Draft', onAR: false }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  it('can delete if user is admin and goal is Not Started and not on AR', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.ADMIN,
+          regionId: 14,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, goalStatus: 'Not Started', onAR: false }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  it('calls delete function on click', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.ADMIN,
+          regionId: 14,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, goalStatus: 'Not Started', onAR: false }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    const url = `${goalApi}?goalIds=1`;
+    fetchMock.delete(url, {});
+    history.push = jest.fn();
+    userEvent.click(deleteButton);
+    await waitFor(() => expect(fetchMock.called(url)).toBe(true));
+    expect(history.push).toHaveBeenCalledWith('/recipient-tta-records/1/region/1/rttapa', { message: 'Goal deleted successfully' });
+    expect(document.querySelector('.smart-hub-border-base-error')).toBeNull();
+  });
+
+  it('handles an error on delete', async () => {
+    const user = {
+      name: 'test@test.com',
+      homeRegionId: 1,
+      permissions: [
+        {
+          scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+          regionId: 1,
+        },
+        {
+          scopeId: SCOPE_IDS.ADMIN,
+          regionId: 14,
+        },
+      ],
+    };
+    renderGoalCard(DEFAULT_PROPS, { ...goal, goalStatus: 'Not Started', onAR: false }, user);
+    userEvent.click(screen.getByTestId('ellipsis-button'));
+    const button = await screen.findByText(/Edit/i);
+    expect(button).toBeInTheDocument();
+    const deleteButton = screen.queryByText(/Delete/i);
+    const url = `${goalApi}?goalIds=1`;
+    fetchMock.delete(url, 500);
+    userEvent.click(deleteButton);
+    history.push = jest.fn();
+    await waitFor(() => expect(fetchMock.called(url)).toBe(true));
+    expect(history.push).not.toHaveBeenCalled();
+    expect(document.querySelector('.smart-hub-border-base-error')).not.toBeNull();
   });
 
   it('can hide the goal options', () => {

--- a/frontend/src/components/GoalCards/constants.js
+++ b/frontend/src/components/GoalCards/constants.js
@@ -22,4 +22,5 @@ export const goalPropTypes = PropTypes.shape({
   goalNumbers: PropTypes.arrayOf(PropTypes.string.isRequired),
   objectives: PropTypes.arrayOf(objectivePropTypes),
   previousStatus: PropTypes.string,
+  onAR: PropTypes.bool,
 });

--- a/frontend/src/permissions.js
+++ b/frontend/src/permissions.js
@@ -141,6 +141,19 @@ const hasApproveActivityReport = (user) => {
 };
 
 /**
+ * Search the user's permissions for a approve report permission regardless of region
+ * @param {*} user - user object
+ * @returns {boolean} - True if the user has approve activity report, false otherwise
+ */
+const hasApproveActivityReportInRegion = (user, regionId) => {
+  const { permissions } = user;
+  return permissions && permissions.find(
+    (p) => p.scopeId === SCOPE_IDS.APPROVE_ACTIVITY_REPORTS
+      && p.regionId === regionId,
+  ) !== undefined;
+};
+
+/**
  * Search the user's permissions for a read/write permisions for a region
  * @param {*} user - user object
  * @param {number} region - region id
@@ -195,4 +208,5 @@ export {
   canChangeGoalStatus,
   canEditOrCreateSessionReports,
   hasApproveActivityReport,
+  hasApproveActivityReportInRegion,
 };

--- a/src/goalServices/getGoalsByActivityRecipient.test.js
+++ b/src/goalServices/getGoalsByActivityRecipient.test.js
@@ -393,6 +393,7 @@ describe('Goals by Recipient Test', () => {
           grantId: 300,
           createdAt: '2021-01-10T19:16:15.842Z',
           onApprovedAR: true,
+          onAR: true,
         }),
         // 8
         Goal.create({
@@ -859,6 +860,11 @@ describe('Goals by Recipient Test', () => {
       expect(goalRowsx[4].reasons).toEqual(['COVID-19 response', 'Complaint']);
       expect(goalRowsx[4].goalTopics).toEqual(['Arcane Mastery', 'Learning Environments', 'Nutrition', 'Physical Health and Screenings']);
       expect(goalRowsx[4].objectives.length).toBe(1);
+
+      goalRowsx.forEach((g) => {
+        expect(g.onAR).toBeDefined();
+        expect(g.onAR).not.toBeNull();
+      });
     });
 
     it('Retrieves All Goals by Recipient', async () => {

--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -545,6 +545,7 @@ export async function getGoalsByActivityRecipient(
       'goalNumber',
       'previousStatus',
       'onApprovedAR',
+      'onAR',
       'isRttapa',
       'source',
       'goalTemplateId',
@@ -702,6 +703,7 @@ export async function getGoalsByActivityRecipient(
       );
       existingGoal.objectiveCount = existingGoal.objectives.length;
       existingGoal.isCurated = isCurated || existingGoal.isCurated;
+      existingGoal.onAR = existingGoal.onAR || current.onAR;
       return {
         goalRows: previous.goalRows,
       };
@@ -725,6 +727,7 @@ export async function getGoalsByActivityRecipient(
       responsesForComparison: responsesForComparison(current),
       isCurated,
       createdVia: current.createdVia,
+      onAR: current.onAR,
     };
 
     const sessionObjectives = current.eventReportPilots


### PR DESCRIPTION
## Description of change

Add a delete button to the goal cards in the RTR under certain circumstances

- User is an admin or has approve reports
- Goal is "Draft" or "Not Started"
- Goal is not on a report

## How to test

- Find a goal that meets the above criteria, and delete it
- Confirm that a goal on a report or a goal in a more "advanced" status can't be deleted
- Confirm that a user without those permissions does not see the delete button either

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2157

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
