### PR TITLE
[TTAHUB-2918] Change "Resources Dashboard" to "Resource Dashboard" in left sidebar

### DIFF
--- a/frontend/src/components/SiteNav.js
+++ b/frontend/src/components/SiteNav.js
@@ -116,7 +116,7 @@ const SiteNav = ({
                     <NavLink
                       to="/dashboards/resources-dashboard"
                     >
-                      Resources Dashboard
+                      Resource Dashboard
                     </NavLink>
                   </li>
                   <li>

--- a/frontend/src/pages/ResourcesDashboard/__tests__/index.js
+++ b/frontend/src/pages/ResourcesDashboard/__tests__/index.js
@@ -252,7 +252,7 @@ const regionTwoInParams = 'region.in[]=2';
 const reportIdInParams = 'region.in[]=1&region.in[]=2&reportId.ctn[]=123';
 const reportPostUrl = '/api/activity-reports/reportsByManyIds';
 
-describe('Resources Dashboard page', () => {
+describe('Resource Dashboard page', () => {
   afterEach(() => fetchMock.restore());
   const renderResourcesDashboard = (user) => {
     render(


### PR DESCRIPTION
## Description of change
Changed instances of "Resources Dashboard" to "Resource Dashboard"


## How to test
Look at name in left navigation bar

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2918


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
