### PR TITLE
[TTAHUB-2580] Cerberus-w190-8: File upload request is vulnerable to IDOR

### DIFF
--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -296,8 +296,7 @@ const uploadHandler = async (req, res) => {
 
     fileName = `${uuidv4()}${fileTypeToUse.ext}`;
     if (reportId) {
-      if (!(await hasReportAuthorization(user, reportId)
-        || (await validateUserAuthForAdmin(userId)))) {
+      if (!(await hasReportAuthorization(user, reportId))) {
         return res.sendStatus(403);
       }
       metadata = await createActivityReportFileMetaData(

--- a/src/routes/files/handlers.js
+++ b/src/routes/files/handlers.js
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs';
 import httpCodes from 'http-codes';
-import { DECIMAL_BASE } from '@ttahub/common';
+import { DECIMAL_BASE, REPORT_STATUSES } from '@ttahub/common';
 import handleErrors from '../../lib/apiErrorHandler';
 import { uploadFile, deleteFileFromS3, getPresignedURL } from '../../lib/s3';
 import addToScanQueue from '../../services/scanQueue';
@@ -75,6 +75,13 @@ const hasReportAuthorization = async (user, reportId) => {
     return false;
   }
   return true;
+};
+
+const reportIsInAnEditableState = async (user, reportId) => {
+  const [report] = await activityReportAndRecipientsById(reportId);
+  const authorization = new ActivityReportPolicy(user, report);
+  console.log('authorization', authorization);
+  return authorization.reportHasEditableStatus();
 };
 
 const deleteOnlyFile = async (req, res) => {
@@ -296,9 +303,17 @@ const uploadHandler = async (req, res) => {
 
     fileName = `${uuidv4()}${fileTypeToUse.ext}`;
     if (reportId) {
-      if (!(await hasReportAuthorization(user, reportId))) {
+      const isAdmin = await validateUserAuthForAdmin(userId);
+      const editable = await reportIsInAnEditableState(user, reportId);
+
+      if (isAdmin && !editable) {
         return res.sendStatus(403);
       }
+
+      if (!(await hasReportAuthorization(user, reportId)) && !isAdmin) {
+        return res.sendStatus(403);
+      }
+
       metadata = await createActivityReportFileMetaData(
         originalFilename,
         fileName,

--- a/src/routes/files/handlers.test.js
+++ b/src/routes/files/handlers.test.js
@@ -197,6 +197,7 @@ describe('File Upload', () => {
     it('tests a file upload', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => true,
       }));
       uploadFile.mockResolvedValue({ key: 'key' });
       const response = await request(app)
@@ -224,6 +225,7 @@ describe('File Upload', () => {
     it('allows an admin to upload a file', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => false,
+        reportHasEditableStatus: () => true,
       }));
       validateUserAuthForAdmin.mockResolvedValue(true);
       uploadFile.mockResolvedValue({ key: 'key' });
@@ -250,9 +252,25 @@ describe('File Upload', () => {
       expect(arf.activityReportId).toBe(report.dataValues.id);
       expect(validate(uuid)).toBe(true);
     });
+    it('disallows an admin to upload a file if the status is not editable', async () => {
+      ActivityReportPolicy.mockImplementation(() => ({
+        canUpdate: () => false,
+        reportHasEditableStatus: () => false,
+      }));
+      validateUserAuthForAdmin.mockResolvedValue(true);
+      uploadFile.mockResolvedValue({ key: 'key' });
+      const response = await request(app)
+        .post('/api/files')
+        .field('reportId', report.dataValues.id)
+        .attach('file', `${__dirname}/testfiles/testfile.pdf`)
+        .expect(403);
+      fileId = response.body.id;
+      expect(uploadFile).not.toHaveBeenCalled();
+    });
     it('tests an unauthorized delete', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => false,
+        reportHasEditableStatus: () => true,
       }));
       await request(app)
         .delete(`/api/files/r/${report.dataValues.id}/1`)
@@ -262,6 +280,7 @@ describe('File Upload', () => {
     it('tests an improper delete', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => true,
       }));
       await request(app)
         .delete(`/api/files/r/${report.dataValues.id}/`)
@@ -271,6 +290,7 @@ describe('File Upload', () => {
     it('deletes a file', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => false,
       }));
       const file = await File.create({
         activityReportId: report.dataValues.id,
@@ -385,6 +405,7 @@ describe('File Upload', () => {
     it('tests a file upload without a report id', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => true,
       }));
       await request(app)
         .post('/api/files')
@@ -395,6 +416,7 @@ describe('File Upload', () => {
     it('tests a file upload without a file', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => true,
       }));
       await request(app)
         .post('/api/files')
@@ -406,6 +428,7 @@ describe('File Upload', () => {
       validateUserAuthForAdmin.mockResolvedValue(false);
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => false,
+        reportHasEditableStatus: () => true,
       }));
       await request(app)
         .post('/api/files')
@@ -433,6 +456,7 @@ describe('File Upload', () => {
     it('tests an incorrect file type', async () => {
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => true,
       }));
       uploadFile.mockResolvedValue({ key: 'key' });
       await request(app)
@@ -449,6 +473,7 @@ describe('File Upload', () => {
       mockAddToScanQueue.mockImplementationOnce(() => Promise.reject());
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => true,
       }));
       uploadFile.mockResolvedValue({ key: 'key' });
       await request(app)
@@ -468,6 +493,7 @@ describe('File Upload', () => {
       uploadFile.mockImplementationOnce(() => Promise.reject());
       ActivityReportPolicy.mockImplementation(() => ({
         canUpdate: () => true,
+        reportHasEditableStatus: () => true,
       }));
       await request(app)
         .post('/api/files')


### PR DESCRIPTION
## Description of change

Remove the admin check in the file upload handler.

The remaining check correctly responds with a 403 if the use can't pass the `hasReportAuthorization` check. This check ensures:

- The user can:
  - write in the region
  - is the author or a collaborator
  - the report has an "editable" status (draft or needs action)

The "or the user is an admin" check that was removed essentially bypassed the above checks, allowing admins to upload files to a report regardless of its "editable" status.

Although the issue doesn't specify which pentest user was used, I think it's likely that they were using one of their admin accounts when they logged this issue, as the behavior is not reproducible with a non-admin user. This PR now ensures it isn't possible with an admin, either.

## How to test

There is a test added to validate this behavior.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2580


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
