### PR TITLE
Accessibility improvements for the goal nudge

### DIFF
--- a/frontend/src/components/GoalForm/GoalNudge.js
+++ b/frontend/src/components/GoalForm/GoalNudge.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Checkbox,
@@ -38,11 +38,19 @@ export default function GoalNudge({
   const [dismissSimilar, setDismissSimilar] = useState(false);
   const [goalTemplates, setGoalTemplates] = useState(null);
 
+  const initiativeRef = useRef();
+
   useEffect(() => {
     if (dismissSimilar) {
       setSimilarGoals([]);
     }
   }, [dismissSimilar]);
+
+  useEffect(() => {
+    if (useOhsInitiativeGoal && initiativeRef.current) {
+      initiativeRef.current.focus();
+    }
+  }, [useOhsInitiativeGoal]);
 
   // using DeepCompareEffect to avoid unnecessary fetches
   // as we have an object (selectedGrants) in the dependency array
@@ -121,6 +129,7 @@ export default function GoalNudge({
         validateGoalName={validateGoalName}
         goalTemplates={goalTemplates || []}
         onSelectNudgedGoal={onSelectNudgedGoal}
+        initiativeRef={initiativeRef}
       />
       <div className="desktop:display-flex flex-justify margin-top-2 smart-hub-maxw-form-field">
         { (goalTemplates && goalTemplates.length > 0) && (

--- a/frontend/src/components/GoalForm/GoalNudgeInitiativePicker.js
+++ b/frontend/src/components/GoalForm/GoalNudgeInitiativePicker.js
@@ -17,6 +17,7 @@ export default function GoalNudgeInitiativePicker({
   validateGoalName,
   goalTemplates,
   onSelectNudgedGoal,
+  initiativeRef,
 }) {
   const [selection, setSelection] = useState('');
 
@@ -40,6 +41,8 @@ export default function GoalNudgeInitiativePicker({
         <Req />
       </Label>
       <Select
+        aria-label="OHS initiative goal"
+        ref={initiativeRef}
         inputId="goal-template"
         name="goal-template"
         className="usa-select"
@@ -68,4 +71,7 @@ GoalNudgeInitiativePicker.propTypes = {
   })).isRequired,
   useOhsInitiativeGoal: PropTypes.bool.isRequired,
   onSelectNudgedGoal: PropTypes.func.isRequired,
+  initiativeRef: PropTypes.shape({
+    current: PropTypes.instanceOf(Element),
+  }).isRequired,
 };

--- a/frontend/src/components/GoalForm/index.js
+++ b/frontend/src/components/GoalForm/index.js
@@ -912,11 +912,12 @@ export default function GoalForm({
         goalTemplateId: goal.id,
       }));
       const created = await createOrUpdateGoals(goals);
+      setAppLoadingText('loading');
       forwardToGoalWithIds(created.map((g) => g.goalIds).flat());
     };
 
     try {
-      setAppLoadingText('Retrieving existing goal');
+      setAppLoadingText('loading existing goal');
       setNudgedGoalSelection(goal);
 
       if (goal.status === 'Suspended') {
@@ -926,6 +927,7 @@ export default function GoalForm({
 
       if (goal.isCurated) {
       // we need to do a little magic here to get the goal
+        setAppLoadingText('creating new ohs initiative goal');
         await onSelectInitiativeGoal();
         return;
       }


### PR DESCRIPTION
## Description of change

- When picking an OHS initiative goal on the goal nudge via keyboard, automatically shift focus **up** from the checkbox to the selector
- Also made some changes to the loading text, and to the labeling so that it was clearer what was happening

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
