### PR TITLE
[TTAHUB-3114] removeGoalsForSessionRecipientsIfNecessary bugfix

### DIFF
--- a/src/models/hooks/sessionReportPilot.js
+++ b/src/models/hooks/sessionReportPilot.js
@@ -308,7 +308,7 @@ export const createGoalsForSessionRecipientsIfNecessary = async (sequelize, sess
 export const removeGoalsForSessionRecipientsIfNecessary = async (sequelize, sessionReportOrInstance, options) => {
   const processSessionReport = async (sessionReport) => {
     let event;
-    let nextSessionRecipients;
+    let nextSessionRecipients = [];
 
     if (sessionReport && sessionReport.data) {
       const data = (typeof sessionReport.data.val === 'string')
@@ -316,7 +316,7 @@ export const removeGoalsForSessionRecipientsIfNecessary = async (sequelize, sess
         : sessionReport.data;
 
       event = data.event;
-      nextSessionRecipients = data.recipients;
+      nextSessionRecipients = data.recipients || [];
     }
 
     if (!event || !event.id || !sessionReport || !sessionReport.id) return;

--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -528,7 +528,9 @@ describe('removeGoalsForSessionRecipientsIfNecessary hook', () => {
             id: '1',
             data: {
               event: { id: '2' },
-              recipients: [],
+              // Leave this commented verifies the bugfix in TTAHUB-3114, where
+              // nextSessionRecipients was never assigned a good value.
+              // recipients: [],
             },
           })),
         },


### PR DESCRIPTION
## Description of change

It was possible that `nextSessionRecipients` never became an array, so the `map` operation threw. It's the only `map` operation in the function, so I think we can be sure it's the culprit of the error seen in the ticket.

This small change just makes sure it's an array.

## How to test

One of the tests was updated to not provide an array value to `data.recipients`, which probably does a good enough job of testing this.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3114


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
