### PR TITLE
[TTTAHUB-2736] Update goal similarity api to use region id

### DIFF
--- a/similarity_api/src/routes/create.py
+++ b/similarity_api/src/routes/create.py
@@ -28,16 +28,22 @@ def create_routes(app: Flask):
       cluster = data["cluster"] if "cluster" in data else False
       include_curated_templates = data["include_curated_templates"] if "include_curated_templates" in data else False
 
+      regionId = data["regionId"] if "regionId" in data else None
+
+      ## If region is not specified, then return error.
+      if regionId is None:
+            return jsonify({"error": "regionId not provided"}), 400
+
       if "text" in data and "recipient_id" in data:
           recipient_id = data["recipient_id"]
           text = data["text"]
-          return find_similar_goals(recipient_id, text, alpha, include_curated_templates)
+          return find_similar_goals(recipient_id, text, alpha, regionId, include_curated_templates)
       elif "text_1" in data and "text_2" in data:
           text_1 = data["text_1"]
           text_2 = data["text_2"]
           return calculate_string_similarity(text_1, text_2)
       elif "recipient_id" in data:
           recipient_id = data["recipient_id"]
-          return compute_goal_similarities(recipient_id, alpha, cluster)
+          return compute_goal_similarities(recipient_id, alpha, cluster, regionId)
       else:
           return jsonify({"error": "recipient_id not provided"}), 400

--- a/src/goalServices/getGoalIdsBySimiliarity.test.js
+++ b/src/goalServices/getGoalIdsBySimiliarity.test.js
@@ -562,7 +562,7 @@ describe('getGoalIdsBySimilarity', () => {
       flags: ['closed_goal_merge_override'],
     };
 
-    const idsSets = await getGoalIdsBySimilarity(recipient.id, user);
+    const idsSets = await getGoalIdsBySimilarity(recipient.id, activeGrant.regionId, user);
 
     // we expect goal group three to be eliminated, so we should have two sets + an empty
     expect(idsSets).toHaveLength(3);

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -2680,7 +2680,7 @@ export const hasMultipleGoalsOnSameActivityReport = (countObject) => Object.valu
 *  ids: number[]
 * }[]
 */
-export async function getGoalIdsBySimilarity(recipientId, user = null) {
+export async function getGoalIdsBySimilarity(recipientId, regionId, user = null) {
   /**
    * if a user has the ability to merged closed curated goals, we will show them in the UI
    */
@@ -2704,7 +2704,7 @@ export async function getGoalIdsBySimilarity(recipientId, user = null) {
 
   // otherwise, we'll create the groups
   // with a little if just in case the similarity API craps out on us (technical term)
-  const similarity = await similarGoalsForRecipient(recipientId, true);
+  const similarity = await similarGoalsForRecipient(recipientId, true, regionId);
   let result = [];
   if (similarity) {
     result = similarity.result;

--- a/src/routes/goals/handlers.js
+++ b/src/routes/goals/handlers.js
@@ -288,11 +288,12 @@ export async function getSimilarGoalsForRecipient(req, res) {
     return;
   }
   const recipientId = parseInt(req.params.recipientId, DECIMAL_BASE);
+  const regionId = parseInt(req.params.regionId, DECIMAL_BASE);
 
   try {
     const userId = await currentUserId(req, res);
     const user = await userById(userId);
-    res.json(await getGoalIdsBySimilarity(recipientId, user));
+    res.json(await getGoalIdsBySimilarity(recipientId, regionId, user));
   } catch (error) {
     await handleErrors(req, res, error, `${logContext}:GET_SIMILAR_GOALS_FOR_RECIPIENT`);
   }

--- a/src/services/similarity.js
+++ b/src/services/similarity.js
@@ -38,11 +38,13 @@ async function postToSimilarity(body) {
 export async function similarGoalsForRecipient(
   recipient_id,
   cluster,
+  regionId,
   refinements = { alpha: 0.9 },
 ) {
   return postToSimilarity({
     recipient_id,
     cluster,
+    regionId,
     ...refinements,
   });
 }


### PR DESCRIPTION
## Description of change

The goal similarity API is not taking into account the region id when getting similar goals. This changes passes the region id to the python endpoint to ensure suggested matches are for the same region.

**Note:** Not sure how we want to handle these if they already exist in the database. We can do a one off delete for these recipients in particular.

## How to test

- Review the code.
- Using a prod db edit a multi region recipient from the RTR (see jira)
- Make sure the list of suggested merge goals are all for the same region.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2736

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
