### PR TITLE
[TTAHUB-2736] Alternate solution for filtering similarity response by region ID

### DIFF
--- a/src/goalServices/getGoalIdsBySimiliarity.test.js
+++ b/src/goalServices/getGoalIdsBySimiliarity.test.js
@@ -562,7 +562,7 @@ describe('getGoalIdsBySimilarity', () => {
       flags: ['closed_goal_merge_override'],
     };
 
-    const idsSets = await getGoalIdsBySimilarity(recipient.id, user);
+    const idsSets = await getGoalIdsBySimilarity(recipient.id, activeGrant.regionId, user);
 
     // we expect goal group three to be eliminated, so we should have two sets + an empty
     expect(idsSets).toHaveLength(3);

--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -2680,7 +2680,7 @@ export const hasMultipleGoalsOnSameActivityReport = (countObject) => Object.valu
 *  ids: number[]
 * }[]
 */
-export async function getGoalIdsBySimilarity(recipientId, user = null) {
+export async function getGoalIdsBySimilarity(recipientId, regionId, user = null) {
   /**
    * if a user has the ability to merged closed curated goals, we will show them in the UI
    */
@@ -2696,6 +2696,7 @@ export async function getGoalIdsBySimilarity(recipientId, user = null) {
     recipientId,
     similiarityWhere,
     hasClosedMergeGoalOverride,
+    regionId,
   );
 
   if (existingRecipientGroups.length) {
@@ -2866,6 +2867,7 @@ export async function getGoalIdsBySimilarity(recipientId, user = null) {
     recipientId,
     similiarityWhere,
     hasClosedMergeGoalOverride,
+    regionId,
   );
 }
 

--- a/src/routes/goals/handlers.js
+++ b/src/routes/goals/handlers.js
@@ -288,11 +288,12 @@ export async function getSimilarGoalsForRecipient(req, res) {
     return;
   }
   const recipientId = parseInt(req.params.recipientId, DECIMAL_BASE);
+  const regionId = parseInt(req.params.regionId, DECIMAL_BASE);
 
   try {
     const userId = await currentUserId(req, res);
     const user = await userById(userId);
-    res.json(await getGoalIdsBySimilarity(recipientId, user));
+    res.json(await getGoalIdsBySimilarity(recipientId, regionId, user));
   } catch (error) {
     await handleErrors(req, res, error, `${logContext}:GET_SIMILAR_GOALS_FOR_RECIPIENT`);
   }

--- a/src/routes/recipient/handlers.js
+++ b/src/routes/recipient/handlers.js
@@ -143,7 +143,7 @@ export async function getGoalsFromRecipientGoalSimilarityGroup(req, res) {
     const response = await getSimilarityGroupById(goalGroupId, {
       finalGoalId: null,
       userHasInvalidated: false,
-    });
+    }, regionId);
 
     if (!response) {
       res.sendStatus(httpCodes.NOT_FOUND);
@@ -161,6 +161,7 @@ export async function getGoalsFromRecipientGoalSimilarityGroup(req, res) {
         sortBy: 'goal',
         sortDir: 'asc',
         offset: 0,
+        limit: 100,
       },
     );
     res.json(recipientGoals);

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -864,7 +864,7 @@ describe('getGoalsFromRecipientGoalSimilarityGroup', () => {
     expect(getSimilarityGroupById).toHaveBeenCalledWith(req.params.goalGroupId, {
       finalGoalId: null,
       userHasInvalidated: false,
-    });
+    }, 1);
     expect(getGoalsByActivityRecipient)
       .toHaveBeenCalledWith(req.params.recipientId, req.params.regionId, {
         goalIds: goals,
@@ -892,7 +892,7 @@ describe('getGoalsFromRecipientGoalSimilarityGroup', () => {
     expect(getSimilarityGroupById).toHaveBeenCalledWith(req.params.goalGroupId, {
       finalGoalId: null,
       userHasInvalidated: false,
-    });
+    }, 1);
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(NOT_FOUND);
   });
 

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -868,6 +868,7 @@ describe('getGoalsFromRecipientGoalSimilarityGroup', () => {
     expect(getGoalsByActivityRecipient)
       .toHaveBeenCalledWith(req.params.recipientId, req.params.regionId, {
         goalIds: goals,
+        limit: 100,
         sortBy: 'goal',
         sortDir: 'asc',
         offset: 0,

--- a/src/services/goalSimilarityGroup.ts
+++ b/src/services/goalSimilarityGroup.ts
@@ -59,7 +59,21 @@ export const flattenSimilarityGroupGoals = (group: SimilarityGroup) => ({
 export async function getSimilarityGroupById(
   similarityGroupId: number,
   where : WhereOptions = {},
+  regionId: number = null,
 ) {
+  const goalsInclude = [];
+  if (regionId) {
+    goalsInclude.push({
+      model: Grant,
+      as: 'grant',
+      attributes: [],
+      required: true,
+      where: {
+        regionId,
+      },
+    });
+  }
+
   const group = await GoalSimilarityGroup.findOne({
     where: {
       ...where,
@@ -71,6 +85,7 @@ export async function getSimilarityGroupById(
         model: Goal,
         as: 'goals',
         attributes: ['id'],
+        include: goalsInclude,
       },
     ],
     attributes: similarityGroupAttributes,
@@ -172,7 +187,7 @@ export async function getSimilarityGroupsByRecipientId(
       model: Goal,
       as: 'goals',
       attributes: ['id', 'goalTemplateId', 'status'],
-      required: false,
+      required: true,
       include: goalsInclude,
     }],
   });

--- a/src/services/goalSimilarityGroup.ts
+++ b/src/services/goalSimilarityGroup.ts
@@ -187,7 +187,7 @@ export async function getSimilarityGroupsByRecipientId(
       model: Goal,
       as: 'goals',
       attributes: ['id', 'goalTemplateId', 'status'],
-      required: true,
+      required: false,
       include: goalsInclude,
     }],
   });


### PR DESCRIPTION
## Description of change
An approach to solving the present user issue detailed in #2043 that wouldn't involve any DB schema updates or having to invalidate any existing similarity groups. Reasons why we might want an alternate approach are detailed in the discussion on that PR.

## How to test
- Load prod data
- Visit /recipient-tta-records/1411/region/5/rttapa. Note the number of similarity goals. Visit each goal; none should take you to blank pages
- Visit /recipient-tta-records/1411/region/9/rttapa. Note the number of similarity goals. The groups should be different than the previous page. Visit each goal; none should take you to blank pages

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2736


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
