### PR TITLE
[TTAHUB-1942] Fix bugs found during review of goal nudge

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -219,7 +219,7 @@ export default function ObjectiveForm({
 
       <ObjectiveSupportType
         onBlurSupportType={validateSupportType}
-        supportType={supportType}
+        supportType={supportType || ''}
         onChangeSupportType={onChangeSupportType}
         inputName={`objective-support-type-${index}`}
         error={errors[OBJECTIVE_FORM_FIELD_INDEXES.SUPPORT_TYPE]}

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -719,13 +719,8 @@ export default function GoalForm({
         type: 'success',
       });
 
-      // if we are not creating a new goal, we want to update the goal ids
-      // for the case of adding a grant to an existing goal. If we are creating a new goal,
-      // we don't keep track of the ids, so we don't need to update them
-      if (!isNew) {
-        const newIds = updatedGoals.flatMap((g) => g.goalIds);
-        setIds(newIds);
-      }
+      const newIds = updatedGoals.flatMap((g) => g.goalIds);
+      setIds(newIds);
     } catch (error) {
       setAlert({
         message: 'There was an error saving your goal',

--- a/src/goalServices/createOrUpdateGoals.test.js
+++ b/src/goalServices/createOrUpdateGoals.test.js
@@ -246,7 +246,7 @@ describe('createOrUpdateGoals', () => {
     expect(order).toStrictEqual([1, 2]);
 
     const objectiveOnTheGoalWithCreatedVias = await Objective.findAll({
-      attributes: ['id', 'createdVia'],
+      attributes: ['id', 'createdVia', 'supportType'],
       where: {
         id: objectivesOnUpdatedGoal.map((obj) => obj.id),
       },
@@ -254,6 +254,9 @@ describe('createOrUpdateGoals', () => {
     });
     const objectiveCreatedVias = objectiveOnTheGoalWithCreatedVias.map((obj) => obj.createdVia);
     expect(objectiveCreatedVias).toStrictEqual([null, 'rtr']);
+
+    const objectiveSupportTypes = objectiveOnTheGoalWithCreatedVias.map((obj) => obj.supportType);
+    expect(objectiveSupportTypes).toStrictEqual(['Maintaining', 'Maintaining']);
 
     const objectiveOnUpdatedGoal = await Objective.findByPk(objective.id, { raw: true });
     expect(objectiveOnUpdatedGoal.id).toBe(objective.id);

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -1439,7 +1439,7 @@ export async function createOrUpdateGoals(goals) {
           rtrOrder: index + 1,
         });
 
-        if (objective.supportType && objective.supportType !== supportType) {
+        if (supportType && objective.supportType !== supportType) {
           objective.set({ supportType });
         }
 


### PR DESCRIPTION
## Description of change

Two additional bugs found while reviewing code in main
- Objective support type was not able to be set on existing objectives
- Creating a new goal created double goals (one draft, one not started)

## How to test

Both of these cases are strictly on the RTR goal form:

- Confirm that support type can be set on existing objectives where none existed
- Create a new goal and confirm that "submitting" that new goal makes just one goal (a not started)

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
