### PR TITLE
[TTAHUB-2647] Add filter to the activity report scopes for goal name

### DIFF
--- a/src/scopes/activityReport/goalName.ts
+++ b/src/scopes/activityReport/goalName.ts
@@ -1,0 +1,22 @@
+import { Op } from 'sequelize';
+import { filterAssociation, argsIncludeExclude } from './utils';
+
+export function withGoalName(searchText: string[]) {
+  const search = [`%${searchText.map((st: string) => st.toLowerCase())}%`];
+
+  return {
+    [Op.and]: [
+      filterAssociation(argsIncludeExclude(true), search, false, 'LIKE'),
+    ],
+  };
+}
+
+export function withoutGoalName(searchText: string[]) {
+  const search = [`%${searchText.map((st) => st.toLowerCase())}%`];
+
+  return {
+    [Op.and]: [
+      filterAssociation(argsIncludeExclude(false), search, false, 'NOT LIKE'),
+    ],
+  };
+}

--- a/src/scopes/activityReport/index.js
+++ b/src/scopes/activityReport/index.js
@@ -31,6 +31,7 @@ import { withResourceAttachment, withoutResourceAttachment } from './resourceAtt
 import { withResourceUrl, withoutResourceUrl } from './resourceUrl';
 import { onlyCollaborators, onlyCreators, bothCollaboratorsAndCreators } from './specialistName';
 import { withActivityReportGoalResponse, withoutActivityReportGoalResponse } from './activityReportGoalResponse';
+import { withGoalName, withoutGoalName } from './goalName';
 
 export const topicToQuery = {
   reportId: {
@@ -127,6 +128,10 @@ export const topicToQuery = {
     aft: (query) => afterEndDate(query),
     win: (query) => withinEndDate(query),
     in: (query) => withinEndDate(query),
+  },
+  goalName: {
+    ctn: (query) => withGoalName(query),
+    nctn: (query) => withoutGoalName(query),
   },
   otherEntities: {
     in: (query) => withOtherEntities(query),

--- a/src/scopes/activityReport/reportText.js
+++ b/src/scopes/activityReport/reportText.js
@@ -1,49 +1,11 @@
 import { Op } from 'sequelize';
-import { filterAssociation } from './utils';
-
-const selectDistinctActivityReports = (join, having) => `
-  SELECT DISTINCT
-    "ActivityReports"."id"
-  FROM "ActivityReports"
-  ${join}
-  GROUP BY "ActivityReports"."id"
-  HAVING ${having}`;
-
-const nextStepsIncludeExclude = (include = true) => {
-  const a = include ? '' : 'bool_or("NextSteps".note IS NULL) OR';
-
-  return selectDistinctActivityReports(
-    'LEFT JOIN "NextSteps" ON "NextSteps"."activityReportId" = "ActivityReports"."id"',
-    `${a} LOWER(STRING_AGG("NextSteps".note, CHR(10)))`,
-  );
-};
-
-const argsIncludeExclude = (include = true) => {
-  const a = include ? '' : 'bool_or("ActivityReportGoals".name IS NULL) OR';
-
-  return selectDistinctActivityReports(
-    'LEFT JOIN "ActivityReportGoals" ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"',
-    `${a} LOWER(STRING_AGG("ActivityReportGoals".name, CHR(10)))`,
-  );
-};
-
-const objectiveTitleAndTtaProvidedIncludeExclude = (include = true) => {
-  const a = include ? '' : 'bool_or("ActivityReportObjectives".title IS NULL OR "ActivityReportObjectives"."ttaProvided" IS NULL) OR';
-
-  return selectDistinctActivityReports(
-    'LEFT JOIN "ActivityReportObjectives" ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"',
-    `${a} LOWER(STRING_AGG(concat_ws(CHR(10), "ActivityReportObjectives".title, "ActivityReportObjectives"."ttaProvided"), CHR(10)))`,
-  );
-};
-
-const activityReportContextandAdditionalNotesIncludeExclude = (include = true) => {
-  const a = include ? '' : 'bool_or("ActivityReports"."context" IS NULL) OR';
-
-  return selectDistinctActivityReports(
-    '',
-    `${a} LOWER(STRING_AGG(concat_ws(CHR(10), "ActivityReports"."context", "ActivityReports"."additionalNotes"), CHR(10)))`,
-  );
-};
+import {
+  filterAssociation,
+  nextStepsIncludeExclude,
+  argsIncludeExclude,
+  objectiveTitleAndTtaProvidedIncludeExclude,
+  activityReportContextandAdditionalNotesIncludeExclude,
+} from './utils';
 
 export function withReportText(searchText) {
   const search = [`%${searchText.map((st) => st.toLowerCase())}%`];

--- a/src/scopes/activityReport/utils.js
+++ b/src/scopes/activityReport/utils.js
@@ -64,3 +64,47 @@ export default function filterArray(
 export function filterAssociation(baseQuery, searchTerms, exclude, comparator = '~*') {
   return filter(baseQuery, searchTerms, exclude, reportInSubQuery, comparator);
 }
+
+const selectDistinctActivityReports = (join, having) => `
+  SELECT DISTINCT
+    "ActivityReports"."id"
+  FROM "ActivityReports"
+  ${join}
+  GROUP BY "ActivityReports"."id"
+  HAVING ${having}`;
+
+export const nextStepsIncludeExclude = (include = true) => {
+  const a = include ? '' : 'bool_or("NextSteps".note IS NULL) OR';
+
+  return selectDistinctActivityReports(
+    'LEFT JOIN "NextSteps" ON "NextSteps"."activityReportId" = "ActivityReports"."id"',
+    `${a} LOWER(STRING_AGG("NextSteps".note, CHR(10)))`,
+  );
+};
+
+export const argsIncludeExclude = (include = true) => {
+  const a = include ? '' : 'bool_or("ActivityReportGoals".name IS NULL) OR';
+
+  return selectDistinctActivityReports(
+    'LEFT JOIN "ActivityReportGoals" ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"',
+    `${a} LOWER(STRING_AGG("ActivityReportGoals".name, CHR(10)))`,
+  );
+};
+
+export const objectiveTitleAndTtaProvidedIncludeExclude = (include = true) => {
+  const a = include ? '' : 'bool_or("ActivityReportObjectives".title IS NULL OR "ActivityReportObjectives"."ttaProvided" IS NULL) OR';
+
+  return selectDistinctActivityReports(
+    'LEFT JOIN "ActivityReportObjectives" ON "ActivityReportObjectives"."activityReportId" = "ActivityReports"."id"',
+    `${a} LOWER(STRING_AGG(concat_ws(CHR(10), "ActivityReportObjectives".title, "ActivityReportObjectives"."ttaProvided"), CHR(10)))`,
+  );
+};
+
+export const activityReportContextandAdditionalNotesIncludeExclude = (include = true) => {
+  const a = include ? '' : 'bool_or("ActivityReports"."context" IS NULL) OR';
+
+  return selectDistinctActivityReports(
+    '',
+    `${a} LOWER(STRING_AGG(concat_ws(CHR(10), "ActivityReports"."context", "ActivityReports"."additionalNotes"), CHR(10)))`,
+  );
+};


### PR DESCRIPTION
## Description of change
This change just puts the backend code in place for the goal name filter. There will be several of these PRs incoming; they are all prerequisite for the frontend ticket, which will come last.

## How to test
Evaluate the code. You can attach "logging: console.log" to the options passed to the ActivityReport.findAlls added to the test to see the SQL generated if that helps evaluate the correctness. Ensure the test adequately covers the use case.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2647


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
