### PR TITLE
[TTAHUB-3187] populate regionId on old session report

### DIFF
--- a/src/migrations/20240715000000-fix-old-session-regions.js
+++ b/src/migrations/20240715000000-fix-old-session-regions.js
@@ -10,6 +10,7 @@ module.exports = {
 
         -- One very old session lacks the regionId value
         -- This finds and sets it
+	DROP TABLE IF EXISTS sr_updates;
         CREATE TEMP TABLE sr_updates
         AS
         WITH updater AS (

--- a/src/migrations/20240715000000-fix-old-session-regions.js
+++ b/src/migrations/20240715000000-fix-old-session-regions.js
@@ -1,0 +1,44 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      await queryInterface.sequelize.query(/* sql */`
+
+        -- One very old session lacks the regionId value
+        -- This finds and sets it
+        CREATE TEMP TABLE sr_updates
+        AS
+        WITH updater AS (
+        UPDATE "SessionReportPilots" srp
+        SET data = JSONB_SET(srp.data,'{regionId}',TO_JSONB(erp."regionId"))
+        FROM "EventReportPilots" erp
+        WHERE erp.id = srp."eventId"
+          AND srp.data->>'regionId' = ''
+        RETURNING
+          srp.id srpid,
+          erp."regionId"
+        ) SELECT * FROM updater
+        ;
+
+        SELECT * FROM sr_updates;
+        -- Looks like:
+        ----------------------
+        --  srpid | regionId
+        -- -------+----------
+        --      2 |        3
+        `, { transaction });
+    },
+  ),
+
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      // If we end up needing to revert this, it would be easier to use a separate
+      // migration using the txid (or a similar identifier) after it's already set
+    },
+  ),
+};

--- a/src/migrations/20240715000000-fix-old-session-regions.js
+++ b/src/migrations/20240715000000-fix-old-session-regions.js
@@ -10,7 +10,7 @@ module.exports = {
 
         -- One very old session lacks the regionId value
         -- This finds and sets it
-	DROP TABLE IF EXISTS sr_updates;
+        DROP TABLE IF EXISTS sr_updates;
         CREATE TEMP TABLE sr_updates
         AS
         WITH updater AS (


### PR DESCRIPTION
## Description of change

The very first Session record ever created back in August 2023 didn't get the regionId (`data->'regionId'`) value populated for some reason. This resulted in not being able to select participants from the region (because there wasn't one) for that session. There's a separate PR to make this selection more robust by using the Event's region if it isn't populated for the session, but this PR fixes the data so that it won't be a problem in any other contexts

## How to test

There's a little test at the end, but also you can also look at https://ttahub.ohs.acf.hhs.gov/training-report/2031/session/2/participants

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3187


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested

### Before merge to main

- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
