### PR TITLE
[NO TICKET] Add a trigger for production PR notifications

### DIFF
--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - production
-    types: [ready_for_review]
+    types: [opened, ready_for_review]
 
 jobs:
   notify_slack:


### PR DESCRIPTION
## Description of change
The GitHub Actions for sending production PR notifications did not trigger when PRs were created in an open state, rather than moving from draft to open.


## How to test
No tests needed

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete

### Before merge to main

- [n/a] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
