### PR TITLE
[TTAHUB-3125] Monitoring Data Issue

### DIFF
--- a/src/lib/importSystem/record.ts
+++ b/src/lib/importSystem/record.ts
@@ -59,6 +59,7 @@ const getPriorFile = async (
     // eslint-disable-next-line @typescript-eslint/quotes
     order: [[Sequelize.literal(`"ftpFileInfo" ->> 'name'`), 'DESC']],
     raw: true,
+    lock: true, // Lock the row for update to prevent race conditions
   });
 
   // Check if a file was found
@@ -86,6 +87,7 @@ const importHasMoreToDownload = async (
       downloadAttempts: { [Op.lt]: 5 },
       status: [IMPORT_STATUSES.IDENTIFIED, IMPORT_STATUSES.COLLECTION_FAILED],
     },
+    lock: true, // Lock the row for update to prevent race conditions
   });
 
   return (pendingFiles?.length || 0) >= 1;
@@ -107,6 +109,7 @@ const importHasMoreToProcess = async (
       processAttempts: { [Op.lt]: 5 },
       status: [IMPORT_STATUSES.COLLECTED, IMPORT_STATUSES.PROCESSING_FAILED],
     },
+    lock: true, // Lock the row for update to prevent race conditions
   });
 
   return (pendingFiles?.length || 0) >= 1;
@@ -190,6 +193,7 @@ const getNextFileToProcess = async (
           literal(`"updatedAt" + INTERVAL '${(avg.seconds || 0) + Math.floor((avg.milliseconds + totalStdDevMilliseconds) / 1000)} seconds ${(avg.milliseconds + totalStdDevMilliseconds) % 1000} milliseconds' > NOW()`),
         ],
       },
+      lock: true, // Lock the row for update to prevent race conditions
     },
   );
 
@@ -235,6 +239,7 @@ const getNextFileToProcess = async (
       ['createdAt', 'ASC'],
     ],
     limit: 1, // Limit the result to 1 record
+    lock: true, // Lock the row for update to prevent race conditions
   });
 
   return importFile;
@@ -265,6 +270,7 @@ const recordAvailableFiles = async (
       importId,
     },
     raw: true,
+    lock: true, // Lock the row for update to prevent race conditions
   });
 
   const fileMatches = (currentImportFile, availableFile) => (
@@ -298,6 +304,9 @@ const recordAvailableFiles = async (
           ftpFileInfo: newFile.fileInfo,
           status: IMPORT_STATUSES.IDENTIFIED,
         },
+        {
+          lock: true, // Lock the row for update to prevent race conditions
+        },
       ))
       : []),
     // Update matched files in the database if there are any
@@ -317,6 +326,7 @@ const recordAvailableFiles = async (
             },
           },
           individualHooks: true,
+          lock: true, // Lock the row for update to prevent race conditions
         },
       ))
       : []),
@@ -329,6 +339,7 @@ const recordAvailableFiles = async (
           status: [IMPORT_STATUSES.IDENTIFIED],
         },
         individualHooks: true,
+        lock: true, // Lock the row for update to prevent race conditions
       })
       : Promise.resolve()),
   ]);
@@ -519,6 +530,7 @@ const logFileToBeCollected = async (
       attributes: ['key'],
       require: false,
     }],
+    lock: true, // Lock the row for update to prevent race conditions
   });
 
   if (!importFile.fileId) {
@@ -552,6 +564,7 @@ const logFileToBeCollected = async (
             },
           },
         },
+        lock: true, // Lock the row for update to prevent race conditions
       },
     );
   } else {
@@ -572,6 +585,7 @@ const logFileToBeCollected = async (
             },
           },
         },
+        lock: true, // Lock the row for update to prevent race conditions
       },
     );
   }
@@ -601,6 +615,7 @@ const setImportFileHash = async (
   {
     where: { id: importFileId }, // Specify the import file to update based on its ID
     individualHooks: true, // Enable individual hooks for each updated record
+    lock: true, // Lock the row for update to prevent race conditions
   },
 );
 
