### PR TITLE
[TTAHUB-1942] Close off another avenue for duplicating a goal

### DIFF
--- a/frontend/src/components/GoalForm/__tests__/index.js
+++ b/frontend/src/components/GoalForm/__tests__/index.js
@@ -237,7 +237,8 @@ describe('create goal', () => {
 
     const submit = await screen.findByRole('button', { name: /submit goal/i });
     userEvent.click(submit);
-    expect(fetchMock.called('/api/goals')).toBeTruthy();
+    expect(fetchMock.called('/api/goals', { method: 'POST' })).toBeTruthy();
+    expect(fetchMock.lastOptions('/api/goals').body).toContain('ids');
   });
 
   it('goals are validated', async () => {
@@ -504,7 +505,8 @@ describe('create goal', () => {
     let save = await screen.findByRole('button', { name: /save and continue/i });
     userEvent.click(save);
 
-    expect(fetchMock.called('/api/goals')).toBeTruthy();
+    expect(fetchMock.called('/api/goals', { method: 'POST' })).toBeTruthy();
+    expect(fetchMock.lastCall('/api/goals')[1].body).toContain('ids');
 
     // restore our fetch mock
     fetchMock.restore();

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -542,6 +542,7 @@ export default function GoalForm({
       const gs = createdGoals.reduce((acc, goal) => {
         const statusToSave = goal.status && goal.status === 'Draft' ? 'Not Started' : goal.status;
         const newGoals = grantsToGoals({
+          ids: goal.ids,
           selectedGrants: goal.grants,
           name: goal.name,
           status: statusToSave,
@@ -797,6 +798,7 @@ export default function GoalForm({
 
       setCreatedGoals(newCreatedGoals.map((goal) => ({
         ...goal,
+        ids: goal.goalIds,
         grants: goal.grants,
         objectives: goal.objectives.map((objective) => ({
           ...objective,


### PR DESCRIPTION
## Description of change

Stop duplicate goal creation (one draft, one not started)

## How to test

![Screenshot 2024-03-01 at 11 18 10 AM](https://github.com/HHS/Head-Start-TTADP/assets/3288586/5b429173-61a6-4420-abf2-5392d7e370bc)

Create a goal on the RTR form, moving through the whole process including submission.
At the end of the process you should not have created any duplicate goals

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-1942


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
