### PR TITLE
[TTAHUB-3096] Include inactive grants that fall within 60 day inactivation date

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -14,7 +14,6 @@ import {
   ActivityReportCollaborator,
   ActivityReportFile,
   sequelize,
-  Sequelize,
   ActivityRecipient,
   File,
   Grant,
@@ -1045,7 +1044,7 @@ export async function setStatus(report, status) {
 export async function possibleRecipients(regionId, activityReportId = null) {
   // If we have an activityReportId get the startDate of the report.
   // We have to consider that we have a report with no ActivityRecipients (ie no way to join).
-  let startDate = activityReportId ? await ActivityReport.findOne({
+  const reportWithStartDate = activityReportId ? await ActivityReport.findOne({
     attributes: ['startDate'],
     where: {
       id: activityReportId,
@@ -1053,8 +1052,9 @@ export async function possibleRecipients(regionId, activityReportId = null) {
   }) : null;
 
   // If we have a valid startDate subtract 61 days from it.
-  if (startDate) {
-    startDate = moment(startDate.startDate).subtract(61, 'days').format('YYYY-MM-DD');
+  let startDate = null;
+  if (reportWithStartDate && reportWithStartDate.startDate) {
+    startDate = moment(reportWithStartDate.startDate).subtract(61, 'days').format('YYYY-MM-DD');
   }
 
   const grants = await Recipient.findAll({

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -1086,10 +1086,10 @@ export async function possibleRecipients(regionId, activityReportId = null) {
             [Op.gte]: sequelize.literal(`
           CASE
             WHEN ${activityReportId ? 'true' : 'false'}
-            THEN (SELECT COALESCE("startDate", NOW()) - INTERVAL '${inactiveDayDuration} days' FROM "ActivityReports" WHERE "id" = ${activityReportId})
+            THEN (SELECT COALESCE("startDate", NOW() - INTERVAL '${inactiveDayDuration} days') FROM "ActivityReports" WHERE "id" = ${activityReportId})
             ELSE date_trunc('day', NOW()) - interval '${inactiveDayDuration} days'
           END
-        `),
+            `),
           },
         },
       ],

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -1,3 +1,4 @@
+import faker from '@faker-js/faker';
 import { APPROVER_STATUSES, REPORT_STATUSES } from '@ttahub/common';
 import db, {
   ActivityReport,
@@ -44,6 +45,12 @@ const ALERT_RECIPIENT_ID = 345;
 
 const RECIPIENT_WITH_PROGRAMS_ID = 425;
 const DOWNLOAD_RECIPIENT_WITH_PROGRAMS_ID = 426;
+
+const INACTIVE_GRANT_ID_ONE = faker.datatype.number({ min: 9999 });
+const INACTIVE_GRANT_ID_TWO = faker.datatype.number({ min: 9999 });
+
+let inactiveActivityReportOne;
+let inactiveActivityReportTwo;
 
 const mockUser = {
   id: 1115665161,
@@ -387,6 +394,56 @@ describe('Activity report service', () => {
         status: 'Active',
         startDate: new Date(),
         endDate: new Date(),
+      });
+
+      // Create a inactive grant with a 'inactivationDate' date less than 60 days ago.
+      await Grant.create({
+        id: INACTIVE_GRANT_ID_ONE,
+        number: faker.datatype.number({ min: 9999 }),
+        recipientId: RECIPIENT_ID,
+        regionId: 19,
+        status: 'Inactive',
+        startDate: new Date(),
+        endDate: new Date(),
+        inactivationDate: new Date(new Date().setDate(new Date().getDate() - 60)),
+      });
+
+      // Create a inactive grant with a 'inactivationDate' date more than 60 days ago.
+      await Grant.create({
+        id: INACTIVE_GRANT_ID_TWO,
+        number: faker.datatype.number({ min: 9999 }),
+        recipientId: RECIPIENT_ID,
+        regionId: 19,
+        status: 'Inactive',
+        startDate: new Date(),
+        endDate: new Date(),
+        inactivationDate: new Date(new Date().setDate(new Date().getDate() - 62)),
+      });
+
+      // Create a ActivityReport within 60 days.
+      inactiveActivityReportOne = await ActivityReport.create({
+        ...submittedReport,
+        userId: mockUser.id,
+        lastUpdatedById: mockUser.id,
+        submissionStatus: REPORT_STATUSES.DRAFT,
+        calculatedStatus: REPORT_STATUSES.DRAFT,
+        activityRecipients: [],
+        // Set a start date that will return the inactive grant.
+        startDate: new Date(new Date().setDate(new Date().getDate() - 62)),
+        endDate: new Date(new Date().setDate(new Date().getDate() - 62)),
+      });
+
+      // Create a ActivityReport outside of 60 days.
+      inactiveActivityReportTwo = await ActivityReport.create({
+        ...submittedReport,
+        userId: mockUser.id,
+        lastUpdatedById: mockUser.id,
+        submissionStatus: REPORT_STATUSES.DRAFT,
+        calculatedStatus: REPORT_STATUSES.DRAFT,
+        activityRecipients: [],
+        // Set a start date that will NOT return the inactive grant.
+        startDate: new Date(new Date().setDate(new Date().getDate() + 64)),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 64)),
       });
     });
 
@@ -1068,8 +1125,19 @@ describe('Activity report service', () => {
       it('retrieves correct recipients in region', async () => {
         const region = 19;
         const recipients = await possibleRecipients(region);
-
         expect(recipients.grants.length).toBe(1);
+
+        // Get the grant with the id ALERT_RECIPIENT_ID.
+        const alertRecipient = recipients.grants[0].grants.filter(
+          (grant) => grant.dataValues.activityRecipientId === RECIPIENT_ID,
+        );
+        expect(alertRecipient.length).toBe(1);
+
+        // Get the grant with the id inactiveGrantIdOne.
+        const inactiveRecipient = recipients.grants[0].grants.filter(
+          (grant) => grant.dataValues.activityRecipientId === INACTIVE_GRANT_ID_ONE,
+        );
+        expect(inactiveRecipient.length).toBe(1);
       });
 
       it('retrieves no recipients in empty region', async () => {
@@ -1077,6 +1145,37 @@ describe('Activity report service', () => {
         const recipients = await possibleRecipients(region);
 
         expect(recipients.grants.length).toBe(0);
+      });
+
+      it('retrieves inactive grant inside of range with report', async () => {
+        const region = 19;
+        const recipients = await possibleRecipients(region, inactiveActivityReportOne.id);
+        expect(recipients.grants.length).toBe(1);
+
+        // Get the grant with the id RECIPIENT_ID.
+        const alertRecipient = recipients.grants[0].grants.filter(
+          (grant) => grant.dataValues.activityRecipientId === RECIPIENT_ID,
+        );
+        expect(alertRecipient.length).toBe(1);
+
+        // Get the grant with the id inactiveGrantIdOne.
+        const inactiveRecipient = recipients.grants[0].grants.filter(
+          (grant) => grant.dataValues.activityRecipientId === INACTIVE_GRANT_ID_ONE,
+        );
+        expect(inactiveRecipient.length).toBe(1);
+      });
+
+      it('doesn\'t retrieve inactive grant outside of range with report', async () => {
+        const region = 19;
+        const recipients = await possibleRecipients(region, inactiveActivityReportTwo.id);
+        expect(recipients.grants.length).toBe(1);
+        expect(recipients.grants[0].grants.length).toBe(1);
+
+        // Get the grant with the id RECIPIENT_ID.
+        const alertRecipient = recipients.grants[0].grants.filter(
+          (grant) => grant.dataValues.activityRecipientId === RECIPIENT_ID,
+        );
+        expect(alertRecipient.length).toBe(1);
       });
     });
 

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -442,8 +442,8 @@ describe('Activity report service', () => {
         calculatedStatus: REPORT_STATUSES.DRAFT,
         activityRecipients: [],
         // Set a start date that will NOT return the inactive grant.
-        startDate: new Date(new Date().setDate(new Date().getDate() + 64)),
-        endDate: new Date(new Date().setDate(new Date().getDate() + 64)),
+        startDate: new Date(new Date().setDate(new Date().getDate() + 62)),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 62)),
       });
     });
 


### PR DESCRIPTION
## Description of change

This change ensures that we only show inactive grants if the inactivation date is 60 days from either todays date for new reports. Or 60 days from the start date if an existing report. In Jon's previous PR he ensures that any grant that was linked via the activity recipient's table will still show in the grant list regardless of date.

## How to test

- Review the code.
- Make sure for a new report we show inactive grants within 60 days from today's date.
- Make sure for existing reports with and without a start date we show inactive grants respectively.
- Make sure Jon's fix in the previous PR still works as expected (see above description).


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3096


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
