### PR TITLE
[TTAHUB-2725] Fix behavior when approver is creator and report is in draft

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/Review.js
@@ -18,6 +18,7 @@ import ApproverStatusList from '../../components/ApproverStatusList';
 import DisplayApproverNotes from '../../components/DisplayApproverNotes';
 import UserContext from '../../../../../UserContext';
 import IndicatesRequiredField from '../../../../../components/IndicatesRequiredField';
+import ApproverSelect from '../Submitter/components/ApproverSelect';
 
 const Review = ({
   additionalNotes,
@@ -30,6 +31,7 @@ const Review = ({
   creatorIsApprover,
   onResetToDraft,
   calculatedStatus,
+  availableApprovers,
 }) => {
   const { handleSubmit, register, watch } = useFormContext();
   const watchTextValue = watch('note');
@@ -100,6 +102,7 @@ const Review = ({
             />
           </div>
         </Fieldset>
+
         { !showDraftViewForApproverAndCreator ? (
           <>
             {
@@ -130,8 +133,31 @@ const Review = ({
                 ))}
               </Dropdown>
             </FormItem>
+
           </>
-        ) : <div className="margin-bottom-3" />}
+        ) : (
+          <div className="margin-bottom-3">
+            <Fieldset className="smart-hub--report-legend margin-top-4" legend="Review and submit report">
+              <p className="margin-top-4">
+                Submitting this form for approval means that you will no longer be in draft
+                mode. Please review all information in each section before submitting to your
+                manager(s) for approval.
+              </p>
+              <FormItem
+                label="Approving manager"
+                name="approvers"
+              >
+                <ApproverSelect
+                  name="approvers"
+                  valueProperty="user.id"
+                  labelProperty="user.fullName"
+                  options={availableApprovers.map((a) => ({ value: a.id, label: a.name }))}
+                />
+              </FormItem>
+            </Fieldset>
+          </div>
+        )}
+
         <ApproverStatusList approverStatus={approverStatusList} />
         {hasIncompletePages && <IncompletePages incompletePages={incompletePages} />}
         <Button disabled={hasIncompletePages} type="submit">{hasBeenReviewed ? 'Update report' : 'Submit'}</Button>
@@ -159,6 +185,10 @@ Review.propTypes = {
   })).isRequired,
   onResetToDraft: PropTypes.func.isRequired,
   calculatedStatus: PropTypes.string.isRequired,
+  availableApprovers: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  })).isRequired,
 };
 
 Review.defaultProps = {

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/__tests__/index.js
@@ -56,6 +56,7 @@ const RenderApprover = ({
         formData={formData}
         isPendingApprover
         pages={pages}
+        availableApprovers={[{ id: 1, name: 'Approver 1' }]}
       >
         <div>
           test

--- a/frontend/src/pages/ActivityReport/Pages/Review/Approver/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Approver/index.js
@@ -19,6 +19,7 @@ const Approver = ({
   pages,
   onResetToDraft,
   onFormSubmit,
+  availableApprovers,
 }) => {
   const {
     additionalNotes,
@@ -130,6 +131,7 @@ const Approver = ({
               creatorIsApprover={author.id === user.id}
               onResetToDraft={onResetToDraft}
               calculatedStatus={calculatedStatus}
+              availableApprovers={availableApprovers}
             />
           )}
         {approved
@@ -145,6 +147,12 @@ const Approver = ({
 };
 
 Approver.propTypes = {
+  availableApprovers: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+  ).isRequired,
   onFormReview: PropTypes.func.isRequired,
   reviewed: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,

--- a/frontend/src/pages/ActivityReport/Pages/Review/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/index.js
@@ -99,6 +99,7 @@ const ReviewSubmit = ({
       {isApprover
         && (
           <Approver
+            availableApprovers={availableApprovers}
             reviewed={reviewed}
             pages={pages}
             additionalNotes={additionalNotes}


### PR DESCRIPTION
## Description of change

Per user request - if a user is an approver and the creator, and the report is in "needs action", allow that user to reset the report to draft.

## How to test

- Load prod data
- Impersonate user 160
- open report 40979
- reset report to draft
- remove yourself (user160) as an approver
- Add a different approver and resubmit

Or, with your own database and environment, set yourself as an approver and creators on a report and then reset that report to draft. Remove yourself as an approver, choose a different approver, and resubmit. 

Confirm that the functionality doesn't exist for approvers who aren't creators, or creators who aren't approvers (on a given report)

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2725


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
