### PR TITLE
Fix for recipient groups component

### DIFF
--- a/frontend/src/components/RecipientsWithGroups.js
+++ b/frontend/src/components/RecipientsWithGroups.js
@@ -2,6 +2,7 @@ import React, {
   useState,
   useEffect,
 } from 'react';
+import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
   Dropdown,
@@ -16,7 +17,7 @@ import GroupAlert from './GroupAlert';
 
 const placeholderText = '- Select -';
 
-const RecipientsWithGroups = () => {
+const RecipientsWithGroups = ({ regionId }) => {
   const {
     control,
     register,
@@ -24,12 +25,11 @@ const RecipientsWithGroups = () => {
     setValue,
   } = useFormContext();
 
-  // Recipients.
-  const regionId = watch('regionId');
   const watchFormRecipients = watch('recipients');
   const watchGroup = watch('recipientGroup');
 
   const [recipientOptions, setRecipientOptions] = useState();
+
   useEffect(() => {
     async function fetchRecipients() {
       if (!recipientOptions && regionId) {
@@ -203,6 +203,10 @@ const RecipientsWithGroups = () => {
         }
     </>
   );
+};
+
+RecipientsWithGroups.propTypes = {
+  regionId: PropTypes.number.isRequired,
 };
 
 export default RecipientsWithGroups;

--- a/frontend/src/pages/SessionForm/pages/participants.js
+++ b/frontend/src/pages/SessionForm/pages/participants.js
@@ -59,6 +59,9 @@ const Participants = ({ formData }) => {
   const isIstVisit = watch('isIstVisit') === 'yes';
   const isNotIstVisit = watch('isIstVisit') === 'no';
 
+  const regionId = watch('regionId');
+  const eventRegionId = formData.event ? formData.event.regionId : null;
+
   // handle existing sessions
   useDeepCompareEffect(() => {
     const {
@@ -141,7 +144,9 @@ const Participants = ({ formData }) => {
 
       {isNotIstVisit && (
         <>
-          <RecipientsWithGroups />
+          <RecipientsWithGroups
+            regionId={regionId || eventRegionId}
+          />
           <div className="margin-top-2">
             <FormItem
               label="Recipient participants"
@@ -184,7 +189,6 @@ const Participants = ({ formData }) => {
 
       {(isIstVisit || isNotIstVisit) && (
       <>
-
         <ParticipantsNumberOfParticipants
           isHybrid={isHybrid}
           register={register}
@@ -251,6 +255,7 @@ Participants.propTypes = {
     recipients: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string,
     })),
+    regionId: PropTypes.number,
     istSelectionComplete: PropTypes.bool,
     event: PropTypes.shape({
       id: PropTypes.number,
@@ -258,6 +263,7 @@ Participants.propTypes = {
       displayId: PropTypes.string,
       status: PropTypes.string,
       pageState: PropTypes.objectOf(PropTypes.string),
+      regionId: PropTypes.number,
     }),
     numberOfParticipants: PropTypes.number,
     numberOfParticipantsInPerson: PropTypes.number,


### PR DESCRIPTION
## Description of change
Just in case a session doesn't have a region ID, check the blob for the event. This way, recipients will be fetched in both cases.

## How to test
You can check this by checking out prod data and taking a look at the support case in the ticket. On this branch, there will be no issue.

You could also manually set a session to have a region ID of "" locally. On main, this would prevent session recipients from being fetched. On this branch, they will still be fetched.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3187


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
