### PR TITLE
[TTAHUB-3003] Update awscli_install.sh to version lock awscli

### DIFF
--- a/automation/common/scripts/awscli_install.sh
+++ b/automation/common/scripts/awscli_install.sh
@@ -63,6 +63,18 @@ function download_aws_cli() {
         log "ERROR" "Failed to download AWS CLI."
         exit 2
     fi
+
+    if command -v gpg > /dev/null 2>&1; then
+      if ! wget "$aws_cli_url.sig" -O "$zip_file.sig"; then
+          log "ERROR" "Failed to download AWS CLI."
+          exit 2
+      fi
+
+      if ! gpg --verify "${sig_file}" "${file}"; then
+          log "ERROR" "Sig verification failed for AWS CLI."
+          exit 2
+      fi
+    fi
     log "INFO" "Download completed successfully."
 }
 
@@ -137,6 +149,12 @@ function cleanup() {
     else
         log "INFO" "The zip file does not exist."
     fi
+    if [ -f "$zip_file.sig" ]; then
+        rm "$zip_file.sig"
+        log "INFO" "The zip sig file has been deleted."
+    else
+        log "INFO" "The zip file does not exist."
+    fi
     if [ -d "$aws_dir" ]; then
         rm -r "$aws_dir"
         log "INFO" "The 'aws' directory has been deleted."
@@ -147,10 +165,10 @@ function cleanup() {
 
 # Main function to control workflow
 main() {
-    local aws_cli_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    local aws_cli_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.15.56.zip"
     local install_dir="/tmp/local/aws-cli"
     local zip_file="/tmp/awscliv2.zip"
-    local zip_sha256="b5f5c31aac4cfd7a6eca58bd6f54ff4ebf4417dc70dc77e8db44ce52aa0723c4"
+    local zip_sha256="f68d3cc42d08a346b55aa531bcc2a0320700e374d87a3282a0f7e48c0f75bff7"
     local bin_dir="/tmp/local/bin"
     local aws_dir="/tmp/local/aws"
 

--- a/automation/common/scripts/awscli_install.sh
+++ b/automation/common/scripts/awscli_install.sh
@@ -70,7 +70,7 @@ function download_aws_cli() {
           exit 2
       fi
 
-      if ! gpg --verify "${sig_file}" "${file}"; then
+      if ! gpg --verify "${zip_file}.sig" "$zip_file"; then
           log "ERROR" "Sig verification failed for AWS CLI."
           exit 2
       fi

--- a/automation/common/scripts/postgrescli_install.sh
+++ b/automation/common/scripts/postgrescli_install.sh
@@ -223,7 +223,7 @@ function cleanup() {
 function main() {
     local deb_url="http://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.6-0+deb12u1_amd64.deb"
     local deb_file="/tmp/postgresql.deb"
-    local deb_sha256="c7143d12f17403821fe7111ff8ac3de3884cf96e"
+    local deb_sha256="f601421f0f075c78df0ee289fbe075f38f52d08362ff2907d1710c26d5e53c39"
     local bin_dir="/tmp/local/bin"
     local tools=("pg_dump" "pg_isready" "pg_restore" "psql" "reindexdb" "vacuumdb")
 


### PR DESCRIPTION
## Description of change

awscli is actively under development, so new versions are released often. This makes hash verification of the latest version fail as soon as the next version is released. This change locks to a specific version.

## How to test
Run db backup script, awscli should download and install without failing the hash verification.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3003


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
