### PR TITLE
[TTAHUIB-2667] Fix unwanted space after activity date

### DIFF
--- a/frontend/src/components/ReadOnlyContent.scss
+++ b/frontend/src/components/ReadOnlyContent.scss
@@ -31,10 +31,11 @@
 // print styles
 
 @media print{
-  .ttahub-read-only-content-section {
-    padding: 0;
-    margin-bottom: 2rem;
-    page-break-inside: avoid;
+  .ttahub-read-only-content-section,
+  .ttahub-read-only-content-section h3 {
+    padding: 0 !important;
+    margin-bottom: 2rem !important;
+    page-break-inside: avoid !important;
   }
 }
 


### PR DESCRIPTION
## Description of change

Looks like this is a known issue in windows where @media print doesn't respect the css unless we use !important.

https://stackoverflow.com/questions/17942969/css-media-print-not-working-at-all

https://www.smashingmagazine.com/2013/03/tips-and-tricks-for-print-style-sheets/

![image](https://github.com/HHS/Head-Start-TTADP/assets/84350609/da54a192-604e-4767-87ce-aed67e0c986c)


After Fix:
![image](https://github.com/HHS/Head-Start-TTADP/assets/84350609/71649156-0515-4ee4-9d8f-75592c2f5dfb)


## How to test

- Review the change
- Make sure there is no unwanted space after 'Activity date' in the 'Print to PDF' when destination is 'Save as PDF'.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2667


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
