### PR TITLE
Revert "[TTAHUB-3040] Fix medium security alert: add nonce to inline styles in CSP"

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -80,7 +80,7 @@ app.use((req, res, next) => {
         'style-src',
         'font-src',
       ),
-      styleSrc: ["'self'", `'nonce-${res.locals.nonce}'`],
+      styleSrc: ["'self'", "'unsafe-inline'"],
       fontSrc: ["'self'"],
       'form-action': ["'self'"],
       scriptSrc: ["'self'", '*.googletagmanager.com'],


### PR DESCRIPTION
Reverts HHS/Head-Start-TTADP#2294

Unfortunately, while this change worked locally, it is not functioning in deployed environments. Reverting.