### PR TITLE
Fix resource dashboard CSV download when there is one AR

### DIFF
--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -985,7 +985,7 @@ export async function downloadAllReports(req, res) {
     const userId = await currentUserId(req, res);
     const readRegions = await setReadRegions(req.query, userId);
 
-    const ids = req.query.id || [];
+    const ids = [(req.query.id || [])].flat();
 
     const reports = await getAllDownloadableActivityReports(
       readRegions['region.in'],


### PR DESCRIPTION
## Description of change
Fix bug that didn't allow exporting a single AR from the resource dashboard

## How to test
Confirm bug is fixed

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