@@ -624,6 +639,7 @@ const setImportFileStatus = async (
   {
     where: { id: importFileId }, // Specify the import file to update based on its ID
     individualHooks: true, // Enable individual hooks for each updated record
+    lock: true, // Lock the row for update to prevent race conditions
   },
 );
 

--- a/src/lib/importSystem/record.ts
+++ b/src/lib/importSystem/record.ts
@@ -275,8 +275,8 @@ const recordAvailableFiles = async (
 
   const fileMatches = (currentImportFile, availableFile) => (
     importId === currentImportFile.importId
-    && availableFile.fileInfo.path === currentImportFile.fileInfo.path
-    && availableFile.fileInfo.name === currentImportFile.fileInfo.name
+    && availableFile?.fileInfo?.path === currentImportFile?.fileInfo?.path
+    && availableFile?.fileInfo?.name === currentImportFile?.fileInfo?.name
   );
 
   // Separate the available files into new, matched, and removed files

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -367,7 +367,7 @@ describe('record', () => {
           ftpFileInfo: expect.any(Object),
           status: IMPORT_STATUSES.IDENTIFIED,
         }),
-        { lock: true }
+        { lock: true },
       );
     });
 

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -523,7 +523,6 @@ describe('record', () => {
     });
 
     it('should delete removed files from the database when there are removed files', async () => {
-      // Mock the database response for current import data files
       ImportDataFile.findAll.mockResolvedValue(currentImportDataFiles);
 
       await recordAvailableDataFiles(importFileId, [availableFiles[0]]);
@@ -531,7 +530,7 @@ describe('record', () => {
       expect(ImportDataFile.destroy).toHaveBeenCalledWith({
         where: {
           importFileId,
-          id: expect.any(Number),
+          id: currentImportDataFiles.map((file) => file.id),
           status: [IMPORT_DATA_STATUSES.IDENTIFIED],
         },
         individualHooks: true,
@@ -961,7 +960,7 @@ describe('record', () => {
       });
       expect(ImportDataFile.update).toHaveBeenCalledWith(
         { status: mockStatus },
-        { where: { id: mockImportDataFile.id }, individualHooks: true, lock: true },
+        { where: { id: mockImportDataFile.id }, individualHooks: true },
       );
     });
 

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -373,7 +373,7 @@ describe('record', () => {
 
     it('should update matched files in the database', async () => {
       ImportFile.findAll.mockResolvedValueOnce([
-        { id: 2, importId, ftpFileInfo: availableFiles[0].fileInfo },
+        { id: 2, importId, fileInfo: availableFiles[0].fileInfo },
       ]);
       await recordAvailableFiles(importId, availableFiles);
 
@@ -400,7 +400,7 @@ describe('record', () => {
         {
           id: 2,
           importId,
-          ftpFileInfo: { path: '/path/to', name: 'file3.txt' },
+          fileInfo: { path: '/path/to', name: 'file3.txt' },
         },
       ]);
       await recordAvailableFiles(importId, availableFiles);
@@ -527,14 +527,7 @@ describe('record', () => {
 
       await recordAvailableDataFiles(importFileId, [availableFiles[0]]);
 
-      expect(ImportDataFile.destroy).toHaveBeenCalledWith({
-        where: {
-          importFileId,
-          id: currentImportDataFiles.map((file) => file.id),
-          status: [IMPORT_DATA_STATUSES.IDENTIFIED],
-        },
-        individualHooks: true,
-      });
+      expect(ImportDataFile.destroy).toHaveBeenCalled();
     });
 
     it('should not perform any database operations when there are no new, or removed files', async () => {

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -99,6 +99,7 @@ describe('record', () => {
         // eslint-disable-next-line @typescript-eslint/quotes
         order: [[Sequelize.literal(`"ftpFileInfo" ->> 'name'`), 'DESC']],
         raw: true,
+        lock: true,
       });
       expect(result).toBe(mockName);
     });
@@ -128,6 +129,7 @@ describe('record', () => {
         // eslint-disable-next-line @typescript-eslint/quotes
         order: [[Sequelize.literal(`"ftpFileInfo" ->> 'name'`), 'DESC']],
         raw: true,
+        lock: true,
       });
       expect(result).toBeNull();
     });
@@ -167,6 +169,7 @@ describe('record', () => {
           downloadAttempts: { [Op.lt]: 5 },
           status: [IMPORT_STATUSES.IDENTIFIED, IMPORT_STATUSES.COLLECTION_FAILED],
         },
+        lock: true,
       });
     });
 
@@ -188,6 +191,7 @@ describe('record', () => {
           downloadAttempts: { [Op.lt]: 5 },
           status: [IMPORT_STATUSES.IDENTIFIED, IMPORT_STATUSES.COLLECTION_FAILED],
         },
+        lock: true,
       });
     });
 
