### PR TITLE
[TTAHUB-2899] Close loophole when removing objectives from OE report

### DIFF
--- a/frontend/src/components/Navigator/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/ActivityReportNavigator.js
@@ -90,7 +90,7 @@ export const packageGoals = (goals, goal, grantIds, prompts) => [
  */
 export const shouldUpdateFormData = (isAutoSave) => {
   if (!isAutoSave) {
-    return false;
+    return true;
   }
 
   const richTextEditors = document.querySelectorAll('.rdw-editor-main');
@@ -207,6 +207,7 @@ const ActivityReportNavigator = ({
     } else {
       newPageState[page.position] = isDirty ? IN_PROGRESS : currentPageState;
     }
+
     return newPageState;
   };
   const onSaveForm = async (isAutoSave = false) => {
@@ -502,6 +503,7 @@ const ActivityReportNavigator = ({
       // update form data
       const { status, ...values } = getValues();
       const data = { ...formData, ...values, pageState: newNavigatorState() };
+
       if (allowUpdateFormData) {
         updateFormData(data);
       }

--- a/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.js
@@ -373,8 +373,8 @@ describe('Navigator', () => {
 });
 
 describe('shouldUpdateFormData', () => {
-  it('if isAutoSave is false, returns false', () => {
-    expect(shouldUpdateFormData(false)).toBe(false);
+  it('if isAutoSave is false, returns true', () => {
+    expect(shouldUpdateFormData(false)).toBe(true);
   });
 
   it('if we are focused on a rich editor, return false', async () => {

--- a/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/OtherEntity.js
@@ -73,7 +73,9 @@ export default function OtherEntity({
           />
         );
       })}
-      <PlusButton text="Add new objective" onClick={onAddNew} />
+      {(recipientIds.length > 0) && (
+        <PlusButton text="Add new objective" onClick={onAddNew} />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ActivityReport/Pages/components/__tests__/OtherEntity.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/__tests__/OtherEntity.js
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import PropTypes from 'prop-types';
 import fetchMock from 'fetch-mock';
 import { FormProvider, useForm } from 'react-hook-form';
 import OtherEntity from '../OtherEntity';
@@ -10,8 +11,7 @@ import UserContext from '../../../../../UserContext';
 
 let setError;
 
-// eslint-disable-next-line react/prop-types
-const RenderOtherEntity = ({ objectivesWithoutGoals }) => {
+const RenderOtherEntity = ({ objectivesWithoutGoals, recipientIds }) => {
   const hookForm = useForm({
     mode: 'onChange',
     defaultValues: {
@@ -24,10 +24,16 @@ const RenderOtherEntity = ({ objectivesWithoutGoals }) => {
   return (
     <UserContext.Provider value={{ user: { flags: [] } }}>
       <FormProvider {...hookForm}>
-        <OtherEntity recipientIds={[]} onSaveDraft={jest.fn()} reportId="123" />
+        <OtherEntity recipientIds={recipientIds} onSaveDraft={jest.fn()} reportId="123" />
       </FormProvider>
     </UserContext.Provider>
   );
+};
+
+RenderOtherEntity.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  objectivesWithoutGoals: PropTypes.arrayOf(PropTypes.object).isRequired,
+  recipientIds: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 
 const objectives = [
@@ -58,20 +64,20 @@ describe('OtherEntity', () => {
     <id>https://acf-ohs.atlassian.net/wiki</id></feed>`);
   });
   it('renders created objectives', async () => {
-    render(<RenderOtherEntity objectivesWithoutGoals={objectives} />);
+    render(<RenderOtherEntity objectivesWithoutGoals={objectives} recipientIds={[1]} />);
 
     const title = await screen.findByText('title', { selector: 'textarea' });
     expect(title).toBeVisible();
   });
 
   it('renders without roles', async () => {
-    render(<RenderOtherEntity objectivesWithoutGoals={objectives} />);
+    render(<RenderOtherEntity objectivesWithoutGoals={objectives} recipientIds={[1]} />);
     const title = await screen.findByText('title', { selector: 'textarea' });
     expect(title).toBeVisible();
   });
 
   it('the button adds a new objective', async () => {
-    render(<RenderOtherEntity objectivesWithoutGoals={[]} />);
+    render(<RenderOtherEntity objectivesWithoutGoals={[]} recipientIds={[1]} />);
     const button = await screen.findByRole('button', { name: /Add new objective/i });
     userEvent.click(button);
     expect(screen.queryAllByText(/objective status/i).length).toBe(1);
@@ -80,7 +86,7 @@ describe('OtherEntity', () => {
   });
 
   it('displays errors', async () => {
-    render(<RenderOtherEntity objectivesWithoutGoals={[]} />);
+    render(<RenderOtherEntity objectivesWithoutGoals={[]} recipientIds={[1]} />);
     const button = await screen.findByRole('button', { name: /Add new objective/i });
     userEvent.click(button);
     expect(screen.queryAllByText(/objective status/i).length).toBe(1);
@@ -89,5 +95,11 @@ describe('OtherEntity', () => {
 
     setError('objectivesWithoutGoals[0].title', { type: 'required', message: 'ENTER A TITLE' });
     await waitFor(() => expect(screen.queryByText(/ENTER A TITLE/i)).toBeVisible());
+  });
+
+  it('hides plus button when there are no recipients selected errors', async () => {
+    render(<RenderOtherEntity objectivesWithoutGoals={[]} recipientIds={[]} />);
+    const button = screen.queryByRole('button', { name: /Add new objective/i });
+    expect(button).toBeNull();
   });
 });

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -733,6 +733,43 @@ test.describe('Activity Report', () => {
     await expect(page.getByRole('link', { name: `R0${regionNumber}-AR-${arNumber}` })).toBeVisible();
   });
 
+  test('properly updates form state for other entity reports', async ({ page }) => {
+    await page.goto('http://localhost:3000/');
+    await page.getByRole('link', { name: 'Activity Reports' }).click();
+    await page.getByRole('button', { name: '+ New Activity Report' }).click();
+
+    await page.locator('label').filter({ hasText: 'Other entity' }).click();
+    await page.locator('#activityRecipients div').filter({ hasText: '- Select -' }).nth(1).click();
+    await page.locator('#react-select-3-option-0').click();
+    await page.locator('#react-select-3-option-1').click();
+    await page.getByRole('button', { name: 'Goals and objectives Not Started' }).click();
+    await page.waitForTimeout(5000);
+    await page.getByTestId('plusButton').click();
+    await page.getByTestId('form').getByTestId('textarea').fill('Objective for testing. avery specific thing');
+    await page.getByTestId('form').getByTestId('textarea').press('Tab');
+    await page.getByRole('button', { name: 'Get help choosing topics' }).press('Tab');
+    await page.getByLabel('Topics  *').press('ArrowDown');
+    await page.getByLabel('Topics  *').press('Enter');
+    await page.getByLabel('Topics  *').press('Tab');
+  
+    await blur(page);
+
+    await page.getByText('TTA provided *Normal').click();
+    await page.getByRole('textbox', { name: 'TTA provided for objective, required' }).press('Enter');
+    await page.getByText('Support type *').click();
+    await page.getByRole('combobox', { name: 'Support type' }).selectOption('Introducing');
+  
+    await page.getByRole('button', { name: 'Save objectives' }).click();
+    await page.getByRole('button', { name: 'Save and continue' }).click();
+    await page.getByRole('button', { name: 'Goals and objectives Complete' }).click();
+    await page.getByTestId('ellipsis-button').click();
+    await page.getByTestId('menu').getByTestId('button').click();
+    await page.getByRole('button', { name: 'Remove this objective' }).click();
+    await page.getByRole('button', { name: 'This button will remove the objective from the activity report' }).click();
+    await page.getByRole('button', { name: 'Supporting attachments Complete' }).click();
+    await page.getByRole('button', { name: 'Goals and objectives In Progress' }).click();
+  });
+
   test('can remove objective', async ({ page }) => {
     await getFullName(page);
 
@@ -882,7 +919,7 @@ test.describe('Activity Report', () => {
 
     await p2;
 
-    await page.getByTestId('form').locator('div').filter({ hasText: 'Create new goal' }).nth(3).click();
+    await page.getByText('Select recipient\'s goal *Test goal for preserving objectives').click();
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
     await page.getByRole('button', { name: 'Keep objective' }).click();


### PR DESCRIPTION
## Description of change

Logic for "shouldAutoUpdate" is exactly backwards. The function was intended to catch autosaves when a user was in the middle of updating TTA provided. If we are _not_ auto-saving, it's fine to update form data, since that means a user has manually initiated a save.

This PR fixes this logic, as well as adds an e2e test to verify this behavior. It also fixes a perceivable loss of data that I encountered while testing; you need to enter other entities before entering objectives.

## How to test

- Create an other-entity report
- Add required data, including objectives
- Delete objectives
- Note the form state is updated in the side nav and you can no longer submit a report

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2899


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
