### PR TITLE
[TTAHUB-3192] Fetch topics separately for RTTAPA

### DIFF
--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -486,7 +486,7 @@ function calculatePreviousStatus(goal) {
   // otherwise we check to see if there is the goal is on an activity report,
   // and also check the status
   if (goal.objectives.length) {
-    const onAr = goal.objectives.some((objective) => objective.activityReports.length);
+    const onAr = goal.objectives.some((objective) => objective.onApprovedAR);
     const isCompletedOrInProgress = goal.objectives.some((objective) => objective.status === 'In Progress' || objective.status === 'Complete');
 
     if (onAr && isCompletedOrInProgress) {
@@ -708,11 +708,12 @@ export async function getGoalsByActivityRecipient(
             model: ActivityReportObjective,
             as: 'activityReportObjectives',
             attributes: ['id', 'objectiveId'],
+            separate: true,
             include: [
               {
                 model: Topic,
-                through: [],
                 as: 'topics',
+                attributes: ['name'],
               },
             ],
           },
@@ -733,25 +734,6 @@ export async function getGoalsByActivityRecipient(
             where: {
               calculatedStatus: REPORT_STATUSES.APPROVED,
             },
-            include: [
-              {
-                model: ActivityRecipient,
-                as: 'activityRecipients',
-                attributes: ['activityReportId', 'grantId'],
-                required: true,
-                include: [
-                  {
-                    required: true,
-                    model: Grant,
-                    as: 'grant',
-                    attributes: ['id', 'recipientId'],
-                    where: {
-                      recipientId,
-                    },
-                  },
-                ],
-              },
-            ],
           },
         ],
       },


### PR DESCRIPTION
## Description of change
Fetch topics data on the RTTAPA with Sequelize's ```separate: true``` flag, since the current way seems to run up against some limit with certain recipients.

## How to test
Confirm the RTTAPA cards display the correct topics. Open the case from the support ticket. Confirm that the recipient is visible and that the goal query doesn't time out and display an error in the front end.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3192


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
