### PR TITLE
[TTAHUB-2553]Fix historical duplicate args

### DIFF
--- a/src/migrations/20240801000000-merge_duplicate_args.js
+++ b/src/migrations/20240801000000-merge_duplicate_args.js
@@ -1,0 +1,41 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      await queryInterface.sequelize.query(`
+
+      -- Call the preexisting function for deduping args
+      -- created in 20240520000000-merge_duplicate_args.js
+      SELECT dedupe_args();
+
+      -- The expected results look like:
+      -- op_order |     op_name     | record_cnt
+      ------------+-----------------+------------
+      --        1 | relinked_argfrs |          0
+      --        2 | deleted_argfrs  |          0
+      --        3 | relinked_argrs  |          0
+      --        4 | deleted_argrs   |          0
+      --        5 | deleted_args    |         66
+      SELECT
+        1 op_order,
+        'relinked_argfrs' op_name,
+        COUNT(*) record_cnt
+      FROM relinked_argfrs
+      UNION SELECT 2, 'deleted_argfrs', COUNT(*) FROM deleted_argfrs
+      UNION SELECT 3, 'relinked_argrs', COUNT(*) FROM relinked_argrs
+      UNION SELECT 4, 'deleted_argrs', COUNT(*) FROM deleted_argrs
+      UNION SELECT 5, 'deleted_args', COUNT(*) FROM deleted_args
+      ORDER BY 1;
+      `, { transaction });
+    });
+  },
+  async down() {
+    // rolling back merges and deletes would be a mess
+  },
+};


### PR DESCRIPTION
## Description of change

This issue hasn't been seen in months and a number of possible causes of the problem have been fixed so this just cleans up historical cases

## How to test

All this does is run `SELECT dedupe_args();`, which ideally never does anything, but will fix historical duplicate ARGs by merging down to one single record anchoring all the metadata about the link between any given AR and Goal pair. 66 dupes are expected to be deleted in this case and no metadata moved.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2553

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [x] Code is meaningfully tested

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
