### PR TITLE
[TTAHUB-3053] Allow admins to unlock the POC section of a training report

### DIFF
--- a/frontend/src/components/PocCompleteCheckbox.js
+++ b/frontend/src/components/PocCompleteCheckbox.js
@@ -4,9 +4,11 @@ import { Checkbox } from '@trussworks/react-uswds';
 import { useController, useFormContext } from 'react-hook-form';
 import moment from 'moment';
 import UserContext from '../UserContext';
+import isAdmin from '../permissions';
 
 export default function PocCompleteCheckbox({ userId, isPoc }) {
   const { user } = useContext(UserContext);
+  const userIsAdmin = isAdmin(user);
   const { register, setValue } = useFormContext();
   const {
     field: {
@@ -41,7 +43,7 @@ export default function PocCompleteCheckbox({ userId, isPoc }) {
 
   return (
     <>
-      {isPoc && hasValidEmailRole() ? (
+      {(isPoc && hasValidEmailRole()) || (userIsAdmin) ? (
         <>
           <Checkbox
             id={namePocComplete}

--- a/frontend/src/components/__tests__/PocCompleteCheckbox.js
+++ b/frontend/src/components/__tests__/PocCompleteCheckbox.js
@@ -1,0 +1,134 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+import { SCOPE_IDS } from '@ttahub/common';
+import moment from 'moment';
+import PocCompleteCheckbox from '../PocCompleteCheckbox';
+import UserContext from '../../UserContext';
+import { NOT_STARTED } from '../Navigator/constants';
+
+describe('PocCompleteCheckbox', () => {
+  const userId = 1;
+
+  const defaultFormValues = {
+    id: 1,
+    ownerId: null,
+    eventId: 'sdfgsdfg',
+    eventDisplayId: 'event-display-id',
+    eventName: 'Event name',
+    regionId: 1,
+    status: 'In progress',
+    pageState: {
+      1: NOT_STARTED,
+      2: NOT_STARTED,
+    },
+    event: {
+      pocIds: [],
+    },
+
+  };
+
+  const defaultUser = { user: { id: userId, roles: [{ name: 'GSM' }] } };
+
+  const RenderPocCompleteCheckbox = ({
+    formValues = defaultFormValues,
+    user = defaultUser,
+    isPoc = true,
+  }) => {
+    const hookForm = useForm({
+      mode: 'onBlur',
+      defaultValues: formValues,
+    });
+
+    return (
+      <UserContext.Provider value={user}>
+        <FormProvider {...hookForm}>
+          <PocCompleteCheckbox
+            userId={userId}
+            isPoc={isPoc}
+          />
+        </FormProvider>
+      </UserContext.Provider>
+
+    );
+  };
+
+  it('should update form values when checkbox is checked', () => {
+    act(() => {
+      render(<RenderPocCompleteCheckbox />);
+    });
+
+    const checkbox = screen.getByLabelText('Email the event creator and collaborator to let them know my work is complete.');
+
+    userEvent.click(checkbox);
+
+    const pocCompleteId = document.querySelector('#pocCompleteId');
+    const pocCompleteDate = document.querySelector('#pocCompleteDate');
+
+    expect(pocCompleteId).toHaveValue(String(userId));
+    expect(pocCompleteDate).toHaveValue(moment().format('YYYY-MM-DD'));
+  });
+
+  it('unchecking sets hidden inputs to null', () => {
+    act(() => {
+      render(<RenderPocCompleteCheckbox />);
+    });
+
+    const checkbox = screen.getByLabelText('Email the event creator and collaborator to let them know my work is complete.');
+
+    userEvent.click(checkbox);
+    userEvent.click(checkbox); // second toggles it off
+
+    const pocCompleteId = document.querySelector('#pocCompleteId');
+    const pocCompleteDate = document.querySelector('#pocCompleteDate');
+
+    expect(pocCompleteId).toHaveValue('');
+    expect(pocCompleteDate).toHaveValue('');
+  });
+
+  it('does not show checkbox for invalid email roles', () => {
+    const user = { user: { id: userId, roles: [{ name: 'invalid role' }] } };
+
+    act(() => {
+      render(<RenderPocCompleteCheckbox user={user} />);
+    });
+
+    const checkbox = screen.queryByLabelText('Email the event creator and collaborator to let them know my work is complete.');
+
+    expect(checkbox).not.toBeInTheDocument();
+  });
+
+  it('does not show checkbox for non-poc users', () => {
+    act(() => {
+      render(<RenderPocCompleteCheckbox isPoc={false} />);
+    });
+
+    const checkbox = screen.queryByLabelText('Email the event creator and collaborator to let them know my work is complete.');
+
+    expect(checkbox).not.toBeInTheDocument();
+  });
+
+  it('admin users see the checkbox as well', () => {
+    const user = {
+      user: {
+        id: userId,
+        roles: [{ name: 'invalid role' }],
+        permissions: [{
+          scopeId: SCOPE_IDS.ADMIN,
+          regionId: 14,
+        }],
+      },
+    };
+
+    act(() => {
+      render(<RenderPocCompleteCheckbox user={user} />);
+    });
+
+    const checkbox = screen.queryByLabelText('Email the event creator and collaborator to let them know my work is complete.');
+
+    expect(checkbox).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description of change
Add the ability for admins to "unlock" sections of the training report sessions erroneously marked as complete by the point of contact user.

## How to test
- Restore the most recent prod backup
- Impersonate the user in the Jira ticket
- Confirm that /training-report/2029/session/50/next-steps is not editable
- As an admin, visit that URL and uncheck the "notify... [etc]" checkbox
- Re-impersonate that original user and confirm that that page is again editable

Otherwise, mark complete the POC part of the session as a POC user. Then, as an admin, unlock that section and confirm it can now be updated again by the POC user.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3053


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
