### PR TITLE
[TTAHUB-2828] Group permissions update for session report

### DIFF
--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -107,6 +107,8 @@ export default class EventReport {
   }
 
   canGetGroupsForEditingSession() {
+    if (this.isAdmin()) { return true; }
+
     return !!this.permissions.find((p) => [
       SCOPES.READ_WRITE_TRAINING_REPORTS,
       SCOPES.POC_TRAINING_REPORTS,

--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -106,6 +106,13 @@ export default class EventReport {
     ].includes(p.scopeId) && p.regionId === regionId);
   }
 
+  canGetGroupsForEditingSession() {
+    return !!this.permissions.find((p) => [
+      SCOPES.READ_WRITE_TRAINING_REPORTS,
+      SCOPES.POC_TRAINING_REPORTS,
+    ].includes(p.scopeId) && p.regionId === this.eventReport.regionId);
+  }
+
   isAdmin() {
     return !!this.permissions.find(
       (p) => p.scopeId === SCOPES.ADMIN,
@@ -125,7 +132,6 @@ export default class EventReport {
   }
 
   // some handy & fun aliases
-
   canEditEvent() {
     return this.isAdmin() || this.isAuthor() || this.isPoc();
   }

--- a/src/policies/event.test.js
+++ b/src/policies/event.test.js
@@ -87,6 +87,12 @@ describe('Event Report policies', () => {
       const policy = new EventReport(authorRegion2, eventRegion1);
       expect(policy.canGetGroupsForEditingSession()).toBe(false);
     });
+
+    it('is true if the user is admin', () => {
+      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const policy = new EventReport(admin, eventRegion1);
+      expect(policy.canGetGroupsForEditingSession()).toBe(true);
+    });
   });
 
   describe('canDelete', () => {

--- a/src/policies/event.test.js
+++ b/src/policies/event.test.js
@@ -22,6 +22,7 @@ const createUser = ({
   write = false,
   read = false,
   admin = false,
+  poc = false,
   regionId = 1,
 }) => {
   const permissions = [];
@@ -40,12 +41,17 @@ const createUser = ({
     permissions.push({ scopeId: SCOPES.ADMIN, regionId });
   }
 
+  if (poc) {
+    permissions.push({ scopeId: SCOPES.POC_TRAINING_REPORTS, regionId });
+  }
+
   return { id: nextUserId, permissions };
 };
 
 const authorRegion1 = createUser({ write: true, regionId: 1 });
 const authorRegion2 = createUser({ write: true, regionId: 2 });
 const authorRegion1Collaborator = createUser({ write: true, regionId: 1 });
+const pocRegion1 = createUser({ poc: true, regionId: 1 });
 const admin = createUser({ admin: true });
 
 describe('Event Report policies', () => {
@@ -60,6 +66,26 @@ describe('Event Report policies', () => {
       const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
       const policy = new EventReport(authorRegion2, eventRegion1);
       expect(policy.canCreate()).toBe(false);
+    });
+  });
+
+  describe('canGetGroupsForEditingSession', () => {
+    it('is true if the user has write permissions in the region', () => {
+      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const policy = new EventReport(authorRegion1, eventRegion1);
+      expect(policy.canGetGroupsForEditingSession()).toBe(true);
+    });
+
+    it('is true if the user has poc permissions in the region', () => {
+      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const policy = new EventReport(pocRegion1, eventRegion1);
+      expect(policy.canGetGroupsForEditingSession()).toBe(true);
+    });
+
+    it('is false if the user does not have write permissions in the region', () => {
+      const eventRegion1 = createEvent({ ownerId: authorRegion1, regionId: 1 });
+      const policy = new EventReport(authorRegion2, eventRegion1);
+      expect(policy.canGetGroupsForEditingSession()).toBe(false);
     });
   });
 

--- a/src/routes/sessionReports/handlers.js
+++ b/src/routes/sessionReports/handlers.js
@@ -178,9 +178,11 @@ export async function getGroups(req, res) {
   const userId = await currentUserId(req, res);
   const user = await userById(userId);
   const regionNumber = parseInt(region, DECIMAL_BASE);
-  const eventPolicy = new EventReport(user, { regionNumber });
+  const eventPolicy = new EventReport(user, { regionId: regionNumber });
   // Has correct TR permissions.
-  if (!eventPolicy.canWriteInRegion(regionNumber)) {
+  if (
+    !eventPolicy.canGetGroupsForEditingSession()
+  ) {
     res.sendStatus(403);
     return;
   }

--- a/src/routes/sessionReports/handlers.test.js
+++ b/src/routes/sessionReports/handlers.test.js
@@ -122,7 +122,7 @@ describe('session report handlers', () => {
       });
       // Mock permissions.
       EventReport.mockImplementationOnce(() => ({
-        canWriteInRegion: () => true,
+        canGetGroupsForEditingSession: () => true,
       }));
       // Group response.
       const groupsByRegionResponse = [{ name: 'name', id: 1 }];
@@ -148,7 +148,7 @@ describe('session report handlers', () => {
       });
       // Mock permissions.
       EventReport.mockImplementationOnce(() => ({
-        canWriteInRegion: () => false,
+        canGetGroupsForEditingSession: () => false,
       }));
       await getGroups(
         { session: { userId: 1 }, params: { }, query: { region: 1 } },


### PR DESCRIPTION
## Description of change
Update the group permissions so that POC can get a list of groups

## How to test
To recreate support issue:
- Use the most recent production data
- Impersonate the user from the ticket, using the report noted. 
- Edit sessions using a group (participants page > is ist report? no. > checkbox should appear)

To recreate in a vanilla setup
- Create a TR and a group in the matching region. Add a poc user as co-owner
- As a POC user without read/write permissions, access the session report as above and confirm the behavior

## Issue(s)
* https://jira.acf.gov/browse/TTAHUB-2828


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
