### PR TITLE
[TTAHUB-2659] Co-owners can't change public/private setting

### DIFF
--- a/frontend/src/pages/AccountManagement/MyGroups.js
+++ b/frontend/src/pages/AccountManagement/MyGroups.js
@@ -77,8 +77,6 @@ export default function MyGroups({ match }) {
   const watchShareWithEveryone = watch(GROUP_FIELD_NAMES.SHARE_WITH_EVERYONE);
   const watchCoOwners = watch(GROUP_FIELD_NAMES.CO_OWNERS);
 
-  const isCoOwner = watchCoOwners.some((coOwner) => coOwner.value === user.id);
-
   const { groupId } = match.params;
   const [recipientOptions, setRecipientOptions] = useState([]);
   const [userOptions, setUserOptions] = useState([]);
@@ -90,11 +88,14 @@ export default function MyGroups({ match }) {
   const { myGroups, setMyGroups } = useContext(MyGroupsContext);
   const { isAppLoading, setIsAppLoading } = useContext(AppLoadingContext);
 
+  const [groupCreator, setGroupCreator] = useState(null);
+
   useEffect(() => {
     async function getGroup() {
       setIsAppLoading(true);
       try {
         const fetchedGroup = await fetchGroup(groupId);
+        setGroupCreator(fetchedGroup.creator);
         if (fetchedGroup) {
           // Reset form values.
           reset({
@@ -122,6 +123,8 @@ export default function MyGroups({ match }) {
       getGroup();
     }
   }, [groupId, setIsAppLoading, reset, usersFetched, recipientsFetched]);
+
+  const isCreator = !groupId || (groupCreator && user.id === groupCreator.id);
 
   useEffect(() => {
     // get grants/recipients for user
@@ -308,7 +311,7 @@ export default function MyGroups({ match }) {
           </div>
           <div className="margin-top-4">
             <h2 className="margin-bottom-2">Group permissions</h2>
-            {!isCoOwner && (
+            {isCreator && (
             <div className="margin-top-3 display-flex flex-align-end flex-align-center">
               <Controller
                 control={control}

--- a/frontend/src/pages/AccountManagement/MyGroups.js
+++ b/frontend/src/pages/AccountManagement/MyGroups.js
@@ -291,7 +291,7 @@ export default function MyGroups({ match }) {
 
             </div>
           </FormGroup>
-          <div className="margin-top-4">
+          <div className="margin-top-3">
             <label className="display-block margin-bottom-1">
               Recipients
               {' '}
@@ -331,7 +331,7 @@ export default function MyGroups({ match }) {
             </div>
             )}
             {!watchIsPrivate && (
-              <div className="margin-top-4">
+              <div className="margin-top-3">
                 <label className="display-block margin-bottom-1">
                   Add co-owner
                   {' '}
@@ -350,7 +350,7 @@ export default function MyGroups({ match }) {
                     disabled={isAppLoading}
                   />
                 </label>
-                <div className="margin-top-4">
+                <div className="margin-top-3">
                   <label htmlFor={GROUP_FIELD_NAMES.NAME} className="display-block margin-bottom-1">
                     Who do you want to share this group with?
                     {' '}
@@ -386,7 +386,7 @@ export default function MyGroups({ match }) {
                 </div>
                 {
                   watchShareWithEveryone === GROUP_SHARED_WITH.INDIVIDUALS && (
-                    <div className="margin-top-4">
+                    <div className="margin-top-3">
                       <label className="display-block margin-bottom-1">
                         Invite individuals
                         {' '}

--- a/frontend/src/pages/AccountManagement/MyGroups.js
+++ b/frontend/src/pages/AccountManagement/MyGroups.js
@@ -10,6 +10,7 @@ import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import {
   Alert, Button, Checkbox, FormGroup, TextInput, Radio,
 } from '@trussworks/react-uswds';
+import UserContext from '../../UserContext';
 import colors from '../../colors';
 import IndicatesRequiredField from '../../components/IndicatesRequiredField';
 import Req from '../../components/Req';
@@ -71,10 +72,12 @@ export default function MyGroups({ match }) {
       [GROUP_FIELD_NAMES.SHARE_WITH_EVERYONE]: null,
     },
   });
-
+  const { user } = useContext(UserContext);
   const watchIsPrivate = watch(GROUP_FIELD_NAMES.IS_PRIVATE);
   const watchShareWithEveryone = watch(GROUP_FIELD_NAMES.SHARE_WITH_EVERYONE);
   const watchCoOwners = watch(GROUP_FIELD_NAMES.CO_OWNERS);
+
+  const isCoOwner = watchCoOwners.some((coOwner) => coOwner.value === user.id);
 
   const { groupId } = match.params;
   const [recipientOptions, setRecipientOptions] = useState([]);
@@ -152,8 +155,8 @@ export default function MyGroups({ match }) {
         const groupUsers = await getGroupUsers(groupId || 'new');
 
         // Set available.
-        const mappedUsers = groupUsers.map((user) => ({
-          value: user.userId, label: user.name,
+        const mappedUsers = groupUsers.map((mUser) => ({
+          value: mUser.userId, label: mUser.name,
         }));
 
         setUserOptions(mappedUsers);
@@ -305,6 +308,7 @@ export default function MyGroups({ match }) {
           </div>
           <div className="margin-top-4">
             <h2 className="margin-bottom-2">Group permissions</h2>
+            {!isCoOwner && (
             <div className="margin-top-3 display-flex flex-align-end flex-align-center">
               <Controller
                 control={control}
@@ -325,6 +329,7 @@ export default function MyGroups({ match }) {
                 )}
               />
             </div>
+            )}
             {!watchIsPrivate && (
               <div className="margin-top-4">
                 <label className="display-block margin-bottom-1">

--- a/frontend/src/pages/AccountManagement/__tests__/MyGroups.js
+++ b/frontend/src/pages/AccountManagement/__tests__/MyGroups.js
@@ -179,7 +179,7 @@ describe('MyGroups', () => {
         },
       ],
       creator: {
-        id: 1,
+        id: 23,
         name: 'Creator User',
       },
     });
@@ -495,7 +495,7 @@ describe('MyGroups', () => {
       individuals: [],
       coOwners: [],
       creator: {
-        id: 1,
+        id: 23,
         name: 'Creator User',
       },
     });

--- a/frontend/src/pages/AccountManagement/__tests__/MyGroups.js
+++ b/frontend/src/pages/AccountManagement/__tests__/MyGroups.js
@@ -13,18 +13,25 @@ import { GROUP_SHARED_WITH } from '@ttahub/common/src/constants';
 import MyGroups, { GROUP_FIELD_NAMES } from '../MyGroups';
 import MyGroupsProvider from '../../../components/MyGroupsProvider';
 import AppLoadingContext from '../../../AppLoadingContext';
+import UserContext from '../../../UserContext';
 
 const error = 'This group name already exists, please use a different name';
+
+const user = {
+  id: 23,
+};
 
 describe('MyGroups', () => {
   const renderMyGroups = (groupId = null) => {
     render(
       <MemoryRouter>
-        <AppLoadingContext.Provider value={{ isAppLoading: false, setIsAppLoading: jest.fn() }}>
-          <MyGroupsProvider>
-            <MyGroups match={{ params: { groupId }, path: '/my-groups/', url: '' }} />
-          </MyGroupsProvider>
-        </AppLoadingContext.Provider>
+        <UserContext.Provider value={{ user }}>
+          <AppLoadingContext.Provider value={{ isAppLoading: false, setIsAppLoading: jest.fn() }}>
+            <MyGroupsProvider>
+              <MyGroups match={{ params: { groupId }, path: '/my-groups/', url: '' }} />
+            </MyGroupsProvider>
+          </AppLoadingContext.Provider>
+        </UserContext.Provider>
       </MemoryRouter>,
     );
   };
@@ -635,6 +642,74 @@ describe('MyGroups', () => {
       userEvent.click(removeCoOwner);
       await waitFor(() => {
         expect(screen.queryByText(/you can only choose up to three co-owners./i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  it('coOwners cant change the is public check box', async () => {
+    fetchMock.get('/api/groups/1', {
+      id: 1,
+      name: 'group1',
+      isPublic: true,
+      groupCollaborators: [],
+      sharedWith: GROUP_SHARED_WITH.INDIVIDUALS,
+      grants: [
+        {
+          recipientInfo: 'Grant 1 - 11111111 - HS',
+          regionId: 1,
+          recipientId: 1,
+          number: '11111111',
+          id: 1,
+          granteeName: 'Grant Name 1',
+          recipient: {
+            name: 'Recipient Name 1',
+            id: 1,
+          },
+          GroupGrant: {
+            id: 1,
+            grantId: 1,
+            groupId: 1,
+          },
+        },
+      ],
+      coOwners: [
+        {
+          id: 23, // Active co-owner.
+          name: 'co-owner1',
+        },
+      ],
+      individuals: [
+        {
+          id: 3,
+          name: 'individual1',
+        },
+      ],
+      creator: {
+        id: 1,
+        name: 'Creator User',
+      },
+    });
+
+    act(() => {
+      renderMyGroups(1);
+    });
+
+    const input = screen.getByLabelText(/Group name/i);
+    expect(input).toBeInTheDocument();
+    await act(async () => {
+      await waitFor(() => {
+        expect(input.value).toBe('group1');
+        expect(screen.getByText(/grant 1 - 11111111 - hs/i)).toBeInTheDocument();
+
+        expect(screen.getByText(/co-owner1/i)).toBeInTheDocument();
+        expect(screen.getByText(/individual1/i)).toBeInTheDocument();
+
+        // Expect check box 'Keep this group private.' to not be checked.
+        expect(screen.queryAllByRole('checkbox', { name: /keep this group private\./i }).length).toBe(0);
+
+        // Assert radio button 'Individuals in my region' is checked.
+        const radio = screen.getByLabelText(/Individuals in my region/i);
+        expect(radio).toBeChecked();
       });
     });
   });


### PR DESCRIPTION
## Description of change

If a co-owner edits a group they can't change the 'is private' checkbox this can only be updated by the creator.

## How to test

1. Create a group and add a co-owner
2. Edit the group as the co-owner 
3. Verify they cannot see the is private checkbox
4. Edit the group as the creator
5. Verify they can see and change the is private checkbox.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2659


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
