### PR TITLE
[TTAHUB-2510] Add IST visit dropdown to session form

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ parameters:
     default: "mb/TTAHUB-2501/front-end-goal-name-filter"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "jp/2751/focus"
+    default: "mb/TTAHUB-2510/add-IST-visit-dropdown"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/frontend/src/pages/SessionForm/__tests__/index.js
+++ b/frontend/src/pages/SessionForm/__tests__/index.js
@@ -42,6 +42,7 @@ describe('SessionReportForm', () => {
     fetchMock.get('/api/alerts', []);
     fetchMock.get('/api/topic', [{ id: 1, name: 'Behavioral Health' }]);
     fetchMock.get('/api/users/statistics', {});
+    fetchMock.get('/api/courses', []);
     fetchMock.get('/api/national-center', [
       'DTL',
       'HBHS',
@@ -49,6 +50,7 @@ describe('SessionReportForm', () => {
       'PFMO',
     ].map((name, id) => ({ id, name })));
     fetchMock.get('/api/feeds/item?tag=ttahub-topic', mockRSSData());
+    fetchMock.get('/api/feeds/item?tag=ttahub-tta-support-type', mockRSSData());
   });
 
   it('creates a new session if id is "new"', async () => {
@@ -330,6 +332,8 @@ describe('SessionReportForm', () => {
       specialistNextSteps: [{ note: 'A', completeDate: '01/01/2024' }],
       recipientNextSteps: [{ note: 'B', completeDate: '01/01/2024' }],
       language: ['English'],
+      isIstVisit: 'Yes',
+      regionalOfficeTta: ['DTL'],
     };
 
     fetchMock.get(url, formData);

--- a/frontend/src/pages/SessionForm/components/ParticipantsNumberOfParticipants.js
+++ b/frontend/src/pages/SessionForm/components/ParticipantsNumberOfParticipants.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TextInput } from '@trussworks/react-uswds';
+import FormItem from '../../../components/FormItem';
+
+export default function ParticipantsNumberOfParticipants({ register, isHybrid }) {
+  return (
+    <div>
+      {isHybrid ? (
+        <>
+          <div>
+            <FormItem
+              label="Number of participants attending in person "
+              name="numberOfParticipantsInPerson"
+              required
+            >
+              <div className="maxw-card-lg">
+                <TextInput
+                  id="numberOfParticipantsInPerson"
+                  name="numberOfParticipantsInPerson"
+                  type="number"
+                  min={1}
+                  required
+                  inputRef={
+                        register({
+                          required: 'Enter number of participants attending in person',
+                          valueAsNumber: true,
+                          min: {
+                            value: 1,
+                            message: 'Number of participants can not be zero or negative',
+                          },
+                        })
+                      }
+                />
+              </div>
+            </FormItem>
+          </div>
+          <div>
+            <FormItem
+              label="Number of participants attending virtually "
+              name="numberOfParticipantsVirtually"
+              required
+            >
+              <div className="maxw-card-lg">
+                <TextInput
+                  required
+                  id="numberOfParticipantsVirtually"
+                  name="numberOfParticipantsVirtually"
+                  type="number"
+                  min={1}
+                  inputRef={
+                        register({
+                          required: 'Enter number of participants attending virtually',
+                          valueAsNumber: true,
+                          min: {
+                            value: 1,
+                            message: 'Number of participants can not be zero or negative',
+                          },
+                        })
+                      }
+                />
+              </div>
+            </FormItem>
+          </div>
+        </>
+      ) : (
+        <div>
+          <FormItem
+            label="Number of participants "
+            name="numberOfParticipants"
+          >
+            <div className="maxw-card-lg">
+              <TextInput
+                required
+                id="numberOfParticipants"
+                name="numberOfParticipants"
+                type="number"
+                min={1}
+                inputRef={
+                      register({
+                        required: 'Enter number of participants',
+                        valueAsNumber: true,
+                        min: {
+                          value: 1,
+                          message: 'Number of participants can not be zero or negative',
+                        },
+                      })
+                    }
+              />
+            </div>
+          </FormItem>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ParticipantsNumberOfParticipants.propTypes = {
+  register: PropTypes.func.isRequired,
+  isHybrid: PropTypes.bool.isRequired,
+};

--- a/frontend/src/pages/SessionForm/components/ParticipantsReadOnly.js
+++ b/frontend/src/pages/SessionForm/components/ParticipantsReadOnly.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Helmet } from 'react-helmet';
+import { capitalize } from 'lodash';
+import PocCompleteView from '../../../components/PocCompleteView';
+import ReadOnlyField from '../../../components/ReadOnlyField';
+
+export default function ParticipantsReadOnly({ formData, userId }) {
+  const isHybrid = formData.deliveryMethod === 'hybrid';
+  const isIstVisit = formData.isIstVisit === 'yes';
+  const isNotIstVisit = formData.isIstVisit === 'no';
+
+  return (
+    <PocCompleteView formData={formData} userId={userId}>
+      <Helmet>
+        <title>Session Participants</title>
+      </Helmet>
+      {isNotIstVisit && (
+      <ReadOnlyField label="Recipients">
+        {formData.recipients.map((r) => r.label).join('\n')}
+      </ReadOnlyField>
+      )}
+      {isIstVisit && (
+      <ReadOnlyField label="Regional Office/TTA">
+        {formData.regionalOfficeTta.join(', ')}
+      </ReadOnlyField>
+      )}
+
+      {isHybrid ? (
+        <>
+          <ReadOnlyField label="Number of participants attending in person">
+            {formData.numberOfParticipantsInPerson}
+          </ReadOnlyField>
+          <ReadOnlyField label="Number of participants attending virtually">
+            {formData.numberOfParticipantsVirtually}
+          </ReadOnlyField>
+        </>
+      ) : (
+        <ReadOnlyField label="Number of participants">
+          {formData.numberOfParticipants}
+        </ReadOnlyField>
+      )}
+      <ReadOnlyField label="Recipient participants">
+        {formData.participants.join('\n')}
+      </ReadOnlyField>
+      <ReadOnlyField label="Delivery method">
+        {capitalize(formData.deliveryMethod)}
+      </ReadOnlyField>
+      <ReadOnlyField label="Language used">
+        {formData.language.join('\n')}
+      </ReadOnlyField>
+    </PocCompleteView>
+  );
+}
+
+ParticipantsReadOnly.propTypes = {
+  formData: PropTypes.shape({
+    recipients: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string,
+    })),
+    numberOfParticipants: PropTypes.number,
+    numberOfParticipantsInPerson: PropTypes.number,
+    numberOfParticipantsVirtually: PropTypes.number,
+    participants: PropTypes.arrayOf(PropTypes.string),
+    deliveryMethod: PropTypes.string,
+    language: PropTypes.arrayOf(PropTypes.string),
+    isIstVisit: PropTypes.string,
+    regionalOfficeTta: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+  userId: PropTypes.number.isRequired,
+};

--- a/frontend/src/pages/SessionForm/constants.js
+++ b/frontend/src/pages/SessionForm/constants.js
@@ -26,7 +26,6 @@ export const sessionSummaryFields = {
 };
 
 export const participantsFields = {
-  participants: [],
   deliveryMethod: '',
   numberOfParticipants: '',
   language: [],

--- a/frontend/src/pages/SessionForm/constants.js
+++ b/frontend/src/pages/SessionForm/constants.js
@@ -2,22 +2,27 @@ import React from 'react';
 import { NOT_STARTED } from '../../components/Navigator/constants';
 
 export const NO_ERROR = <></>;
-export const sessionSummaryFields = {
-  // not including start date or end date
-  // because when I do, it seems to befuddle the
-  // loading of the form
+
+export const sessionSummaryRequiredFields = {
   sessionName: '',
   duration: '',
   context: '',
   objective: '',
   objectiveTopics: [],
   objectiveTrainers: [],
-  objectiveResources: [],
   objectiveSupportType: '',
-  files: [],
   regionId: '',
   ttaProvided: '',
+};
+
+export const sessionSummaryFields = {
+  // not including start date or end date
+  // because when I do, it seems to befuddle the
+  // loading of the form
+  ...sessionSummaryRequiredFields,
+  objectiveResources: [],
   courses: [],
+  files: [],
 };
 
 export const participantsFields = {
@@ -25,6 +30,7 @@ export const participantsFields = {
   deliveryMethod: '',
   numberOfParticipants: '',
   language: [],
+  isIstVisit: '',
 };
 
 export const nextStepsFields = {
@@ -57,4 +63,12 @@ export const defaultValues = {
 export const pageComplete = (
   hookForm,
   fields,
-) => fields.every((field) => hookForm.getValues(field));
+) => fields.every((field) => {
+  const val = hookForm.getValues(field);
+
+  if (Array.isArray(val)) {
+    return val.length > 0;
+  }
+
+  return !!(val);
+});

--- a/frontend/src/pages/SessionForm/pages/__tests__/participants.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/participants.js
@@ -82,6 +82,7 @@ describe('participants', () => {
       eventName: 'Event name',
       regionId: 1,
       status: 'In progress',
+      isIstVisit: 'no',
       recipients: [],
       pageState: {
         1: NOT_STARTED,
@@ -175,6 +176,24 @@ describe('participants', () => {
         );
       });
     });
+
+    it('toggles IST questions conditionally', async () => {
+      act(() => {
+        render(<RenderParticipants />);
+      });
+      await waitFor(() => expect(fetchMock.called(participantsUrl)).toBeTruthy());
+      await selectEvent.select(screen.getByLabelText(/recipients/i), 'R0');
+
+      act(() => {
+        userEvent.click(
+          screen.getByLabelText(/yes/i),
+        );
+      });
+
+      expect(screen.getByLabelText(/yes/i)).toBeChecked();
+      await selectEvent.select(screen.getByLabelText(/Regional Office\/TTA/i), 'TTAC');
+    });
+
     it('shows read only mode', async () => {
       const readOnlyFormValues = {
         ...defaultFormValues,
@@ -231,6 +250,7 @@ describe('participants', () => {
         numberOfParticipantsVirtually: 1,
         participants: ['Home Visitor'],
         language: ['English'],
+        isIstVisit: 'no',
       };
 
       act(() => {
@@ -253,6 +273,44 @@ describe('participants', () => {
       expect(virtuallyLabel).toBeVisible();
     });
 
+    it('shows read only mode correctly for ist visit selection', async () => {
+      const readOnlyFormValues = {
+        ...defaultFormValues,
+        pocComplete: true,
+        pocCompleteId: userId,
+        pocCompleteDate: todaysDate,
+        event: {
+          pocIds: [userId],
+        },
+        recipients: [
+          {
+            id: 1,
+            label: 'R1 R1 G1',
+          },
+        ],
+        deliveryMethod: 'hybrid',
+        numberOfParticipants: 2,
+        numberOfParticipantsInPerson: 1,
+        numberOfParticipantsVirtually: 1,
+        participants: ['Home Visitor'],
+        language: ['English'],
+        isIstVisit: 'yes',
+        regionalOfficeTta: ['AA', 'TTAC'],
+      };
+
+      act(() => {
+        render(<RenderParticipants formValues={readOnlyFormValues} />);
+      });
+      await waitFor(async () => expect(await screen.findByText('Home Visitor')).toBeVisible());
+
+      // confirm alert
+      const alert = await screen.findByText(/sent an email to the event creator and collaborator/i);
+      expect(alert).toBeVisible();
+
+      const regionalOfficeTta = await screen.findByText(/aa, ttac/i);
+      expect(regionalOfficeTta).toBeVisible();
+    });
+
     describe('groups', () => {
       it('correctly shows and hides all group options', async () => {
         render(<RenderParticipants />);
@@ -260,7 +318,7 @@ describe('participants', () => {
         // Click the use group checkbox.
         let useGroupCheckbox = await screen.findByRole('checkbox', { name: /use group/i });
 
-        await act(() => {
+        act(() => {
           userEvent.click(useGroupCheckbox);
         });
 
@@ -270,7 +328,7 @@ describe('participants', () => {
 
         // Uncheck the use group checkbox.
         useGroupCheckbox = screen.getByRole('checkbox', { name: /use group/i });
-        await act(() => {
+        act(() => {
           userEvent.click(useGroupCheckbox);
         });
 
@@ -296,7 +354,7 @@ describe('participants', () => {
 
         // Click the use group checkbox.
         const useGroupCheckbox = await screen.findByRole('checkbox', { name: /use group/i });
-        await act(() => {
+        act(() => {
           userEvent.click(useGroupCheckbox);
         });
 

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -28,18 +28,19 @@ import ParticipantsReadOnly from '../components/ParticipantsReadOnly';
 const placeholderText = '- Select -';
 
 const ROLE_OPTIONS = [
-  'AA',
+  'Admin. Assistant',
   'COR',
-  'ECM',
-  'ECS',
-  'FES',
-  'GS',
-  'GSM',
-  'HS',
-  'PS',
-  'RPM',
-  'SPS',
-  'SS',
+  'Early Childhood Manager',
+  'Early Childhood Specialist',
+  'Family Engagement Specialist',
+  'Grantee Specialist',
+  'Grantee Specialist Manager',
+  'Grants Specialist',
+  'Health Specialist',
+  'Program Specialist',
+  'Region Program Manager',
+  'Supervisory Program Specialist',
+  'System Specialist',
   'TTAC',
 ];
 

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -70,7 +70,7 @@ const Participants = ({ formData }) => {
     }
 
     if (!istSelectionComplete) {
-      setValue('istVisitSelectionRequired', true);
+      setValue('istSelectionComplete', true);
     }
   }, [formData, setValue]);
 

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -58,6 +58,23 @@ const Participants = ({ formData }) => {
   const isIstVisit = watch('isIstVisit') === 'yes';
   const isNotIstVisit = watch('isIstVisit') === 'no';
 
+  // handle existing sessions
+  useDeepCompareEffect(() => {
+    const {
+      istSelectionComplete,
+      recipients,
+    } = formData;
+
+    if (!istSelectionComplete && recipients.length) {
+      setValue('isIstVisit', 'no');
+    }
+
+    if (!istSelectionComplete) {
+      setValue('istVisitSelectionRequired', true);
+    }
+  }, [formData, setValue]);
+
+  // clear values between toggles
   useDeepCompareEffect(() => {
     if (isIstVisit) {
       setValue('recipients', []);
@@ -105,6 +122,7 @@ const Participants = ({ formData }) => {
           className="smart-hub--report-checkbox"
           inputRef={register({ required: 'Select one' })}
         />
+        <input type="hidden" name="istSelectionComplete" ref={register} />
       </FormItem>
 
       {isNotIstVisit && (
@@ -295,6 +313,7 @@ Participants.propTypes = {
     recipients: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string,
     })),
+    istSelectionComplete: PropTypes.bool,
     event: PropTypes.shape({
       id: PropTypes.number,
       name: PropTypes.string,

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -63,9 +63,12 @@ const Participants = ({ formData }) => {
     const {
       istSelectionComplete,
       recipients,
+      participants,
     } = formData;
 
-    if (!istSelectionComplete && recipients && recipients.length) {
+    const formStarted = (recipients && recipients.length) || (participants && participants.length);
+
+    if (!istSelectionComplete && formStarted) {
       setValue('isIstVisit', 'no');
     }
 
@@ -78,6 +81,7 @@ const Participants = ({ formData }) => {
   useDeepCompareEffect(() => {
     if (isIstVisit) {
       setValue('recipients', []);
+      setValue('participants', []);
     }
 
     if (isNotIstVisit) {
@@ -126,7 +130,26 @@ const Participants = ({ formData }) => {
       </FormItem>
 
       {isNotIstVisit && (
-        <RecipientsWithGroups />
+        <>
+          <RecipientsWithGroups />
+          <div className="margin-top-2">
+            <FormItem
+              label="Recipient participants "
+              name="participants"
+            >
+              <MultiSelect
+                name="participants"
+                control={control}
+                placeholderText={placeholderText}
+                options={
+              recipientParticipants
+                .map((participant) => ({ value: participant, label: participant }))
+                }
+                required="Select at least one participant"
+              />
+            </FormItem>
+          </div>
+        </>
       )}
 
       {isIstVisit && (
@@ -149,23 +172,6 @@ const Participants = ({ formData }) => {
       </div>
       )}
 
-      <div className="margin-top-2">
-        <FormItem
-          label="Recipient participants "
-          name="participants"
-        >
-          <MultiSelect
-            name="participants"
-            control={control}
-            placeholderText={placeholderText}
-            options={
-              recipientParticipants
-                .map((participant) => ({ value: participant, label: participant }))
-            }
-            required="Select at least one participant"
-          />
-        </FormItem>
-      </div>
       <div aria-live="polite">
         {isHybrid ? (
           <>
@@ -341,11 +347,11 @@ export const isPageComplete = (hookForm) => {
   const { isIstVisit } = hookForm.getValues();
 
   if (isIstVisit === 'yes') {
-    return pageComplete(hookForm, [...fields, 'regionalOfficeTta']);
+    return pageComplete(hookForm, [...fields, 'regionalOfficeTta'], true);
   }
 
   if (isIstVisit === 'no') {
-    return pageComplete(hookForm, [...fields, 'recipients']);
+    return pageComplete(hookForm, [...fields, 'recipients', 'participants']);
   }
 
   return pageComplete(hookForm, fields);

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -9,7 +9,6 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
   Button,
   Radio,
-  TextInput,
 } from '@trussworks/react-uswds';
 import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
 import MultiSelect from '../../../components/MultiSelect';
@@ -18,6 +17,7 @@ import {
   pageComplete,
 } from '../constants';
 import { recipientParticipants } from '../../ActivityReport/constants'; // TODO - move to @ttahub/common
+import ParticipantsNumberOfParticipants from '../components/ParticipantsNumberOfParticipants';
 import FormItem from '../../../components/FormItem';
 import useTrainingReportRole from '../../../hooks/useTrainingReportRole';
 import useTrainingReportTemplateDeterminator from '../../../hooks/useTrainingReportTemplateDeterminator';
@@ -64,9 +64,18 @@ const Participants = ({ formData }) => {
       istSelectionComplete,
       recipients,
       participants,
+      numberOfParticipantsInPerson,
+      numberOfParticipantsVirtually,
+      numberOfParticipants,
     } = formData;
 
-    const formStarted = (recipients && recipients.length) || (participants && participants.length);
+    const formStarted = (
+      recipients && recipients.length
+    ) || (
+      participants && participants.length
+    ) || numberOfParticipantsInPerson
+    || numberOfParticipantsVirtually
+    || numberOfParticipants;
 
     if (!istSelectionComplete && formStarted) {
       setValue('isIstVisit', 'no');
@@ -134,7 +143,7 @@ const Participants = ({ formData }) => {
           <RecipientsWithGroups />
           <div className="margin-top-2">
             <FormItem
-              label="Recipient participants "
+              label="Recipient participants"
               name="participants"
             >
               <MultiSelect
@@ -172,93 +181,15 @@ const Participants = ({ formData }) => {
       </div>
       )}
 
-      <div aria-live="polite">
-        {isHybrid ? (
-          <>
-            <div>
-              <FormItem
-                label="Number of participants attending in person "
-                name="numberOfParticipantsInPerson"
-                required
-              >
-                <div className="maxw-card-lg">
-                  <TextInput
-                    id="numberOfParticipantsInPerson"
-                    name="numberOfParticipantsInPerson"
-                    type="number"
-                    min={1}
-                    required
-                    inputRef={
-                        register({
-                          required: 'Enter number of participants attending in person',
-                          valueAsNumber: true,
-                          min: {
-                            value: 1,
-                            message: 'Number of participants can not be zero or negative',
-                          },
-                        })
-                      }
-                  />
-                </div>
-              </FormItem>
-            </div>
-            <div>
-              <FormItem
-                label="Number of participants attending virtually "
-                name="numberOfParticipantsVirtually"
-                required
-              >
-                <div className="maxw-card-lg">
-                  <TextInput
-                    required
-                    id="numberOfParticipantsVirtually"
-                    name="numberOfParticipantsVirtually"
-                    type="number"
-                    min={1}
-                    inputRef={
-                        register({
-                          required: 'Enter number of participants attending virtually',
-                          valueAsNumber: true,
-                          min: {
-                            value: 1,
-                            message: 'Number of participants can not be zero or negative',
-                          },
-                        })
-                      }
-                  />
-                </div>
-              </FormItem>
-            </div>
-          </>
-        ) : (
-          <div>
-            <FormItem
-              label="Number of participants "
-              name="numberOfParticipants"
-            >
-              <div className="maxw-card-lg">
-                <TextInput
-                  required
-                  id="numberOfParticipants"
-                  name="numberOfParticipants"
-                  type="number"
-                  min={1}
-                  inputRef={
-                      register({
-                        required: 'Enter number of participants',
-                        valueAsNumber: true,
-                        min: {
-                          value: 1,
-                          message: 'Number of participants can not be zero or negative',
-                        },
-                      })
-                    }
-                />
-              </div>
-            </FormItem>
-          </div>
-        )}
-      </div>
+      {(isIstVisit || isNotIstVisit) && (
+      <>
+
+        <ParticipantsNumberOfParticipants
+          isHybrid={isHybrid}
+          register={register}
+        />
+      </>
+      )}
       <div className="margin-top-2">
         <FormItem
           label="How was the activity conducted?"

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -35,7 +35,7 @@ const ROLE_OPTIONS = [
   'Family Engagement Specialist',
   'Grantee Specialist',
   'Grantee Specialist Manager',
-  'Grants Specialist',
+  'Grants Management Specialist',
   'Health Specialist',
   'Program Specialist',
   'Region Program Manager',

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -65,7 +65,7 @@ const Participants = ({ formData }) => {
       recipients,
     } = formData;
 
-    if (!istSelectionComplete && recipients.length) {
+    if (!istSelectionComplete && recipients && recipients.length) {
       setValue('isIstVisit', 'no');
     }
 

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -37,6 +37,7 @@ import {
   sessionSummaryFields,
   pageComplete,
   NO_ERROR,
+  sessionSummaryRequiredFields,
 } from '../constants';
 import FormItem from '../../../components/FormItem';
 import FileTable from '../../../components/FileUploader/FileTable';
@@ -645,22 +646,19 @@ SessionSummary.propTypes = {
 };
 
 const fields = [...Object.keys(sessionSummaryFields), 'endDate', 'startDate'];
+const requiredFields = [...Object.keys(sessionSummaryRequiredFields), 'endDate', 'startDate'];
 const path = 'session-summary';
 const position = 1;
 
 const ReviewSection = () => <><h2>Event summary</h2></>;
 export const isPageComplete = (hookForm) => {
-  const {
-    objectiveTrainers, objectiveTopics, courses, useIpdCourses,
-  } = hookForm.getValues();
+  const { useIpdCourses } = hookForm.getValues();
 
-  if (!objectiveTrainers || !objectiveTrainers.length
-    || !objectiveTopics || !objectiveTopics.length
-    || (useIpdCourses && !courses.length)) {
-    return false;
+  if (useIpdCourses) {
+    return pageComplete(hookForm, [...requiredFields, 'courses']);
   }
 
-  return pageComplete(hookForm, fields);
+  return pageComplete(hookForm, requiredFields);
 };
 
 export default {

--- a/tests/e2e/training-report.spec.ts
+++ b/tests/e2e/training-report.spec.ts
@@ -61,6 +61,9 @@ test('can fill out and complete a training and session report', async ({ page })
   await page.waitForTimeout(5000);
 
   // session participants
+  await page.getByTestId('form').getByText('No').click();
+  await blur(page);
+
   await page.getByText(/Recipients/i).click();
   await page.keyboard.press('ArrowDown');
   await page.keyboard.press('Enter');


### PR DESCRIPTION
## Description of change

Add drop down for IST visit and add audience of TTA/RO

## How to test

- Session form, participants section
- New field: "is this an IST visit?" 
- If no, you can choose recipients
- If yes, you choose from a list of roles

Confirm that the above works and matches the design. Note: this is deployed to sandbox currently.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2510


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
