### PR TITLE
[TTAHUB-2895] Hide edit button if the user has incorrect permissions

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -110,7 +110,8 @@ function GoalCard({
     setObjectivesExpanded(!objectivesExpanded);
   };
 
-  const hasEditButtonPermissions = canEditOrCreateGoals(user, parseInt(regionId, DECIMAL_BASE));
+  const hasEditButtonPermissions = canEditOrCreateGoals(user, parseInt(regionId, DECIMAL_BASE))
+    || isAdmin(user);
   const determineMenuItems = () => {
     // Create default menu items.
     const createdMenuItems = [

--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -112,24 +112,26 @@ function GoalCard({
 
   const hasEditButtonPermissions = canEditOrCreateGoals(user, parseInt(regionId, DECIMAL_BASE));
   const determineMenuItems = () => {
-    // Create default menu items.
-    const createdMenuItems = [
-      ...(goalStatus === 'Closed' ? [{
+    // Add reopen button if user has permissions and the goal is closed.
+    const createdMenuItems = [];
+
+    if (goalStatus === 'Closed' && hasEditButtonPermissions) {
+      createdMenuItems.push({
         label: 'Reopen',
         onClick: () => {
           showReopenGoalModal(id);
         },
-      }] : []),
-    ];
-    // Add edit button if user has permissions or if the goal is closed.
-    if (hasEditButtonPermissions || goalStatus === 'Closed') {
-      createdMenuItems.push({
-        label: goalStatus === 'Closed' ? 'View' : 'Edit',
-        onClick: () => {
-          history.push(`/recipient-tta-records/${recipientId}/region/${regionId}/goals?id[]=${ids.join(',')}`);
-        },
       });
     }
+
+    // Add edit button if user has permissions or if the goal is closed.
+    createdMenuItems.push({
+      label: goalStatus === 'Closed' || !hasEditButtonPermissions ? 'View' : 'Edit',
+      onClick: () => {
+        history.push(`/recipient-tta-records/${recipientId}/region/${regionId}/goals?id[]=${ids.join(',')}`);
+      },
+    });
+
     return createdMenuItems;
   };
   const menuItems = determineMenuItems();

--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -110,8 +110,7 @@ function GoalCard({
     setObjectivesExpanded(!objectivesExpanded);
   };
 
-  const hasEditButtonPermissions = canEditOrCreateGoals(user, parseInt(regionId, DECIMAL_BASE))
-    || isAdmin(user);
+  const hasEditButtonPermissions = canEditOrCreateGoals(user, parseInt(regionId, DECIMAL_BASE));
   const determineMenuItems = () => {
     // Create default menu items.
     const createdMenuItems = [

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -631,5 +631,29 @@ describe('Goals Table', () => {
       const editGoal = await screen.findByRole('button', { name: /Edit/i });
       expect(editGoal).toBeVisible();
     });
+
+    it('Shows edit if the user doesnt have the permission but is an admin', async () => {
+      const user = {
+        ...defaultUser,
+        permissions: [
+          {
+            scopeId: SCOPE_IDS.READ_ACTIVITY_REPORTS,
+            regionId: 1,
+          },
+          {
+            scopeId: SCOPE_IDS.ADMIN,
+            regionId: 1,
+          },
+        ],
+      };
+
+      renderTable({ goals: [baseGoals[0]], goalsCount: 1 }, user);
+
+      const menuToggle = await screen.findByRole('button', { name: /Actions for goal 4598/i });
+      userEvent.click(menuToggle);
+
+      const editGoal = await screen.findByRole('button', { name: /Edit/i });
+      expect(editGoal).toBeVisible();
+    });
   });
 });

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -600,4 +600,36 @@ describe('Goals Table', () => {
       expect(history.push).toHaveBeenCalled();
     });
   });
+
+  describe('Context Menu with Different User Permissions', () => {
+    it('Hides the edit button if the user doesn\'t have permissions', async () => {
+      const user = {
+        ...defaultUser,
+        permissions: [
+          {
+            scopeId: SCOPE_IDS.READ_ACTIVITY_REPORTS,
+            regionId: 1,
+          },
+        ],
+      };
+
+      renderTable({ goals: [baseGoals[0]], goalsCount: 1 }, user);
+
+      const menuToggle = await screen.findByRole('button', { name: /Actions for goal 4598/i });
+      userEvent.click(menuToggle);
+
+      const editGoal = screen.queryByRole('button', { name: /Edit/i });
+      expect(editGoal).toBe(null);
+    });
+
+    it('Shows the edit button if the user has permissions', async () => {
+      renderTable({ goals: [baseGoals[0]], goalsCount: 1 }, defaultUser);
+
+      const menuToggle = await screen.findByRole('button', { name: /Actions for goal 4598/i });
+      userEvent.click(menuToggle);
+
+      const editGoal = await screen.findByRole('button', { name: /Edit/i });
+      expect(editGoal).toBeVisible();
+    });
+  });
 });

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -620,6 +620,14 @@ describe('Goals Table', () => {
 
       const editGoal = screen.queryByRole('button', { name: /Edit/i });
       expect(editGoal).toBe(null);
+
+      // Find the View button.
+      const viewGoal = await screen.findByRole('button', { name: 'View' });
+      expect(viewGoal).toBeVisible();
+
+      // Hides the Reopen button.
+      const reopenOptions = screen.queryAllByRole('button', { name: 'Reopen' });
+      expect(reopenOptions.length).toBe(0);
     });
 
     it('Shows the edit button if the user has permissions', async () => {
@@ -630,6 +638,57 @@ describe('Goals Table', () => {
 
       const editGoal = await screen.findByRole('button', { name: /Edit/i });
       expect(editGoal).toBeVisible();
+
+      // hides the reopen button.
+      const reopenOptions = screen.queryAllByRole('button', { name: 'Reopen' });
+      expect(reopenOptions.length).toBe(0);
+    });
+
+    it('Hides the reopen button if the user doesn\'t have permissions', async () => {
+      const user = {
+        ...defaultUser,
+        permissions: [
+          {
+            scopeId: SCOPE_IDS.READ_ACTIVITY_REPORTS,
+            regionId: 1,
+          },
+        ],
+      };
+
+      renderTable({ goals: [{ ...baseGoals[2], goalStatus: 'Closed' }], goalsCount: 1 }, user);
+      const menuToggle = await screen.findByRole('button', { name: /Actions for goal 65478/i });
+      userEvent.click(menuToggle);
+
+      // Verify the button Reopen is not visible.
+      const reopenOptions = screen.queryAllByRole('button', { name: 'Reopen' });
+      expect(reopenOptions.length).toBe(0);
+
+      // Shows the view button.
+      const viewGoal = await screen.findByRole('button', { name: 'View' });
+      expect(viewGoal).toBeVisible();
+    });
+
+    it('Shows the reopen button if the user has permissions', async () => {
+      const user = {
+        ...defaultUser,
+        permissions: [
+          {
+            scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS,
+            regionId: 1,
+          },
+        ],
+      };
+
+      renderTable({ goals: [{ ...baseGoals[2], goalStatus: 'Closed' }], goalsCount: 1 }, user);
+      const menuToggle = await screen.findByRole('button', { name: /Actions for goal 65478/i });
+      userEvent.click(menuToggle);
+
+      // Verify the button Reopen is not visible.
+      expect(await screen.findByRole('button', { name: 'Reopen' })).toBeVisible();
+
+      // Shows the view button.
+      const viewGoal = await screen.findByRole('button', { name: 'View' });
+      expect(viewGoal).toBeVisible();
     });
   });
 });

--- a/frontend/src/components/GoalCards/__tests__/GoalCards.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCards.js
@@ -631,29 +631,5 @@ describe('Goals Table', () => {
       const editGoal = await screen.findByRole('button', { name: /Edit/i });
       expect(editGoal).toBeVisible();
     });
-
-    it('Shows edit if the user doesnt have the permission but is an admin', async () => {
-      const user = {
-        ...defaultUser,
-        permissions: [
-          {
-            scopeId: SCOPE_IDS.READ_ACTIVITY_REPORTS,
-            regionId: 1,
-          },
-          {
-            scopeId: SCOPE_IDS.ADMIN,
-            regionId: 1,
-          },
-        ],
-      };
-
-      renderTable({ goals: [baseGoals[0]], goalsCount: 1 }, user);
-
-      const menuToggle = await screen.findByRole('button', { name: /Actions for goal 4598/i });
-      userEvent.click(menuToggle);
-
-      const editGoal = await screen.findByRole('button', { name: /Edit/i });
-      expect(editGoal).toBeVisible();
-    });
   });
 });

