### PR TITLE
[TTAHUB-2572] Add groups to TR participants

### DIFF
--- a/frontend/src/components/GroupAlert.js
+++ b/frontend/src/components/GroupAlert.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert as USWDSAlert,
+} from '@trussworks/react-uswds';
+
+export default function GroupAlert({
+  resetGroup,
+}) {
+  return (
+    <>
+      <USWDSAlert type="info">
+        You&apos;ve successfully modified the group&apos;s recipients for this
+        report. Changes here do not affect the group itself.
+        <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
+          Reset or select a different group.
+        </button>
+      </USWDSAlert>
+    </>
+  );
+}
+
+GroupAlert.propTypes = {
+  resetGroup: PropTypes.func.isRequired,
+};

--- a/frontend/src/components/RecipientsWithGroups.js
+++ b/frontend/src/components/RecipientsWithGroups.js
@@ -1,0 +1,227 @@
+import React, {
+  useState,
+  useEffect,
+} from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
+// import PropTypes from 'prop-types';
+import {
+  Dropdown,
+  Checkbox,
+  Alert as USWDSAlert,
+} from '@trussworks/react-uswds';
+import { DECIMAL_BASE } from '@ttahub/common';
+import { useFormContext } from 'react-hook-form';
+import { getPossibleSessionParticipants, getGroupsForSession } from '../fetchers/session';
+import FormItem from './FormItem';
+import MultiSelect from './MultiSelect';
+
+const placeholderText = '- Select -';
+
+const RecipientsWithGroups = () => {
+  const {
+    control,
+    register,
+    watch,
+    setValue,
+  } = useFormContext();
+
+  // Recipients.
+  const regionId = watch('regionId');
+  const watchFormRecipients = watch('recipients');
+  const watchGroup = watch('recipientGroup');
+
+  const [recipientOptions, setRecipientOptions] = useState();
+  useEffect(() => {
+    async function fetchRecipients() {
+      if (!recipientOptions && regionId) {
+        const data = await getPossibleSessionParticipants(regionId);
+        setRecipientOptions(data);
+      }
+    }
+    fetchRecipients();
+  }, [recipientOptions, regionId]);
+
+  const options = (recipientOptions || []).map((recipient) => ({
+    label: recipient.name,
+    options: recipient.grants.map((grant) => ({
+      value: grant.id,
+      label: grant.name,
+    })),
+  }));
+
+  // Groups.
+  const [groups, setGroups] = useState([]);
+  const [useGroups, setUseGroups] = useState(false);
+  const [groupRecipientIds, setGroupRecipientIds] = useState([]);
+  const [showGroupInfo, setShowGroupInfo] = useState(false);
+  const [fetchedGroups, setFetchedGroups] = useState(false);
+  useEffect(() => {
+    async function fetchGroups() {
+      if (regionId && !fetchedGroups) {
+        setFetchedGroups(true);
+        const retrievedGroups = await getGroupsForSession(regionId);
+
+        // Add recipientIds to groups.
+        const groupsWithRecipientIds = retrievedGroups.map((group) => ({
+          ...group,
+          // Match groups to grants as recipients could have multiple grants.
+          recipients: group.grants.map((g) => g.id),
+        }));
+        setGroups(groupsWithRecipientIds);
+      }
+    }
+    fetchGroups();
+  }, [regionId, groups, fetchedGroups]);
+
+  useDeepCompareEffect(() => {
+    if (useGroups) {
+      // Determine if there are any recipients that are not in the group.
+      const usedRecipientIds = (watchFormRecipients || []).map((r) => r.value);
+      const selectedRecipientsNotInGroup = usedRecipientIds.filter(
+        (option) => !groupRecipientIds.includes(option),
+      );
+
+      // If the user changes recipients manually while using groups.
+      if (watchGroup
+      && (groupRecipientIds.length !== watchFormRecipients.length
+        || selectedRecipientsNotInGroup.length > 0)) {
+        setShowGroupInfo(true);
+        setUseGroups(false);
+        setValue('recipientGroup', null, { shouldValidate: false });
+        setGroupRecipientIds([]);
+      }
+    }
+  }, [groupRecipientIds, setValue, useGroups, watchFormRecipients, watchGroup]);
+
+  const renderRecipients = () => (
+    <div className="margin-top-2">
+      <FormItem
+        label="Recipients "
+        name="recipients"
+      >
+        <MultiSelect
+          name="recipients"
+          control={control}
+          simple={false}
+          required="Select at least one recipient"
+          options={options}
+          placeholderText={placeholderText}
+        />
+      </FormItem>
+    </div>
+  );
+
+  const resetGroup = (checkUseGroup = true) => {
+    setValue('recipientGroup', null, { shouldValidate: false });
+    setGroupRecipientIds([]);
+    setValue('recipients', [], { shouldValidate: false });
+    setShowGroupInfo(false);
+    if (checkUseGroup) {
+      setUseGroups(true);
+    }
+  };
+
+  const toggleUseGroup = (event) => {
+    const { target: { checked = null } = {} } = event;
+    // Reset.
+    resetGroup(false);
+    setUseGroups(checked);
+  };
+
+  const handleGroupChange = (event) => {
+    const { value: groupId } = event.target;
+    const groupToUse = groups.find((group) => group.id === parseInt(groupId, 10));
+
+    // Get all selectedRecipients the have ids in the recipientIds array.
+    const selectedGroupRecipients = options.reduce((acc, curr) => {
+      const groupRecipients = curr.options.filter(
+        (option) => groupToUse.recipients.includes(parseInt(option.value, DECIMAL_BASE)),
+      );
+      return [...acc, ...groupRecipients];
+    }, []);
+
+    // Set selected recipients.
+    const recipientsToSet = selectedGroupRecipients.map((r) => (
+      {
+        ...r, name: r.label, activityRecipientId: r.value,
+      }));
+    setValue('recipients', recipientsToSet, { shouldValidate: true });
+    const recipientsToSetIds = recipientsToSet.map((r) => (r.value));
+    setGroupRecipientIds(recipientsToSetIds);
+  };
+
+  return (
+    <>
+      {
+        showGroupInfo && (
+        <USWDSAlert type="info">
+          You&apos;ve successfully modified the group&apos;s recipients for this
+          report. Changes here do not affect the group itself.
+          <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
+            Reset or select a different group.
+          </button>
+        </USWDSAlert>
+        )
+        }
+      {
+        useGroups ? (
+          <div className="margin-top-2">
+            <FormItem
+              label="Group name"
+              name="recipientGroup"
+            >
+              <Dropdown
+                required
+                control={control}
+                id="recipientGroup"
+                name="recipientGroup"
+                inputRef={register({ required: 'Select a group' })}
+                onAbort={resetGroup}
+                onChange={handleGroupChange}
+              >
+                <option value="" disabled selected hidden>- Select -</option>
+                {groups.map((group) => (
+                  <option key={group.id} value={group.id}>{group.name}</option>
+                ))}
+              </Dropdown>
+            </FormItem>
+          </div>
+        )
+          : renderRecipients()
+      }
+      {
+          groups.length > 0
+           && (
+           <div className="smart-hub-activity-summary-use-group margin-top-1">
+             <Checkbox
+               id="use-group"
+               label="Use group"
+               className="smart-hub--report-checkbox"
+               onChange={toggleUseGroup}
+               checked={useGroups}
+             />
+           </div>
+           )
+        }
+      {
+          useGroups
+            ? renderRecipients()
+            : null
+        }
+    </>
+  );
+};
+
+/*
+RecipientsWithGroups.propTypes = {
+  regionId: PropTypes.number.isRequired,
+};
+*/
+
+/*
+RecipientsWithGroups.defaultProps = {
+  value: '',
+};
+*/
+
+export default RecipientsWithGroups;

