### PR TITLE
Update expected imports given new CSV

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -4,6 +4,8 @@ const singleLineLogger = (
   queryString,
 ) => console.log(queryString.replace(/\n/g, '\\n')); // eslint-disable-line no-console
 
+const suppressSuccessMessage = process.env.SUPPRESS_SUCCESS_MESSAGE === 'true';
+
 const connectionValidation = async (connection) => {
   try {
     /*
@@ -28,8 +30,11 @@ const connectionValidation = async (connection) => {
     };
 
     const result = await connection.query(queryConfig);
-    // eslint-disable-next-line no-console
-    console.info('Connection validated successfully');
+
+    if (!suppressSuccessMessage) {
+      // eslint-disable-next-line no-console
+      console.info('Connection validated successfully');
+    }
     return !!result;
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/frontend/src/pages/Admin/TrainingReports.js
+++ b/frontend/src/pages/Admin/TrainingReports.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import CsvImport from './components/CsvImport';
+import Req from '../../components/Req';
 
 function TrainingReports() {
   const primaryIdColumn = 'Event ID';
@@ -8,12 +9,143 @@ function TrainingReports() {
 
   const requiredCsvHeaders = [
     'Event ID',
-    'Edit Title',
-    'Creator',
+    'Event Title',
+    'IST/Creator',
   ];
 
   return (
     <>
+      <details>
+        <summary>Instructions for CSV</summary>
+
+        <div>
+          <p className="usa-hint">
+            Column names and values need to match exactly. Required columns are marked with
+            {' '}
+            <Req />
+            .
+          </p>
+          <ul className="usa-list">
+            <li>
+              <strong>
+                Event ID
+              </strong>
+              :
+              {' '}
+              Single line text value
+              <Req />
+            </li>
+            <li>
+              <strong>
+                Event Title
+              </strong>
+              :
+              {' '}
+              Single line text value
+              <Req />
+            </li>
+            <li>
+              <strong>
+                IST/Creator
+              </strong>
+              :
+              {' '}
+              Single line text value, user email address
+              <Req />
+            </li>
+            <li>
+              <strong>
+                Event Organizer - Type of Event
+              </strong>
+              :
+              {' '}
+              One of
+              {' '}
+              <em>Regional PD Event (with National Centers)</em>
+              {' '}
+              or
+              {' '}
+              <em>IST TTA/Visit</em>
+            </li>
+            <li>
+              <strong>
+                National Centers
+              </strong>
+              :
+              {' '}
+              A three or four digit national center identifier.
+              This will find and attach the associated user as a collaborator on the event.
+            </li>
+            <li>
+              <strong>
+                Event Duration
+              </strong>
+              :
+              {' '}
+              One of
+              {' '}
+              <em>1 day or less</em>
+              {' '}
+              or
+              {' '}
+              <em>Multi-Day single event</em>
+              or
+              {' '}
+              <em>Series</em>
+            </li>
+            <li>
+              <strong>
+                Reason(s) for PD
+              </strong>
+              :
+              {' '}
+              A list of reasons, separated by new lines.
+              Any reasons not matching one of the reasons we expect will be ignored.
+            </li>
+            <li>
+              <strong>
+                Vision/Goal/Outcomes for the PD Event
+              </strong>
+              :
+              {' '}
+              A free text field. Formatting other than spaces or new lines will not be preserved.
+            </li>
+            <li>
+              <strong>
+                Target Population(s)
+              </strong>
+              :
+              {' '}
+              A list of populations, separated by new lines.
+              Any reasons not matching one of the target populations we expect will be ignored.
+            </li>
+            <li>
+              <strong>
+                Audience
+              </strong>
+              :
+              {' '}
+              One of
+              {' '}
+              <em>Regional office/TTA</em>
+              {' '}
+              or
+              {' '}
+              <em>Recipients</em>
+            </li>
+            <li>
+              <strong>
+                Designated Region POC for Event/Request
+              </strong>
+              :
+              {' '}
+              A list of Hub user&apos;s names, seperated by the &quot;&#x2F;&quot; character.
+              Any names not matching an existing user will be ignored.
+            </li>
+          </ul>
+        </div>
+
+      </details>
       <CsvImport
         requiredCsvHeaders={requiredCsvHeaders}
         typeName={typeName}

--- a/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
@@ -385,6 +385,8 @@ const EventSummary = ({ additionalData, datePickerKey }) => {
         </Label>
         <Dropdown required id="trainingType" name="trainingType" inputRef={register({ required: 'Select a training type' })}>
           <option>Series</option>
+          <option>Multi-Day single event</option>
+          <option>1 day or less</option>
         </Dropdown>
       </div>
 

--- a/src/policies/event.js
+++ b/src/policies/event.js
@@ -26,6 +26,11 @@ export default class EventReport {
     ].includes(p.scopeId) && p.regionId === this.eventReport.regionId);
   }
 
+  hasPocInRegion() {
+    // eslint-disable-next-line max-len
+    return !!this.permissions.find((p) => p.scopeId === SCOPES.POC_TRAINING_REPORTS && p.regionId === this.eventReport.regionId);
+  }
+
   /**
    * Determines if the user has write access to the specified region
    * or to the region of their current event report.

--- a/src/services/event.test.js
+++ b/src/services/event.test.js
@@ -445,31 +445,48 @@ describe('event service', () => {
   });
 
   describe('tr import', () => {
-    let user;
     let data;
     let buffer;
     let created;
-    const eventIdsToDestroy = [];
 
     const userId = faker.datatype.number();
+    const pocId = faker.datatype.number();
+    let poc;
+    const collaboratorId = faker.datatype.number();
+    let collaborator;
 
-    const eventId = 'R01-TR-02-3333';
+    let ncOne;
+    let ncTwo;
+
+    const eventId = 'R01-TR-3333';
     const regionId = 1;
-    const editTitle = 'Hogwarts Academy';
-    const istName = 'Harry Potter';
+    const eventTitle = 'Hogwarts Academy';
     const email = 'smartsheetevents@ss.com';
     const audience = 'Recipients';
     const vision = 'To learn';
-    const duration = 'Series';
+    const trainingType = 'Series';
     const targetPopulation = `"Program Staff
     Affected by Disaster"`;
     const reasons = `"Complaint
     Planning/Coordination"`;
-    const organizer = 'Dumbledore';
+    const typeOfEvent = 'IST TTA/Visit';
 
-    const headings = ['Event ID', 'Edit Title', 'IST Name:', 'Creator', 'Event Organizer - Type of Event', 'Event Duration/# NC Days of Support', 'Reason for Activity', 'Target Population(s)', 'Audience', 'Overall Vision/Goal for the PD Event'];
+    const headings = [
+      'IST/Creator',
+      'Event ID',
+      'Event Title',
+      'Event Organizer - Type of Event',
+      'National Centers',
+      'Event Duration',
+      'Reason(s) for PD',
+      'Vision/Goal/Outcomes for the PD Event',
+      'Target Population(s)',
+      'Audience',
+      'Designated Region POC for Event/Request',
+    ];
 
     beforeAll(async () => {
+      // owner
       await db.User.create({
         id: userId,
         homeRegionId: regionId,
@@ -477,55 +494,114 @@ describe('event service', () => {
         hsesUserId: faker.datatype.string(),
         email,
         lastLogin: new Date(),
+        name: `${faker.name.firstName()} ${faker.name.lastName()}`,
       });
+
       await db.Permission.create({
         userId,
         regionId: 1,
         scopeId: SCOPES.READ_WRITE_TRAINING_REPORTS,
       });
-      user = await db.User.findOne({ where: { id: userId } });
+
+      // collaborator
+      collaborator = await db.User.create({
+        id: collaboratorId,
+        homeRegionId: regionId,
+        hsesUsername: faker.datatype.string(),
+        hsesUserId: faker.datatype.string(),
+        email: faker.internet.email(),
+        lastLogin: new Date(),
+        name: `${faker.name.firstName()} ${faker.name.lastName()}`,
+      });
+
+      await db.Permission.create({
+        userId: collaboratorId,
+        regionId: 1,
+        scopeId: SCOPES.READ_WRITE_TRAINING_REPORTS,
+      });
+
+      // poc
+      poc = await db.User.create({
+        id: pocId,
+        homeRegionId: regionId,
+        hsesUsername: faker.datatype.string(),
+        hsesUserId: faker.datatype.string(),
+        email: faker.internet.email(),
+        lastLogin: new Date(),
+        name: `${faker.name.firstName()} ${faker.name.lastName()}`,
+      });
+
+      await db.Permission.create({
+        userId: pocId,
+        regionId: 1,
+        scopeId: SCOPES.POC_TRAINING_REPORTS,
+      });
+
+      // national centers
+      ncOne = await db.NationalCenter.create({
+        name: faker.hacker.abbreviation(),
+      });
+
+      // owner for national center 1
+      await db.NationalCenterUser.create({
+        userId,
+        nationalCenterId: ncOne.id,
+      });
+
+      ncTwo = await db.NationalCenter.create({
+        name: faker.hacker.abbreviation(),
+      });
+
+      // collab is national center user 2
+      await db.NationalCenterUser.create({
+        userId: collaboratorId,
+        nationalCenterId: ncTwo.id,
+      });
+
       data = `${headings.join(',')}
-${eventId},${editTitle},${istName},${email},${organizer},${duration},${reasons},${targetPopulation},${audience},${vision}
-R01-TR-4234,bad_title,bad_istname,bad_email,bad_organizer,bad_duration,bad_reasons,bad_target,${audience},bad_vision`;
+${email},${eventId},${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},${audience},${poc.name}`;
 
       buffer = Buffer.from(data);
     });
 
     afterAll(async () => {
-      await db.User.destroy({ where: { id: userId } });
       await db.EventReportPilot.destroy({ where: { ownerId: userId } });
-      // await db.EventReportPilot.destroy({ where: { id: created.id } });
-      await db.Permission.destroy({ where: { userId } });
+      await db.NationalCenterUser.destroy({
+        where: { userId: [userId, collaboratorId] },
+      });
+      await db.NationalCenter.destroy({ where: { id: [ncOne.id, ncTwo.id] } });
+      await db.Permission.destroy({ where: { id: [userId, collaboratorId, pocId] } });
+      await db.User.destroy({ where: { id: [userId, collaboratorId, pocId] } });
     });
 
     it('imports good data correctly', async () => {
       const result = await csvImport(buffer);
+
+      expect(result.errors).toEqual([]);
+      expect(result.count).toEqual(1);
 
       // eventId is now a field in the jsonb body of the "data" column on
       // db.EventReportPilot.
       // Let's make sure it exists.
       created = await db.EventReportPilot.findOne({
         where: { 'data.eventId': eventId },
-        raw: true,
       });
+
+      expect(created).not.toBeNull();
 
       expect(created).toHaveProperty('ownerId', userId);
       expect(created).toHaveProperty('regionId', regionId);
       expect(created.data.reasons).toEqual(['Complaint', 'Planning/Coordination']);
       expect(created.data.vision).toEqual(vision);
-      expect(created.data.audience).toEqual(audience);
+      expect(created.data.eventIntendedAudience).toEqual(audience);
       expect(created.data.targetPopulations).toEqual(['Program Staff', 'Affected by Disaster']);
-      expect(created.data.eventOrganizer).toEqual(organizer);
+      expect(created.data.eventOrganizer).toEqual(typeOfEvent);
       expect(created.data.creator).toEqual(email);
-      expect(created.data.istName).toEqual(istName);
-      expect(created.data.eventName).toEqual(editTitle);
-      expect(created.data.eventDuration).toEqual(duration);
-
-      expect(result.count).toEqual(1);
-      expect(result.errors).toEqual(['User bad_email does not exist']);
+      expect(created.data.eventName).toEqual(eventTitle);
+      expect(created.data.trainingType).toEqual(trainingType);
 
       const secondImport = `${headings.join(',')}
-${eventId},bad_title,bad_istname,${email},bad_organizer,bad_duration,bad_reasons,bad_target,${audience},bad_vision`;
+${email},${eventId},${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},${audience},${poc.name}`;
 
       // Subsequent import with event ID that already exists in the database
       // should skip importing this TR.
@@ -536,9 +612,12 @@ ${eventId},bad_title,bad_istname,${email},bad_organizer,bad_duration,bad_reasons
 
     it('gives an error if the user can\'t write in the region', async () => {
       await db.Permission.destroy({ where: { userId } });
-      const result = await csvImport(buffer);
+      const d = `${headings.join(',')}
+${email},R01-TR-3334,${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},${audience},${poc.name}`;
+      const b = Buffer.from(d);
+      const result = await csvImport(b);
       expect(result.count).toEqual(0);
-      expect(result.errors).toEqual([`User ${email} does not have permission to write in region ${regionId}`, 'User bad_email does not exist']);
+      expect(result.errors).toEqual([`User ${email} does not have permission to write in region ${regionId}`]);
       await db.Permission.create({
         userId,
         regionId: 1,
@@ -546,36 +625,56 @@ ${eventId},bad_title,bad_istname,${email},bad_organizer,bad_duration,bad_reasons
       });
     });
 
-    it('skips rows that don\'t start with the correct prefix', async () => {
-      const reportId = 'R01-TR-5842';
-      const dataToTest = `${headings.join(',')}
-${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,tr_reasons,tr_target,${audience},tr_vision
-01-TR-4256,tr_title,tr_istname,${email},tr_organizer,tr_duration,tr_reasons,tr_target,${audience},tr_vision
-R-TR-3426,tr_title,tr_istname,${email},tr_organizer,tr_duration,tr_reasons,tr_target,${audience},tr_vision`;
+    it('errors if the POC user lacks permissions', async () => {
+      await db.Permission.destroy({ where: { userId: pocId } });
+      const d = `${headings.join(',')}
+${email},R01-TR-3334,${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},${audience},${poc.name}`;
+      const b = Buffer.from(d);
+      const result = await csvImport(b);
+      expect(result.count).toEqual(0);
+      expect(result.errors).toEqual([`User ${poc.name} does not have POC permission in region ${regionId}`]);
+      await db.Permission.create({
+        userId: pocId,
+        regionId: 1,
+        scopeId: SCOPES.POC_TRAINING_REPORTS,
+      });
+    });
 
-      eventIdsToDestroy.push(reportId);
+    it('errors if the IST Collaborator user lacks permissions', async () => {
+      await db.Permission.destroy({ where: { userId: collaboratorId } });
+      const d = `${headings.join(',')}
+${email},R01-TR-3334,${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},${audience},${poc.name}`;
+      const b = Buffer.from(d);
+      const result = await csvImport(b);
+      expect(result.count).toEqual(0);
+      expect(result.errors).toEqual([`User ${collaborator.name} does not have permission to write in region ${regionId}`]);
+      await db.Permission.create({
+        userId: collaboratorId,
+        regionId: 1,
+        scopeId: SCOPES.READ_WRITE_TRAINING_REPORTS,
+      });
+    });
+
+    it('skips rows that don\'t start with the correct prefix', async () => {
+      const dataToTest = `${headings.join(',')}
+${email},01-TR-4256,${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},${audience},${poc.name}`;
 
       const bufferWithSkips = Buffer.from(dataToTest);
 
       const result = await csvImport(bufferWithSkips);
-      expect(result.count).toEqual(1);
-      expect(result.skipped.length).toEqual(2);
+      expect(result.skipped.length).toEqual(1);
       expect(result.skipped).toEqual(
-        ['Invalid "Event ID" format expected R##-TR-#### received 01-TR-4256', 'Invalid "Event ID" format expected R##-TR-#### received R-TR-3426'],
+        ['Invalid "Event ID" format expected R##-TR-#### received 01-TR-4256'],
       );
     });
 
     it('only imports valid columns ignores others', async () => {
       const mixedColumns = `${headings.join(',')},Extra Column`;
       const reportId = 'R01-TR-3478';
-      const dataToTest = `${mixedColumns}
-${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,tr_reasons,tr_target,${audience},tr_vision,extra_data`;
-
-      eventIdsToDestroy.push(reportId);
-
-      const bufferWithSkips = Buffer.from(dataToTest);
-
-      const result = await csvImport(bufferWithSkips);
+      const d = `${mixedColumns}
+${email},${reportId},${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},${audience},${poc.name},JIBBER-JABBER`;
+      const b = Buffer.from(d);
+      const result = await csvImport(b);
       expect(result.count).toEqual(1);
       expect(result.skipped.length).toEqual(0);
       expect(result.errors.length).toEqual(0);
@@ -585,26 +684,21 @@ ${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,tr_reasons,tr_
       });
       expect(importedEvent).not.toBeNull();
 
-      // Assert 11 core fields, plus goal and goals[].
-      expect(Object.keys(importedEvent.data).length).toEqual(12);
       // Assert data does not contain the extra column.
       expect(importedEvent.data).not.toHaveProperty('Extra Column');
     });
 
     it('only imports valid reasons ignores others', async () => {
+      const mixedColumns = `${headings.join(',')},Extra Column`;
       const reportId = 'R01-TR-9528';
       const reasonsToTest = `"New Director or Management
       Complaint
       Planning/Coordination
       Invalid Reason"`;
-      const dataToTest = `${headings.join(',')}
-${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,${reasonsToTest},tr_target,${audience},tr_vision`;
-
-      eventIdsToDestroy.push(reportId);
-
-      const bufferWithSkips = Buffer.from(dataToTest);
-
-      const result = await csvImport(bufferWithSkips);
+      const d = `${mixedColumns}
+${email},${reportId},${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasonsToTest},${vision},${targetPopulation},${audience},${poc.name},JIBBER-JABBER`;
+      const b = Buffer.from(d);
+      const result = await csvImport(b);
       expect(result.count).toEqual(1);
       expect(result.skipped.length).toEqual(0);
       expect(result.errors.length).toEqual(0);
@@ -613,24 +707,20 @@ ${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,${reasonsToTes
         where: { 'data.eventId': reportId },
       });
       expect(importedEvent).not.toBeNull();
-
-      // Assert data.reasons contains only valid reasons.
       expect(importedEvent.data.reasons).toEqual(['New Director or Management', 'Complaint', 'Planning/Coordination']);
     });
 
     it('only imports valid target populations ignores others', async () => {
+      const mixedColumns = `${headings.join(',')},Extra Column`;
       const reportId = 'R01-TR-6578';
       const tgtPopToTest = `"Program Staff
-      Pregnant Women / Pregnant Persons
-      Invalid Pop"`;
-      const dataToTest = `${headings.join(',')}
-${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,Complaint,${tgtPopToTest},${audience},tr_vision`;
+          Pregnant Women / Pregnant Persons
+          Invalid Pop"`;
 
-      eventIdsToDestroy.push(reportId);
-
-      const bufferWithSkips = Buffer.from(dataToTest);
-
-      const result = await csvImport(bufferWithSkips);
+      const d = `${mixedColumns}
+${email},${reportId},${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${tgtPopToTest},${audience},${poc.name},JIBBER-JABBER`;
+      const b = Buffer.from(d);
+      const result = await csvImport(b);
       expect(result.count).toEqual(1);
       expect(result.skipped.length).toEqual(0);
       expect(result.errors.length).toEqual(0);
@@ -639,36 +729,19 @@ ${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,Complaint,${tg
         where: { 'data.eventId': reportId },
       });
       expect(importedEvent).not.toBeNull();
-
-      // Assert data.reasons contains only valid reasons.
       expect(importedEvent.data.targetPopulations).toEqual(['Program Staff', 'Pregnant Women / Pregnant Persons']);
     });
 
     it('skips rows that have an invalid audience', async () => {
       const reportId = 'R01-TR-5725';
-      const dataToTest = `${headings.join(',')}
-${reportId},tr_title,tr_istname,${email},tr_organizer,tr_duration,tr_reasons,tr_target,"Regional office/TTA",tr_vision
-R01-TR-4658,tr_title,tr_istname,${email},tr_organizer,tr_duration,tr_reasons,tr_target,"Invalid Audience",tr_vision`;
-
-      eventIdsToDestroy.push(reportId);
-
-      const bufferWithSkips = Buffer.from(dataToTest);
-
-      const result = await csvImport(bufferWithSkips);
-      expect(result.count).toEqual(1);
+      const mixedColumns = `${headings.join(',')},Extra Column`;
+      const d = `${mixedColumns}
+${email},${reportId},${eventTitle},${typeOfEvent},${ncTwo.name},${trainingType},${reasons},${vision},${targetPopulation},Invalid Audience,${poc.name},JIBBER-JABBER`;
+      const b = Buffer.from(d);
+      const result = await csvImport(b);
+      expect(result.count).toEqual(0);
       expect(result.skipped.length).toEqual(1);
-      expect(result.skipped).toEqual(['Value "Invalid Audience" is invalid for column "Audience". Must be of one of Recipients, Regional office/TTA: R01-TR-4658']);
-
-      // Retrieve the imported event.
-      const importedEvent = await db.EventReportPilot.findOne({
-        where: { 'data.eventId': reportId },
-      });
-
-      // Assert the imported event is not null.
-      expect(importedEvent).not.toBeNull();
-
-      // Assert the imported event has the correct audience.
-      expect(importedEvent.data.audience).toEqual('Regional office/TTA');
+      expect(result.skipped).toEqual(['Value "Invalid Audience" is invalid for column "Audience". Must be of one of Recipients, Regional office/TTA: R01-TR-5725']);
     });
   });
 


### PR DESCRIPTION
## Description of change
The jira ticket has great, detailed information on the change but essentially it was four-fold: 

- Import and populate the POC in the form
- Fix the audience field so it populates the form
- Fix the event duration field so that it populates the "training type" field in the form
- Add clear specifications to the admin import page so we have a reference for expected headings and content
- Automatically populate the collaborators based on the National Center column in the import

## How to test
Confirm using the XSLX file attached to the ticket that the fields are imported correctly. You may need to massage the data slightly, which I expect an engineer will do when the training reports are imported.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3240


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
