### PR TITLE
[TTAHUB-2745] Prevent saving of session reports in data blob

### DIFF
--- a/frontend/src/pages/TrainingReportForm/index.js
+++ b/frontend/src/pages/TrainingReportForm/index.js
@@ -234,6 +234,7 @@ export default function TrainingReportForm({ match }) {
         pocIds,
         collaboratorIds,
         regionId,
+        sessionReports,
         ...data
       } = hookForm.getValues();
 


### PR DESCRIPTION
## Description of change

User was unable to save event due to the fact the the payload became too large. After some investigation it turns out we were saving nested session reports with each save in the blob.

This fix removes the session reports from the event save data.

## How to test

-Review the code
-Impersonate the user from the JIRA ticket you should be able to save the event without issue.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2745


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
