### PR TITLE
[TTAHUB-3125] Monitoring Data Issue

### DIFF
--- a/src/lib/importSystem/process.ts
+++ b/src/lib/importSystem/process.ts
@@ -487,9 +487,10 @@ const processZipFileFromS3 = async (
 
   // Destructure properties from the importFile object
   const {
-    dataValues: { importFileId, processAttempts = 0 },
-    file: { key },
-    import: { definitions: processDefinitions },
+    importFileId,
+    processAttempts = 0,
+    fileKey: key,
+    importDefinitions: processDefinitions,
   } = importFile;
 
   // These must be let to properly wrap the population in a try/catch

--- a/src/lib/importSystem/tests/process.test.js
+++ b/src/lib/importSystem/tests/process.test.js
@@ -2,7 +2,6 @@
 import { DataTypes, Op } from 'sequelize';
 import { processRecords } from '../process';
 import XMLStream from '../../stream/xml';
-import db from '../../../models';
 import { modelForTable } from '../../modelUtils';
 
 // Mock the external modules

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -290,16 +290,16 @@ describe('record', () => {
         definitions: [
           {
             "keys": [
-              "statusId"
+              "statusId",
             ],
-            "path": ".",
-            "encoding": "utf16le",
-            "fileName": "AMS_ReviewStatus.xml",
-            "remapDef": {
-              "Name": "name",
-              "StatusId": "statusId"
+            path: '.',
+            encoding: 'utf16le',
+            fileName: 'AMS_ReviewStatus.xml',
+            remapDef: {
+              Name: 'name',
+              StatusId: 'statusId',
             },
-            "tableName": "MonitoringReviewStatuses"
+            tableName: 'MonitoringReviewStatuses',
           },
         ],
       };
@@ -331,7 +331,7 @@ describe('record', () => {
         order: [['createdAt', 'ASC']],
         limit: 1,
         lock: true,
-        raw:true,
+        raw: true,
       });
 
       expect(File.findOne).toHaveBeenCalledWith({
@@ -339,7 +339,7 @@ describe('record', () => {
         where: {
           id: mockImportFile.fileId,
         },
-        raw:true,
+        raw: true,
       });
 
       expect(Import.findOne).toHaveBeenCalledWith({
@@ -347,7 +347,7 @@ describe('record', () => {
         where: {
           id: mockImportFile.importId,
         },
-        raw:true,
+        raw: true,
       });
 
       expect(result).toEqual({
@@ -410,7 +410,7 @@ describe('record', () => {
         order: [['createdAt', 'ASC']],
         limit: 1,
         lock: true,
-        raw:true,
+        raw: true,
       });
     });
   });

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -289,8 +289,8 @@ describe('record', () => {
         id: mockImportFile.fileId,
         definitions: [
           {
-            "keys": [
-              "statusId",
+            keys: [
+              'statusId',
             ],
             path: '.',
             encoding: 'utf16le',

--- a/src/lib/importSystem/tests/record.test.js
+++ b/src/lib/importSystem/tests/record.test.js
@@ -50,6 +50,7 @@ jest.mock('../../../models', () => ({
   },
   File: {
     create: jest.fn(),
+    findOne: jest.fn(),
   },
   ZALImportFile: {
     findAll: jest.fn().mockReturnValue([]),
@@ -622,9 +623,7 @@ describe('record', () => {
       ImportFile.findOne.mockResolvedValue({
         id: 1,
         fileId: null,
-        dataValues: {
-          downloadAttempts: 0,
-        },
+        downloadAttempts: 0,
       });
 
       File.create.mockResolvedValue({
@@ -665,7 +664,7 @@ describe('record', () => {
       expect(result).toEqual({
         importFileId: 1,
         key: '/import/123/uuid-mock.txt',
-        attempts: 0,
+        attempts: 1,
       });
     });
 
@@ -673,14 +672,12 @@ describe('record', () => {
       ImportFile.findOne.mockResolvedValue({
         id: 1,
         fileId: 2,
-        file: {
-          dataValues: {
-            key: '/import/123/uuid-mock.txt',
-          },
-        },
-        dataValues: {
-          downloadAttempts: 1,
-        },
+        downloadAttempts: 1,
+      });
+
+      File.findOne.mockResolvedValue({
+        id: 2,
+        key: '/import/123/uuid-mock.txt',
       });
 
       const result = await logFileToBeCollected(importId, availableFile);
@@ -696,7 +693,7 @@ describe('record', () => {
       expect(result).toEqual({
         importFileId: 1,
         key: '/import/123/uuid-mock.txt',
-        attempts: 1,
+        attempts: 2,
       });
     });
   });

--- a/src/workers/transactionWrapper.ts
+++ b/src/workers/transactionWrapper.ts
@@ -1,6 +1,5 @@
 import httpContext from 'express-http-context';
 import { addAuditTransactionSettings, removeFromAuditedTransactions } from '../models/auditModelGenerator';
-import { sequelize } from '../models';
 import { handleWorkerErrors } from '../lib/apiErrorHandler';
 import { auditLogger } from '../logger';
 
@@ -20,11 +19,13 @@ const transactionQueueWrapper = (
 ) => async (job: Job): Promise<any> => {
   const startTime = Date.now();
   return httpContext.ns.runPromise(async () => {
-    httpContext.set('loggedUser', job.referenceData.userId);
-    httpContext.set('impersonationUserId', job.referenceData.impersonationUserId);
+    httpContext.set('loggedUser', job?.referenceData?.userId);
+    httpContext.set('impersonationUserId', job?.referenceData?.impersonationUserId);
     httpContext.set('sessionSig', job.id);
     httpContext.set('auditDescriptor', originalFunction.name);
     try {
+      // eslint-ignore-next-line global-require
+      const { sequelize } = require('../models');
       // eslint-disable-next-line @typescript-eslint/return-await
       return await sequelize.transaction(async (transaction) => {
         httpContext.set('transactionId', transaction.id);

--- a/src/workers/transactionWrapper.ts
+++ b/src/workers/transactionWrapper.ts
@@ -24,7 +24,7 @@ const transactionQueueWrapper = (
     httpContext.set('sessionSig', job.id);
     httpContext.set('auditDescriptor', originalFunction.name);
     try {
-      // eslint-ignore-next-line global-require
+      // eslint-disable-next-line global-require
       const { sequelize } = require('../models');
       // eslint-disable-next-line @typescript-eslint/return-await
       return await sequelize.transaction(async (transaction) => {


### PR DESCRIPTION
## Description of change
Prior change broke the download in a different way then it was broken before. Now its fixed, with row level locking.


## How to test
add/rename a file to a current/future date in `test-sftp/` and use the importSystemCLI to download and import it.
yarn import:system <download or process> <import id => 1>
or 
nodejs build/server/src/tools/importSystemCLI.js <download or process> <import id => 1>

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3125


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
