### PR TITLE
[TTAHUB-3040] Fix medium security alert: add nonce to inline styles in CSP

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -80,7 +80,7 @@ app.use((req, res, next) => {
         'style-src',
         'font-src',
       ),
-      styleSrc: ["'self'", "'unsafe-inline'"],
+      styleSrc: ["'self'", `'nonce-${res.locals.nonce}'`],
       fontSrc: ["'self'"],
       'form-action': ["'self'"],
       scriptSrc: ["'self'", '*.googletagmanager.com'],


### PR DESCRIPTION
## Description of change
This PR addresses a medium security alert identified during the dynamic security scan. The scan flagged the use of unsafe-inline in the style-src directive of our CSP. To mitigate this risk, we have updated our CSP configuration to include a nonce for inline styles.


## How to test

- Verify that the application works as expected with the updated CSP configuration.
- Confirm that the dynamic security scan no longer flags the unsafe-inline issue.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3040


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete

### Before merge to main

- [n/a] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
