### PR TITLE
[TTAHUB-3117] handle exceptions in goal policy

### DIFF
--- a/src/policies/goals.js
+++ b/src/policies/goals.js
@@ -103,7 +103,11 @@ export default class Goal {
   }
 
   canView() {
+    if (!this.goal || !this.goal.grant) {
+      return false;
+    }
     const region = this.goal.grant.regionId;
+
     return this.canReadInRegion(region);
   }
 }

--- a/src/policies/goals.test.js
+++ b/src/policies/goals.test.js
@@ -216,4 +216,52 @@ describe('Goals policies', () => {
       expect(policy.isOnApprovedActivityReports()).toBe(true);
     });
   });
+
+  describe('canView', () => {
+    it('returns false if no goal', () => {
+      const user = {
+        permissions: [
+          {
+            regionId: 2,
+            scopeId: SCOPES.APPROVE_REPORTS,
+          },
+        ],
+      };
+
+      const policy = new Goal(user);
+      expect(policy.canView()).toBe(false);
+    });
+
+    it('returns false if goal has no grant', () => {
+      const user = {
+        permissions: [
+          {
+            regionId: 2,
+            scopeId: SCOPES.APPROVE_REPORTS,
+          },
+        ],
+      };
+
+      const policy = new Goal(user, {});
+      expect(policy.canView()).toBe(false);
+    });
+
+    it('returns true if user has permissions in that region', () => {
+      const user = {
+        permissions: [
+          {
+            regionId: 2,
+            scopeId: SCOPES.APPROVE_REPORTS,
+          },
+        ],
+      };
+
+      const goal = {
+        grant: { regionId: 2 },
+      };
+
+      const policy = new Goal(user, goal);
+      expect(policy.canView()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Description of change
It looks like we don't gracefully handle the case where when checking goal.canView(), we pass in an ID that doesn't return a record. This adds an "if" statement and some tests to confirm.

## How to test
Confirm the unit tests resolve the problem listed in the Jira, I think those should be sufficient.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3117


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