--- a/frontend/src/components/RecipientsWithGroups.js
+++ b/frontend/src/components/RecipientsWithGroups.js
@@ -192,11 +192,11 @@ const RecipientsWithGroups = () => {
       {
           groups.length > 0
            && (
-           <div className="smart-hub-activity-summary-use-group margin-top-1">
+           <div className="smart-hub-activity-summary-use-group margin-top-0">
              <Checkbox
                id="use-group"
                label="Use group"
-               className="smart-hub--report-checkbox"
+               className="margin-top-1"
                onChange={toggleUseGroup}
                checked={useGroups}
              />

--- a/frontend/src/components/RecipientsWithGroups.js
+++ b/frontend/src/components/RecipientsWithGroups.js
@@ -3,17 +3,16 @@ import React, {
   useEffect,
 } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-// import PropTypes from 'prop-types';
 import {
   Dropdown,
   Checkbox,
-  Alert as USWDSAlert,
 } from '@trussworks/react-uswds';
 import { DECIMAL_BASE } from '@ttahub/common';
 import { useFormContext } from 'react-hook-form';
 import { getPossibleSessionParticipants, getGroupsForSession } from '../fetchers/session';
 import FormItem from './FormItem';
 import MultiSelect from './MultiSelect';
+import GroupAlert from './GroupAlert';
 
 const placeholderText = '- Select -';
 
@@ -154,13 +153,7 @@ const RecipientsWithGroups = () => {
     <>
       {
         showGroupInfo && (
-        <USWDSAlert type="info">
-          You&apos;ve successfully modified the group&apos;s recipients for this
-          report. Changes here do not affect the group itself.
-          <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
-            Reset or select a different group.
-          </button>
-        </USWDSAlert>
+          <GroupAlert resetGroup={resetGroup} />
         )
         }
       {
@@ -211,17 +204,5 @@ const RecipientsWithGroups = () => {
     </>
   );
 };
-
-/*
-RecipientsWithGroups.propTypes = {
-  regionId: PropTypes.number.isRequired,
-};
-*/
-
-/*
-RecipientsWithGroups.defaultProps = {
-  value: '',
-};
-*/
 
 export default RecipientsWithGroups;

--- a/frontend/src/fetchers/__tests__/session.js
+++ b/frontend/src/fetchers/__tests__/session.js
@@ -9,6 +9,7 @@ import {
   uploadSessionObjectiveFiles,
   deleteSessionObjectiveFile,
   getPossibleSessionParticipants,
+  getGroupsForSession,
 } from '../session';
 
 const sessionsUrl = join('/', 'api', 'session-reports');
@@ -73,5 +74,11 @@ describe('session fetchers', () => {
     fetchMock.get(join(sessionsUrl, 'participants', regionId), response);
     const result = await getPossibleSessionParticipants(regionId);
     expect(result).toEqual(response);
+  });
+  it('returns the groups', async () => {
+    const expected = { id: 1 };
+    fetchMock.get(join(sessionsUrl, 'groups', '?region=1'), expected);
+    const report = await getGroupsForSession('1');
+    expect(report).toEqual(expected);
   });
 });

--- a/frontend/src/fetchers/session.js
+++ b/frontend/src/fetchers/session.js
@@ -50,3 +50,8 @@ export const getPossibleSessionParticipants = async (regionId) => {
   const response = await get(join(sessionsUrl, 'participants', String(regionId)));
   return response.json();
 };
+
+export const getGroupsForSession = async (regionId) => {
+  const response = await get(join(sessionsUrl, 'groups', `?region=${regionId}`));
+  return response.json();
+};

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -255,8 +255,8 @@ const ActivitySummary = ({
         {
         showGroupInfo && (
         <USWDSAlert type="info">
-          You&apos;ve successfully modified the Group&apos;s recipients for this
-          report. Changes here do not affect the Group itself.
+          You&apos;ve successfully modified the group&apos;s recipients for this
+          report. Changes here do not affect the group itself.
           <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
             Reset or select a different group.
           </button>

--- a/frontend/src/pages/ActivityReport/Pages/activitySummary.js
+++ b/frontend/src/pages/ActivityReport/Pages/activitySummary.js
@@ -13,7 +13,6 @@ import {
   TextInput,
   Checkbox,
   Label,
-  Alert as USWDSAlert,
   Dropdown,
 } from '@trussworks/react-uswds';
 import moment from 'moment';
@@ -41,6 +40,7 @@ import { reportIsEditable } from '../../../utils';
 import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
 import NavigatorButtons from '../../../components/Navigator/components/NavigatorButtons';
 import './activitySummary.scss';
+import GroupAlert from '../../../components/GroupAlert';
 
 const ActivitySummary = ({
   recipients,
@@ -254,13 +254,7 @@ const ActivitySummary = ({
         </div>
         {
         showGroupInfo && (
-        <USWDSAlert type="info">
-          You&apos;ve successfully modified the group&apos;s recipients for this
-          report. Changes here do not affect the group itself.
-          <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
-            Reset or select a different group.
-          </button>
-        </USWDSAlert>
+          <GroupAlert resetGroup={resetGroup} />
         )
         }
         {

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -276,7 +276,6 @@ function ActivityReport({
         ];
 
         const [recipients, collaborators, availableApprovers, groups] = await Promise.all(apiCalls);
-
         const isCollaborator = report.activityReportCollaborators
           && report.activityReportCollaborators.find((u) => u.userId === user.id);
 

--- a/frontend/src/pages/SessionForm/pages/__tests__/participants.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/participants.js
@@ -20,7 +20,7 @@ import AppLoadingContext from '../../../../AppLoadingContext';
 
 const sessionsUrl = join('/', 'api', 'session-reports');
 const participantsUrl = join(sessionsUrl, 'participants', '1');
-
+const groupsUrl = join(sessionsUrl, 'groups', '?region=1');
 function mockRecipients(howMany) {
   const mock = [];
   // eslint-disable-next-line no-plusplus
@@ -34,8 +34,12 @@ function mockRecipients(howMany) {
           name: `R${i} G${i}`,
         },
         {
-          id: i,
+          id: i + 1,
           name: `R${i} G${i + 1}`,
+        },
+        {
+          id: i + 2,
+          name: `R${i} G${i + 2}`,
         },
       ],
     });
@@ -78,6 +82,7 @@ describe('participants', () => {
       eventName: 'Event name',
       regionId: 1,
       status: 'In progress',
+      recipients: [],
       pageState: {
         1: NOT_STARTED,
         2: NOT_STARTED,
@@ -120,7 +125,11 @@ describe('participants', () => {
     };
 
     beforeEach(async () => {
+      // Mock recipients.
       fetchMock.get(participantsUrl, mockRecipients(3));
+      // Mock groups.
+      const mockGroups = [{ id: 1, name: 'group 1', grants: [{ id: 0 }, { id: 1 }] }, { id: 2, name: 'group 2', grants: [{ id: 2 }, { id: 3 }] }];
+      fetchMock.get(groupsUrl, mockGroups);
     });
 
     afterEach(async () => {
@@ -242,6 +251,78 @@ describe('participants', () => {
       expect(inPersonLabel).toBeVisible();
       const virtuallyLabel = await screen.findByText(/Number of participants attending virtually/i);
       expect(virtuallyLabel).toBeVisible();
+    });
+
+    describe('groups', () => {
+      it('correctly shows and hides all group options', async () => {
+        render(<RenderParticipants />);
+
+        // Click the use group checkbox.
+        let useGroupCheckbox = await screen.findByRole('checkbox', { name: /use group/i });
+
+        await act(() => {
+          userEvent.click(useGroupCheckbox);
+        });
+
+        // Correctly shows the group drop down.
+        const groupOption = screen.getByRole('combobox', { name: /group name required/i });
+        expect(groupOption).toBeInTheDocument();
+
+        // Uncheck the use group checkbox.
+        useGroupCheckbox = screen.getByRole('checkbox', { name: /use group/i });
+        await act(() => {
+          userEvent.click(useGroupCheckbox);
+        });
+
+        // Assert that the group drop down is no longer visible.
+        expect(groupOption).not.toBeInTheDocument();
+      });
+
+      it('hides the use group check box if we dont have any groups', async () => {
+        fetchMock.get(groupsUrl, [], { overwriteRoutes: true });
+        render(<RenderParticipants />);
+        expect(screen.queryAllByRole('checkbox', { name: /use group/i }).length).toBe(0);
+      });
+
+      it('correctly shows message if group recipients are changed', async () => {
+        act(() => {
+          render(<RenderParticipants />);
+        });
+        await waitFor(() => expect(fetchMock.called(participantsUrl)).toBeTruthy());
+        await waitFor(() => expect(fetchMock.called(groupsUrl)).toBeTruthy());
+
+        await selectEvent.select(screen.getByLabelText(/recipients/i), 'R0 G0');
+        expect(screen.getByText(/R0 G0/i)).toBeVisible();
+
+        // Click the use group checkbox.
+        const useGroupCheckbox = await screen.findByRole('checkbox', { name: /use group/i });
+        await act(() => {
+          userEvent.click(useGroupCheckbox);
+        });
+
+        // Correctly shows the group drop down.
+        const groupOption = screen.getByRole('combobox', { name: /group name required/i });
+        expect(groupOption).toBeInTheDocument();
+
+        await act(async () => {
+          const groupSelectBox = await screen.findByRole('combobox', { name: /group name required/i });
+          userEvent.selectOptions(groupSelectBox, 'group 1');
+          await waitFor(() => {
+          // expect Group 2 to be visible.
+            expect(screen.getByText('group 1')).toBeVisible();
+          });
+        });
+
+        await selectEvent.select(screen.getByLabelText(/recipients/i), 'R0 G2');
+        expect(screen.getByText(/you've successfully modified the group/i)).toBeInTheDocument();
+
+        // Make sure reset works.
+        const resetButton = screen.getByRole('button', { name: /reset or select a different group\./i });
+        userEvent.click(resetButton);
+
+        // Assert use group check box is checked.
+        expect(useGroupCheckbox).toBeChecked();
+      });
     });
   });
 });

--- a/frontend/src/pages/SessionForm/pages/__tests__/participants.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/participants.js
@@ -199,7 +199,7 @@ describe('participants', () => {
       act(() => {
         render(<RenderParticipants formValues={readOnlyFormValues} />);
       });
-      await waitFor(() => expect(fetchMock.called(participantsUrl)).toBeTruthy());
+      await waitFor(async () => expect(await screen.findByText('Home Visitor')).toBeVisible());
 
       // confirm alert
       const alert = await screen.findByText(/sent an email to the event creator and collaborator/i);
@@ -236,7 +236,7 @@ describe('participants', () => {
       act(() => {
         render(<RenderParticipants formValues={readOnlyFormValues} />);
       });
-      await waitFor(() => expect(fetchMock.called(participantsUrl)).toBeTruthy());
+      await waitFor(async () => expect(await screen.findByText('Home Visitor')).toBeVisible());
 
       // confirm alert
       const alert = await screen.findByText(/sent an email to the event creator and collaborator/i);

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -70,6 +70,8 @@ const Participants = ({ formData }) => {
   useEffect(() => {
     async function fetchGroups() {
       if (regionId && !fetchedGroups) {
+        setFetchedGroups(true);
+        console.log('Fetch Groups');
         const retrievedGroups = await getGroupsForSession(regionId);
 
         // Add recipientIds to groups.
@@ -79,7 +81,6 @@ const Participants = ({ formData }) => {
           recipients: group.grants.map((g) => g.id),
         }));
         setGroups(groupsWithRecipientIds);
-        setFetchedGroups(true);
       }
     }
     fetchGroups();

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -69,7 +69,6 @@ const Participants = ({ formData }) => {
   const [fetchedGroups, setFetchedGroups] = useState(false);
   useEffect(() => {
     async function fetchGroups() {
-      console.log('Fire Fetch Group Effect');
       if (regionId && !fetchedGroups) {
         const retrievedGroups = await getGroupsForSession(regionId);
 
@@ -88,7 +87,6 @@ const Participants = ({ formData }) => {
 
   useDeepCompareEffect(() => {
     if (useGroups) {
-      console.log('Fire Use Deep Compare Effect');
       // Determine if there are any recipients that are not in the group.
       const usedRecipientIds = (watchFormRecipients || []).map((r) => r.value);
       const selectedRecipientsNotInGroup = usedRecipientIds.filter(

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -71,7 +71,6 @@ const Participants = ({ formData }) => {
     async function fetchGroups() {
       if (regionId && !fetchedGroups) {
         setFetchedGroups(true);
-        console.log('Fetch Groups');
         const retrievedGroups = await getGroupsForSession(regionId);
 
         // Add recipientIds to groups.
@@ -218,8 +217,8 @@ const Participants = ({ formData }) => {
       {
         showGroupInfo && (
         <USWDSAlert type="info">
-          You&apos;ve successfully modified the Group&apos;s recipients for this
-          report. Changes here do not affect the Group itself.
+          You&apos;ve successfully modified the group&apos;s recipients for this
+          report. Changes here do not affect the group itself.
           <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
             Reset or select a different group.
           </button>

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -1,19 +1,13 @@
 import React, {
-  useState,
-  useEffect,
   useContext,
 } from 'react';
-import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Helmet } from 'react-helmet';
-import { LANGUAGES, DECIMAL_BASE } from '@ttahub/common';
+import { LANGUAGES } from '@ttahub/common';
 import { useFormContext } from 'react-hook-form';
 import {
   Button,
   Radio,
   TextInput,
-  Dropdown,
-  Checkbox,
-  Alert as USWDSAlert,
 } from '@trussworks/react-uswds';
 import { capitalize } from 'lodash';
 import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
@@ -24,12 +18,12 @@ import {
 } from '../constants';
 import { recipientParticipants } from '../../ActivityReport/constants'; // TODO - move to @ttahub/common
 import FormItem from '../../../components/FormItem';
-import { getPossibleSessionParticipants, getGroupsForSession } from '../../../fetchers/session';
 import useTrainingReportRole from '../../../hooks/useTrainingReportRole';
 import useTrainingReportTemplateDeterminator from '../../../hooks/useTrainingReportTemplateDeterminator';
 import UserContext from '../../../UserContext';
 import PocCompleteView from '../../../components/PocCompleteView';
 import ReadOnlyField from '../../../components/ReadOnlyField';
+import RecipientsWithGroups from '../../../components/RecipientsWithGroups';
 
 const placeholderText = '- Select -';
 
@@ -38,81 +32,11 @@ const Participants = ({ formData }) => {
     control,
     register,
     watch,
-    setValue,
   } = useFormContext();
 
   const { user } = useContext(UserContext);
   const { isPoc } = useTrainingReportRole(formData.event, user.id);
   const showReadOnlyView = useTrainingReportTemplateDeterminator(formData, isPoc);
-
-  const regionId = watch('regionId');
-  const watchFormRecipients = watch('recipients');
-  const watchGroup = watch('recipientGroup');
-
-  const [recipientOptions, setRecipientOptions] = useState();
-  useEffect(() => {
-    async function fetchRecipients() {
-      if (!recipientOptions && regionId) {
-        const data = await getPossibleSessionParticipants(regionId);
-        setRecipientOptions(data);
-      }
-    }
-
-    fetchRecipients();
-  }, [recipientOptions, regionId]);
-
-  // Get Groups.
-  const [groups, setGroups] = useState([]);
-  const [useGroups, setUseGroups] = useState(false);
-  const [groupRecipientIds, setGroupRecipientIds] = useState([]);
-  const [showGroupInfo, setShowGroupInfo] = useState(false);
-  const [fetchedGroups, setFetchedGroups] = useState(false);
-  useEffect(() => {
-    async function fetchGroups() {
-      if (regionId && !fetchedGroups) {
-        setFetchedGroups(true);
-        const retrievedGroups = await getGroupsForSession(regionId);
-
-        // Add recipientIds to groups.
-        const groupsWithRecipientIds = retrievedGroups.map((group) => ({
-          ...group,
-          // Match groups to grants as recipients could have multiple grants.
-          recipients: group.grants.map((g) => g.id),
-        }));
-        setGroups(groupsWithRecipientIds);
-      }
-    }
-    fetchGroups();
-  }, [regionId, groups, fetchedGroups]);
-
-  useDeepCompareEffect(() => {
-    if (useGroups) {
-      // Determine if there are any recipients that are not in the group.
-      const usedRecipientIds = (watchFormRecipients || []).map((r) => r.value);
-      const selectedRecipientsNotInGroup = usedRecipientIds.filter(
-        (option) => !groupRecipientIds.includes(option),
-      );
-
-      // If the user changes recipients manually while using groups.
-      if (watchGroup
-      && (groupRecipientIds.length !== watchFormRecipients.length
-        || selectedRecipientsNotInGroup.length > 0)) {
-        setShowGroupInfo(true);
-        setUseGroups(false);
-        setValue('recipientGroup', null, { shouldValidate: false });
-        setGroupRecipientIds([]);
-      }
-    }
-  }, [groupRecipientIds, setValue, useGroups, watchFormRecipients, watchGroup]);
-
-  const options = (recipientOptions || []).map((recipient) => ({
-    label: recipient.name,
-    options: recipient.grants.map((grant) => ({
-      value: grant.id,
-      label: grant.name,
-    })),
-  }));
-
   const isHybrid = watch('deliveryMethod') === 'hybrid';
 
   if (showReadOnlyView) {
@@ -151,125 +75,13 @@ const Participants = ({ formData }) => {
     );
   }
 
-  const renderRecipients = () => (
-    <div className="margin-top-2">
-      <FormItem
-        label="Recipients "
-        name="recipients"
-      >
-        <MultiSelect
-          name="recipients"
-          control={control}
-          simple={false}
-          required="Select at least one recipient"
-          options={options}
-          placeholderText={placeholderText}
-        />
-      </FormItem>
-    </div>
-  );
-
-  const resetGroup = (checkUseGroup = true) => {
-    setValue('recipientGroup', null, { shouldValidate: false });
-    setGroupRecipientIds([]);
-    setValue('recipients', [], { shouldValidate: false });
-    setShowGroupInfo(false);
-    if (checkUseGroup) {
-      setUseGroups(true);
-    }
-  };
-
-  const toggleUseGroup = (event) => {
-    const { target: { checked = null } = {} } = event;
-    // Reset.
-    resetGroup(false);
-    setUseGroups(checked);
-  };
-
-  const handleGroupChange = (event) => {
-    const { value: groupId } = event.target;
-    const groupToUse = groups.find((group) => group.id === parseInt(groupId, 10));
-
-    // Get all selectedRecipients the have ids in the recipientIds array.
-    const selectedGroupRecipients = options.reduce((acc, curr) => {
-      const groupRecipients = curr.options.filter(
-        (option) => groupToUse.recipients.includes(parseInt(option.value, DECIMAL_BASE)),
-      );
-      return [...acc, ...groupRecipients];
-    }, []);
-
-    // Set selected recipients.
-    const recipientsToSet = selectedGroupRecipients.map((r) => (
-      {
-        ...r, name: r.label, activityRecipientId: r.value,
-      }));
-    setValue('recipients', recipientsToSet, { shouldValidate: true });
-    const recipientsToSetIds = recipientsToSet.map((r) => (r.value));
-    setGroupRecipientIds(recipientsToSetIds);
-  };
-
   return (
     <>
       <Helmet>
         <title>Session Participants</title>
       </Helmet>
       <IndicatesRequiredField />
-      {
-        showGroupInfo && (
-        <USWDSAlert type="info">
-          You&apos;ve successfully modified the group&apos;s recipients for this
-          report. Changes here do not affect the group itself.
-          <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
-            Reset or select a different group.
-          </button>
-        </USWDSAlert>
-        )
-        }
-      {
-        useGroups ? (
-          <div className="margin-top-2">
-            <FormItem
-              label="Group name"
-              name="recipientGroup"
-            >
-              <Dropdown
-                required
-                control={control}
-                id="recipientGroup"
-                name="recipientGroup"
-                inputRef={register({ required: 'Select a group' })}
-                onAbort={resetGroup}
-                onChange={handleGroupChange}
-              >
-                <option value="" disabled selected hidden>- Select -</option>
-                {groups.map((group) => (
-                  <option key={group.id} value={group.id}>{group.name}</option>
-                ))}
-              </Dropdown>
-            </FormItem>
-          </div>
-        )
-          : renderRecipients()
-      }
-      {
-          groups.length > 0
-           && (
-           <div className="smart-hub-activity-summary-use-group margin-top-1">
-             <Checkbox
-               id="use-group"
-               label="Use group"
-               className="smart-hub--report-checkbox"
-               onChange={toggleUseGroup}
-               checked={useGroups}
-             />
-           </div>
-           )
-        }
-      {
-          useGroups
-            ? renderRecipients(1, 5)
-            : null
-        }
+      <RecipientsWithGroups />
       <div className="margin-top-2">
         <FormItem
           label="Recipient participants "

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -69,6 +69,7 @@ const Participants = ({ formData }) => {
   const [fetchedGroups, setFetchedGroups] = useState(false);
   useEffect(() => {
     async function fetchGroups() {
+      console.log('Fire Fetch Group Effect');
       if (regionId && !fetchedGroups) {
         const retrievedGroups = await getGroupsForSession(regionId);
 
@@ -86,22 +87,23 @@ const Participants = ({ formData }) => {
   }, [regionId, groups, fetchedGroups]);
 
   useDeepCompareEffect(() => {
-    // Get all selected recipients that are NOT in the watchGroup.recipients array.
-    const usedRecipientIds = (watchFormRecipients || []).map((r) => r.value);
-    // const usedRecipientIds = watchFormRecipients.map((r) => r.value);
-    const selectedRecipientsNotInGroup = usedRecipientIds.filter(
-      (option) => !groupRecipientIds.includes(option),
-    );
+    if (useGroups) {
+      console.log('Fire Use Deep Compare Effect');
+      // Determine if there are any recipients that are not in the group.
+      const usedRecipientIds = (watchFormRecipients || []).map((r) => r.value);
+      const selectedRecipientsNotInGroup = usedRecipientIds.filter(
+        (option) => !groupRecipientIds.includes(option),
+      );
 
-    // If the user changes recipients manually while using groups.
-    if (useGroups
-      && watchGroup
+      // If the user changes recipients manually while using groups.
+      if (watchGroup
       && (groupRecipientIds.length !== watchFormRecipients.length
         || selectedRecipientsNotInGroup.length > 0)) {
-      setShowGroupInfo(true);
-      setUseGroups(false);
-      setValue('recipientGroup', null, { shouldValidate: false });
-      setGroupRecipientIds([]);
+        setShowGroupInfo(true);
+        setUseGroups(false);
+        setValue('recipientGroup', null, { shouldValidate: false });
+        setGroupRecipientIds([]);
+      }
     }
   }, [groupRecipientIds, setValue, useGroups, watchFormRecipients, watchGroup]);
 

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -3,13 +3,17 @@ import React, {
   useEffect,
   useContext,
 } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Helmet } from 'react-helmet';
-import { LANGUAGES } from '@ttahub/common';
+import { LANGUAGES, DECIMAL_BASE } from '@ttahub/common';
 import { useFormContext } from 'react-hook-form';
 import {
   Button,
   Radio,
   TextInput,
+  Dropdown,
+  Checkbox,
+  Alert as USWDSAlert,
 } from '@trussworks/react-uswds';
 import { capitalize } from 'lodash';
 import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
@@ -20,7 +24,7 @@ import {
 } from '../constants';
 import { recipientParticipants } from '../../ActivityReport/constants'; // TODO - move to @ttahub/common
 import FormItem from '../../../components/FormItem';
-import { getPossibleSessionParticipants } from '../../../fetchers/session';
+import { getPossibleSessionParticipants, getGroupsForSession } from '../../../fetchers/session';
 import useTrainingReportRole from '../../../hooks/useTrainingReportRole';
 import useTrainingReportTemplateDeterminator from '../../../hooks/useTrainingReportTemplateDeterminator';
 import UserContext from '../../../UserContext';
@@ -34,6 +38,7 @@ const Participants = ({ formData }) => {
     control,
     register,
     watch,
+    setValue,
   } = useFormContext();
 
   const { user } = useContext(UserContext);
@@ -41,6 +46,8 @@ const Participants = ({ formData }) => {
   const showReadOnlyView = useTrainingReportTemplateDeterminator(formData, isPoc);
 
   const regionId = watch('regionId');
+  const watchFormRecipients = watch('recipients');
+  const watchGroup = watch('recipientGroup');
 
   const [recipientOptions, setRecipientOptions] = useState();
   useEffect(() => {
@@ -53,6 +60,50 @@ const Participants = ({ formData }) => {
 
     fetchRecipients();
   }, [recipientOptions, regionId]);
+
+  // Get Groups.
+  const [groups, setGroups] = useState([]);
+  const [useGroups, setUseGroups] = useState(false);
+  const [groupRecipientIds, setGroupRecipientIds] = useState([]);
+  const [showGroupInfo, setShowGroupInfo] = useState(false);
+  const [fetchedGroups, setFetchedGroups] = useState(false);
+  useEffect(() => {
+    async function fetchGroups() {
+      if (regionId && !fetchedGroups) {
+        const retrievedGroups = await getGroupsForSession(regionId);
+
+        // Add recipientIds to groups.
+        const groupsWithRecipientIds = retrievedGroups.map((group) => ({
+          ...group,
+          // Match groups to grants as recipients could have multiple grants.
+          recipients: group.grants.map((g) => g.id),
+        }));
+        setGroups(groupsWithRecipientIds);
+        setFetchedGroups(true);
+      }
+    }
+    fetchGroups();
+  }, [regionId, groups, fetchedGroups]);
+
+  useDeepCompareEffect(() => {
+    // Get all selected recipients that are NOT in the watchGroup.recipients array.
+    const usedRecipientIds = (watchFormRecipients || []).map((r) => r.value);
+    // const usedRecipientIds = watchFormRecipients.map((r) => r.value);
+    const selectedRecipientsNotInGroup = usedRecipientIds.filter(
+      (option) => !groupRecipientIds.includes(option),
+    );
+
+    // If the user changes recipients manually while using groups.
+    if (useGroups
+      && watchGroup
+      && (groupRecipientIds.length !== watchFormRecipients.length
+        || selectedRecipientsNotInGroup.length > 0)) {
+      setShowGroupInfo(true);
+      setUseGroups(false);
+      setValue('recipientGroup', null, { shouldValidate: false });
+      setGroupRecipientIds([]);
+    }
+  }, [groupRecipientIds, setValue, useGroups, watchFormRecipients, watchGroup]);
 
   const options = (recipientOptions || []).map((recipient) => ({
     label: recipient.name,
@@ -100,28 +151,125 @@ const Participants = ({ formData }) => {
     );
   }
 
+  const renderRecipients = () => (
+    <div className="margin-top-2">
+      <FormItem
+        label="Recipients "
+        name="recipients"
+      >
+        <MultiSelect
+          name="recipients"
+          control={control}
+          simple={false}
+          required="Select at least one recipient"
+          options={options}
+          placeholderText={placeholderText}
+        />
+      </FormItem>
+    </div>
+  );
+
+  const resetGroup = (checkUseGroup = true) => {
+    setValue('recipientGroup', null, { shouldValidate: false });
+    setGroupRecipientIds([]);
+    setValue('recipients', [], { shouldValidate: false });
+    setShowGroupInfo(false);
+    if (checkUseGroup) {
+      setUseGroups(true);
+    }
+  };
+
+  const toggleUseGroup = (event) => {
+    const { target: { checked = null } = {} } = event;
+    // Reset.
+    resetGroup(false);
+    setUseGroups(checked);
+  };
+
+  const handleGroupChange = (event) => {
+    const { value: groupId } = event.target;
+    const groupToUse = groups.find((group) => group.id === parseInt(groupId, 10));
+
+    // Get all selectedRecipients the have ids in the recipientIds array.
+    const selectedGroupRecipients = options.reduce((acc, curr) => {
+      const groupRecipients = curr.options.filter(
+        (option) => groupToUse.recipients.includes(parseInt(option.value, DECIMAL_BASE)),
+      );
+      return [...acc, ...groupRecipients];
+    }, []);
+
+    // Set selected recipients.
+    const recipientsToSet = selectedGroupRecipients.map((r) => (
+      {
+        ...r, name: r.label, activityRecipientId: r.value,
+      }));
+    setValue('recipients', recipientsToSet, { shouldValidate: true });
+    const recipientsToSetIds = recipientsToSet.map((r) => (r.value));
+    setGroupRecipientIds(recipientsToSetIds);
+  };
+
   return (
     <>
       <Helmet>
         <title>Session Participants</title>
       </Helmet>
       <IndicatesRequiredField />
-      <div className="margin-top-2">
-        <FormItem
-          label="Recipients "
-          name="recipients"
-        >
-          <MultiSelect
-            name="recipients"
-            control={control}
-            simple={false}
-            required="Select at least one recipient"
-            options={options}
-            placeholderText={placeholderText}
-          />
-        </FormItem>
-      </div>
-
+      {
+        showGroupInfo && (
+        <USWDSAlert type="info">
+          You&apos;ve successfully modified the Group&apos;s recipients for this
+          report. Changes here do not affect the Group itself.
+          <button type="button" className="smart-hub-activity-summary-group-info usa-button usa-button--unstyled" onClick={resetGroup}>
+            Reset or select a different group.
+          </button>
+        </USWDSAlert>
+        )
+        }
+      {
+        useGroups ? (
+          <div className="margin-top-2">
+            <FormItem
+              label="Group name"
+              name="recipientGroup"
+            >
+              <Dropdown
+                required
+                control={control}
+                id="recipientGroup"
+                name="recipientGroup"
+                inputRef={register({ required: 'Select a group' })}
+                onAbort={resetGroup}
+                onChange={handleGroupChange}
+              >
+                <option value="" disabled selected hidden>- Select -</option>
+                {groups.map((group) => (
+                  <option key={group.id} value={group.id}>{group.name}</option>
+                ))}
+              </Dropdown>
+            </FormItem>
+          </div>
+        )
+          : renderRecipients()
+      }
+      {
+          groups.length > 0
+           && (
+           <div className="smart-hub-activity-summary-use-group margin-top-1">
+             <Checkbox
+               id="use-group"
+               label="Use group"
+               className="smart-hub--report-checkbox"
+               onChange={toggleUseGroup}
+               checked={useGroups}
+             />
+           </div>
+           )
+        }
+      {
+          useGroups
+            ? renderRecipients(1, 5)
+            : null
+        }
       <div className="margin-top-2">
         <FormItem
           label="Recipient participants "

--- a/src/routes/sessionReports/handlers.test.js
+++ b/src/routes/sessionReports/handlers.test.js
@@ -5,6 +5,7 @@ import {
   getHandler,
   updateHandler,
   getParticipants,
+  getGroups,
 } from './handlers';
 import {
   createSession,
@@ -15,10 +16,20 @@ import {
 } from '../../services/sessionReports';
 import EventReport from '../../policies/event';
 import { findEventBySmartsheetIdSuffix, findEventByDbId } from '../../services/event';
+import { userById } from '../../services/users';
+import SCOPES from '../../middleware/scopeConstants';
+import { groupsByRegion } from '../../services/groups';
 
 jest.mock('../../services/event');
 jest.mock('../../policies/event');
 jest.mock('../../services/sessionReports');
+jest.mock('../../services/users', () => ({
+  userById: jest.fn(),
+  usersWithPermissions: jest.fn(),
+}));
+jest.mock('../../services/groups', () => ({
+  groupsByRegion: jest.fn(),
+}));
 
 describe('session report handlers', () => {
   const mockEvent = {
@@ -43,6 +54,7 @@ describe('session report handlers', () => {
       end: jest.fn(),
     })),
     sendStatus: jest.fn(),
+    json: jest.fn(),
   };
 
   beforeEach(() => {
@@ -93,6 +105,56 @@ describe('session report handlers', () => {
       findSessionsByEventId.mockResolvedValue(null);
       await getHandler({ params: { eventId: 0 } }, mockResponse);
       expect(mockResponse.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('getGroups', () => {
+    it('returns the groups', async () => {
+      // Mock userById with correct permissions.
+      userById.mockResolvedValueOnce({
+        id: 1,
+        permissions: [
+          {
+            scopeId: SCOPES.READ_WRITE_TRAINING_REPORTS,
+            regionId: 1,
+          },
+        ],
+      });
+      // Mock permissions.
+      EventReport.mockImplementationOnce(() => ({
+        canWriteInRegion: () => true,
+      }));
+      // Group response.
+      const groupsByRegionResponse = [{ name: 'name', id: 1 }];
+      groupsByRegion.mockResolvedValueOnce(groupsByRegionResponse);
+
+      await getGroups(
+        { session: { userId: 1 }, params: { }, query: { region: 1 } },
+        mockResponse,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(groupsByRegionResponse);
+    });
+
+    it('returns 403 with incorrect permissions', async () => {
+      // Mock userById with correct permissions.
+      userById.mockResolvedValueOnce({
+        id: 1,
+        permissions: [
+          {
+            scopeId: SCOPES.READ_TRAINING_REPORTS,
+            regionId: 1,
+          },
+        ],
+      });
+      // Mock permissions.
+      EventReport.mockImplementationOnce(() => ({
+        canWriteInRegion: () => false,
+      }));
+      await getGroups(
+        { session: { userId: 1 }, params: { }, query: { region: 1 } },
+        mockResponse,
+      );
+      expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
     });
   });
 

--- a/src/routes/sessionReports/index.js
+++ b/src/routes/sessionReports/index.js
@@ -6,6 +6,7 @@ import {
   getHandler,
   deleteHandler,
   getParticipants,
+  getGroups,
 } from './handlers';
 import { checkIdParam } from '../../middleware/checkIdParamMiddleware';
 
@@ -18,5 +19,6 @@ router.get('/eventId/:eventId', transactionWrapper(getHandler, `${context} /even
 router.post('/', transactionWrapper(createHandler, context));
 router.put('/id/:id', transactionWrapper(updateHandler, context));
 router.delete('/id/:id', transactionWrapper(deleteHandler, context));
+router.get('/groups', transactionWrapper(getGroups));
 
 export default router;


### PR DESCRIPTION
## Description of change

This change add the ability to select groups on the **TR > session > participants** page. This follows the same logic as the AR group selection. This serves to simply auto populate the recipients. If the group recipents are altered a information message is shown asking if they want to start over.

## How to test

- Review all code
- Create a group for a select region add some recipients.
- Find and Event for the same region and select the group
Verify: All recipients populate and you can save the report
- Do the same thing as the above two steps but modify (add/remove) recipients.
Verify: You should get an information message saying group recipients have been modified and you can reset.

- You should still be able to edit an existing TR session participants without issue.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2572


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
