### PR TITLE
[TTAHUB-3147] Adjust cron start times

### DIFF
--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -17,11 +17,11 @@ import { logger, auditLogger } from '../logger';
 // Run at 4 am ET
 const schedule = '0 4 * * *';
 // Run daily at 4 pm
-const dailySched = '0 16 * * 1-5';
+const dailySched = '1 16 * * 1-5';
 // Run at 4 pm every Friday
-const weeklySched = '0 16 * * 5';
+const weeklySched = '5 16 * * 5';
 // Run at 4 pm on the last of the month
-const monthlySched = '0 16 28-31 * *';
+const monthlySched = '10 16 28-31 * *';
 const timezone = 'America/New_York';
 
 const runJob = () => {

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -1,4 +1,5 @@
 const { Model } = require('sequelize');
+const { auditLogger } = require('../logger');
 const generateFullName = require('./helpers/generateFullName');
 
 export default (sequelize, DataTypes) => {
@@ -26,7 +27,12 @@ export default (sequelize, DataTypes) => {
     },
     fullName: {
       type: DataTypes.VIRTUAL,
-      get() {
+      get() {       
+        if (!this.user) {
+          const { stack } = new Error();
+          auditLogger.error(`Access attempt to undefined user for userID: ${this.userId}, stack: ${stack}`);
+          return '';
+        }
         const roles = this.roles && this.roles.length
           ? this.roles : this.user.roles;
         return generateFullName(this.user.name, roles);

--- a/src/models/activityReportCollaborator.js
+++ b/src/models/activityReportCollaborator.js
@@ -27,7 +27,7 @@ export default (sequelize, DataTypes) => {
     },
     fullName: {
       type: DataTypes.VIRTUAL,
-      get() {       
+      get() {
         if (!this.user) {
           const { stack } = new Error();
           auditLogger.error(`Access attempt to undefined user for userID: ${this.userId}, stack: ${stack}`);

--- a/src/models/tests/activityReportCollaborator.test.js
+++ b/src/models/tests/activityReportCollaborator.test.js
@@ -1,0 +1,22 @@
+import { ActivityReportCollaborator } from '..';
+import { auditLogger } from '../../logger';
+
+describe('ActivityReportCollaborator Model', () => {
+  it('should handle undefined user gracefully', () => {
+    const instance = new ActivityReportCollaborator();
+    instance.user = undefined;
+    instance.userId = 1;
+
+    expect(() => instance.fullName).not.toThrow();
+    expect(auditLogger.error).toHaveBeenCalled();
+    expect(instance.fullName).toBe('');
+  });
+
+  it('should return correct fullName when user and roles are defined', () => {
+    const instance = new ActivityReportCollaborator();
+    instance.user = { name: 'Joe Brown', roles: [{ name: 'Admin' }] };
+    instance.roles = [{ name: 'GS' }];
+
+    expect(instance.fullName).toEqual('Joe Brown, GS');
+  });
+});

--- a/src/models/tests/activityReportCollaborator.test.js
+++ b/src/models/tests/activityReportCollaborator.test.js
@@ -1,6 +1,8 @@
 import { ActivityReportCollaborator } from '..';
 import { auditLogger } from '../../logger';
 
+jest.mock('../../logger');
+
 describe('ActivityReportCollaborator Model', () => {
   it('should handle undefined user gracefully', () => {
     const instance = new ActivityReportCollaborator();


### PR DESCRIPTION
## Description of change
Issue TTAHUB-3146 shows up in production at 16:00 EST which is the current time to run the digest notifications. Unfortunately, this issue does not show up locally. This PR changes the run time of the different digest notifications as well as adds logging in a place that looks like it could be causing the error.


## How to test
Verify the tests pass.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3147


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
