### PR TITLE
[TTAHUB-3095] Don't remove expired grants from the recipients dropdown when an AR is unlocked

### DIFF
--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -103,7 +103,7 @@ export const getRecipients = async (region) => {
 };
 
 export const getRecipientsForExistingAR = async (region, reportId) => {
-  const url = join(activityReportUrl, 'activity-recipients/', `${reportId}`, '/', `?region=${region}`);
+  const url = join(activityReportUrl, `${reportId}`, 'activity-recipients', `?region=${region}`);
   const recipients = await get(url);
   return recipients.json();
 };

--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -102,6 +102,11 @@ export const getRecipients = async (region) => {
   return recipients.json();
 };
 
+export const getRecipientsForAR = async (region, reportId) => {
+  const recipients = await get(join(activityReportUrl, 'activity-recipients/', reportId, '/', `?region=${region}`));
+  return recipients.json();
+};
+
 export const getGoals = async (grantIds) => {
   const params = grantIds.map((grantId) => `grantIds=${grantId}`);
   const url = join(activityReportUrl, 'goals', `?${params.join('&')}`);

--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -102,7 +102,7 @@ export const getRecipients = async (region) => {
   return recipients.json();
 };
 
-export const getRecipientsForExistingAR = async (region, reportId) => {
+export const getRecipientsForExistingAR = async (reportId) => {
   const url = join(activityReportUrl, `${reportId}`, 'activity-recipients');
   const recipients = await get(url);
   return recipients.json();

--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -103,7 +103,7 @@ export const getRecipients = async (region) => {
 };
 
 export const getRecipientsForExistingAR = async (region, reportId) => {
-  const url = join(activityReportUrl, `${reportId}`, 'activity-recipients', `?region=${region}`);
+  const url = join(activityReportUrl, `${reportId}`, 'activity-recipients');
   const recipients = await get(url);
   return recipients.json();
 };

--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -103,7 +103,8 @@ export const getRecipients = async (region) => {
 };
 
 export const getRecipientsForExistingAR = async (region, reportId) => {
-  const recipients = await get(join(activityReportUrl, 'activity-recipients/', reportId, '/', `?region=${region}`));
+  const url = join(activityReportUrl, 'activity-recipients/', `${reportId}`, '/', `?region=${region}`);
+  const recipients = await get(url);
   return recipients.json();
 };
 

--- a/frontend/src/fetchers/activityReports.js
+++ b/frontend/src/fetchers/activityReports.js
@@ -102,7 +102,7 @@ export const getRecipients = async (region) => {
   return recipients.json();
 };
 
-export const getRecipientsForAR = async (region, reportId) => {
+export const getRecipientsForExistingAR = async (region, reportId) => {
   const recipients = await get(join(activityReportUrl, 'activity-recipients/', reportId, '/', `?region=${region}`));
   return recipients.json();
 };

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -42,7 +42,7 @@ describe('ActivityReport', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
-    fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', recipients);
+    fetchMock.get('/api/activity-reports/1/activity-recipients', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', [{
       id: 110,
       name: 'Group 1',
@@ -156,7 +156,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
-      fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/1/activity-recipients', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -228,7 +228,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
-      fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/1/activity-recipients', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -366,7 +366,7 @@ describe('ActivityReport', () => {
 
   describe('resetToDraft', () => {
     it('navigates to the correct page', async () => {
-      fetchMock.get('/api/activity-reports/3/activity-recipients?region=1', recipients);
+      fetchMock.get('/api/activity-reports/3/activity-recipients', recipients);
       const data = formData();
       // load the report
       fetchMock.get('/api/activity-reports/3', {

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -42,6 +42,7 @@ describe('ActivityReport', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
+    fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', [{
       id: 110,
       name: 'Group 1',
@@ -155,6 +156,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -226,6 +228,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -363,6 +366,7 @@ describe('ActivityReport', () => {
 
   describe('resetToDraft', () => {
     it('navigates to the correct page', async () => {
+      fetchMock.get('/api/activity-reports/activity-recipients/3/?region=1', recipients);
       const data = formData();
       // load the report
       fetchMock.get('/api/activity-reports/3', {

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -42,7 +42,7 @@ describe('ActivityReport', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
-    fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', recipients);
+    fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', [{
       id: 110,
       name: 'Group 1',
@@ -156,7 +156,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
-      fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -228,7 +228,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
-      fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -366,7 +366,7 @@ describe('ActivityReport', () => {
 
   describe('resetToDraft', () => {
     it('navigates to the correct page', async () => {
-      fetchMock.get('/api/activity-reports/3/activity-recipients/?region=1', recipients);
+      fetchMock.get('/api/activity-reports/3/activity-recipients?region=1', recipients);
       const data = formData();
       // load the report
       fetchMock.get('/api/activity-reports/3', {

--- a/frontend/src/pages/ActivityReport/__tests__/index.js
+++ b/frontend/src/pages/ActivityReport/__tests__/index.js
@@ -42,7 +42,7 @@ describe('ActivityReport', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
-    fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', recipients);
+    fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', [{
       id: 110,
       name: 'Group 1',
@@ -156,7 +156,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
-      fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -228,7 +228,7 @@ describe('ActivityReport', () => {
       };
 
       fetchMock.get('/api/activity-reports/activity-recipients?region=1', groupRecipients, { overwriteRoutes: true });
-      fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', groupRecipients, { overwriteRoutes: true });
+      fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', groupRecipients, { overwriteRoutes: true });
 
       const data = formData();
       fetchMock.get('/api/activity-reports/1', { ...data, activityRecipients: [] });
@@ -366,7 +366,7 @@ describe('ActivityReport', () => {
 
   describe('resetToDraft', () => {
     it('navigates to the correct page', async () => {
-      fetchMock.get('/api/activity-reports/activity-recipients/3/?region=1', recipients);
+      fetchMock.get('/api/activity-reports/3/activity-recipients/?region=1', recipients);
       const data = formData();
       // load the report
       fetchMock.get('/api/activity-reports/3', {

--- a/frontend/src/pages/ActivityReport/__tests__/localStorage.js
+++ b/frontend/src/pages/ActivityReport/__tests__/localStorage.js
@@ -37,7 +37,7 @@ describe('Local storage fallbacks', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
-    fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', recipients);
+    fetchMock.get('/api/activity-reports/1/activity-recipients', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', []);
     fetchMock.get('/api/users/collaborators?region=1', []);
     fetchMock.get('/api/activity-reports/approvers?region=1', []);

--- a/frontend/src/pages/ActivityReport/__tests__/localStorage.js
+++ b/frontend/src/pages/ActivityReport/__tests__/localStorage.js
@@ -37,7 +37,7 @@ describe('Local storage fallbacks', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
-    fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', recipients);
+    fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', []);
     fetchMock.get('/api/users/collaborators?region=1', []);
     fetchMock.get('/api/activity-reports/approvers?region=1', []);

--- a/frontend/src/pages/ActivityReport/__tests__/localStorage.js
+++ b/frontend/src/pages/ActivityReport/__tests__/localStorage.js
@@ -37,7 +37,7 @@ describe('Local storage fallbacks', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
-    fetchMock.get('/api/activity-reports/1/activity-recipients/?region=1', recipients);
+    fetchMock.get('/api/activity-reports/1/activity-recipients?region=1', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', []);
     fetchMock.get('/api/users/collaborators?region=1', []);
     fetchMock.get('/api/activity-reports/approvers?region=1', []);

--- a/frontend/src/pages/ActivityReport/__tests__/localStorage.js
+++ b/frontend/src/pages/ActivityReport/__tests__/localStorage.js
@@ -37,6 +37,7 @@ describe('Local storage fallbacks', () => {
 
   beforeEach(() => {
     fetchMock.get('/api/activity-reports/activity-recipients?region=1', recipients);
+    fetchMock.get('/api/activity-reports/activity-recipients/1/?region=1', recipients);
     fetchMock.get('/api/activity-reports/groups?region=1', []);
     fetchMock.get('/api/users/collaborators?region=1', []);
     fetchMock.get('/api/activity-reports/approvers?region=1', []);

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -288,7 +288,6 @@ function ActivityReport({
 
         const apiCalls = [
           getRecips(),
-          // getRecipientsForAR(report.regionId, reportId.current),
           getCollaborators(report.regionId),
           getApprovers(report.regionId),
           getGroupsForActivityReport(report.regionId),

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -34,7 +34,7 @@ import {
   submitReport,
   saveReport,
   getReport,
-  getRecipients,
+  getRecipientsForAR,
   createReport,
   getCollaborators,
   getApprovers,
@@ -278,7 +278,7 @@ function ActivityReport({
         }
 
         const apiCalls = [
-          getRecipients(report.regionId),
+          getRecipientsForAR(report.regionId, reportId.current),
           getCollaborators(report.regionId),
           getApprovers(report.regionId),
           getGroupsForActivityReport(report.regionId),

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -280,7 +280,7 @@ function ActivityReport({
 
         const getRecips = async () => {
           if (reportId.current && reportId.current !== 'new') {
-            return getRecipientsForExistingAR(report.regionId, reportId.current);
+            return getRecipientsForExistingAR(reportId.current);
           }
 
           return getRecipients(report.regionId);

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -34,13 +34,14 @@ import {
   submitReport,
   saveReport,
   getReport,
-  getRecipientsForAR,
+  getRecipientsForExistingAR,
   createReport,
   getCollaborators,
   getApprovers,
   reviewReport,
   resetToDraft,
   getGroupsForActivityReport,
+  getRecipients,
 } from '../../fetchers/activityReports';
 import useLocalStorage, { setConnectionActiveWithError } from '../../hooks/useLocalStorage';
 import NetworkContext, { isOnlineMode } from '../../NetworkContext';
@@ -277,8 +278,17 @@ function ActivityReport({
           };
         }
 
+        const getRecips = async () => {
+          if (reportId.current && reportId.current !== 'new') {
+            return getRecipientsForExistingAR(report.regionId, reportId.current);
+          }
+
+          return getRecipients(report.regionId);
+        };
+
         const apiCalls = [
-          getRecipientsForAR(report.regionId, reportId.current),
+          getRecips(),
+          // getRecipientsForAR(report.regionId, reportId.current),
           getCollaborators(report.regionId),
           getApprovers(report.regionId),
           getGroupsForActivityReport(report.regionId),

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -722,6 +722,14 @@ export async function getActivityRecipients(req, res) {
   res.json(activityRecipients);
 }
 
+export async function getActivityRecipientsReportId(req, res) {
+  const { region } = req.query;
+  const { reportId } = req.params;
+  const targetRegion = parseInt(region, DECIMAL_BASE);
+  const activityRecipients = await possibleRecipients(targetRegion, reportId);
+  res.json(activityRecipients);
+}
+
 /**
  * Retrieve an activity report
  *

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -724,9 +724,9 @@ export async function getActivityRecipients(req, res) {
 
 export async function getActivityRecipientsForExistingReport(req, res) {
   const { region } = req.query;
-  const { reportId } = req.params;
+  const { activityReportId } = req.params;
   const targetRegion = parseInt(region, DECIMAL_BASE);
-  const activityRecipients = await possibleRecipients(targetRegion, reportId);
+  const activityRecipients = await possibleRecipients(targetRegion, activityReportId);
   res.json(activityRecipients);
 }
 

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -725,6 +725,17 @@ export async function getActivityRecipients(req, res) {
 export async function getActivityRecipientsForExistingReport(req, res) {
   const { region } = req.query;
   const { activityReportId } = req.params;
+
+  const [report] = await activityReportAndRecipientsById(req.params.activityReportId);
+  const userId = await currentUserId(req, res);
+  const user = await userById(userId);
+  const authorization = new ActivityReport(user, report);
+
+  if (!authorization.canGet()) {
+    res.sendStatus(403);
+    return;
+  }
+
   const targetRegion = parseInt(region, DECIMAL_BASE);
   const activityRecipients = await possibleRecipients(targetRegion, activityReportId);
   res.json(activityRecipients);

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -723,10 +723,9 @@ export async function getActivityRecipients(req, res) {
 }
 
 export async function getActivityRecipientsForExistingReport(req, res) {
-  const { region } = req.query;
   const { activityReportId } = req.params;
 
-  const [report] = await activityReportAndRecipientsById(req.params.activityReportId);
+  const [report] = await activityReportAndRecipientsById(activityReportId);
   const userId = await currentUserId(req, res);
   const user = await userById(userId);
   const authorization = new ActivityReport(user, report);
@@ -736,7 +735,7 @@ export async function getActivityRecipientsForExistingReport(req, res) {
     return;
   }
 
-  const targetRegion = parseInt(region, DECIMAL_BASE);
+  const targetRegion = parseInt(report.regionId, DECIMAL_BASE);
   const activityRecipients = await possibleRecipients(targetRegion, activityReportId);
   res.json(activityRecipients);
 }

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -722,7 +722,7 @@ export async function getActivityRecipients(req, res) {
   res.json(activityRecipients);
 }
 
-export async function getActivityRecipientsReportId(req, res) {
+export async function getActivityRecipientsForExistingReport(req, res) {
   const { region } = req.query;
   const { reportId } = req.params;
   const targetRegion = parseInt(region, DECIMAL_BASE);

--- a/src/routes/activityReports/index.js
+++ b/src/routes/activityReports/index.js
@@ -9,7 +9,7 @@ import {
   getReports,
   getReportAlerts,
   getActivityRecipients,
-  getActivityRecipientsReportId,
+  getActivityRecipientsForExistingReport,
   getGoals,
   reviewReport,
   resetToDraft,
@@ -41,7 +41,7 @@ router.post('/', transactionWrapper(createReport));
 router.get('/approvers', transactionWrapper(getApprovers));
 router.get('/groups', transactionWrapper(getGroups));
 router.get('/activity-recipients', transactionWrapper(getActivityRecipients));
-router.get('/activity-recipients/:reportId', transactionWrapper(getActivityRecipientsReportId));
+router.get('/activity-recipients/:reportId', transactionWrapper(getActivityRecipientsForExistingReport));
 router.get('/goals', transactionWrapper(getGoals));
 router.post('/goals', transactionWrapper(createGoalsForReport));
 router.post('/objectives', transactionWrapper(saveOtherEntityObjectivesForReport));

--- a/src/routes/activityReports/index.js
+++ b/src/routes/activityReports/index.js
@@ -9,6 +9,7 @@ import {
   getReports,
   getReportAlerts,
   getActivityRecipients,
+  getActivityRecipientsReportId,
   getGoals,
   reviewReport,
   resetToDraft,
@@ -40,6 +41,7 @@ router.post('/', transactionWrapper(createReport));
 router.get('/approvers', transactionWrapper(getApprovers));
 router.get('/groups', transactionWrapper(getGroups));
 router.get('/activity-recipients', transactionWrapper(getActivityRecipients));
+router.get('/activity-recipients/:reportId', transactionWrapper(getActivityRecipientsReportId));
 router.get('/goals', transactionWrapper(getGoals));
 router.post('/goals', transactionWrapper(createGoalsForReport));
 router.post('/objectives', transactionWrapper(saveOtherEntityObjectivesForReport));

--- a/src/routes/activityReports/index.js
+++ b/src/routes/activityReports/index.js
@@ -62,5 +62,6 @@ router.put('/:activityReportId/review', checkActivityReportIdParam, transactionW
 router.put('/:activityReportId/submit', checkActivityReportIdParam, transactionWrapper(submitReport));
 router.put('/:activityReportId/unlock', checkActivityReportIdParam, transactionWrapper(unlockReport));
 router.put('/:activityReportId/goals/edit', checkActivityReportIdParam, transactionWrapper(setGoalAsActivelyEdited));
+router.get('/:activityReportId/activity-recipients', transactionWrapper(getActivityRecipientsForExistingReport));
 
 export default router;

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -1144,7 +1144,7 @@ export async function possibleRecipients(regionId, activityReportId = null) {
             model: Program,
             as: 'programs',
             attributes: ['programType'],
-            required: true,
+            required: false,
           },
           {
             model: Recipient,


### PR DESCRIPTION
## Description of change

Modifies `possibleRecipients` to accept an optional report id. If the report id is provided, it returns recipients that *may be expired, but have been used on this report previously*.

It also adds a new endpoint

`/api/activity-report/activity-recipients/:reportId`

## How to test

Use the seeded data. Be Hermione. Give yourself unlock permissions. The report with id 9999 already has a recipient that is Inactive. Unlock report 9999. Edit it, go to the account summary, remove the recipient from the dropdown, expand the dropdown and you should still have the old recipient in the list even though they are expired. Save the report. Be sure the save takes effect.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3095


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
