### PR TITLE
[TTAHUB-2787] Improve missing goal response experience somewhat

### DIFF
--- a/frontend/src/components/Navigator/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/ActivityReportNavigator.js
@@ -210,7 +210,7 @@ const ActivityReportNavigator = ({
 
     return newPageState;
   };
-  const onSaveForm = async (isAutoSave = false) => {
+  const onSaveForm = async (isAutoSave = false, forceUpdate = false) => {
     setSavingLoadScreen(isAutoSave);
     if (!editable) {
       setIsAppLoading(false);
@@ -222,7 +222,7 @@ const ActivityReportNavigator = ({
     try {
       // Always clear the previous error message before a save.
       updateErrorMessage();
-      await onSave(data);
+      await onSave(data, forceUpdate);
       updateLastSaveTime(moment());
     } catch (error) {
       updateErrorMessage('A network error has prevented us from saving your activity report to our database. Your work is safely saved to your web browser in the meantime.');

--- a/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.js
@@ -286,6 +286,7 @@ describe('Navigator', () => {
         },
         second: 'on',
       },
+      false,
     ));
   });
 
@@ -321,7 +322,7 @@ describe('Navigator', () => {
       ...initialData,
       pageState: { ...initialData.pageState, 2: IN_PROGRESS },
       second: 'on',
-    }));
+    }, false));
     await waitFor(() => expect(updatePage).toHaveBeenCalledWith(1));
   });
 

--- a/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
@@ -47,7 +47,27 @@ const SomeGoalsHaveNoPromptResponse = ({
         ))}
       </ul>
 