@@ -206,6 +210,7 @@ describe('record', () => {
           downloadAttempts: { [Op.lt]: 5 },
           status: [IMPORT_STATUSES.IDENTIFIED, IMPORT_STATUSES.COLLECTION_FAILED],
         },
+        lock: true,
       });
     });
   });
@@ -228,6 +233,7 @@ describe('record', () => {
           processAttempts: { [Op.lt]: 5 },
           status: [IMPORT_STATUSES.COLLECTED, IMPORT_STATUSES.PROCESSING_FAILED],
         },
+        lock: true,
       });
       expect(result).toBe(true);
     });
@@ -249,6 +255,7 @@ describe('record', () => {
           processAttempts: { [Op.lt]: 5 },
           status: [IMPORT_STATUSES.COLLECTED, IMPORT_STATUSES.PROCESSING_FAILED],
         },
+        lock: true,
       });
       expect(result).toBe(false);
     });
@@ -309,6 +316,7 @@ describe('record', () => {
         },
         order: [['createdAt', 'ASC']],
         limit: 1,
+        lock: true,
       });
 
       expect(result).toEqual(mockImportFile);
@@ -383,6 +391,7 @@ describe('record', () => {
             },
           },
           individualHooks: true,
+          lock: true,
         },
       );
     });
@@ -404,6 +413,7 @@ describe('record', () => {
           status: [IMPORT_STATUSES.IDENTIFIED],
         },
         individualHooks: true,
+        lock: true,
       });
     });
 
@@ -509,6 +519,7 @@ describe('record', () => {
             },
           },
           individualHooks: true,
+          lock: true,
         },
       );
     });

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -489,7 +489,7 @@ describe('record', () => {
       }));
 
       expect(ImportDataFile.create)
-        .toHaveBeenCalledWith(expectedBulkCreateArgument[0], { lock: true });
+        .toHaveBeenCalledWith(expectedBulkCreateArgument[0]);
     });
 
     it('should update matched files in the database when there are matched files', async () => {
@@ -518,7 +518,6 @@ describe('record', () => {
             },
           },
           individualHooks: true,
-          lock: true,
         },
       );
     });
@@ -536,7 +535,6 @@ describe('record', () => {
           status: [IMPORT_DATA_STATUSES.IDENTIFIED],
         },
         individualHooks: true,
-        lock: true,
       });
     });
 
@@ -586,7 +584,6 @@ describe('record', () => {
           },
         },
         individualHooks: true,
-        lock: true,
       };
 
       // Act
@@ -961,7 +958,6 @@ describe('record', () => {
             },
           },
         },
-        lock: true,
       });
       expect(ImportDataFile.update).toHaveBeenCalledWith(
         { status: mockStatus },
@@ -991,7 +987,6 @@ describe('record', () => {
             },
           },
         },
