### PR TITLE
[TTAHUB-3138] Remove null transactions from hooks

### DIFF
--- a/src/goalServices/changeGoalStatus.ts
+++ b/src/goalServices/changeGoalStatus.ts
@@ -16,7 +16,6 @@ export default async function changeGoalStatus({
   newStatus,
   reason,
   context,
-  transaction = null,
 }: GoalStatusChangeParams) {
   const [user, goal] = await Promise.all([
     db.User.findOne({
@@ -32,7 +31,6 @@ export default async function changeGoalStatus({
           },
         },
       ],
-      ...(transaction ? { transaction } : {}),
     }),
     db.Goal.findByPk(goalId),
   ]);

--- a/src/lib/awsElasticSearch/datacollector.js
+++ b/src/lib/awsElasticSearch/datacollector.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import { AWS_ELASTIC_SEARCH_INDEXES } from '../../constants';
 
-const collectActivityReportData = async (ids, sequelize, transaction) => {
+const collectActivityReportData = async (ids, sequelize) => {
   // Recipient Steps.
   const recipientNextStepsToIndex = await sequelize.models.NextStep.findAll({
     attributes: ['activityReportId', 'note'],
@@ -15,7 +15,6 @@ const collectActivityReportData = async (ids, sequelize, transaction) => {
       ['note', 'ASC'],
     ],
     raw: true,
-    transaction,
   });
 
   // Specialist Steps.
@@ -31,7 +30,6 @@ const collectActivityReportData = async (ids, sequelize, transaction) => {
       ['note', 'ASC'],
     ],
     raw: true,
-    transaction,
   });
   // Goals.
   const goalsToIndex = await sequelize.models.ActivityReportGoal.findAll({
@@ -45,7 +43,6 @@ const collectActivityReportData = async (ids, sequelize, transaction) => {
       ['name', 'ASC'],
     ],
     raw: true,
-    transaction,
   });
   // Objectives.
   const objectivesToIndex = await sequelize.models.ActivityReportObjective.findAll({
@@ -59,7 +56,6 @@ const collectActivityReportData = async (ids, sequelize, transaction) => {
       ['title', 'ASC'],
     ],
     raw: true,
-    transaction,
   });
 
   // Objective resource links.
@@ -86,7 +82,6 @@ const collectActivityReportData = async (ids, sequelize, transaction) => {
       ['resource', 'url', 'ASC'],
     ],
     raw: true,
-    transaction,
   });
   return {
     recipientNextStepsToIndex,
@@ -97,11 +92,11 @@ const collectActivityReportData = async (ids, sequelize, transaction) => {
   };
 };
 
-const collectModelData = async (ids, indexName, sequelize, transaction = null) => {
+const collectModelData = async (ids, indexName, sequelize) => {
   switch (indexName) {
     // Activity Reports.
     case AWS_ELASTIC_SEARCH_INDEXES.ACTIVITY_REPORTS:
-      return collectActivityReportData(ids, sequelize, transaction);
+      return collectActivityReportData(ids, sequelize);
     default:
       throw new Error(`AWS Elasticsearch: Unable to find index of type "${indexName}".`);
   }

--- a/src/models/hooks/activityReport.js
+++ b/src/models/hooks/activityReport.js
@@ -636,7 +636,6 @@ const automaticStatusChangeOnApprovalForGoals = async (sequelize, instance, opti
           newStatus: status,
           reason: 'Activity Report approved',
           context: null,
-          transaction: options.transaction,
         });
       }
       // removing hooks because we don't want to trigger the automatic status change

--- a/src/models/hooks/objective.js
+++ b/src/models/hooks/objective.js
@@ -211,7 +211,6 @@ const propogateStatusToParentGoal = async (sequelize, instance, options) => {
           newStatus: 'In Progress',
           reason: 'Objective moved to In Progress',
           context: null,
-          transaction: options.transaction,
         });
       }
     }


### PR DESCRIPTION
## Description of change

In two places in the hooks, we could possibly be setting the transaction to null. I ignored the migrations/migration helpers where this was the case as well.

## How to test
Confirm using the audit log that the operations affected use the same transaction as the main one (there is a column that allows you to do these forensics)

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3138


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
