### PR TITLE
[TTAHUB-3057] Migration to remove unwanted objectives

### DIFF
--- a/src/migrations/20240610110823-remove-unwanted-objectives.js
+++ b/src/migrations/20240610110823-remove-unwanted-objectives.js
@@ -3,68 +3,120 @@ const {
 } = require('../lib/migration');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
     async (transaction) => {
       await prepMigration(queryInterface, transaction, __filename);
       await queryInterface.sequelize.query(/* sql */`
 
+      -- Get all unwanted objectives for this Goal.
+      DROP TABLE IF EXISTS ObjectivesToRemove;
+      CREATE TEMP TABLE ObjectivesToRemove
+            AS
+      SELECT
+      o."id"
+      FROM "Objectives" o
+      LEFT JOIN "ActivityReportObjectives" aro
+        ON o.id = aro."objectiveId"
+      LEFT JOIN "ActivityReports" ar
+        ON aro."activityReportId" = ar.id
+      WHERE o."goalId" = 66089
+        AND o."status" = 'Not Started'
+        AND COALESCE(ar."calculatedStatus",'draft') = 'draft';
+
       -- Delete from ARO Topics.
-      DELETE FROM "ActivityReportObjectiveTopics" where "activityReportObjectiveId" IN (
+      DROP TABLE IF EXISTS DeleteTopics;
+      CREATE TEMP TABLE DeleteTopics
+            AS
+      WITH updatetopics AS (
+      DELETE FROM "ActivityReportObjectiveTopics" WHERE "activityReportObjectiveId" IN (
         SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
-            179385,
-            179427,
-            179494,
-            179500,
-            179550,
-            179606,
-            179635,
-            179556,
-            180440,
-            177557) AND "status" = 'Not Started'
-        );
+          SELECT id FROM ObjectivesToRemove
+        )
+      )
+      RETURNING
+      id
+      ) SELECT * FROM updatetopics;
+
+
 
      -- Delete from ARO Resources.
-        DELETE FROM "ActivityReportObjectiveResources" where "activityReportObjectiveId" IN (
-            SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
-                179385,
-                179427,
-                179494,
-                179500,
-                179550,
-                179606,
-                179635,
-                179556,
-                180440,
-                177557) AND "status" = 'Not Started'
-            );
+     DROP TABLE IF EXISTS DeleteResources;
+      CREATE TEMP TABLE DeleteResources
+            AS
+      WITH updateresources AS (
+      DELETE FROM "ActivityReportObjectiveResources" WHERE "activityReportObjectiveId" IN (
+        SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
+          SELECT id FROM ObjectivesToRemove
+        )
+      )
+      RETURNING
+      id
+      ) SELECT * FROM updateresources;
+
+      -- Delete from ARO Files.
+      DROP TABLE IF EXISTS DeleteFiles;
+      CREATE TEMP TABLE DeleteFiles
+            AS
+      WITH updatedfiles AS (
+      DELETE FROM "ActivityReportObjectiveFiles" WHERE "activityReportObjectiveId" IN (
+        SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
+          SELECT id FROM ObjectivesToRemove
+        )
+      )
+      RETURNING
+      id
+      ) SELECT * FROM updatedfiles;
+
+      -- Delete from AR Courses.
+      DROP TABLE IF EXISTS DeleteCourses;
+      CREATE TEMP TABLE DeleteCourses
+            AS
+      WITH updatedcourses AS (
+      DELETE FROM "ActivityReportObjectiveCourses" WHERE "activityReportObjectiveId" IN (
+        SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
+          SELECT id FROM ObjectivesToRemove
+        )
+      )
+      RETURNING
+      id
+      ) SELECT * FROM updatedcourses;
 
       -- Delete ARO's.
+      DROP TABLE IF EXISTS DeleteAROs;
+      CREATE TEMP TABLE DeleteAROs
+            AS
+      WITH updatearos AS (
       DELETE FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
-        SELECT id FROM "Objectives" WHERE id IN (
-            179385,
-            179427,
-            179494,
-            179500,
-            179550,
-            179606,
-            179635,
-            179556,
-            180440,
-            177557) AND "status" = 'Not Started'
-      );
+        SELECT id FROM ObjectivesToRemove
+      )
+      RETURNING
+      id
+      ) SELECT * FROM updatearos;
 
-        -- Delete objectives.
-        DELETE FROM "Objectives" WHERE id IN (
-          179385,
-          179427,
-          179494,
-          179500,
-          179550,
-          179606,
-          179635,
-          179556,
-          180440,
-          177557) AND "status" = 'Not Started';
+      -- Delete objectives.
+      DROP TABLE IF EXISTS DeleteObjectives;
+      CREATE TEMP TABLE DeleteObjectives
+            AS
+      WITH updateobjectives AS (
+      DELETE FROM "Objectives" WHERE id IN (
+         SELECT id FROM ObjectivesToRemove
+      )
+      RETURNING
+      id
+      ) SELECT * FROM updateobjectives;
+
+      -- Get Delete counts using union.
+      SELECT COUNT(*), 'ARO Topics' FROM DeleteTopics
+      UNION ALL
+      SELECT COUNT(*), 'ARO Resources' FROM DeleteResources
+      UNION ALL
+      SELECT COUNT(*), 'ARO Files' FROM DeleteFiles
+      UNION ALL
+      SELECT COUNT(*), 'ARO Courses' FROM DeleteCourses
+      UNION ALL
+      SELECT COUNT(*), 'AROs' FROM DeleteAROs
+      UNION ALL
+      SELECT COUNT(*), 'Objectives' FROM DeleteObjectives;
         `, { transaction });
     },
   ),

