### PR TITLE
Use default docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ executors:
   docker-executor:
     # for docker you must specify an image to use for the primary container
     docker:
-      - image: cimg/node:20.11.1-browsers
+      - image: cimg/node:18.18.2-browsers
   docker-postgres-executor:
     docker:
-      - image: cimg/node:20.11.1-browsers
+      - image: cimg/node:18.18.2-browsers
         environment:
           DATABASE_URL: postgresql://postgres@localhost/ttasmarthub
       - image: circleci/postgres:12.4-ram
@@ -21,7 +21,7 @@ executors:
       - image: cimg/python:3.9.18
   docker-postgres-elasticsearch-executor:
     docker:
-      - image: cimg/node:20.11.1-browsers
+      - image: cimg/node:18.18.2-browsers
         environment:
           DATABASE_URL: postgresql://postgres@localhost/ttasmarthub
       - image: circleci/postgres:12.4-ram

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ executors:
   docker-executor:
     # for docker you must specify an image to use for the primary container
     docker:
-      - image: cimg/node:18.18.2-browsers
+      - image: cimg/node:20.11.1-browsers
   docker-postgres-executor:
     docker:
-      - image: cimg/node:18.18.2-browsers
+      - image: cimg/node:20.11.1-browsers
         environment:
           DATABASE_URL: postgresql://postgres@localhost/ttasmarthub
       - image: circleci/postgres:12.4-ram
@@ -21,7 +21,7 @@ executors:
       - image: cimg/python:3.9.18
   docker-postgres-elasticsearch-executor:
     docker:
-      - image: cimg/node:18.18.2-browsers
+      - image: cimg/node:20.11.1-browsers
         environment:
           DATABASE_URL: postgresql://postgres@localhost/ttasmarthub
       - image: circleci/postgres:12.4-ram

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - run:
           name: Audit vulnerability of backend node_modules
           command: |
@@ -379,7 +379,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - run:
           name: Syft SBOM
           environment:
@@ -451,7 +451,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - run:
           name: Start server
           command: |
@@ -492,7 +492,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - run:
           name: Start server
           command: |
@@ -533,7 +533,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - run:
           name: Start server
           command: |


### PR DESCRIPTION
## Description of change

Ignore the name of this branch.

This PR just changes the tag for `setup_remote_docker` to `default` because the current one was removed.

This has no effect on deployments to cloud.gov AFAIK.

## How to test

CI passes.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
