### PR TITLE
Fix duplicating goals on two reports from support cases

### DIFF
--- a/src/goalServices/reduceGoals.ts
+++ b/src/goalServices/reduceGoals.ts
@@ -422,9 +422,9 @@ export function reduceGoals(
   const objectivesReducer = forReport ? reduceObjectivesForActivityReport : reduceObjectives;
 
   const where = (g: IReducedGoal, currentValue: IGoalModelInstance) => (forReport
-    ? g.name === currentValue.dataValues.name
-    : g.name === currentValue.dataValues.name
-        && g.status === currentValue.dataValues.status);
+    ? (g.name || '').trim() === (currentValue.dataValues.name || '').trim()
+    : (g.name || '').trim() === (currentValue.dataValues.name || '').trim()
+   && g.status === currentValue.dataValues.status);
 
   function getGoalCollaboratorDetails(
     collabType: string,

--- a/src/migrations/20240802204120-repair-multiple-aros.js
+++ b/src/migrations/20240802204120-repair-multiple-aros.js
@@ -1,0 +1,27 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      // somehow this ARO was duplicated three times. This migration repairs it.
+      // To verify, view the report (45555) as it's owner and confirm that the goals and
+      // objectives page shows 1 goal with TTA provided and 2 files
+      await queryInterface.sequelize.query(/* sql */`
+        DELETE FROM "ActivityReportObjectiveFiles" WHERE "activityReportObjectiveId" IN (232020, 232022);
+        DELETE FROM "ActivityReportObjectives" WHERE id IN (232020, 232022)
+     
+        `, { transaction });
+    },
+  ),
+
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      // If we end up needing to revert this, it would be easier to use a separate
+      // migration using the txid (or a similar identifier) after it's already set
+    },
+  ),
+};


### PR DESCRIPTION
## Description of change
In two (reported) instances, goals ended up with new lines at the end, so I revised the reducer to capture this as the same goal. Additionally, we have a report where multiple AROs were created for a Objective/AR combination. No idea how.

## How to test
- Prod DB
- Confirm the support cases are resolved (goals not duplicated, all information present)

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3266
* https://jira.acf.gov/browse/TTAHUB-3267


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