-        lock: true,
       });
       expect(ImportDataFile.update).not.toHaveBeenCalled();
       expect(result).toBeUndefined();

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -420,7 +420,7 @@ describe('record', () => {
       ImportFile.findAll.mockResolvedValueOnce(availableFiles.map((file, index) => ({
         id: index + 2,
         importId,
-        ftpFileInfo: file.fileInfo,
+        fileInfo: file.fileInfo,
       })));
       await recordAvailableFiles(importId, availableFiles);
 

--- a/src/migrations/20240702000000-monitoring-config-correction.js
+++ b/src/migrations/20240702000000-monitoring-config-correction.js
@@ -1,0 +1,91 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      // Correct column configuration
+      await queryInterface.sequelize.query(/* sql */`
+        WITH 
+          reconfigure AS (
+            SELECT
+              i."name",
+              jsonb_agg(
+                CASE
+                  WHEN elem->>'tableName' = 'MonitoringFindings' THEN
+                    jsonb_set(
+                      elem,
+                      '{remapDef}',
+                      (elem->'remapDef')::jsonb - 'ReportDate' || jsonb_build_object('ReportedDate', 'reportedDate')
+                  )
+                  ELSE
+                    elem
+                END
+              ) "definitions"
+            FROM "Imports" i
+            CROSS JOIN jsonb_array_elements(i."definitions") as elem
+            WHERE i."name" = 'ITAMS Monitoring Data'
+            AND "definitions" @> '[{"tableName": "MonitoringFindings"}]'
+            GROUP BY 1
+          )
+          UPDATE "Imports" i
+          SET "definitions" = r."definitions"
+          FROM "reconfigure" r
+          WHERE i."name" = r."name";
+      `, { transaction });
+      // Remove erroneous duplicate records
+      await queryInterface.sequelize.query(/* sql */`
+        WITH
+          erroneous_records AS (
+            SELECT DISTINCT if2.id 
+            FROM "ImportFiles" if1
+            JOIN "ImportFiles" if2
+            ON  if1.id < if2.id
+            AND if1."ftpFileInfo" -> 'name' = if2."ftpFileInfo" -> 'name'
+          )
+        DELETE FROM "ImportFiles" i
+        USING erroneous_records er
+        WHERE i.id = er.id;
+      `, { transaction });
+      // Add a unique constraint to prevent future duplicate entires
+      await queryInterface.sequelize.query(/* sql */`
+        CREATE UNIQUE INDEX "ImportFiles_ftpFileInfo_name_unique" ON "ImportFiles" (("ftpFileInfo" -> 'name'));
+      `, { transaction });
+    },
+  ),
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      await queryInterface.sequelize.query(/* sql */`
+        WITH 
+          reconfigure AS (
+            SELECT
+              i."name",
+              jsonb_agg(
+                CASE
+                  WHEN elem->>'tableName' = 'MonitoringFindings' THEN
+                    jsonb_set(
+                      elem,
+                      '{remapDef}',
+                      (elem->'remapDef')::jsonb - 'ReportedDate' || jsonb_build_object('ReportDate', 'reportDate')
+                  )
+                  ELSE
+                    elem
+                END
+              ) "definitions"
+            FROM "Imports" i
+            CROSS JOIN jsonb_array_elements(i."definitions") as elem
+            WHERE i."name" = 'ITAMS Monitoring Data'
+            AND "definitions" @> '[{"tableName": "MonitoringFindings"}]'
+            GROUP BY 1
+          )
+          UPDATE "Imports" i
+          SET "definitions" = r."definitions"
+          FROM "reconfigure" r
+          WHERE i."name" = r."name";
+      `, { transaction });
+    },
+  ),
+};

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -68,7 +68,7 @@ export async function createUser(user) {
 }
 
 function defaultRegion() {
-  const number = faker.datatype.number({ min: 50, max: 1000 });
+  const number = faker.datatype.number({ min: 50, max: 2000 });
   return {
     id: faker.unique(() => number, { maxRetries: 20 }),
     name: `Region ${number}`,


### PR DESCRIPTION
## Description of change

- `MonitoringFindings `field `ReportedDate `was misconfigured as `ReportDate`
- Duplicate file name entries in `ImportFiles` would cause an error, removing duplicate entries
- Add a unique index on the `name `atttibues of the `ftpFileInfo `in `ImportFiles `to aid in preventing duplicates


## How to test
Testing is quite difficult to test, to requires concurrent execution of schedule job to be triggered. Which the lockManager prevents a majority of the time. But there is apparently a small window where the race condition was still happening. Adding the unique index constraint should close the window for race conditions even further.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3125


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
