### PR TITLE
[TTAHUB-2764] Don't suggest merging two goals that are identical and connected to different grant numbers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ parameters:
     default: "al/ttahub-2570/flat-resource-sql"
     type: string
   sandbox_git_branch:  # change to feature branch to test deployment
-    default: "mb/TTAHUB/frontend-for-tr-dashboard"
+    default: "kw-no-identical-merge"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/src/goalServices/helpers.js
+++ b/src/goalServices/helpers.js
@@ -11,7 +11,7 @@ const goalFieldTransate = {
 const findOrFailExistingGoal = (needle, haystack, translate = goalFieldTransate) => {
   const needleCollaborators = (needle.collaborators || []).map(
     (c) => c.goalCreatorName,
-  ).filter(Boolean) ?? [];
+  ).filter(Boolean);
 
   const haystackCollaborators = haystack.flatMap(
     (g) => (g.collaborators || []).map((c) => c.goalCreatorName).filter(Boolean),
@@ -22,7 +22,11 @@ const findOrFailExistingGoal = (needle, haystack, translate = goalFieldTransate)
     && g[translate.name].trim() === needle.name.trim()
     && g[translate.source] === needle.source
     && g[translate.responsesForComparison] === responsesForComparison(needle)
-    && haystackCollaborators.some((c) => needleCollaborators.includes(c))
+    && (
+      // Check if both needle and haystack goal have no valid collaborators
+      (needleCollaborators.length === 0 && (g.collaborators || []).every(c => c.goalCreatorName === undefined)) || 
+      haystackCollaborators.some((c) => needleCollaborators.includes(c))
+    )
   ));
 };
 

--- a/src/goalServices/helpers.js
+++ b/src/goalServices/helpers.js
@@ -24,8 +24,9 @@ const findOrFailExistingGoal = (needle, haystack, translate = goalFieldTransate)
     && g[translate.responsesForComparison] === responsesForComparison(needle)
     && (
       // Check if both needle and haystack goal have no valid collaborators
-      (needleCollaborators.length === 0 && (g.collaborators || []).every(c => c.goalCreatorName === undefined)) || 
-      haystackCollaborators.some((c) => needleCollaborators.includes(c))
+      (needleCollaborators.length === 0 && (g.collaborators || [])
+        .every((c) => c.goalCreatorName === undefined))
+      || haystackCollaborators.some((c) => needleCollaborators.includes(c))
     )
   ));
 };

--- a/src/services/recipient.test.js
+++ b/src/services/recipient.test.js
@@ -869,12 +869,12 @@ describe('Recipient DB service', () => {
 
     it('properly de-duplicates based on responses', async () => {
       const { goalRows } = await getGoalsByActivityRecipient(recipient.id, region, {});
-      expect(goalRows.length).toBe(4);
+      expect(goalRows.length).toBe(3);
 
       const doubler = goalRows.find((r) => r.responsesForComparison === 'not sure,dont have to');
       expect(doubler).toBeTruthy();
 
-      expect(doubler.ids.length).toBe(1);
+      expect(doubler.ids.length).toBe(2);
 
       const singler = goalRows.find((r) => r.responsesForComparison === 'gotta');
       expect(singler).toBeTruthy();
@@ -1062,16 +1062,16 @@ describe('Recipient DB service', () => {
     it('successfully reduces data without losing topics', async () => {
       const goalsForRecord = await getGoalsByActivityRecipient(recipient.id, 5, {});
 
-      expect(goalsForRecord.count).toBe(2);
-      expect(goalsForRecord.goalRows.length).toBe(2);
+      expect(goalsForRecord.count).toBe(1);
+      expect(goalsForRecord.goalRows.length).toBe(1);
       expect(goalsForRecord.allGoalIds.length).toBe(2);
 
       const goal = goalsForRecord.goalRows[0];
-      expect(goal.reasons.length).toBe(0);
+      expect(goal.reasons.length).toBe(1);
 
       expect(goal.objectives.length).toBe(1);
       const objective = goal.objectives[0];
-      expect(objective.topics.length).toBe(1);
+      expect(objective.topics.length).toBe(4);
       expect(objective.supportType).toBe('Planning');
     });
   });


### PR DESCRIPTION
## Description of change
This update adds a check for an empty 'creator' field on goals that are candidates for roll-up.


## How to test
Confirm that identical goals with different grant numbers are not split when they lack a designated creator.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2764


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
