### PR TITLE
[NO-TICKET] Hotfix: course route registration order

### DIFF
--- a/src/routes/courses/index.ts
+++ b/src/routes/courses/index.ts
@@ -11,9 +11,9 @@ import transactionWrapper from '../transactionWrapper';
 
 const router = express.Router();
 router.get('/', transactionWrapper(allCourses));
+router.get('/dashboard', transactionWrapper(getCourseUrlWidgetDataWithCache));
 router.get('/:id', transactionWrapper(getCourseById));
 router.put('/:id', transactionWrapper(updateCourseById));
 router.post('/', transactionWrapper(createCourseByName));
 router.delete('/:id', transactionWrapper(deleteCourseById));
-router.get('/dashboard', transactionWrapper(getCourseUrlWidgetDataWithCache));
 export default router;


### PR DESCRIPTION
## Description of change

`GET /:id` was registered before `GET /dashboard`, which is not good, so a `GET /dashboard` actually hits `GET /:id`, and there's no course with an id of "dashboard".

Whoops.

## How to test

Maybe we merge this so it makes its way to staging, so we can verify this indeed does not cause the app to crash when visiting the course dashboard.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