-      { (missingGoalData.length > 0) && (
+      {(missingGoalData.length === 1) && (
+      <ul className="usa-list">
+        {missingGoalData.map((goal) => (
+          <li key={goal.id}>
+            <Link
+              aria-label={`Edit goal ${goal.id} in a new tab`}
+              to={`/recipient-tta-records/${goal.recipientId}/region/${goal.regionId}/goals?id[]=${goal.id}`}
+              target="_blank"
+            >
+              {goal.recipientName}
+              {' '}
+              {goal.grantNumber}
+              {' '}
+              {goal.id}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      )}
+
+      { (missingGoalData.length > 1) && (
         <details>
           <summary>Complete your goals</summary>
           <ul className="usa-list">

--- a/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
@@ -10,7 +10,7 @@ const SomeGoalsHaveNoPromptResponse = ({
   goalsMissingResponses,
   regionId,
 }) => {
-  const [missingGoalData, setMissingGoalData] = useState([]);
+  const [missingGoalData, setMissingGoalData] = useState();
 
   async function fetchMissingData(goalIds) {
     try {
@@ -30,6 +30,10 @@ const SomeGoalsHaveNoPromptResponse = ({
     fetchMissingData(ids);
   }, [goalsMissingResponses, regionId]);
 
+  if (!missingGoalData || !missingGoalData.length) {
+    return null;
+  }
+
   return (
     <Alert validation noIcon slim type="error">
       <strong>Some goals are incomplete</strong>
@@ -44,34 +48,34 @@ const SomeGoalsHaveNoPromptResponse = ({
       </ul>
 
       { (missingGoalData.length > 0) && (
-      <details>
-        <summary>Complete your goals</summary>
-        <ul className="usa-list">
-          {missingGoalData.map((goal) => (
-            <li key={goal.id}>
-              <Link
-                aria-label={`Edit goal ${goal.id} in a new tab`}
-                to={`/recipient-tta-records/${goal.recipientId}/region/${goal.regionId}/goals?id[]=${goal.id}`}
-                target="_blank"
-              >
-                {goal.recipientName}
-                {' '}
-                {goal.grantNumber}
-                {' '}
-                {goal.id}
-              </Link>
-            </li>
-          ))}
-        </ul>
-        <Button
-          unstyled
-          onClick={() => {
-            fetchMissingData(goalsMissingResponses.map((goal) => goal.goalIds).flat());
-          }}
-        >
-          Refresh list of goals
-        </Button>
-      </details>
+        <details>
+          <summary>Complete your goals</summary>
+          <ul className="usa-list">
+            {missingGoalData.map((goal) => (
+              <li key={goal.id}>
+                <Link
+                  aria-label={`Edit goal ${goal.id} in a new tab`}
+                  to={`/recipient-tta-records/${goal.recipientId}/region/${goal.regionId}/goals?id[]=${goal.id}`}
+                  target="_blank"
+                >
+                  {goal.recipientName}
+                  {' '}
+                  {goal.grantNumber}
+                  {' '}
+                  {goal.id}
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <Button
+            unstyled
+            onClick={() => {
+              fetchMissingData(goalsMissingResponses.map((goal) => goal.goalIds).flat());
+            }}
+          >
+            Refresh list of goals
+          </Button>
+        </details>
       )}
 
     </Alert>

--- a/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/SomeGoalsHaveNoPromptResponse.js
@@ -5,6 +5,46 @@ import { Alert, Button } from '@trussworks/react-uswds';
 import { Link } from 'react-router-dom';
 import { missingDataForActivityReport } from '../../../../fetchers/goals';
 
+const MissingGoalDataList = ({ missingGoalData }) => (
+  <ul className="usa-list">
+    {missingGoalData.map((goal) => (
+      <li key={goal.id}>
+        <Link
+          aria-label={`Edit goal ${goal.id} in a new tab`}
+          to={`/recipient-tta-records/${goal.recipientId}/region/${goal.regionId}/goals?id[]=${goal.id}`}
+          target="_blank"
+        >
+          {goal.recipientName}
+          {' '}
+          {goal.grantNumber}
+          {' '}
+          {goal.id}
+        </Link>
+      </li>
+    ))}
+  </ul>
+);
+
+MissingGoalDataList.propTypes = {
+  missingGoalData: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    recipientId: PropTypes.number,
+    regionId: PropTypes.number,
+    recipientName: PropTypes.string,
+    grantNumber: PropTypes.string,
+  })).isRequired,
+};
+
+const RefreshListOfGoalsButton = ({ onClick }) => (
+  <Button unstyled onClick={onClick}>
+    Refresh list of goals
+  </Button>
+);
+
+RefreshListOfGoalsButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
 const SomeGoalsHaveNoPromptResponse = ({
   promptsMissingResponses,
   goalsMissingResponses,
@@ -21,6 +61,10 @@ const SomeGoalsHaveNoPromptResponse = ({
       console.error('Error fetching missing data', error);
     }
   }
+
+  const onClickRefresh = async () => {
+    await fetchMissingData(goalsMissingResponses.map((goal) => goal.goalIds).flat());
+  };
 
   useDeepCompareEffect(() => {
     const ids = goalsMissingResponses.map((goal) => goal.goalIds).flat();
@@ -48,53 +92,17 @@ const SomeGoalsHaveNoPromptResponse = ({
       </ul>
 
       {(missingGoalData.length === 1) && (
-      <ul className="usa-list">
-        {missingGoalData.map((goal) => (
-          <li key={goal.id}>
-            <Link
-              aria-label={`Edit goal ${goal.id} in a new tab`}
-              to={`/recipient-tta-records/${goal.recipientId}/region/${goal.regionId}/goals?id[]=${goal.id}`}
-              target="_blank"
-            >
-              {goal.recipientName}
-              {' '}
-              {goal.grantNumber}
-              {' '}
-              {goal.id}
-            </Link>
-          </li>
-        ))}
-      </ul>
+        <>
+          <MissingGoalDataList missingGoalData={missingGoalData} />
+          <RefreshListOfGoalsButton onClick={onClickRefresh} />
+        </>
       )}
 
       { (missingGoalData.length > 1) && (
         <details>
           <summary>Complete your goals</summary>
-          <ul className="usa-list">
-            {missingGoalData.map((goal) => (
-              <li key={goal.id}>
-                <Link
-                  aria-label={`Edit goal ${goal.id} in a new tab`}
-                  to={`/recipient-tta-records/${goal.recipientId}/region/${goal.regionId}/goals?id[]=${goal.id}`}
-                  target="_blank"
-                >
-                  {goal.recipientName}
-                  {' '}
-                  {goal.grantNumber}
-                  {' '}
-                  {goal.id}
-                </Link>
-              </li>
-            ))}
-          </ul>
-          <Button
-            unstyled
-            onClick={() => {
-              fetchMissingData(goalsMissingResponses.map((goal) => goal.goalIds).flat());
-            }}
-          >
-            Refresh list of goals
-          </Button>
+          <MissingGoalDataList missingGoalData={missingGoalData} />
+          <RefreshListOfGoalsButton onClick={onClickRefresh} />
         </details>
       )}
 

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/Draft.js
@@ -167,6 +167,7 @@ const Draft = ({
           regionId={regionId}
           promptsMissingResponses={promptsMissingResponses}
           goalsMissingResponses={goalsMissingResponses}
+          onSaveDraft={onSaveForm}
         />
         )}
         <div className="margin-top-3">

--- a/frontend/src/pages/ActivityReport/Pages/Review/Submitter/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/Submitter/__tests__/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
 import { REPORT_STATUSES, SCOPE_IDS } from '@ttahub/common';
 import userEvent from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
@@ -75,6 +76,7 @@ const renderReview = (
     displayId: 'R01-AR-23424',
     id: 1,
     creatorRole,
+    regionId: 1,
   };
 
   if (hasIncompleteGoalPrompts) {
@@ -84,6 +86,7 @@ const renderReview = (
         allGoalsHavePromptResponse: false,
         title: 'FEI Goal',
       }],
+      goalIds: [1, 2],
     }];
   }
 
@@ -136,6 +139,15 @@ describe('Submitter review page', () => {
     });
 
     it('shows an error if goals are missing prompts', async () => {
+      fetchMock.get('/api/goals/region/1/incomplete?goalIds=1&goalIds=2', [
+        {
+          id: 2, recipientId: 1, regionId: 1, recipientName: 'recipient1', grantNumber: 'grant1',
+        },
+        {
+          id: 3, recipientId: 1, regionId: 1, recipientName: 'recipient1', grantNumber: 'grant1',
+        },
+      ]);
+
       renderReview(
         REPORT_STATUSES.DRAFT,
         jest.fn(),

--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/SomeGoalsHaveNoPromptResponse.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/SomeGoalsHaveNoPromptResponse.js
@@ -16,6 +16,7 @@ describe('SomeGoalsHaveNoPromptResponse', () => {
         promptsMissingResponses={['prompt1', 'prompt2']}
         goalsMissingResponses={[{ goalIds: [1, 2] }, { goalIds: [3] }]}
         regionId={1}
+        onSaveDraft={jest.fn()}
         {...props}
       />
     </MemoryRouter>
@@ -23,7 +24,10 @@ describe('SomeGoalsHaveNoPromptResponse', () => {
 
   const url = '/api/goals/region/1/incomplete?goalIds=1&goalIds=2&goalIds=3';
 
-  afterEach(() => fetchMock.restore());
+  afterEach(() => {
+    fetchMock.restore();
+    jest.clearAllMocks();
+  });
 
   it('displays the message and fetches the data', async () => {
     fetchMock.get(url, [
@@ -37,12 +41,13 @@ describe('SomeGoalsHaveNoPromptResponse', () => {
         id: 3, recipientId: 1, regionId: 1, recipientName: 'recipient1', grantNumber: 'grant1',
       },
     ]);
-    render(<RenderSomeGoalsHaveNoPromptResponse />);
+    const onSaveDraft = jest.fn();
+    render(<RenderSomeGoalsHaveNoPromptResponse onSaveDraft={onSaveDraft} />);
     const item = await screen.findByText('Some goals are incomplete');
     expect(item).toBeVisible();
     expect(fetchMock.called(url)).toBeTruthy();
-    const summary = screen.getByText('Complete your goals');
-    userEvent.click(summary);
+    const summary = screen.getByText('Incomplete goals');
+    expect(summary).toBeVisible();
     const link = await screen.findByText('recipient1 grant1 1');
     expect(link).toBeVisible();
     const link2 = await screen.findByText('recipient1 grant1 2');
@@ -56,61 +61,35 @@ describe('SomeGoalsHaveNoPromptResponse', () => {
     const detailsElement = document.querySelector('details');
     expect(detailsElement).toBeTruthy();
 
-    fetchMock.restore();
-    expect(fetchMock.called(url)).toBeFalsy();
-    fetchMock.get(url, [
-      {
-        id: 2, recipientId: 1, regionId: 1, recipientName: 'recipient1', grantNumber: 'grant1',
-      },
-      {
-        id: 3, recipientId: 1, regionId: 1, recipientName: 'recipient1', grantNumber: 'grant1',
-      },
-    ]);
     const reset = await screen.findByText('Refresh list of goals');
     act(() => {
       userEvent.click(reset);
     });
-    expect(fetchMock.called(url)).toBeTruthy();
-  });
 
-  it('displays slightly differently for one result', async () => {
-    fetchMock.get(url, [
-      {
-        id: 1, recipientId: 1, regionId: 1, recipientName: 'recipient1', grantNumber: 'grant1',
-      },
-    ]);
-    render(<RenderSomeGoalsHaveNoPromptResponse />);
-    const item = await screen.findByText('Some goals are incomplete');
-    expect(item).toBeVisible();
-    expect(fetchMock.called(url)).toBeTruthy();
-
-    const link = await screen.findByText('recipient1 grant1 1');
-    expect(link).toBeVisible();
-
-    const summaryElement = document.querySelector('summary');
-    expect(summaryElement).toBeFalsy();
-
-    const detailsElement = document.querySelector('details');
-    expect(detailsElement).toBeFalsy();
+    expect(onSaveDraft).toHaveBeenCalledTimes(1);
   });
 
   it('handles error to fetch', async () => {
     fetchMock.get(url, 500);
-    render(<RenderSomeGoalsHaveNoPromptResponse />);
+    act(() => {
+      render(<RenderSomeGoalsHaveNoPromptResponse />);
+    });
     expect(fetchMock.called(url)).toBeTruthy();
-    const item = screen.queryByText('Some goals are incomplete');
-    expect(item).toBe(null);
-    const summary = screen.queryAllByText('Complete your goals');
+    const item = await screen.findByText('Some goals are incomplete');
+    expect(item).toBeVisible();
+    const summary = screen.queryAllByText('Incomplete goals');
     expect(summary.length).toBe(0);
   });
 
   it('handles empty result', async () => {
     fetchMock.get(url, []);
-    render(<RenderSomeGoalsHaveNoPromptResponse />);
+    act(() => {
+      render(<RenderSomeGoalsHaveNoPromptResponse />);
+    });
     expect(fetchMock.called(url)).toBeTruthy();
-    const item = screen.queryByText('Some goals are incomplete');
-    expect(item).toBe(null);
-    const summary = screen.queryAllByText('Complete your goals');
+    const item = await screen.findByText('Some goals are incomplete');
+    expect(item).toBeVisible();
+    const summary = screen.queryAllByText('Incomplete goals');
     expect(summary.length).toBe(0);
   });
 

--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/SomeGoalsHaveNoPromptResponse.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/SomeGoalsHaveNoPromptResponse.js
@@ -70,24 +70,38 @@ describe('SomeGoalsHaveNoPromptResponse', () => {
   it('handles error to fetch', async () => {
     fetchMock.get(url, 500);
     render(<RenderSomeGoalsHaveNoPromptResponse />);
-    const item = await screen.findByText('Some goals are incomplete');
-    expect(item).toBeVisible();
     expect(fetchMock.called(url)).toBeTruthy();
+    const item = screen.queryByText('Some goals are incomplete');
+    expect(item).toBe(null);
+    const summary = screen.queryAllByText('Complete your goals');
+    expect(summary.length).toBe(0);
+  });
+
+  it('handles empty result', async () => {
+    fetchMock.get(url, []);
+    render(<RenderSomeGoalsHaveNoPromptResponse />);
+    expect(fetchMock.called(url)).toBeTruthy();
+    const item = screen.queryByText('Some goals are incomplete');
+    expect(item).toBe(null);
     const summary = screen.queryAllByText('Complete your goals');
     expect(summary.length).toBe(0);
   });
 
   it('does not fetch with no region', async () => {
     render(<RenderSomeGoalsHaveNoPromptResponse regionId={null} />);
-    const item = await screen.findByText('Some goals are incomplete');
-    expect(item).toBeVisible();
+    const item = screen.queryByText('Some goals are incomplete');
+    expect(item).toBe(null);
+    const summary = screen.queryAllByText('Complete your goals');
+    expect(summary.length).toBe(0);
     expect(fetchMock.called()).toBeFalsy();
   });
 
   it('does not fetch with no ids', async () => {
     render(<RenderSomeGoalsHaveNoPromptResponse goalsMissingResponses={[]} />);
-    const item = await screen.findByText('Some goals are incomplete');
-    expect(item).toBeVisible();
+    const item = screen.queryByText('Some goals are incomplete');
+    expect(item).toBe(null);
+    const summary = screen.queryAllByText('Complete your goals');
+    expect(summary.length).toBe(0);
     expect(fetchMock.called()).toBeFalsy();
   });
 });

--- a/frontend/src/pages/ActivityReport/Pages/Review/__tests__/SomeGoalsHaveNoPromptResponse.js
+++ b/frontend/src/pages/ActivityReport/Pages/Review/__tests__/SomeGoalsHaveNoPromptResponse.js
@@ -50,6 +50,12 @@ describe('SomeGoalsHaveNoPromptResponse', () => {
     const link3 = await screen.findByText('recipient1 grant1 3');
     expect(link3).toBeVisible();
 
+    const summaryElement = document.querySelector('summary');
+    expect(summaryElement).toBeTruthy();
+
+    const detailsElement = document.querySelector('details');
+    expect(detailsElement).toBeTruthy();
+
     fetchMock.restore();
     expect(fetchMock.called(url)).toBeFalsy();
     fetchMock.get(url, [
@@ -65,6 +71,27 @@ describe('SomeGoalsHaveNoPromptResponse', () => {
       userEvent.click(reset);
     });
     expect(fetchMock.called(url)).toBeTruthy();
+  });
+
+  it('displays slightly differently for one result', async () => {
+    fetchMock.get(url, [
+      {
+        id: 1, recipientId: 1, regionId: 1, recipientName: 'recipient1', grantNumber: 'grant1',
+      },
+    ]);
+    render(<RenderSomeGoalsHaveNoPromptResponse />);
+    const item = await screen.findByText('Some goals are incomplete');
+    expect(item).toBeVisible();
+    expect(fetchMock.called(url)).toBeTruthy();
+
+    const link = await screen.findByText('recipient1 grant1 1');
+    expect(link).toBeVisible();
+
+    const summaryElement = document.querySelector('summary');
+    expect(summaryElement).toBeFalsy();
+
+    const detailsElement = document.querySelector('details');
+    expect(detailsElement).toBeFalsy();
   });
 
   it('handles error to fetch', async () => {

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -90,6 +90,7 @@ export const formatReportWithSaveBeforeConversion = async (
   userHasOneRole,
   reportId,
   approverIds,
+  forceUpdate,
 ) => {
   // if it isn't a new report, we compare it to the last response from the backend (formData)
   // and pass only the updated to save report
@@ -104,7 +105,7 @@ export const formatReportWithSaveBeforeConversion = async (
   // formData stores them as MM/DD/YYYY so we are good in that instance
   const thereIsANeedToParseDates = !isEmpty;
 
-  const updatedReport = isEmpty
+  const updatedReport = isEmpty && !forceUpdate
     ? { ...formData }
     : await saveReport(
       reportId.current, {
@@ -455,7 +456,7 @@ function ActivityReport({
     history.push(newPath, state);
   };
 
-  const onSave = async (data) => {
+  const onSave = async (data, forceUpdate = false) => {
     const approverIds = data.approvers.map((a) => a.user.id);
     try {
       if (reportId.current === 'new') {
@@ -490,6 +491,7 @@ function ActivityReport({
           userHasOneRole,
           reportId,
           approverIds,
+          forceUpdate,
         );
 
         let reportData = updatedReport;

--- a/src/goalServices/getGoalsMissingDataForActivityReportSubmission.test.js
+++ b/src/goalServices/getGoalsMissingDataForActivityReportSubmission.test.js
@@ -1,4 +1,5 @@
 import faker from '@faker-js/faker';
+import { uniq } from 'lodash';
 import { CREATION_METHOD, GOAL_STATUS } from '../constants';
 import {
   Grant,
@@ -22,6 +23,7 @@ describe('getGoalsMissingDataForActivityReportSubmission', () => {
 
   let goalOne;
   let goalTwo;
+  let goalThree;
   let recipient;
   let activeGrant;
 
@@ -54,6 +56,13 @@ describe('getGoalsMissingDataForActivityReportSubmission', () => {
       goalTemplateId: template.id,
     });
 
+    goalThree = await createGoal({
+      status: GOAL_STATUS.IN_PROGRESS,
+      name: goalTitle,
+      grantId: activeGrant.id,
+      goalTemplateId: template.id,
+    });
+
     const prompt = await GoalTemplateFieldPrompt.create({
       goalTemplateId: template.id,
       ordinal: 1,
@@ -72,12 +81,20 @@ describe('getGoalsMissingDataForActivityReportSubmission', () => {
       onAR: false,
       onApprovedAR: false,
     });
+
+    await GoalFieldResponse.create({
+      goalTemplateFieldPromptId: prompt.id,
+      goalId: goalThree.id,
+      response: [],
+      onAR: false,
+      onApprovedAR: false,
+    });
   });
 
   afterAll(async () => {
     await GoalFieldResponse.destroy({
       where: {
-        goalId: goalOne.id,
+        goalId: [goalOne.id, goalTwo.id, goalThree.id],
       },
       individualHooks: true,
     });
@@ -91,7 +108,7 @@ describe('getGoalsMissingDataForActivityReportSubmission', () => {
 
     await Goal.destroy({
       where: {
-        id: [goalOne.id, goalTwo.id],
+        id: [goalOne.id, goalTwo.id, goalThree.id],
       },
       force: true,
       individualHooks: true,
@@ -122,13 +139,29 @@ describe('getGoalsMissingDataForActivityReportSubmission', () => {
   });
 
   it('fetches and filters', async () => {
-    const goals = await getGoalsMissingDataForActivityReportSubmission([goalOne.id, goalTwo.id]);
-    expect(goals).toHaveLength(1);
-    const [goal] = goals;
-    expect(goal.id).toBe(goalTwo.id);
-    expect(goal.recipientId).toBe(recipient.id);
-    expect(goal.recipientName).toBe(recipient.name);
-    expect(goal.grantNumber).toBe(activeGrant.number);
-    expect(goal.regionId).toBe(activeGrant.regionId);
+    const goals = await getGoalsMissingDataForActivityReportSubmission(
+      [goalOne.id, goalTwo.id, goalThree.id],
+    );
+    expect(goals).toHaveLength(2);
+
+    const goalIds = goals.map((g) => g.id);
+    expect(goalIds).toContain(goalTwo.id);
+    expect(goalIds).toContain(goalThree.id);
+
+    const recipientIds = uniq(goals.map((g) => g.recipientId));
+    expect(recipientIds).toHaveLength(1);
+    expect(recipientIds).toContain(recipient.id);
+
+    const recipientNames = uniq(goals.map((g) => g.recipientName));
+    expect(recipientNames).toHaveLength(1);
+    expect(recipientNames).toContain(recipient.name);
+
+    const grantNumbers = uniq(goals.map((g) => g.grantNumber));
+    expect(grantNumbers).toHaveLength(1);
+    expect(grantNumbers).toContain(activeGrant.number);
+
+    const regionIds = uniq(goals.map((g) => g.regionId));
+    expect(regionIds).toHaveLength(1);
+    expect(regionIds).toContain(activeGrant.regionId);
   });
 });

--- a/src/goalServices/getGoalsMissingDataForActivityReportSubmission.ts
+++ b/src/goalServices/getGoalsMissingDataForActivityReportSubmission.ts
@@ -1,3 +1,4 @@
+import { Op } from 'sequelize';
 import db from '../models';
 
 const {
@@ -29,6 +30,11 @@ export default async function getGoalsMissingDataForActivityReportSubmission(goa
         as: 'responses',
         required: false,
         attributes: [],
+        where: {
+          response: {
+            [Op.ne]: [],
+          },
+        },
       },
       {
         model: Grant,


### PR DESCRIPTION
## Description of change
Fix bug reported where 1 recipient with no root cause was not showing up in the alert we show in the activity report for this very purpose.

## How to test

1. RTR: Create FEI goal for two different recipients. Add root cause for one recipient. The second recipient does not have a root cause for the FEI goal.
2. Create AR with both recipients and fill in all mandatory fields. 
3. You will see an error message that root cause is missing, and a hyperlink to link to the goal page
4. Using the link, edit the goal in the RTR
5. Returning to the AR (it should still be open in an existing tab), click "refresh goal data" on the alert
6. If there are no goals missing data, the alert should disappear.

## Issue(s)
* https://jira.acf.gov/browse/TTAHUB-2787

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
