### PR TITLE
Fix unassociated label issue

### DIFF
--- a/frontend/src/components/GoalForm/Form.js
+++ b/frontend/src/components/GoalForm/Form.js
@@ -136,17 +136,25 @@ export default function Form({
         collaborators={collaborators}
       />
 
-      <GrantSelect
-        selectedGrants={selectedGrants}
-        isOnReport={isOnReport}
-        setSelectedGrants={setSelectedGrants}
-        possibleGrants={possibleGrants}
-        validateGrantNumbers={validateGrantNumbers}
-        error={errors[FORM_FIELD_INDEXES.GRANTS]}
-        isLoading={isAppLoading}
-        goalStatus={status}
-        userCanEdit={userCanEdit}
-      />
+      <FormFieldThatIsSometimesReadOnly
+        permissions={[
+          status !== 'Closed',
+          userCanEdit,
+          possibleGrants.length > 1,
+          !isOnReport,
+        ]}
+        label="Recipient grant numbers"
+        value={selectedGrants.map((grant) => grant.numberWithProgramTypes).join(', ')}
+      >
+        <GrantSelect
+          selectedGrants={selectedGrants}
+          setSelectedGrants={setSelectedGrants}
+          possibleGrants={possibleGrants}
+          validateGrantNumbers={validateGrantNumbers}
+          error={errors[FORM_FIELD_INDEXES.GRANTS]}
+          isLoading={isAppLoading}
+        />
+      </FormFieldThatIsSometimesReadOnly>
 
       <GoalName
         goalName={goalName}

--- a/frontend/src/components/GoalForm/GrantSelect.js
+++ b/frontend/src/components/GoalForm/GrantSelect.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 import {
@@ -13,50 +13,39 @@ import Req from '../Req';
 export default function GrantSelect({
   error,
   selectedGrants,
-  isOnReport,
   setSelectedGrants,
   possibleGrants,
   validateGrantNumbers,
   inputName,
   label,
   isLoading,
-  goalStatus,
-  userCanEdit,
 }) {
-  const cannotEdit = useMemo(() => isOnReport || goalStatus === 'Closed' || possibleGrants.length === 1 || !userCanEdit, [goalStatus, isOnReport, possibleGrants.length, userCanEdit]);
-
   return (
     <FormGroup error={error.props.children}>
-      <Label htmlFor={inputName} className={cannotEdit ? 'text-bold' : ''}>
+      <Label htmlFor={inputName}>
         {label}
         {' '}
-        {!isOnReport ? <Req /> : null }
+        <Req />
       </Label>
-      {cannotEdit ? (
-        <p className="margin-top-0 usa-prose">{selectedGrants.map((grant) => grant.numberWithProgramTypes).join(', ')}</p>
-      ) : (
-        <>
-          {error}
-          <Select
-            placeholder=""
-            inputId={inputName}
-            onChange={setSelectedGrants}
-            options={possibleGrants}
-            styles={selectOptionsReset}
-            components={{
-              DropdownIndicator: null,
-            }}
-            className="usa-select"
-            closeMenuOnSelect={false}
-            value={selectedGrants}
-            isMulti
-            onBlur={() => validateGrantNumbers(SELECT_GRANTS_ERROR)}
-            isDisabled={isLoading}
-            getOptionLabel={(option) => option.numberWithProgramTypes}
-            getOptionValue={(option) => option.id}
-          />
-        </>
-      )}
+      {error}
+      <Select
+        placeholder=""
+        inputId={inputName}
+        onChange={setSelectedGrants}
+        options={possibleGrants}
+        styles={selectOptionsReset}
+        components={{
+          DropdownIndicator: null,
+        }}
+        className="usa-select"
+        closeMenuOnSelect={false}
+        value={selectedGrants}
+        isMulti
+        onBlur={() => validateGrantNumbers(SELECT_GRANTS_ERROR)}
+        isDisabled={isLoading}
+        getOptionLabel={(option) => option.numberWithProgramTypes}
+        getOptionValue={(option) => option.id}
+      />
     </FormGroup>
   );
 }
@@ -67,7 +56,6 @@ GrantSelect.propTypes = {
     label: PropTypes.string,
     value: PropTypes.number,
   })).isRequired,
-  isOnReport: PropTypes.bool.isRequired,
   setSelectedGrants: PropTypes.func.isRequired,
   possibleGrants: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
@@ -77,8 +65,6 @@ GrantSelect.propTypes = {
   inputName: PropTypes.string,
   label: PropTypes.string,
   isLoading: PropTypes.bool,
-  goalStatus: PropTypes.string.isRequired,
-  userCanEdit: PropTypes.bool.isRequired,
 };
 
 GrantSelect.defaultProps = {

--- a/frontend/src/components/GoalForm/__tests__/GrantSelect.js
+++ b/frontend/src/components/GoalForm/__tests__/GrantSelect.js
@@ -8,21 +8,18 @@ import GrantSelect from '../GrantSelect';
 
 describe('GrantSelect', () => {
   const renderGrantSelect = (
-    validateGrantNumbers = jest.fn(), userCanEdit = true, selectedGrants = [],
+    validateGrantNumbers = jest.fn(),
   ) => {
     render((
       <div>
         <GrantSelect
           error={<></>}
           setSelectedGrants={jest.fn()}
-          selectedGrants={selectedGrants}
+          selectedGrants={[]}
           validateGrantNumbers={validateGrantNumbers}
           label="Select grants"
           inputName="grantSelect"
           isLoading={false}
-          isOnReport={false}
-          goalStatus="Not Started"
-          userCanEdit={userCanEdit}
           possibleGrants={[
             {
               value: 1,


### PR DESCRIPTION
## Description of change

Turned up during accessibility review this morning: labels should be associated with an input or not there at all, looks like we had a bad case in there.

## How to test

Confirm visual function is the same and that you can't conjure a label without an input (or etc) in the RTR grant select 

## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
