### PR TITLE
[TTAHUB-3115] Fix bug in createGoalsForSessionRecipientsIfNecessary

### DIFF
--- a/src/models/hooks/sessionReportPilot.js
+++ b/src/models/hooks/sessionReportPilot.js
@@ -134,7 +134,7 @@ const participantsAndNextStepsComplete = async (sequelize, instance, options) =>
 
 const extractEventData = (sessionReport) => {
   let event;
-  let recipients;
+  let recipients = [];
 
   if (sessionReport && sessionReport.data) {
     const data = (typeof sessionReport.data.val === 'string')
@@ -142,7 +142,7 @@ const extractEventData = (sessionReport) => {
       : sessionReport.data;
 
     event = data.event;
-    recipients = data.recipients;
+    recipients = Array.isArray(data.recipients) ? data.recipients : [data.recipients].filter((recipient) => recipient !== undefined);
   }
 
   return { event, recipients };

--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -478,6 +478,32 @@ describe('createGoalsForSessionRecipientsIfNecessary hook', () => {
     expect(mockSequelize.models.GoalCollaborator.update).toHaveBeenCalledTimes(0);
   });
 
+  it('doesn\'t fail when recipients is null', async () => {
+    const mockSequelize = {
+      Sequelize: { Model: jest.fn() },
+      models: { Goal: { create: jest.fn(), findOne: jest.fn(() => true) } },
+    };
+
+    const mockInstanceNoRecipients = {
+      id: 1,
+      data: {
+        event: {
+          id: '2',
+          data: { goal: 'Increase knowledge about X' },
+        },
+        recipients: null,
+      },
+    };
+
+    await createGoalsForSessionRecipientsIfNecessary(
+      mockSequelize,
+      mockInstanceNoRecipients,
+      mockOptions,
+    );
+
+    expect(mockSequelize.models.Goal.create).not.toHaveBeenCalled();
+  });
+
   it('does not create a new goal if one already exists', async () => {
     const mockSequelize = {
       Sequelize: {


### PR DESCRIPTION
## Description of change

This error:

```
TypeError: Cannot read properties of undefined (reading 'Symbol(Symbol.asyncIterator)').
```

Was generated here:


```
    for await (const { value: grantValue } of recipients) {
```

...because recipients could not be iterated. This PR ensures recipients is always an array, and therefore can be iterated. A test was written to cover this case.

This bug is really similar to TTAHUB-3114 where recipients was also not an array in the `removeGoalsForSessionRecipientsIfNecessary` hook.

## How to test

Ensure the logic for both the fix and the test looks good to you and that the test passes.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3115


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
