### PR TITLE
[TTAHUB-3022] Backup production DB on each deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1069,6 +1069,20 @@ workflows:
       - dynamic_security_scan:
           requires:
             - build_and_lint
+      - backup_upload_production:
+          requires:
+            - test_backend
+            - test_frontend
+            - test_e2e
+            - test_api
+            - test_similarity_api
+            - test_utils
+            - cucumber_test
+            - dynamic_security_scan
+          filters:
+            branches:
+              only:
+                - << pipeline.parameters.prod_git_branch >>
       - deploy:
           requires:
             - test_backend


### PR DESCRIPTION
## Description of change

Add step in circleci to auto-backup production as part of the deployment process, So that any failed deployment can be reverted back to a known good state.


## How to test
It runs the same DB backup function that the scheduled backup does, just as part of the production deployment job. Only the production deployment job.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3022


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