--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -107,7 +107,6 @@ export default function Form({
   const showAlert = isOnReport && status !== 'Closed';
 
   const notClosedWithEditPermission = (() => (status !== 'Closed' && userCanEdit))();
-
   return (
     <div className="ttahub-create-goals-form">
       { fetchError ? <Alert type="error" role="alert">{ fetchError }</Alert> : null}
@@ -197,6 +196,7 @@ export default function Form({
           !isCurated,
           status !== 'Closed',
           createdVia !== 'tr',
+          userCanEdit,
         ]}
         label="Goal source"
         value={uniq(Object.values(source || {})).join(', ') || ''}

--- a/frontend/src/components/GoalForm/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/ObjectiveForm.js
@@ -17,6 +17,7 @@ import AppLoadingContext from '../../AppLoadingContext';
 import ObjectiveSuspendModal from '../ObjectiveSuspendModal';
 import ObjectiveStatusSuspendReason from '../ObjectiveStatusSuspendReason';
 import ObjectiveSupportType from '../ObjectiveSupportType';
+import FormFieldThatIsSometimesReadOnly from './FormFieldThatIsSometimesReadOnly';
 
 const [
   objectiveTitleError,
@@ -227,13 +228,22 @@ export default function ObjectiveForm({
         error={errors[OBJECTIVE_FORM_FIELD_INDEXES.STATUS_SUSPEND_REASON]}
       />
 
-      <ObjectiveSupportType
-        onBlurSupportType={validateSupportType}
-        supportType={supportType || ''}
-        onChangeSupportType={onChangeSupportType}
-        inputName={`objective-support-type-${index}`}
-        error={errors[OBJECTIVE_FORM_FIELD_INDEXES.SUPPORT_TYPE]}
-      />
+      <FormFieldThatIsSometimesReadOnly
+        permissions={[
+          userCanEdit,
+          goalStatus !== 'Closed',
+        ]}
+        label="Support type"
+        value={supportType}
+      >
+        <ObjectiveSupportType
+          onBlurSupportType={validateSupportType}
+          supportType={supportType || ''}
+          onChangeSupportType={onChangeSupportType}
+          inputName={`objective-support-type-${index}`}
+          error={errors[OBJECTIVE_FORM_FIELD_INDEXES.SUPPORT_TYPE]}
+        />
+      </FormFieldThatIsSometimesReadOnly>
 
       <ObjectiveStatus
         status={status}

--- a/frontend/src/components/GoalForm/__tests__/Form.js
+++ b/frontend/src/components/GoalForm/__tests__/Form.js
@@ -37,6 +37,7 @@ describe('Goal Form > Form component', () => {
     objectives = [],
     fetchError = '',
     user = DEFAULT_USER,
+    userCanEdit = true,
   ) => {
     render(
       <UserContext.Provider value={{
@@ -91,7 +92,7 @@ describe('Goal Form > Form component', () => {
             onUploadFile={jest.fn()}
             validateGoalNameAndRecipients={jest.fn()}
             prompts={goal.prompts}
-            userCanEdit
+            userCanEdit={userCanEdit}
             source={goal.source}
             setSource={jest.fn()}
             createdVia={goal.createdVia || 'activityReport'}
@@ -143,6 +144,47 @@ describe('Goal Form > Form component', () => {
     sourceSelects.forEach((sourceSelect) => {
       expect(sourceSelect).toBeEnabled();
     });
+  });
+
+  it('disables the goal source if userCanEdit is false', () => {
+    renderGoalForm(
+      {
+        ...DEFAULT_GOAL,
+        createdVia: 'activityReport',
+        selectedGrants: [{ id: 1, numberWithProgramTypes: 'GRANT_NUMBER EHS' }],
+        source: { 'GRANT_NUMBER EHS': 'Not Training event' },
+      },
+      [],
+      '',
+      { ...DEFAULT_USER, permissions: [{ regionId: 1, scopeId: SCOPE_IDS.READ_ACTIVITY_REPORTS }] },
+      false,
+    );
+
+    expect(screen.getByText(/goal source/i)).toBeVisible();
+    expect(screen.queryAllByRole('combobox', { name: /goal source/i }).length).toBe(0);
+  });
+
+  it('enables the goal source if userCanEdit is true', () => {
+    renderGoalForm(
+      {
+        ...DEFAULT_GOAL,
+        createdVia: 'activityReport',
+        selectedGrants: [{ id: 1, numberWithProgramTypes: 'GRANT_NUMBER EHS' }],
+        source: { 'GRANT_NUMBER EHS': 'Not Training event' },
+      },
+      [],
+      '',
+      {
+        ...DEFAULT_USER,
+        permissions: [
+          { regionId: 1, scopeId: SCOPE_IDS.READ_WRITE_ACTIVITY_REPORTS },
+        ],
+      },
+      true,
+    );
+
+    expect(screen.getByText(/goal source/i)).toBeVisible();
+    expect(screen.queryAllByRole('combobox', { name: /goal source/i }).length).toBe(1);
   });
 
   it('shows an error when the fetch has failed', async () => {

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -34,7 +34,7 @@ describe('ObjectiveForm', () => {
     ],
     id: 123,
     status: 'Not started',
-    supportType: 'Coaching',
+    supportType: 'Maintaining',
   };
 
   const index = 1;
@@ -181,6 +181,7 @@ describe('ObjectiveForm', () => {
     );
 
     expect(screen.getByText('Support type')).toBeVisible();
+    expect(screen.getByText('Maintaining')).toBeVisible();
     expect(screen.queryAllByRole('combobox', { name: /support type/i }).length).toBe(0);
   });
 
@@ -199,6 +200,7 @@ describe('ObjectiveForm', () => {
     );
 
     expect(screen.getByText('Support type')).toBeVisible();
+    expect(screen.getByText('Maintaining')).toBeVisible();
     expect(screen.queryAllByRole('combobox', { name: /support type/i }).length).toBe(0);
   });
 
@@ -217,6 +219,8 @@ describe('ObjectiveForm', () => {
     );
 
     expect(screen.getByText('Support type')).toBeVisible();
-    expect(screen.getByRole('combobox', { name: /support type/i })).toBeVisible();
+    const supportType = await screen.findByRole('combobox', { name: /support type/i });
+    expect(supportType).toBeVisible();
+    expect(screen.getByText('Maintaining')).toBeVisible();
   });
 });

--- a/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
+++ b/frontend/src/components/GoalForm/__tests__/ObjectiveForm.js
@@ -34,6 +34,7 @@ describe('ObjectiveForm', () => {
     ],
     id: 123,
     status: 'Not started',
+    supportType: 'Coaching',
   };
 
   const index = 1;
@@ -44,6 +45,7 @@ describe('ObjectiveForm', () => {
     setObjectiveError = jest.fn(),
     setObjective = jest.fn(),
     goalStatus = 'Draft',
+    userCanEdit = true,
   ) => {
     render((
       <UserContext.Provider value={{ user: { flags: [] } }}>
@@ -70,7 +72,7 @@ describe('ObjectiveForm', () => {
             'Curriculum (Instructional or Parenting)',
             'Data and Evaluation',
           ].map((name, id) => ({ id, name }))}
-          userCanEdit
+          userCanEdit={userCanEdit}
         />
       </UserContext.Provider>
     ));
@@ -162,5 +164,59 @@ describe('ObjectiveForm', () => {
 
     const label = await screen.findByText('Link to TTA resource');
     expect(label).toBeVisible();
+  });
+
+  it('displays support type as read only when user cannot edit', async () => {
+    const removeObjective = jest.fn();
+    const setObjectiveError = jest.fn();
+    const setObjective = jest.fn();
+
+    renderObjectiveForm(
+      defaultObjective,
+      removeObjective,
+      setObjectiveError,
+      setObjective,
+      'In Progress',
+      false,
+    );
+
+    expect(screen.getByText('Support type')).toBeVisible();
+    expect(screen.queryAllByRole('combobox', { name: /support type/i }).length).toBe(0);
+  });
+
+  it('displays support type as read only when goal is closed', async () => {
+    const removeObjective = jest.fn();
+    const setObjectiveError = jest.fn();
+    const setObjective = jest.fn();
+
+    renderObjectiveForm(
+      defaultObjective,
+      removeObjective,
+      setObjectiveError,
+      setObjective,
+      'Closed',
+      true,
+    );
+
+    expect(screen.getByText('Support type')).toBeVisible();
+    expect(screen.queryAllByRole('combobox', { name: /support type/i }).length).toBe(0);
+  });
+
+  it('displays support type when goal is not closed and user has permission', async () => {
+    const removeObjective = jest.fn();
+    const setObjectiveError = jest.fn();
+    const setObjective = jest.fn();
+
+    renderObjectiveForm(
+      defaultObjective,
+      removeObjective,
+      setObjectiveError,
+      setObjective,
+      'In Progress',
+      true,
+    );
+
+    expect(screen.getByText('Support type')).toBeVisible();
+    expect(screen.getByRole('combobox', { name: /support type/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description of change

1. If a user doesn't have permission to create reports in a region they shouldn't be able to edit a RTR goal in that region. That being said they should be able to view the goal with read only permissions.
2. If a user is read only they shouldn't be able to change the goal source OR support type when viewing the goal.

_Note: Confirmed with Angela even if the user is an admin but doesn't have the permission hide the option._

## How to test

1. Visit the RTR without the write permission for that region. You should not be able to edit the goal (but should be able to view). Add the permission for that region you now should be able to edit.
2. Viewing a goal with read only permissions shouldn't allow the user to change the goal source OR support type. 

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2895


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
