### PR TITLE
[TTAHUB-3134] Allow admins to delete goals 

### DIFF
--- a/src/policies/goals.js
+++ b/src/policies/goals.js
@@ -52,7 +52,11 @@ export default class Goal {
         )
         && permission.regionId === region),
     );
-    return !isUndefined(permissions);
+
+    // eslint-disable-next-line max-len
+    const isAdmin = find(this.user.permissions, (permission) => permission.scopeId === SCOPES.ADMIN);
+
+    return isAdmin || !isUndefined(permissions);
   }
 
   // refactored to take a region id rather than directly check

--- a/src/policies/goals.js
+++ b/src/policies/goals.js
@@ -56,7 +56,7 @@ export default class Goal {
     // eslint-disable-next-line max-len
     const isAdmin = find(this.user.permissions, (permission) => permission.scopeId === SCOPES.ADMIN);
 
-    return isAdmin || !isUndefined(permissions);
+    return !isUndefined(isAdmin) || !isUndefined(permissions);
   }
 
   // refactored to take a region id rather than directly check

--- a/src/policies/goals.test.js
+++ b/src/policies/goals.test.js
@@ -76,13 +76,30 @@ describe('Goals policies', () => {
       const goal = {
         objectives: [],
         grant: { regionId: 2 },
-
       };
       const user = {
         permissions: [
           {
             regionId: 2,
             scopeId: SCOPES.READ_WRITE_REPORTS,
+          },
+        ],
+      };
+
+      const policy = new Goal(user, goal);
+      expect(policy.canDelete()).toBe(true);
+    });
+
+    it('returns true if user is admin', async () => {
+      const goal = {
+        objectives: [],
+        grant: { regionId: 2 },
+      };
+      const user = {
+        permissions: [
+          {
+            regionId: 14,
+            scopeId: SCOPES.ADMIN,
           },
         ],
       };

--- a/src/routes/goals/handlers.js
+++ b/src/routes/goals/handlers.js
@@ -200,14 +200,14 @@ export async function deleteGoal(req, res) {
     }));
 
     if (!permissions.every((permission) => permission)) {
-      res.sendStatus(401);
+      res.sendStatus(httpCodes.UNAUTHORIZED);
       return;
     }
 
     const deletedGoal = await destroyGoal(ids);
 
     if (!deletedGoal) {
-      res.sendStatus(404);
+      res.sendStatus(httpCodes.NOT_FOUND);
       return;
     }
 


### PR DESCRIPTION
## Description of change
In addition to read/write reports and approve reports, admins should be able to delete goals regardless of region.

## How to test
Load the prod dataset and confirm that you, as an admin user, can delete the goals listed in the Jira ticket

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3134


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
