### PR TITLE
[TTAHUB-2679] Monitoring data, attempting to redownload after already processing

### DIFF
--- a/src/lib/importSystem/record.ts
+++ b/src/lib/importSystem/record.ts
@@ -256,7 +256,6 @@ const recordAvailableFiles = async (
     ],
     where: {
       importId,
-      status: { [Op.not]: IMPORT_STATUSES.PROCESSED },
     },
     raw: true,
   });

--- a/src/lib/importSystem/record.ts
+++ b/src/lib/importSystem/record.ts
@@ -47,10 +47,17 @@ const getPriorFile = async (
     ],
     where: {
       importId,
-      status,
+      [Op.or]: [
+        { status },
+        {
+          status: IMPORT_STATUSES.COLLECTION_FAILED,
+          downloadAttempts: { [Op.gt]: 5 },
+        },
+      ],
     },
     // Ordering the results by ftpFileInfo.date in descending order
-    order: [['id', 'DESC']],
+    // eslint-disable-next-line @typescript-eslint/quotes
+    order: [[Sequelize.literal(`"ftpFileInfo" ->> 'name'`), 'DESC']],
     raw: true,
   });
 

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -88,10 +88,16 @@ describe('record', () => {
         ],
         where: {
           importId,
-          status,
+          [Op.or]: [
+            { status },
+            {
+              status: IMPORT_STATUSES.COLLECTION_FAILED,
+              downloadAttempts: { [Op.gt]: 5 },
+            },
+          ],
         },
         // eslint-disable-next-line @typescript-eslint/quotes
-        order: [['id', 'DESC']],
+        order: [[Sequelize.literal(`"ftpFileInfo" ->> 'name'`), 'DESC']],
         raw: true,
       });
       expect(result).toBe(mockName);
@@ -111,10 +117,16 @@ describe('record', () => {
         ],
         where: {
           importId,
-          status,
+          [Op.or]: [
+            { status },
+            {
+              status: IMPORT_STATUSES.COLLECTION_FAILED,
+              downloadAttempts: { [Op.gt]: 5 },
+            },
+          ],
         },
         // eslint-disable-next-line @typescript-eslint/quotes
-        order: [['id', 'DESC']],
+        order: [[Sequelize.literal(`"ftpFileInfo" ->> 'name'`), 'DESC']],
         raw: true,
       });
       expect(result).toBeNull();


### PR DESCRIPTION
## Description of change
The filter by status was not valid, as we need to not attempt to redownload if the file has already been downloaded and processed.


## How to test
Fully process a file, then try to download more files. should not attempt to download again.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2679


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
