### PR TITLE
[TTAHUB-3165] Fix FK error during goal similarity groups invalidation after goal update

### DIFF
--- a/src/models/hooks/goal.js
+++ b/src/models/hooks/goal.js
@@ -133,7 +133,7 @@ const invalidateGoalSimilarityGroupsOnUpdate = async (sequelize, instance, optio
 
     if (!goalId) return;
 
-    const similarityGroup = await sequelize.models.GoalSimilarityGroup.findOne({
+    const similarityGroups = await sequelize.models.GoalSimilarityGroup.findAll({
       attributes: ['recipientId', 'id'],
       include: [
         {
@@ -149,18 +149,20 @@ const invalidateGoalSimilarityGroupsOnUpdate = async (sequelize, instance, optio
       transaction: options.transaction,
     });
 
-    if (!similarityGroup) return;
+    if (similarityGroups.length === 0) return;
+
+    const groupIds = similarityGroups.map((group) => group.id);
 
     await sequelize.models.GoalSimilarityGroupGoal.destroy({
       where: {
-        goalSimilarityGroupId: similarityGroup.id,
+        goalSimilarityGroupId: groupIds,
       },
       transaction: options.transaction,
     });
 
     await sequelize.models.GoalSimilarityGroup.destroy({
       where: {
-        recipientId: similarityGroup.recipientId,
+        id: groupIds,
         userHasInvalidated: false,
         finalGoalId: null,
       },

--- a/src/models/hooks/goal.test.js
+++ b/src/models/hooks/goal.test.js
@@ -132,6 +132,49 @@ describe('goal hooks', () => {
       expect(result.length).toEqual(0);
     });
 
+    it('should invalidate similarity groups on a goal name update', async () => {
+      // Create a single goal
+      const goal = await createGoal({ grantId: grant.id, status: GOAL_STATUS.IN_PROGRESS });
+
+      // Create two similarity groups
+      const group1 = await GoalSimilarityGroupModel.create({
+        recipientId: recipient.id,
+        userHasInvalidated: false,
+        finalGoalId: null,
+      });
+
+      const group2 = await GoalSimilarityGroupModel.create({
+        recipientId: recipient.id,
+        userHasInvalidated: false,
+        finalGoalId: null,
+      });
+
+      // Associate the single goal with both groups
+      await GoalSimilarityGroupGoalModel.create({
+        goalSimilarityGroupId: group1.id,
+        goalId: goal.id,
+      });
+
+      await GoalSimilarityGroupGoalModel.create({
+        goalSimilarityGroupId: group2.id,
+        goalId: goal.id,
+      });
+
+      // Update the name of the goal
+      await goal.update({ name: 'New Name' }, { individualHooks: true });
+
+      // Check the results to ensure both groups are invalidated
+      const result = await GoalSimilarityGroupModel.findAll({
+        where: {
+          recipientId: recipient.id,
+          userHasInvalidated: false,
+          finalGoalId: null,
+        },
+      });
+
+      expect(result.length).toEqual(0);
+    });
+
     it('should invalidate similarity groups on goal destroy', async () => {
       const goal = await createGoal({ grantId: grant.id, status: GOAL_STATUS.IN_PROGRESS });
 


### PR DESCRIPTION
## Description of change
This PR addresses a Foreign Key constraint error that occurs when a goal similarity group can't be deleted due to a goalSimilarityGroupGoal still referencing it. With this fix, we are now looking for all goalSimilarityGroupGoal entries that are associated with the groups being deleted.


## How to test
Look at the code and verify that the tests pass

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3165


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
