### PR TITLE
[TTAHUB-2989] Cleanup report cache function to ensure reports can be completed

### DIFF
--- a/src/services/reportCache.js
+++ b/src/services/reportCache.js
@@ -399,7 +399,7 @@ export const cachePrompts = async (
 const cacheGoalMetadata = async (
   goal,
   reportId,
-  isActivelyBeingEditing,
+  isActivelyEdited,
   prompts,
   isMultiRecipientReport = false,
 ) => {
@@ -422,7 +422,7 @@ const cacheGoalMetadata = async (
       closeSuspendContext: goal.closeSuspendContext,
       endDate: goal.endDate,
       isRttapa: null,
-      isActivelyEdited: isActivelyBeingEditing || false,
+      isActivelyEdited: isActivelyEdited || false,
       source: goal.source,
     }, {
       where: { id: activityReportGoalId },
@@ -441,13 +441,22 @@ const cacheGoalMetadata = async (
       endDate: goal.endDate,
       source: goal.source,
       isRttapa: null,
-      isActivelyEdited: isActivelyBeingEditing || false,
+      isActivelyEdited: isActivelyEdited || false,
     }, {
       individualHooks: true,
       returning: true,
       plain: true,
     });
   }
+
+  // cleanup any stray ARGs for that goal/report combo
+  await ActivityReportGoal.destroy({
+    where: {
+      goalId: goal.id,
+      activityReportId: reportId,
+      id: { [Op.ne]: arg.id },
+    },
+  });
 
   const finalPromises = [
     Goal.update({ onAR: true }, { where: { id: goal.id }, individualHooks: true }),


### PR DESCRIPTION
## Description of change
Support case: user would save their goal, the save would complete, and then the goal would disappear. Examining the data, there were two ActivityReportGoals for that report/goal combo. It's unclear how something like that could happen, but in the case that it does, I've added code to cleanup after each ARG create or update.

## How to test
Download the newest prod db from keybase. Impersonate the user mentioned in the support ticket. View that report, go to the goals section, and click save. You should see the saved data in the "read-only goal" grey box.  Confirm that the report can be submitted.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2989


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
