### PR TITLE
[TTAHUB-2677] Allow creator-approvers to reset to draft

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -66,8 +66,6 @@ const Review = ({
 
   const showReset = (calculatedStatus !== REPORT_STATUSES.DRAFT && creatorIsApprover);
 
-  console.log({ showReset, calculatedStatus, creatorIsApprover });
-
   return (
     <>
       <h2>{pendingOtherApprovals ? 'Pending other approvals' : 'Review and approve report'}</h2>

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { REPORT_STATUSES } from '@ttahub/common';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { useFormContext } from 'react-hook-form';
@@ -7,6 +8,7 @@ import {
   Dropdown, Form, Label, Fieldset, Button,
 } from '@trussworks/react-uswds';
 import { Editor } from 'react-draft-wysiwyg';
+import { useHistory } from 'react-router-dom';
 import IncompletePages from '../IncompletePages';
 import { managerReportStatuses, DATE_DISPLAY_FORMAT } from '../../../../../Constants';
 import { getEditorState } from '../../../../../utils';
@@ -25,11 +27,25 @@ const Review = ({
   dateSubmitted,
   pages,
   showDraftViewForApproverAndCreator,
+  creatorIsApprover,
+  onResetToDraft,
+  calculatedStatus,
 }) => {
   const { handleSubmit, register, watch } = useFormContext();
   const watchTextValue = watch('note');
   const textAreaClass = watchTextValue !== '' ? 'yes-print' : 'no-print';
   const { user } = useContext(UserContext);
+  const history = useHistory();
+
+  const onReset = async () => {
+    try {
+      await onResetToDraft();
+      history.push('/activity-reports');
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  };
 
   const defaultEditorState = getEditorState(additionalNotes || 'No creator notes');
   const otherManagerNotes = approverStatusList
@@ -47,6 +63,11 @@ const Review = ({
   const incompletePages = filtered.map((f) => f.label);
   const hasIncompletePages = incompletePages.length > 0;
   const formattedDateSubmitted = dateSubmitted ? moment(dateSubmitted).format(DATE_DISPLAY_FORMAT) : '';
+
+  const showReset = (calculatedStatus !== REPORT_STATUSES.DRAFT && creatorIsApprover);
+
+  console.log({ showReset, calculatedStatus, creatorIsApprover });
+
   return (
     <>
       <h2>{pendingOtherApprovals ? 'Pending other approvals' : 'Review and approve report'}</h2>
@@ -116,6 +137,7 @@ const Review = ({
         <ApproverStatusList approverStatus={approverStatusList} />
         {hasIncompletePages && <IncompletePages incompletePages={incompletePages} />}
         <Button disabled={hasIncompletePages} type="submit">{hasBeenReviewed ? 'Update report' : 'Submit'}</Button>
+        {showReset && <Button className="margin-bottom-3" type="button" outline onClick={onReset}>Reset to Draft</Button>}
       </Form>
     </>
   );
@@ -131,11 +153,14 @@ Review.propTypes = {
     status: PropTypes.string,
   })),
   showDraftViewForApproverAndCreator: PropTypes.bool.isRequired,
+  creatorIsApprover: PropTypes.bool,
   pages: PropTypes.arrayOf(PropTypes.shape({
     state: PropTypes.string,
     review: PropTypes.bool,
     label: PropTypes.string,
   })).isRequired,
+  onResetToDraft: PropTypes.func.isRequired,
+  calculatedStatus: PropTypes.string.isRequired,
 };
 
 Review.defaultProps = {
@@ -143,6 +168,7 @@ Review.defaultProps = {
   additionalNotes: '',
   approverStatusList: [],
   dateSubmitted: null,
+  creatorIsApprover: false,
 };
 
 export default Review;

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/__tests__/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/__tests__/Review.js
@@ -1,0 +1,77 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
+import Review from '../Review';
+import UserContext from '../../../../../../UserContext';
+
+jest.mock('react-router-dom', () => ({
+  useHistory: jest.fn(),
+}));
+
+describe('Review component', () => {
+  const RenderReview = ({ onResetToDraft = jest.fn, creatorIsApprover = false, calculatedStatus = 'draft' }) => {
+    const hookForm = useForm({
+      defaultValues: { name: [] },
+      mode: 'all',
+    });
+
+    return (
+      <FormProvider {...hookForm}>
+        <UserContext.Provider value={{ user: { id: 1 } }}>
+          <Review
+            onFormReview={jest.fn()}
+            pages={[]}
+            showDraftViewForApproverAndCreator={false}
+            creatorIsApprover={creatorIsApprover}
+            onResetToDraft={onResetToDraft}
+            calculatedStatus={calculatedStatus}
+            approverStatusList={[{ user: { id: 1 }, note: 'Test' }]}
+          />
+        </UserContext.Provider>
+      </FormProvider>
+    );
+  };
+
+  it('renders the component', () => {
+    render(<RenderReview />);
+    expect(screen.getByText('Review and approve report')).toBeInTheDocument();
+  });
+
+  it('calls onResetToDraft and redirects to /activity-reports when onReset is called', async () => {
+    const onResetToDraft = jest.fn();
+    const historyPush = jest.fn();
+    useHistory.mockReturnValueOnce({
+      push: historyPush,
+    });
+
+    render(<RenderReview
+      calculatedStatus="submitted"
+      creatorIsApprover
+      onResetToDraft={onResetToDraft}
+    />);
+    fireEvent.click(screen.getByText('Reset to Draft'));
+
+    expect(onResetToDraft).toHaveBeenCalled();
+  });
+  it('handles error to reset to draft', async () => {
+    const onResetToDraft = jest.fn(() => {
+      throw new Error('Error');
+    });
+    const historyPush = jest.fn();
+    useHistory.mockReturnValueOnce({
+      push: historyPush,
+    });
+
+    render(<RenderReview
+      calculatedStatus="submitted"
+      creatorIsApprover
+      onResetToDraft={onResetToDraft}
+    />);
+    fireEvent.click(screen.getByText('Reset to Draft'));
+
+    expect(onResetToDraft).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/index.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 import moment from 'moment-timezone';
 import { Alert } from '@trussworks/react-uswds';
 import { REPORT_STATUSES } from '@ttahub/common';
+import UserContext from '../../../../../UserContext';
 import Review from './Review';
 import Approved from '../Approved';
 import Container from '../../../../../components/Container';
@@ -16,6 +17,8 @@ const Approver = ({
   error,
   isPendingApprover,
   pages,
+  onResetToDraft,
+  onFormSubmit,
 }) => {
   const {
     additionalNotes,
@@ -43,6 +46,7 @@ const Approver = ({
     displayId: formData.displayId,
   };
   const { author } = formData;
+  const { user } = useContext(UserContext);
 
   const pendingApprovalCount = approvers ? approvers.filter((a) => !a.status || a.status === 'needs_action').length : 0;
   const approverCount = approvers ? approvers.length : 0;
@@ -54,6 +58,8 @@ const Approver = ({
   const showDraftViewForApproverAndCreator = (
     approverIsAlsoCreator && calculatedStatus === REPORT_STATUSES.DRAFT
   );
+
+  const submissionFunction = showDraftViewForApproverAndCreator ? onFormSubmit : onFormReview;
 
   const renderTopAlert = () => {
     if (showDraftViewForApproverAndCreator) {
@@ -117,10 +123,13 @@ const Approver = ({
               pendingOtherApprovals={pendingOtherApprovals}
               additionalNotes={additionalNotes}
               dateSubmitted={submittedDate}
-              onFormReview={onFormReview}
+              onFormReview={submissionFunction}
               approverStatusList={approvers}
               pages={pages}
               showDraftViewForApproverAndCreator={showDraftViewForApproverAndCreator}
+              creatorIsApprover={author.id === user.id}
+              onResetToDraft={onResetToDraft}
+              calculatedStatus={calculatedStatus}
             />
           )}
         {approved
@@ -162,6 +171,8 @@ Approver.propTypes = {
     review: PropTypes.bool,
     label: PropTypes.string,
   })).isRequired,
+  onResetToDraft: PropTypes.func.isRequired,
+  onFormSubmit: PropTypes.func.isRequired,
 };
 
 Approver.defaultProps = {

--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/index.js
@@ -155,7 +155,7 @@ describe('ReviewSubmit', () => {
         allComplete, isApprover, isPendingApprover, calculatedStatus, formData, onSubmit, onReview,
       );
       userEvent.selectOptions(screen.getByTestId('dropdown'), ['approved']);
-      const reviewButton = await screen.findByRole('button');
+      const reviewButton = await screen.findByRole('button', { name: 'Submit' });
       userEvent.click(reviewButton);
       await waitFor(() => expect(onReview).toHaveBeenCalled());
     });
@@ -177,7 +177,7 @@ describe('ReviewSubmit', () => {
         allComplete, isApprover, isPendingApprover, calculatedStatus, formData, onSubmit, onReview,
       );
       userEvent.selectOptions(screen.getByTestId('dropdown'), ['approved']);
-      const reviewButton = await screen.findByRole('button');
+      const reviewButton = await screen.findByRole('button', { name: 'Submit' });
       userEvent.click(reviewButton);
       const error = await screen.findByText('Unable to review report');
       expect(error).toBeVisible();

--- a/frontend/src/pages/ActivityReport/Pages/Review/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/index.js
@@ -106,6 +106,8 @@ const ReviewSubmit = ({
             error={error}
             formData={formData}
             isPendingApprover={isPendingApprover}
+            onResetToDraft={onReset}
+            onFormSubmit={onFormSubmit}
           >
             <>
               <Accordion bordered={false} items={items} />

--- a/frontend/src/pages/ActivityReport/Pages/components/ApproverStatusList.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/ApproverStatusList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { uniqueId } from 'lodash';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationCircle, faCheck, faMinus } from '@fortawesome/free-solid-svg-icons';
@@ -29,7 +30,7 @@ const ApproverStatusList = ({
   approverStatus,
 }) => {
   const displayApproverStatusList = () => approverStatus.map((s) => (
-    <li className="margin-bottom-205" key={s.user.fullName}>
+    <li className="margin-bottom-205" key={uniqueId('approver-status-list-')}>
       {getStatusIcon(s.status)}
       <b>{getDisplayStatus(s.status)}</b>
       {s.status === 'approved' ? ' by ' : ' from '}

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -360,7 +360,7 @@ test.describe('Activity Report', () => {
     await page.getByTestId('dropdown').selectOption('approved');
 
     // submit approval
-    await page.getByTestId('form').getByTestId('button').click();
+    await page.getByTestId('form').getByRole('button', { name: 'Submit' }).click();
 
     // this is in the 'approved activity reports' table
     await page.getByRole('rowheader', { name: `R0${regionNumber}-AR-${arNumber}` }).click();
@@ -615,7 +615,7 @@ test.describe('Activity Report', () => {
     await page.getByTestId('dropdown').selectOption('approved');
 
     // submit approval
-    await page.getByTestId('form').getByTestId('button').click();
+    await page.getByTestId('form').getByRole('button', { name: 'Submit' }).click();
 
     // check first recipient
     await page.getByRole('link', { name: 'Recipient TTA Records' }).click();


### PR DESCRIPTION
## Description of change
Reset to draft was not available for creator-approvers (users who were creators and approvers on the same report)
This change allows creator-approvers to reset a report to draft

## How to test
Create a report. Set yourself as an approver. Submit it. You should be reset to draft, as well as be able to resubmit.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2677


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