--- a/src/migrations/20240610110823-remove-unwanted-objectives.js
+++ b/src/migrations/20240610110823-remove-unwanted-objectives.js
@@ -7,6 +7,37 @@ module.exports = {
     async (transaction) => {
       await prepMigration(queryInterface, transaction, __filename);
       await queryInterface.sequelize.query(/* sql */`
+
+      -- Delete from ARO Topics.
+      DELETE FROM "ActivityReportObjectiveTopics" where "activityReportObjectiveId" IN (
+        SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
+            179385,
+            179427,
+            179494,
+            179500,
+            179550,
+            179606,
+            179635,
+            179556,
+            180440,
+            177557) AND "status" = 'Not Started'
+        );
+
+     -- Delete from ARO Resources.
+        DELETE FROM "ActivityReportObjectiveResources" where "activityReportObjectiveId" IN (
+            SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
+                179385,
+                179427,
+                179494,
+                179500,
+                179550,
+                179606,
+                179635,
+                179556,
+                180440,
+                177557) AND "status" = 'Not Started'
+            );
+
       -- Delete ARO's.
       DELETE FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
         SELECT id FROM "Objectives" WHERE id IN (

--- a/src/migrations/20240610110823-remove-unwanted-objectives.js
+++ b/src/migrations/20240610110823-remove-unwanted-objectives.js
@@ -27,7 +27,7 @@ module.exports = {
       DROP TABLE IF EXISTS DeleteTopics;
       CREATE TEMP TABLE DeleteTopics
             AS
-      WITH updatetopics AS (
+      WITH delete_topics AS (
       DELETE FROM "ActivityReportObjectiveTopics" WHERE "activityReportObjectiveId" IN (
         SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
           SELECT id FROM ObjectivesToRemove
@@ -35,7 +35,7 @@ module.exports = {
       )
       RETURNING
       id
-      ) SELECT * FROM updatetopics;
+      ) SELECT * FROM delete_topics;
 
 
 
@@ -43,7 +43,7 @@ module.exports = {
      DROP TABLE IF EXISTS DeleteResources;
       CREATE TEMP TABLE DeleteResources
             AS
-      WITH updateresources AS (
+      WITH deleted_resources AS (
       DELETE FROM "ActivityReportObjectiveResources" WHERE "activityReportObjectiveId" IN (
         SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
           SELECT id FROM ObjectivesToRemove
@@ -51,13 +51,13 @@ module.exports = {
       )
       RETURNING
       id
-      ) SELECT * FROM updateresources;
+      ) SELECT * FROM deleted_resources;
 
       -- Delete from ARO Files.
       DROP TABLE IF EXISTS DeleteFiles;
       CREATE TEMP TABLE DeleteFiles
             AS
-      WITH updatedfiles AS (
+      WITH deleted_files AS (
       DELETE FROM "ActivityReportObjectiveFiles" WHERE "activityReportObjectiveId" IN (
         SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
           SELECT id FROM ObjectivesToRemove
@@ -65,13 +65,13 @@ module.exports = {
       )
       RETURNING
       id
-      ) SELECT * FROM updatedfiles;
+      ) SELECT * FROM deleted_files;
 
       -- Delete from AR Courses.
       DROP TABLE IF EXISTS DeleteCourses;
       CREATE TEMP TABLE DeleteCourses
             AS
-      WITH updatedcourses AS (
+      WITH deleted_courses AS (
       DELETE FROM "ActivityReportObjectiveCourses" WHERE "activityReportObjectiveId" IN (
         SELECT id FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
           SELECT id FROM ObjectivesToRemove
@@ -79,31 +79,31 @@ module.exports = {
       )
       RETURNING
       id
-      ) SELECT * FROM updatedcourses;
+      ) SELECT * FROM deleted_courses;
 
       -- Delete ARO's.
       DROP TABLE IF EXISTS DeleteAROs;
       CREATE TEMP TABLE DeleteAROs
             AS
-      WITH updatearos AS (
+      WITH deleted_aros AS (
       DELETE FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
         SELECT id FROM ObjectivesToRemove
       )
       RETURNING
       id
-      ) SELECT * FROM updatearos;
+      ) SELECT * FROM deleted_aros;
 
       -- Delete objectives.
       DROP TABLE IF EXISTS DeleteObjectives;
       CREATE TEMP TABLE DeleteObjectives
             AS
-      WITH updateobjectives AS (
+      WITH deleted_objectives AS (
       DELETE FROM "Objectives" WHERE id IN (
          SELECT id FROM ObjectivesToRemove
       )
       RETURNING
       id
-      ) SELECT * FROM updateobjectives;
+      ) SELECT * FROM deleted_objectives;
 
       -- Get Delete counts using union.
       SELECT COUNT(*), 'ARO Topics' FROM DeleteTopics
@@ -117,6 +117,15 @@ module.exports = {
       SELECT COUNT(*), 'AROs' FROM DeleteAROs
       UNION ALL
       SELECT COUNT(*), 'Objectives' FROM DeleteObjectives;
+
+      -- Drop all tables.
+      DROP TABLE IF EXISTS ObjectivesToRemove;
+      DROP TABLE IF EXISTS DeleteTopics;
+      DROP TABLE IF EXISTS DeleteResources;
+      DROP TABLE IF EXISTS DeleteFiles;
+      DROP TABLE IF EXISTS DeleteCourses;
+      DROP TABLE IF EXISTS DeleteAROs;
+      DROP TABLE IF EXISTS DeleteObjectives;
         `, { transaction });
     },
   ),

