### PR TITLE
[TTAHUB-2567] Allow admin users to skip existing goals when creating multi-recipient goals from the admin

### DIFF
--- a/frontend/src/pages/Admin/Goals/Create.js
+++ b/frontend/src/pages/Admin/Goals/Create.js
@@ -174,15 +174,20 @@ export default function Create() {
         </Helmet>
         <Container>
           <h2>Create goals</h2>
-          <p>
+          <p className="usa-prose">
             Successfully created
             {' '}
             {response.goals.length}
             {' '}
             goals.
           </p>
+          {response.message && (
+            <p className="usa-prose">
+              {response.message}
+            </p>
+          )}
           {response.activityReport && (
-            <p>
+            <p className="usa-prose">
               Successfully created activity report
               {' '}
               <Link to={`/activity-reports/${response.activityReport.id}`}>
@@ -356,45 +361,25 @@ export default function Create() {
               userCanEdit
             />
 
+            <FormGroup>
+              <Checkbox
+                label="Skip creating goals for recipients who already have them"
+                name="createMissingGoals"
+                id="createMissingGoals"
+                inputRef={register()}
+              />
+
+              <div className="usa-hint">
+                Checking this box means instead of showing an error,
+                existing goals will be skipped.
+                (Existing goals will not be updated)
+              </div>
+            </FormGroup>
+
             {(response && response.isError) && (
-              <Alert type="error">
-                {response.message}
-
-                {(response.grantsForWhichGoalWillBeCreated
-                  && response.grantsForWhichGoalWillBeCreated.length > 0) && (
-                  <>
-                    <br />
-                    <span style={{ display: 'inline-block' }} className="margin-top-1">
-                      Create goals just for grants
-                      {' '}
-                      {response.grantsForWhichGoalWillBeCreated.join(', ')}
-                      {' '}
-                      instead?
-                    </span>
-                    <br />
-                    <Button
-                      className="margin-top-0"
-                      onClick={async () => {
-                        const values = hookForm.getValues();
-
-                        const newValues = {
-                          ...values,
-                          selectedGrants: JSON.stringify(response
-                            .grantsForWhichGoalWillBeCreated
-                            .map((g) => ({ id: g }))),
-                        };
-
-                        await onSubmit(newValues);
-                      }}
-                      type="button"
-                      unstyled
-                    >
-                      Create goals for missing grants
-                    </Button>
-                  </>
-                )}
-
-              </Alert>
+            <Alert type="error">
+              {response.message}
+            </Alert>
             )}
 
             <Button type="submit">Submit</Button>

--- a/frontend/src/pages/Admin/Goals/__tests__/Create.js
+++ b/frontend/src/pages/Admin/Goals/__tests__/Create.js
@@ -270,28 +270,6 @@ describe('Create', () => {
 
     await waitFor(() => expect(fetchMock.called(createGoalsUrl)).toBe(true));
     expect(await screen.findByText(/Goal name already exists for grants 2/i)).toBeInTheDocument();
-
-    fetchMock.restore();
-    const createGoalsForMissingGrants = await screen.findByRole('button', { name: 'Create goals for missing grants' });
-
-    fetchMock.post(createGoalsUrl, {
-      activityReport: {
-        id: 1,
-        displayId: 'R01-123-01',
-      },
-      goals: [{ id: 1 }],
-      isError: false,
-      message: '',
-    });
-
-    act(() => {
-      userEvent.click(createGoalsForMissingGrants);
-    });
-
-    expect(fetchMock.called(createGoalsUrl)).toBe(true);
-    const { body } = fetchMock.lastOptions();
-    const { selectedGrants } = JSON.parse(body);
-    expect(JSON.parse(selectedGrants)).toEqual([{ id: 4 }]);
   });
   it('displays generic error message when an unknown error occurs', async () => {
     fetchMock.get(templatesUrl, []);
@@ -393,7 +371,7 @@ describe('Create', () => {
       },
       goals: [{ id: 1 }],
       isError: false,
-      message: '',
+      message: 'A message of confirmation',
     });
 
     const submitButton = await screen.findByRole('button', { name: /Submit/i });
@@ -404,5 +382,6 @@ describe('Create', () => {
     await waitFor(() => expect(fetchMock.called(createGoalsUrl)).toBe(true));
     expect(await screen.findByText(/successfully created 1 goals/i)).toBeInTheDocument();
     expect(await screen.findByText(/R01-123-01/i)).toBeInTheDocument();
+    expect(await screen.findByText(/A message of confirmation/i)).toBeInTheDocument();
   });
 });

--- a/src/goalServices/goals.alt.test.js
+++ b/src/goalServices/goals.alt.test.js
@@ -168,12 +168,14 @@ describe('Goals DB service', () => {
         where: {
           userId: user.id,
         },
+        force: true,
       });
 
       await Goal.destroy({
         where: {
           id: goalIds,
         },
+        force: true,
       });
 
       await GoalTemplate.destroy({

--- a/src/goalServices/goals.alt.test.js
+++ b/src/goalServices/goals.alt.test.js
@@ -61,6 +61,7 @@ describe('Goals DB service', () => {
     let user;
     let recipient;
     let grant;
+    let secondGrant;
     let template;
 
     const existingGoalName = faker.datatype.string(100);
@@ -89,6 +90,15 @@ describe('Goals DB service', () => {
 
       // Grant.
       grant = await Grant.create({
+        id: faker.datatype.number(),
+        number: faker.datatype.string(),
+        recipientId: recipient.id,
+        regionId: 1,
+        startDate: new Date(),
+        endDate: new Date(),
+      });
+
+      secondGrant = await Grant.create({
         id: faker.datatype.number(),
         number: faker.datatype.string(),
         recipientId: recipient.id,
@@ -136,7 +146,7 @@ describe('Goals DB service', () => {
     afterAll(async () => {
       const goals = await Goal.findAll({
         where: {
-          grantId: grant.id,
+          grantId: [grant.id, secondGrant.id],
         },
       });
 
@@ -150,7 +160,7 @@ describe('Goals DB service', () => {
 
       await ActivityRecipient.destroy({
         where: {
-          grantId: grant.id,
+          grantId: [grant.id, secondGrant.id],
         },
       });
 
@@ -174,7 +184,7 @@ describe('Goals DB service', () => {
 
       await Grant.destroy({
         where: {
-          id: grant.id,
+          id: [grant.id, secondGrant.id],
         },
       });
 
@@ -198,9 +208,30 @@ describe('Goals DB service', () => {
       });
       expect(response).toEqual({
         isError: true,
-        message: `Goal name already exists for grants ${grant.number}`,
+        message: `A goal with that name already exists for grants ${grant.number}`,
         grantsForWhomGoalAlreadyExists: [grant.id],
       });
+    });
+
+    it('will skip creating but continue if a goal with that name already exists', async () => {
+      const response = await createMultiRecipientGoalsFromAdmin({
+        ...mockRequestData,
+        selectedGrants: JSON.stringify([{ id: grant.id }, { id: secondGrant.id }]),
+        goalText: existingGoalName,
+        createMissingGoals: true,
+      });
+      const {
+        grantsForWhomGoalAlreadyExists,
+        isError,
+        message,
+        goals,
+      } = response;
+      expect(grantsForWhomGoalAlreadyExists.length).toBe(1);
+      expect(isError).toBe(false);
+      expect(message).toBe(`A goal with that name already exists for grants ${grant.number}`);
+      expect(goals).toHaveLength(1);
+      expect(goals[0].name).toBe(existingGoalName);
+      expect(goals[0].grantId).toBe(secondGrant.id);
     });
 
     it('requires a goal name to proceed', async () => {

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -3224,7 +3224,6 @@ export async function createMultiRecipientGoalsFromAdmin(data) {
 
   if (goalsForNameCheck.length && !data.createMissingGoals) {
     isError = true;
-    message = `${message}`;
   }
 
   if (isError) {
@@ -3255,7 +3254,7 @@ export async function createMultiRecipientGoalsFromAdmin(data) {
     goalTemplateId: template ? template.id : null,
   })), { individualHooks: true });
 
-  const goalIds = [...goals, ...goalsForNameCheck].map((g) => g.id);
+  const goalIds = goals.map((g) => g.id);
 
   const promptResponses = (data.goalPrompts || []).map((goalPrompt) => {
     const response = data[goalPrompt.fieldName];
@@ -3306,7 +3305,10 @@ export async function createMultiRecipientGoalsFromAdmin(data) {
     activityReport = await ActivityReport.create(reportData);
 
     await Promise.all([
-      ActivityReportGoal.bulkCreate(goalIds.map((goalId) => ({
+      ActivityReportGoal.bulkCreate([
+        ...goalIds,
+        ...goalsForNameCheck.map((g) => g.id),
+      ].map((goalId) => ({
         activityReportId: activityReport.id,
         goalId,
         isActivelyEdited: true,


### PR DESCRIPTION
## Description of change

- Add a checkbox to the form to allow bypassing existing goals
- Alter the backend handler to optionally skip creating existing goals

## How to test

- Create a group
- Using the create goals form, create an FEI goal
- Add an additional grant to the group
- Attempt to do the same thing again (create an FEI goal for that group)
- You should see an error
- Check the "Skip creating goals for recipients who already have them" box
- Resubmit. It should work without an error and create another FEI goal only for the missing grants.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2567


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
