### PR TITLE
[TTAHUB-2830] Require that CSV is in UTF-8 encoding

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "async": "^3.2.3",
     "browserslist": "^4.16.5",
     "csv-parse": "^4.14.1",
+    "detect-file-encoding-and-language": "^2.4.0",
     "draft-js": "^0.11.7",
     "draftjs-to-html": "^0.9.1",
     "ejs": "^3.1.10",

--- a/frontend/src/pages/Admin/components/CsvImport.js
+++ b/frontend/src/pages/Admin/components/CsvImport.js
@@ -93,7 +93,6 @@ export default function CsvImport(
 
     // Verify correct encoding.
     const encodingInfo = await languageEncoding(files[0]);
-    console.log('enconding', encodingInfo.encoding.toLowerCase());
     if (encodingInfo.encoding.toLowerCase() !== 'utf-8') {
       setError('Please upload a CSV file with UTF-8 encoding.');
       return;

--- a/frontend/src/pages/Admin/components/CsvImport.js
+++ b/frontend/src/pages/Admin/components/CsvImport.js
@@ -97,9 +97,17 @@ export default function CsvImport(
     }
 
     // Verify correct encoding.
-    const encodingInfo = await languageEncoding(files[0]);
-    if (encodingInfo.encoding.toLowerCase() !== 'utf-8') {
-      setError('Please upload a CSV file with UTF-8 encoding.');
+    let correctEncoding = false;
+    try {
+      const encodingInfo = await languageEncoding(files[0]);
+      correctEncoding = encodingInfo.encoding.toLowerCase() === 'utf-8';
+    } catch (err) {
+      setError('Error reading file encoding. Ensure your CSV is using UTF-8 encoding.');
+      return;
+    }
+
+    if (!correctEncoding) {
+      setError('Upload a CSV file with UTF-8 encoding.');
       return;
     }
 

--- a/frontend/src/pages/Admin/components/CsvImport.js
+++ b/frontend/src/pages/Admin/components/CsvImport.js
@@ -38,6 +38,11 @@ export default function CsvImport(
 
   const importCsvFile = async () => {
     try {
+      // If errors return.
+      if (error) {
+        return;
+      }
+
       // Reset summary info.
       setCreated([]);
       setSkipped([]);

--- a/frontend/src/pages/Admin/components/CsvImport.js
+++ b/frontend/src/pages/Admin/components/CsvImport.js
@@ -93,8 +93,10 @@ export default function CsvImport(
 
     // Verify correct encoding.
     const encodingInfo = await languageEncoding(files[0]);
+    console.log('enconding', encodingInfo.encoding.toLowerCase());
     if (encodingInfo.encoding.toLowerCase() !== 'utf-8') {
       setError('Please upload a CSV file with UTF-8 encoding.');
+      return;
     }
 
     const reader = new FileReader();
@@ -260,7 +262,7 @@ export default function CsvImport(
                   </ul>
                 </div>
               )}
-              <Button className="margin-top-2" type="button" onClick={importCsvFile}>
+              <Button className="margin-top-2" type="button" onClick={importCsvFile} disabled={error}>
                 Upload
                 {' '}
                 { typeName }

--- a/frontend/src/pages/Admin/components/CsvImport.js
+++ b/frontend/src/pages/Admin/components/CsvImport.js
@@ -266,7 +266,7 @@ export default function CsvImport(
                   </ul>
                 </div>
               )}
-              <Button className="margin-top-2" type="button" onClick={importCsvFile} disabled={error}>
+              <Button className="margin-top-2" type="button" onClick={importCsvFile}>
                 Upload
                 {' '}
                 { typeName }

--- a/frontend/src/pages/Admin/components/CsvImport.js
+++ b/frontend/src/pages/Admin/components/CsvImport.js
@@ -8,6 +8,7 @@ import {
   Label,
   Button,
 } from '@trussworks/react-uswds';
+import languageEncoding from 'detect-file-encoding-and-language';
 import Container from '../../../components/Container';
 import {
   importCsv,
@@ -75,7 +76,7 @@ export default function CsvImport(
     }
   };
 
-  const onChange = (e) => {
+  const onChange = async (e) => {
     const { files } = e.target;
 
     // Clear error and success messages.
@@ -88,6 +89,12 @@ export default function CsvImport(
       setError('Please upload a CSV file.');
       fileInputRef.current.clearFiles();
       return;
+    }
+
+    // Verify correct encoding.
+    const encodingInfo = await languageEncoding(files[0]);
+    if (encodingInfo.encoding.toLowerCase() !== 'utf-8') {
+      setError('Please upload a CSV file with UTF-8 encoding.');
     }
 
     const reader = new FileReader();

--- a/frontend/src/pages/Admin/components/__tests__/CsvImport.js
+++ b/frontend/src/pages/Admin/components/__tests__/CsvImport.js
@@ -257,7 +257,7 @@ describe('CsvImport', () => {
       userEvent.upload(fileInput, file);
 
       // Assert to see correct import count.
-      await waitFor(() => expect(screen.queryAllByText(/2 test csv will be imported./i)).toBeVisible());
+      await waitFor(() => expect(screen.getByText(/2 test csv will be imported./i)).toBeVisible());
     });
 
     // Assert button 'Upload test csv' is visible.

--- a/frontend/src/pages/Admin/components/__tests__/CsvImport.js
+++ b/frontend/src/pages/Admin/components/__tests__/CsvImport.js
@@ -517,7 +517,14 @@ describe('CsvImport', () => {
     expect(error).toBeVisible();
 
     // Assert button 'Upload csv reports' is visible.
-    const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
+    const uploadButton = await screen.findByRole('button', { name: /Upload test CSV/i });
+
+    // click the upload button.
+    userEvent.click(uploadButton);
+
+    // Make sure the fetch event hasn't fired.
+    expect(fetchMock.calls(testCsvUrl).length).toBe(0);
+
     expect(uploadButton).toBeVisible();
 
     // Clear error message.

--- a/frontend/src/pages/Admin/components/__tests__/CsvImport.js
+++ b/frontend/src/pages/Admin/components/__tests__/CsvImport.js
@@ -114,17 +114,21 @@ describe('CsvImport', () => {
     const fileInput = await screen.findByTestId('file-input-input');
     expect(fileInput).toBeVisible();
 
+    act(async () => {
     // Load 'CSV_Test_Invalid_File_Type.csv' into a file object.
-    const file = new File([duplicateTestCSVFile], 'CSV_Test_Invalid_File_Type.csv', { type: 'text/csv' });
-    userEvent.upload(fileInput, file);
+      const file = new File([duplicateTestCSVFile], 'CSV_Test_Invalid_File_Type.csv', { type: 'text/csv' });
+      userEvent.upload(fileInput, file);
+      await waitFor(async () => {
+        // eslint-disable-next-line max-len
+        // Assert to see if error message 'Duplicate Event IDs found. Please correct and try again.'.
+        const error = await screen.findByText(/duplicate primary ids found\. please correct and try again\. duplicates: event test/i);
+        expect(error).toBeVisible();
 
-    // Assert to see if error message 'Duplicate Event IDs found. Please correct and try again.'.
-    const error = await screen.findByText(/duplicate primary ids found\. please correct and try again\. duplicates: event test/i);
-    expect(error).toBeVisible();
-
-    // Assert button 'Upload csv reports' is visible.f
-    const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
-    expect(uploadButton).toBeVisible();
+        // Assert button 'Upload csv reports' is visible.f
+        const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
+        expect(uploadButton).toBeVisible();
+      });
+    });
   });
 
   it('displays missing columns error', async () => {
@@ -145,17 +149,22 @@ describe('CsvImport', () => {
     const fileInput = await screen.findByTestId('file-input-input');
     expect(fileInput).toBeVisible();
 
+    act(async () => {
     // Load 'Test_CSV_Duplicate_EventIds.csv' into a file object.
-    const file = new File([missingCoumnsTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
-    userEvent.upload(fileInput, file);
+      const file = new File([missingCoumnsTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
+      userEvent.upload(fileInput, file);
 
-    // Assert to see if error message 'Duplicate Event IDs found. Please correct and try again.'.
-    const error = await screen.findByText(/Required headers missing: Primary ID, Edit Title, Creator/i);
-    expect(error).toBeVisible();
+      await waitFor(async () => {
+        // eslint-disable-next-line max-len
+        // Assert to see if error message 'Duplicate Event IDs found. Please correct and try again.'.
+        const error = await screen.findByText(/Required headers missing: Primary ID, Edit Title, Creator/i);
+        expect(error).toBeVisible();
 
-    // Assert button 'Upload test csv' is visible.
-    const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
-    expect(uploadButton).toBeVisible();
+        // Assert button 'Upload test csv' is visible.
+        const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
+        expect(uploadButton).toBeVisible();
+      });
+    });
   });
 
   it('displays invalid columns', async () => {
@@ -190,17 +199,22 @@ describe('CsvImport', () => {
     const fileInput = await screen.findByTestId('file-input-input');
     expect(fileInput).toBeVisible();
 
+    act(async () => {
     // Load 'Test_CSV_Duplicate_EventIds.csv' into a file object.
-    const file = new File([invalidColumnTestCsvFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
-    userEvent.upload(fileInput, file);
+      const file = new File([invalidColumnTestCsvFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
+      userEvent.upload(fileInput, file);
 
-    // Assert to see if error message 'Duplicate Event IDs found. Please correct and try again.'.
-    const error = await screen.findByText(/Invalid headers found: Invalid Column/i);
-    expect(error).toBeVisible();
+      await waitFor(async () => {
+        // eslint-disable-next-line max-len
+        // Assert to see if error message 'Duplicate Event IDs found. Please correct and try again.'.
+        const error = await screen.findByText(/Invalid headers found: Invalid Column/i);
+        expect(error).toBeVisible();
 
-    // Assert button 'Upload test csv' is visible.
-    const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
-    expect(uploadButton).toBeVisible();
+        // Assert button 'Upload test csv' is visible.
+        const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
+        expect(uploadButton).toBeVisible();
+      });
+    });
   });
 
   it('ignores invalid columns', async () => {
@@ -275,34 +289,39 @@ describe('CsvImport', () => {
       },
     });
 
+    act(async () => {
     // Click button 'Upload test csv'.
-    userEvent.click(uploadButton);
+      userEvent.click(uploadButton);
 
-    // Assert to see correct import count.
-    const success = await screen.findByText(/2 test csv imported successfully./i);
-    expect(success).toBeVisible();
+      await waitFor(async () => {
+        // Assert to see correct import count.
+        const success = await screen.findByText(/2 test csv imported successfully./i);
+        expect(success).toBeVisible();
 
-    // assert to see the text '2 skipped' and then check each skipped event in its own <li> element
-    const skippedHeader = await screen.findByText(/2 skipped/i);
-    expect(skippedHeader).toBeVisible();
-    const eventId1 = within(skippedHeader).getByText(/event id 1/i);
-    expect(eventId1).toBeInTheDocument();
-    const eventId2 = within(skippedHeader).getByText(/event id 2/i);
-    expect(eventId2).toBeInTheDocument();
+        // eslint-disable-next-line max-len
+        // assert to see the text '2 skipped' and then check each skipped event in its own <li> element
+        const skippedHeader = await screen.findByText(/2 skipped/i);
+        expect(skippedHeader).toBeVisible();
+        const eventId1 = within(skippedHeader).getByText(/event id 1/i);
+        expect(eventId1).toBeInTheDocument();
+        const eventId2 = within(skippedHeader).getByText(/event id 2/i);
+        expect(eventId2).toBeInTheDocument();
 
-    // assert to see the text '2 errors: event id 2, event id 3'.
-    const errorsHeader = await screen.findByText(/2 errors/i);
-    expect(errorsHeader).toBeVisible();
-    const errorEventId2 = within(errorsHeader).getByText(/event id 2/i);
-    expect(errorEventId2).toBeInTheDocument();
-    const errorEventId3 = within(errorsHeader).getByText(/event id 3/i);
-    expect(errorEventId3).toBeInTheDocument();
+        // assert to see the text '2 errors: event id 2, event id 3'.
+        const errorsHeader = await screen.findByText(/2 errors/i);
+        expect(errorsHeader).toBeVisible();
+        const errorEventId2 = within(errorsHeader).getByText(/event id 2/i);
+        expect(errorEventId2).toBeInTheDocument();
+        const errorEventId3 = within(errorsHeader).getByText(/event id 3/i);
+        expect(errorEventId3).toBeInTheDocument();
 
-    expect(uploadButton).toBeVisible();
+        expect(uploadButton).toBeVisible();
 
-    // Assert the text '2 events will be imported.' is no longer displayed.
-    const info = screen.queryAllByText(/2 tests csvs will be imported./i);
-    expect(info.length).toBe(0);
+        // Assert the text '2 events will be imported.' is no longer displayed.
+        const info = screen.queryAllByText(/2 tests csvs will be imported./i);
+        expect(info.length).toBe(0);
+      });
+    });
   });
 
   it('displays optional summary results', async () => {
@@ -323,13 +342,12 @@ describe('CsvImport', () => {
     const fileInput = await screen.findByTestId('file-input-input');
     expect(fileInput).toBeVisible();
 
+    act(async () => {
     // Load 'Test_CSV_Duplicate_EventIds.csv' into a file object.
-    const file = new File([goodTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
-    userEvent.upload(fileInput, file);
-
-    // Assert to see correct import count.
-    const error = await screen.findByText(/2 test csv will be imported./i);
-    expect(error).toBeVisible();
+      const file = new File([goodTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
+      userEvent.upload(fileInput, file);
+      await waitFor(() => expect(screen.getByText(/2 test csv will be imported./i)).toBeVisible());
+    });
 
     // Assert button 'Upload test csv' is visible.
     const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
@@ -350,60 +368,66 @@ describe('CsvImport', () => {
       },
     });
 
-    // Click button 'Upload test csv'.
-    userEvent.click(uploadButton);
+    act(async () => {
+      // Click button 'Upload test csv'.
+      userEvent.click(uploadButton);
 
-    // Assert to see correct import count.
-    const success = await screen.findByText(/2 test csv imported successfully./i);
-    expect(success).toBeVisible();
+      await waitFor(async () => {
+        // Assert to see correct import count.
+        const success = await screen.findByText(/2 test csv imported successfully./i);
+        expect(success).toBeVisible();
 
-    // assert to see the text '2 crated' and then check each skipped event in its own <li> element
-    const crate3dHeader = await screen.findByText(/2 created/i);
-    expect(crate3dHeader).toBeVisible();
-    const createdEvent1 = within(crate3dHeader).getByText(/created course 1/i);
-    expect(createdEvent1).toBeInTheDocument();
-    const createdEvent2 = within(crate3dHeader).getByText(/created course 2/i);
-    expect(createdEvent2).toBeInTheDocument();
+        // eslint-disable-next-line max-len
+        // assert to see the text '2 crated' and then check each skipped event in its own <li> element
+        const crate3dHeader = await screen.findByText(/2 created/i);
+        expect(crate3dHeader).toBeVisible();
+        const createdEvent1 = within(crate3dHeader).getByText(/created course 1/i);
+        expect(createdEvent1).toBeInTheDocument();
+        const createdEvent2 = within(crate3dHeader).getByText(/created course 2/i);
+        expect(createdEvent2).toBeInTheDocument();
 
-    // assert to see the text '2 skipped' and then check each skipped event in its own <li> element
-    const skippedHeader = await screen.findByText(/2 skipped/i);
-    expect(skippedHeader).toBeVisible();
-    const eventId1 = within(skippedHeader).getByText(/event id 1/i);
-    expect(eventId1).toBeInTheDocument();
-    const eventId2 = within(skippedHeader).getByText(/event id 2/i);
-    expect(eventId2).toBeInTheDocument();
+        // eslint-disable-next-line max-len
+        // assert to see the text '2 skipped' and then check each skipped event in its own <li> element
+        const skippedHeader = await screen.findByText(/2 skipped/i);
+        expect(skippedHeader).toBeVisible();
+        const eventId1 = within(skippedHeader).getByText(/event id 1/i);
+        expect(eventId1).toBeInTheDocument();
+        const eventId2 = within(skippedHeader).getByText(/event id 2/i);
+        expect(eventId2).toBeInTheDocument();
 
-    // assert to see the text '2 errors: event id 2, event id 3'.
-    const errorsHeader = await screen.findByText(/2 errors/i);
-    expect(errorsHeader).toBeVisible();
-    const errorEventId2 = within(errorsHeader).getByText(/event id 2/i);
-    expect(errorEventId2).toBeInTheDocument();
-    const errorEventId3 = within(errorsHeader).getByText(/event id 3/i);
-    expect(errorEventId3).toBeInTheDocument();
+        // assert to see the text '2 errors: event id 2, event id 3'.
+        const errorsHeader = await screen.findByText(/2 errors/i);
+        expect(errorsHeader).toBeVisible();
+        const errorEventId2 = within(errorsHeader).getByText(/event id 2/i);
+        expect(errorEventId2).toBeInTheDocument();
+        const errorEventId3 = within(errorsHeader).getByText(/event id 3/i);
+        expect(errorEventId3).toBeInTheDocument();
 
-    // assert to see the text '2 updated'.
-    const updatedHeader = await screen.findByText(/2 updated/i);
-    expect(updatedHeader).toBeVisible();
-    const updatedCourseId1 = within(updatedHeader).getByText(/updated course 1/i);
-    expect(updatedCourseId1).toBeInTheDocument();
-    const updatedCourseId2 = within(updatedHeader).getByText(/updated course 2/i);
-    expect(updatedCourseId2).toBeInTheDocument();
+        // assert to see the text '2 updated'.
+        const updatedHeader = await screen.findByText(/2 updated/i);
+        expect(updatedHeader).toBeVisible();
+        const updatedCourseId1 = within(updatedHeader).getByText(/updated course 1/i);
+        expect(updatedCourseId1).toBeInTheDocument();
+        const updatedCourseId2 = within(updatedHeader).getByText(/updated course 2/i);
+        expect(updatedCourseId2).toBeInTheDocument();
 
-    // assert to see the text '2 replaced'.
-    const replacedHeader = await screen.findByText(/2 replaced/i);
-    expect(replacedHeader).toBeVisible();
-    const replacedCourseId1 = within(replacedHeader).getByText(/replaced course 1/i);
-    expect(replacedCourseId1).toBeInTheDocument();
-    const replacedCourseId2 = within(replacedHeader).getByText(/replaced course 2/i);
-    expect(replacedCourseId2).toBeInTheDocument();
+        // assert to see the text '2 replaced'.
+        const replacedHeader = await screen.findByText(/2 replaced/i);
+        expect(replacedHeader).toBeVisible();
+        const replacedCourseId1 = within(replacedHeader).getByText(/replaced course 1/i);
+        expect(replacedCourseId1).toBeInTheDocument();
+        const replacedCourseId2 = within(replacedHeader).getByText(/replaced course 2/i);
+        expect(replacedCourseId2).toBeInTheDocument();
 
-    // assert to see the text '2 deleted'.
-    const deletedHeader = await screen.findByText(/2 deleted/i);
-    expect(deletedHeader).toBeVisible();
-    const deletedCourseId1 = within(deletedHeader).getByText(/deleted course 1/i);
-    expect(deletedCourseId1).toBeInTheDocument();
-    const deletedCourseId2 = within(deletedHeader).getByText(/deleted course 2/i);
-    expect(deletedCourseId2).toBeInTheDocument();
+        // assert to see the text '2 deleted'.
+        const deletedHeader = await screen.findByText(/2 deleted/i);
+        expect(deletedHeader).toBeVisible();
+        const deletedCourseId1 = within(deletedHeader).getByText(/deleted course 1/i);
+        expect(deletedCourseId1).toBeInTheDocument();
+        const deletedCourseId2 = within(deletedHeader).getByText(/deleted course 2/i);
+        expect(deletedCourseId2).toBeInTheDocument();
+      });
+    });
   });
 
   it('displays bad import csv', async () => {
@@ -424,13 +448,13 @@ describe('CsvImport', () => {
     const fileInput = await screen.findByTestId('file-input-input');
     expect(fileInput).toBeVisible();
 
-    // Load 'Test_CSV_Duplicate_EventIds.csv' into a file object.
-    const file = new File([goodTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
-    userEvent.upload(fileInput, file);
+    act(async () => {
+      // Load 'Test_CSV_Duplicate_EventIds.csv' into a file object.
+      const file = new File([goodTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
+      userEvent.upload(fileInput, file);
 
-    // Assert to see correct import count.
-    const error = await screen.findByText(/2 test csv will be imported./i);
-    expect(error).toBeVisible();
+      await waitFor(async () => expect(screen.getByText(/2 test csv will be imported./i)).toBeVisible());
+    });
 
     // Assert button 'Uploadt test csv' is visible.
     const uploadButton = await screen.findByRole('button', { name: /Upload test csv/i });
@@ -439,12 +463,16 @@ describe('CsvImport', () => {
     // Mock fetch error response for url 'test csv'.
     fetchMock.post(testCsvUrl, { status: 500, body: { success: false, count: 0 } });
 
+    act(async () => {
     // Click button 'Upload test csv'.
-    userEvent.click(uploadButton);
+      userEvent.click(uploadButton);
 
-    // Assert to see correct import count.
-    const errorResponse = await screen.findByText(/Error attempting to import test csv./i);
-    expect(errorResponse).toBeVisible();
+      await waitFor(async () => {
+        // Assert to see correct import count.
+        const errorResponse = await screen.findByText(/Error attempting to import test csv./i);
+        expect(errorResponse).toBeVisible();
+      });
+    });
   });
 
   it('displays error if no import file is selected', async () => {
@@ -475,12 +503,16 @@ describe('CsvImport', () => {
     expect(error).toBeVisible();
 
     // Load 'Test_CSV_Duplicate_EventIds.csv' into a file object.
-    const file = new File([goodTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
-    userEvent.upload(fileInput, file);
+    act(async () => {
+      const file = new File([goodTestCSVFile], 'Test_CSV_Duplicate_EventIds.csv', { type: 'text/csv' });
+      userEvent.upload(fileInput, file);
 
-    // Assert to see correct import count.
-    const info = await screen.findByText(/2 test csv will be imported./i);
-    expect(info).toBeVisible();
+      // Assert to see correct import count.
+      await waitFor(async () => {
+        const info = await screen.findByText(/2 test csv will be imported./i);
+        expect(info).toBeVisible();
+      });
+    });
 
     // Assert error message is no longer visible.
     error = screen.queryAllByText(/Please select a file to import./i);
@@ -509,24 +541,24 @@ describe('CsvImport', () => {
     const fileInput = await screen.findByTestId('file-input-input');
     expect(fileInput).toBeVisible();
 
+    act(async () => {
     // Load 'CSV_Test_Invalid_File_Type.csv' into a file object.
-    const file = new File(['bad csv'], 'CSV_Test_Invalid_File_Type.csv', { type: 'text/csv' });
-
-    // Upload file.
-    userEvent.upload(fileInput, file);
-
-    // Assert to see if error message 'Please upload a CSV file with UTF-8 encoding.'.
-    const error = await screen.findByText(/Please upload a CSV file with UTF-8 encoding./i);
-    expect(error).toBeVisible();
+      const file = new File(['bad csv'], 'CSV_Test_Invalid_File_Type.csv', { type: 'text/csv' });
+      // Upload file.
+      userEvent.upload(fileInput, file);
+      // Assert to see if error message 'Please upload a CSV file with UTF-8 encoding.'.
+      await waitFor(async () => expect(await screen.findByText(/Please upload a CSV file with UTF-8 encoding./i)).toBeVisible());
+    });
 
     // Assert button 'Upload csv reports' is visible.
     let uploadButton = await screen.findByRole('button', { name: /Upload test CSV/i });
 
-    // click the upload button.
-    userEvent.click(uploadButton);
-
-    // Make sure the fetch event hasn't fired.
-    expect(fetchMock.calls(testCsvUrl).length).toBe(0);
+    act(async () => {
+      // click the upload button.
+      userEvent.click(uploadButton);
+      // Make sure the fetch event hasn't fired.
+      await waitFor(async () => expect(expect(fetchMock.calls(testCsvUrl).length).toBe(0)));
+    });
 
     expect(uploadButton).toBeVisible();
 
@@ -546,5 +578,36 @@ describe('CsvImport', () => {
 
     // Make sure the fetch event has fired now that we no longer have an error.
     expect(fetchMock.calls(testCsvUrl).length).toBe(1);
+  });
+
+  it('displays csv encoding parsing error', async () => {
+    languageEncoding.mockImplementationOnce(() => {
+      throw new Error('Exception thrown');
+    });
+    const history = createMemoryHistory();
+    render(
+      <Router history={history}>
+        <CsvImport
+          validCsvHeaders={[]}
+          requiredCsvHeaders={[]}
+          typeName="Test CSV"
+          apiPathName="test-csv"
+          primaryIdColumn="Primary ID"
+        />
+      </Router>,
+    );
+
+    // Assert by data-testid 'file-input-input'.
+    const fileInput = await screen.findByTestId('file-input-input');
+    expect(fileInput).toBeVisible();
+
+    act(async () => {
+    // Load 'CSV_Test_Invalid_File_Type.csv' into a file object.
+      const file = new File(['bad csv'], 'CSV_Test_Invalid_File_Type.csv', { type: 'text/csv' });
+      // Upload file.
+      userEvent.upload(fileInput, file);
+      // Assert to see if error message 'Please upload a CSV file with UTF-8 encoding.'.
+      await waitFor(async () => expect(await screen.findByText(/Error reading file encoding. Ensure your CSV is using UTF-8 encoding/i)).toBeVisible());
+    });
   });
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4816,6 +4816,11 @@ destroy@1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
+detect-file-encoding-and-language@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/detect-file-encoding-and-language/-/detect-file-encoding-and-language-2.4.0.tgz#0633b81fbe977c47b82b41c1732aa4534add8541"
+  integrity sha512-moFSAumrGlLCNU5jnaHyCzRUJJu0BCZunfL08iMbnDAgvNnxZad7+WZ26U2dsrIbGChlDPLKmEyEb2tEPUJFkw==
+
 detect-kerning@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-kerning/-/detect-kerning-2.1.2.tgz#4ecd548e4a5a3fc880fe2a50609312d000fa9fc2"


### PR DESCRIPTION
## Description of change

The default encoding of CSV files in Excel is [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252). This is an outdated encoding and as far as I can tell is being replaced by UTF-8. This change ensures that the user is creating their CSV as CSV UTF-8.

**NOTE:** This historical data cleanup for this will be a different ticket.

![image](https://github.com/HHS/Head-Start-TTADP/assets/84350609/a103af1f-5e6c-4aed-9b5e-6c1105c96564)

![image](https://github.com/HHS/Head-Start-TTADP/assets/84350609/a3616dc5-a839-447d-b691-a45f3cad70e2)

## How to test

Import the CSV with the default windows csv encoding you should see an error. Then import a CSV with the CSV UTF-8 **attached to the JIRA**. It should import 113 records and all Spanish chars should show up correctly.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2830


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
