### PR TITLE
[TTAHUB-2132] Add grant status to filter select

### DIFF
--- a/frontend/src/components/filter/__tests__/goalFilters.js
+++ b/frontend/src/components/filter/__tests__/goalFilters.js
@@ -140,7 +140,7 @@ describe('goalFilters', () => {
       const apply = jest.fn();
       renderFilter(() => grantFilter.renderInput('1', 'test', [], apply));
       const grantNumberInput = await screen.findByLabelText('Select grant numbers to filter by');
-      await selectEvent.select(grantNumberInput, ['number EHS, Active']);
+      await selectEvent.select(grantNumberInput, ['number EHS - Active']);
       expect(apply).toHaveBeenCalled();
     });
   });

--- a/frontend/src/components/filter/__tests__/goalFilters.js
+++ b/frontend/src/components/filter/__tests__/goalFilters.js
@@ -109,6 +109,7 @@ describe('goalFilters', () => {
     const grantFilter = grantNumberFilter([{
       numberWithProgramTypes: 'number EHS',
       number: 'number',
+      status: 'Active',
     }]);
 
     const grantFilterWithNoPossibleGrantsYet = grantNumberFilter([]);
@@ -139,7 +140,7 @@ describe('goalFilters', () => {
       const apply = jest.fn();
       renderFilter(() => grantFilter.renderInput('1', 'test', [], apply));
       const grantNumberInput = await screen.findByLabelText('Select grant numbers to filter by');
-      await selectEvent.select(grantNumberInput, ['number EHS']);
+      await selectEvent.select(grantNumberInput, ['number EHS, Active']);
       expect(apply).toHaveBeenCalled();
     });
   });

--- a/frontend/src/components/filter/goalFilters.js
+++ b/frontend/src/components/filter/goalFilters.js
@@ -149,7 +149,7 @@ export const grantNumberFilter = (possibleGrants) => ({
       labelText="Select grant numbers to filter by"
       options={possibleGrants.map((g) => ({
         value: g.number,
-        label: g.numberWithProgramTypes,
+        label: `${g.numberWithProgramTypes}, ${g.status}`,
       }))}
       selectedValues={query}
       mapByValue

--- a/frontend/src/components/filter/goalFilters.js
+++ b/frontend/src/components/filter/goalFilters.js
@@ -149,7 +149,7 @@ export const grantNumberFilter = (possibleGrants) => ({
       labelText="Select grant numbers to filter by"
       options={possibleGrants.map((g) => ({
         value: g.number,
-        label: `${g.numberWithProgramTypes}, ${g.status}`,
+        label: `${g.numberWithProgramTypes} - ${g.status}`,
       }))}
       selectedValues={query}
       mapByValue


### PR DESCRIPTION
## Description of change

This small PR appends the grant's status to its label in the filter selection:

<img width="805" alt="Screenshot 2024-06-20 at 12 33 49 PM" src="https://github.com/HHS/Head-Start-TTADP/assets/17074357/154379f4-fce9-4f5b-95b9-924ba20bdbf7">


This is on the RTR -> RTTAPA tab.


## How to test

The existing test which tests the filter label was updated.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2132


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
