### PR TITLE
[TTAHUB-1144] Fix resource validation

### DIFF
--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -120,18 +120,27 @@ export default function ObjectiveForm({
       setObjectiveError(index, newErrors);
     }
   };
-  const validateResources = () => {
-    let error = <></>;
 
-    const validated = validateListOfResources(resources);
-
+  const validateResourcesPassed = (newResources) => {
+    const validated = validateListOfResources(newResources);
+    let error;
     if (!validated) {
       error = <span className="usa-error-message">{objectiveResourcesError}</span>;
+    } else {
+      error = <></>;
     }
 
     const newErrors = [...errors];
     newErrors.splice(OBJECTIVE_FORM_FIELD_INDEXES.RESOURCES, 1, error);
     setObjectiveError(index, newErrors);
+  };
+
+  const validateResources = () => {
+    validateResourcesPassed(resources);
+  };
+
+  const validateResourcesOnRemove = (newResources) => {
+    validateResourcesPassed(newResources);
   };
 
   const setSuspendReasonError = () => {
@@ -182,6 +191,7 @@ export default function ObjectiveForm({
         isLoading={isAppLoading}
         userCanEdit={userCanEdit}
         toolTipText="Copy & paste web address of TTA resource you'll use for this objective. Usually an ECLKC page."
+        validateOnRemove={validateResourcesOnRemove}
       />
       { title && (
       <ObjectiveFiles

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -25,6 +25,7 @@ export default function ResourceRepeater({
   userCanEdit,
   editingFromActivityReport,
   toolTipText,
+  validateOnRemove,
 }) {
   const readOnly = !editingFromActivityReport
   && ((goalStatus === 'Not Started' && isOnReport) || goalStatus === 'Closed' || !userCanEdit);
@@ -70,7 +71,15 @@ export default function ResourceRepeater({
     const newResources = [...editableResources];
     newResources.splice(i, 1);
     setResources(newResources);
-    validateResources(); // Trigger hook form validation
+
+    // This is an attempt to handle on remove validation for resources.
+    // the AR and RTR use two different approaches to validation.
+    // This works around it by allowing the parent component to pass in a validation function.
+    if (validateOnRemove) {
+      validateOnRemove(newResources);
+    } else {
+      validateResources();
+    }
   };
 
   const updateResource = (value, i) => {
@@ -162,10 +171,12 @@ ResourceRepeater.propTypes = {
   userCanEdit: PropTypes.bool.isRequired,
   editingFromActivityReport: PropTypes.bool,
   toolTipText: PropTypes.string,
+  validateOnRemove: PropTypes.func,
 };
 
 ResourceRepeater.defaultProps = {
   isLoading: false,
   editingFromActivityReport: false,
   toolTipText: 'Copy & paste web address of TTA resource used for this objective. Usually an ECLKC page.',
+  validateOnRemove: null,
 };

--- a/frontend/src/components/GoalForm/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/ResourceRepeater.js
@@ -70,6 +70,7 @@ export default function ResourceRepeater({
     const newResources = [...editableResources];
     newResources.splice(i, 1);
     setResources(newResources);
+    validateResources(); // Trigger hook form validation
   };
 
   const updateResource = (value, i) => {

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import {
-  render, screen,
+  render, screen, fireEvent,
 } from '@testing-library/react';
 import ResourceRepeater from '../ResourceRepeater';
 
@@ -29,6 +29,31 @@ describe('ResourceRepeater', () => {
     expect(resources2).toBeVisible();
     expect(resources2.tagName).toBe('A');
     expect(screen.queryAllByText('Copy & paste web address of TTA resource used for this objective. Usually an ECLKC page.').length).toBe(2);
+  });
+
+  it('calls validateResources() when a resource is removed', async () => {
+    const validateResourcesMock = jest.fn();
+    const resources = [
+      { key: 1, value: 'http://www.resources.com', onAnyReport: false },
+      { key: 2, value: 'http://www.resources2.com', onAnyReport: true },
+    ];
+
+    render(<ResourceRepeater
+      error={<></>}
+      resources={resources}
+      setResources={jest.fn()}
+      validateResources={validateResourcesMock}
+      status="In Progress"
+      isOnReport={false}
+      isLoading={false}
+      goalStatus="In Progress"
+      userCanEdit
+    />);
+
+    const removeButton = screen.getByRole('button', { name: /remove resource 1/i });
+    fireEvent.click(removeButton);
+
+    expect(validateResourcesMock).toHaveBeenCalled();
   });
 
   it('render with alternate tool tip', async () => {

--- a/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
+++ b/frontend/src/components/GoalForm/__tests__/ResourceRepeater.js
@@ -128,4 +128,30 @@ describe('ResourceRepeater', () => {
     expect(resources2).toBeVisible();
     expect(resources2.tagName).toBe('A');
   });
+
+  it('calls validateOnRemove() when a resource is removed', async () => {
+    const validateOnRemoveMock = jest.fn();
+    const resources = [
+      { key: 1, value: 'http://www.resources.com', onAnyReport: false },
+      { key: 2, value: 'http://www.resources2.com', onAnyReport: true },
+    ];
+
+    render(<ResourceRepeater
+      error={<></>}
+      resources={resources}
+      setResources={jest.fn()}
+      validateResources={jest.fn()}
+      status="In Progress"
+      isOnReport={false}
+      isLoading={false}
+      goalStatus="In Progress"
+      userCanEdit
+      validateOnRemove={validateOnRemoveMock}
+    />);
+
+    const removeButton = screen.getByRole('button', { name: /remove resource 1/i });
+    fireEvent.click(removeButton);
+
+    expect(validateOnRemoveMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Description of change

This fixes a bug when an invalid resource is added to the AR or RTR objective. We then remove the bad resource URL but the validation message persists. 

This issue occurs on both the AR and RTR pages:
- For the AR fix we call the validation on remove via the controller onBlur().
- For the RTR we pass a separate function to validate on removal. 
_NOTE: This is because the new setState resources have not yet been updated in react at the time of validation._

## How to test

To test enter an invalid URL on the AR and RTR. Removing the bad URL should clear the invalid URL message.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-1144


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