--- a/src/migrations/20240610110823-remove-unwanted-objectives.js
+++ b/src/migrations/20240610110823-remove-unwanted-objectives.js
@@ -1,0 +1,47 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      await queryInterface.sequelize.query(/* sql */`
+      -- Delete ARO's.
+      DELETE FROM "ActivityReportObjectives" WHERE "objectiveId" IN (
+        SELECT id FROM "Objectives" WHERE id IN (
+            179385,
+            179427,
+            179494,
+            179500,
+            179550,
+            179606,
+            179635,
+            179556,
+            180440,
+            177557) AND "status" = 'Not Started'
+      );
+
+        -- Delete objectives.
+        DELETE FROM "Objectives" WHERE id IN (
+          179385,
+          179427,
+          179494,
+          179500,
+          179550,
+          179606,
+          179635,
+          179556,
+          180440,
+          177557) AND "status" = 'Not Started';
+        `, { transaction });
+    },
+  ),
+
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      // No need to put back unwanted objectives.
+    },
+  ),
+};


### PR DESCRIPTION
## Description of change

There are ten 'Not started' objectives associated with **goal 66089** . This migrations removes them from the db.

Verified all objectives are linked to reports in draft status.
![image](https://github.com/HHS/Head-Start-TTADP/assets/84350609/260a69e3-9fbd-4888-b2ed-41d886f63c1f)


## How to test

- Using the latest prod db you should see ten objectives for this goal not started. After running the migration they should be removed.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3057


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
