### PR TITLE
[TTAHUB-2661] Monitoring issue found when using bulkCreate

### DIFF
--- a/src/lib/importSystem/record.ts
+++ b/src/lib/importSystem/record.ts
@@ -285,16 +285,15 @@ const recordAvailableFiles = async (
 
   return Promise.all([
     // Create new files in the database if there are any
-    (newFiles.length > 0
-      ? ImportFile.bulkCreate(
-        newFiles.map((newFile) => ({
+    ...(newFiles.length > 0
+      ? newFiles.map((newFile) => ImportFile.create(
+        {
           importId,
           ftpFileInfo: newFile.fileInfo,
           status: IMPORT_STATUSES.IDENTIFIED,
-        })),
-        { individualHooks: true },
-      )
-      : Promise.resolve()),
+        },
+      ))
+      : []),
     // Update matched files in the database if there are any
     ...(matchedFiles.length > 0
       ? matchedFiles.map(async (matchedFile) => ImportFile.update(
@@ -386,16 +385,13 @@ const recordAvailableDataFiles = async (
 
   return Promise.all([
     // Create new files in the database if there are any
-    (newFiles.length > 0
-      ? ImportDataFile.bulkCreate(
-        newFiles.map((newFile) => ({
-          importFileId,
-          fileInfo: newFile,
-          status: IMPORT_DATA_STATUSES.IDENTIFIED,
-        })),
-        { individualHooks: true },
-      )
-      : Promise.resolve()),
+    ...(newFiles.length > 0
+      ? newFiles.map((newFile) => ImportDataFile.create({
+        importFileId,
+        fileInfo: newFile,
+        status: IMPORT_DATA_STATUSES.IDENTIFIED,
+      }))
+      : []),
     // Update matched files in the database if there are any
     ...(matchedFiles.length > 0
       ? matchedFiles.map(async (matchedFile) => ImportDataFile.update(

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -33,21 +33,21 @@ jest.mock('../../../models', () => ({
   Import: {
     findOne: jest.fn(),
     findAll: jest.fn(),
-    bulkCreate: jest.fn(),
+    create: jest.fn(),
     update: jest.fn(),
     destroy: jest.fn(),
   },
   ImportFile: {
     findOne: jest.fn(),
     findAll: jest.fn(),
-    bulkCreate: jest.fn(),
+    create: jest.fn(),
     update: jest.fn(),
     destroy: jest.fn(),
   },
   ImportDataFile: {
     findOne: jest.fn(),
     findAll: jest.fn(),
-    bulkCreate: jest.fn(),
+    create: jest.fn(),
     update: jest.fn(),
     destroy: jest.fn(),
   },
@@ -343,15 +343,12 @@ describe('record', () => {
       ImportFile.findAll.mockResolvedValueOnce([]);
       await recordAvailableFiles(importId, availableFiles);
 
-      expect(ImportFile.bulkCreate).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({
-            importId,
-            ftpFileInfo: expect.any(Object),
-            status: IMPORT_STATUSES.IDENTIFIED,
-          }),
-        ]),
-        { individualHooks: true },
+      expect(ImportFile.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          importId: expect.anything(),
+          ftpFileInfo: expect.any(Object),
+          status: IMPORT_STATUSES.IDENTIFIED,
+        }),
       );
     });
 
@@ -406,7 +403,7 @@ describe('record', () => {
       })));
       await recordAvailableFiles(importId, availableFiles);
 
-      expect(ImportFile.bulkCreate).not.toHaveBeenCalled();
+      expect(ImportFile.create).not.toHaveBeenCalled();
       expect(ImportFile.update).toHaveBeenCalled();
       expect(ImportFile.destroy).not.toHaveBeenCalled();
     });
@@ -418,7 +415,7 @@ describe('record', () => {
 
       expect(result).toBeInstanceOf(Array);
       // Assuming there are three types of operations: create, update, delete
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
     });
   });
 
@@ -451,7 +448,7 @@ describe('record', () => {
         .filter((af) => !currentImportDataFiles
           .some((cif) => cif.fileInfo.path === af.path && cif.fileInfo.name === af.name));
 
-      // Mock the database response for bulkCreate
+      // Mock the database response for create
       const mockNewFilesResponse = newFiles
         .map((file) => ({
           ...file,
@@ -459,19 +456,19 @@ describe('record', () => {
           importFileId,
           status: IMPORT_DATA_STATUSES.IDENTIFIED,
         }));
-      ImportDataFile.bulkCreate.mockResolvedValue(mockNewFilesResponse);
+      ImportDataFile.create.mockResolvedValue(mockNewFilesResponse[0]);
 
       await recordAvailableDataFiles(importFileId, availableFiles);
 
-      // Expected argument for bulkCreate should be the new files with additional properties
+      // Expected argument for create should be the new files with additional properties
       const expectedBulkCreateArgument = newFiles.map((newFile) => ({
         importFileId,
         fileInfo: newFile,
         status: IMPORT_DATA_STATUSES.IDENTIFIED,
       }));
 
-      expect(ImportDataFile.bulkCreate)
-        .toHaveBeenCalledWith(expectedBulkCreateArgument, { individualHooks: true });
+      expect(ImportDataFile.create)
+        .toHaveBeenCalledWith(expectedBulkCreateArgument[0]);
     });
 
     it('should update matched files in the database when there are matched files', async () => {
@@ -519,7 +516,7 @@ describe('record', () => {
 
       await recordAvailableDataFiles(importFileId, [availableFiles[0], availableFiles[1]]);
 
-      expect(ImportDataFile.bulkCreate).not.toHaveBeenCalled();
+      expect(ImportDataFile.create).not.toHaveBeenCalled();
       expect(ImportDataFile.update).toHaveBeenCalled();
       expect(ImportDataFile.destroy).not.toHaveBeenCalled();
     });

--- a/src/migrations/20240306000000-monitoring-nonbulkcreate.js
+++ b/src/migrations/20240306000000-monitoring-nonbulkcreate.js
@@ -1,0 +1,17 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      // await prepMigration(queryInterface, transaction, sessionSig);
+      // eslint-disable-next-line @typescript-eslint/quotes
+      await queryInterface.sequelize.query(/* sql */`SELECT setval('"ImportFiles_id_seq"', COALESCE((SELECT MAX(id)+1 FROM "ImportFiles"), 1), false);`, { transaction });
+      // eslint-disable-next-line @typescript-eslint/quotes
+      await queryInterface.sequelize.query(/* sql */`SELECT setval('"ImportDataFiles_id_seq"', COALESCE((SELECT MAX(id)+1 FROM "ImportDataFiles"), 1), false);`, { transaction });
+    });
+  },
+};

--- a/src/migrations/20240306000000-monitoring-nonbulkcreate.js
+++ b/src/migrations/20240306000000-monitoring-nonbulkcreate.js
@@ -7,11 +7,12 @@ module.exports = {
   async up(queryInterface) {
     await queryInterface.sequelize.transaction(async (transaction) => {
       const sessionSig = __filename;
-      // await prepMigration(queryInterface, transaction, sessionSig);
+      await prepMigration(queryInterface, transaction, sessionSig);
       // eslint-disable-next-line @typescript-eslint/quotes
       await queryInterface.sequelize.query(/* sql */`SELECT setval('"ImportFiles_id_seq"', COALESCE((SELECT MAX(id)+1 FROM "ImportFiles"), 1), false);`, { transaction });
       // eslint-disable-next-line @typescript-eslint/quotes
       await queryInterface.sequelize.query(/* sql */`SELECT setval('"ImportDataFiles_id_seq"', COALESCE((SELECT MAX(id)+1 FROM "ImportDataFiles"), 1), false);`, { transaction });
     });
   },
+  async down() {},
 };


### PR DESCRIPTION
## Description of change
There is an issue in sequelize bulkCreate where it does not update the sequence used for the primary key. This prevents additional inserts into the table as any insert will have a key conflict.

## How to test
Run monitoring, add a file to the sftp, run monitoring again. The new file should be handle correctly.

## Issue(s)

* https://ocio-jira.acf.hhs.gov/browse/TTAHUB-2661


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
