### PR TITLE
[TTAHUB-2578] Check status in event policy before deleting

### DIFF
--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -85,7 +85,12 @@ export default class EventReport {
   }
 
   canDelete() {
-    if (this.eventReport.data.status !== TRAINING_REPORT_STATUSES.NOT_STARTED) {
+    const ALLOWED_DELETED_STATUS = [
+      TRAINING_REPORT_STATUSES.NOT_STARTED,
+      TRAINING_REPORT_STATUSES.SUSPENDED,
+    ];
+
+    if (!ALLOWED_DELETED_STATUS.includes(this.eventReport.data.status)) {
       return false;
     }
 

--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -1,3 +1,4 @@
+import { TRAINING_REPORT_STATUSES } from '@ttahub/common';
 import SCOPES from '../middleware/scopeConstants';
 
 export default class EventReport {
@@ -84,6 +85,10 @@ export default class EventReport {
   }
 
   canDelete() {
+    if (this.eventReport.data.status !== TRAINING_REPORT_STATUSES.NOT_STARTED) {
+      return false;
+    }
+
     return this.isAdmin() || this.isAuthor();
   }
 

--- a/src/policies/event.test.js
+++ b/src/policies/event.test.js
@@ -1,3 +1,4 @@
+import { TRAINING_REPORT_STATUSES } from '@ttahub/common';
 import SCOPES from '../middleware/scopeConstants';
 import EventReport from './event';
 
@@ -6,12 +7,13 @@ const createEvent = ({
   pocIds = [1],
   collaboratorIds = [],
   regionId = 1,
+  data = {},
 }) => ({
   ownerId,
   pocIds,
   collaboratorIds,
   regionId,
-  data: {},
+  data,
 });
 
 let nextUserId = 0;
@@ -63,19 +65,61 @@ describe('Event Report policies', () => {
 
   describe('canDelete', () => {
     it('is true if the user is an admin', () => {
-      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1,
+        regionId: 1,
+        data: { status: TRAINING_REPORT_STATUSES.NOT_STARTED },
+      });
       const policy = new EventReport(admin, eventRegion1);
       expect(policy.canDelete()).toBe(true);
     });
 
     it('is true if the user is the author', () => {
-      const eventRegion1 = createEvent({ ownerId: authorRegion1.id, regionId: 1 });
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1.id,
+        regionId: 1,
+        data: { status: TRAINING_REPORT_STATUSES.NOT_STARTED },
+      });
       const policy = new EventReport(authorRegion1, eventRegion1);
       expect(policy.canDelete()).toBe(true);
     });
 
+    it('is false if the event is in progress', () => {
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1.id,
+        regionId: 1,
+        data: { status: TRAINING_REPORT_STATUSES.IN_PROGRESS },
+      });
+      const policy = new EventReport(authorRegion1, eventRegion1);
+      expect(policy.canDelete()).toBe(false);
+    });
+
+    it('is false if the event is complete', () => {
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1.id,
+        regionId: 1,
+        data: { status: TRAINING_REPORT_STATUSES.COMPLETE },
+      });
+      const policy = new EventReport(authorRegion1, eventRegion1);
+      expect(policy.canDelete()).toBe(false);
+    });
+
+    it('is false if the event is suspended', () => {
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1.id,
+        regionId: 1,
+        data: { status: TRAINING_REPORT_STATUSES.SUSPENDED },
+      });
+      const policy = new EventReport(authorRegion1, eventRegion1);
+      expect(policy.canDelete()).toBe(false);
+    });
+
     it('is false if the user is not an admin or the author', () => {
-      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const eventRegion1 = createEvent({
+        ownerId: authorRegion1,
+        regionId: 1,
+        data: { status: TRAINING_REPORT_STATUSES.NOT_STARTED },
+      });
       const policy = new EventReport(authorRegion2, eventRegion1);
       expect(policy.canDelete()).toBe(false);
     });

--- a/src/policies/event.test.js
+++ b/src/policies/event.test.js
@@ -104,14 +104,14 @@ describe('Event Report policies', () => {
       expect(policy.canDelete()).toBe(false);
     });
 
-    it('is false if the event is suspended', () => {
+    it('is true if the event is suspended', () => {
       const eventRegion1 = createEvent({
         ownerId: authorRegion1.id,
         regionId: 1,
         data: { status: TRAINING_REPORT_STATUSES.SUSPENDED },
       });
       const policy = new EventReport(authorRegion1, eventRegion1);
-      expect(policy.canDelete()).toBe(false);
+      expect(policy.canDelete()).toBe(true);
     });
 
     it('is false if the user is not an admin or the author', () => {


### PR DESCRIPTION
## Description of change

Training reports should only be able to be deleted if the report is either "Not Started" or "Suspended".
Pen test revealed a vulnerability where requests could be intercepted, the event ID changed, and an event in another status deleted.

This PR adds code to check the event status in the canDelete provision in the policy.

## How to test
You can use a tool like Burpsuite or Postman (I used postman) to observe the vulnerability. Don't ask me to explain how to use Burpsuite, I have no idea. Otherwise, confirm that the tests pass and that reports/status will be checked to have the correct result.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2578


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
