### PR TITLE
[TTAHUB-3279] Fix playwright artifacts storage in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,7 +449,7 @@ commands:
             #!/bin/bash
             CONTROL_FILE="/tmp/stop_tail"
             rm -f $CONTROL_FILE
-            
+
             # Start tailing logs
             cf logs tta-automation &
 
@@ -509,7 +509,7 @@ commands:
             # Signal the log monitoring to stop
             CONTROL_FILE="/tmp/stop_tail"
             touch $CONTROL_FILE
-            
+
             # Wait for the log monitoring process to terminate
             sleep 5
 
@@ -799,7 +799,7 @@ jobs:
           name: Run playwright tests
           command: yarn e2e:ci
       - store_artifacts:
-          path: playwright/e2e
+          path: tests/e2e
       - store_test_results:
           path: tests/e2e/report/
     resource_class: large
@@ -838,7 +838,7 @@ jobs:
           name: Run playwright tests
           command: yarn e2e:api
       - store_artifacts:
-          path: playwright/api
+          path: tests/api
       - store_test_results:
           path: tests/api/report/
     resource_class: large
@@ -872,7 +872,7 @@ jobs:
           name: Run playwright tests
           command: yarn e2e:utils
       - store_artifacts:
-          path: playwright/utilsTests
+          path: tests/utilsTests
     resource_class: large
   cucumber_test:
     executor: docker-postgres-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,7 +801,7 @@ jobs:
       - store_artifacts:
           path: tests/e2e
       - store_test_results:
-          path: tests/e2e/report/
+          path: tests/e2e/test-results/
     resource_class: large
   test_api:
     executor: docker-postgres-executor
@@ -840,7 +840,7 @@ jobs:
       - store_artifacts:
           path: tests/api
       - store_test_results:
-          path: tests/api/report/
+          path: tests/api/test-results/
     resource_class: large
   test_utils:
     executor: docker-postgres-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,7 +801,7 @@ jobs:
       - store_artifacts:
           path: tests/e2e
       - store_test_results:
-          path: tests/e2e/test-results/
+          path: tests/e2e/test-results/report/
     resource_class: large
   test_api:
     executor: docker-postgres-executor
@@ -840,7 +840,7 @@ jobs:
       - store_artifacts:
           path: tests/api
       - store_test_results:
-          path: tests/api/test-results/
+          path: tests/api/test-results/report/
     resource_class: large
   test_utils:
     executor: docker-postgres-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -800,8 +800,6 @@ jobs:
           command: yarn e2e:ci
       - store_artifacts:
           path: tests/e2e
-      - store_test_results:
-          path: tests/e2e/e2e-html-report
     resource_class: large
   test_api:
     executor: docker-postgres-executor
@@ -839,8 +837,6 @@ jobs:
           command: yarn e2e:api
       - store_artifacts:
           path: tests/api
-      - store_test_results:
-          path: tests/api/api-html-report
     resource_class: large
   test_utils:
     executor: docker-postgres-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -800,6 +800,8 @@ jobs:
           command: yarn e2e:ci
       - store_artifacts:
           path: playwright/e2e
+      - store_test_results:
+          path: tests/e2e/report/
     resource_class: large
   test_api:
     executor: docker-postgres-executor
@@ -837,6 +839,8 @@ jobs:
           command: yarn e2e:api
       - store_artifacts:
           path: playwright/api
+      - store_test_results:
+          path: tests/api/report/
     resource_class: large
   test_utils:
     executor: docker-postgres-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,7 +801,7 @@ jobs:
       - store_artifacts:
           path: tests/e2e
       - store_test_results:
-          path: tests/e2e/test-results/report/
+          path: tests/e2e/e2e-html-report
     resource_class: large
   test_api:
     executor: docker-postgres-executor
@@ -840,7 +840,7 @@ jobs:
       - store_artifacts:
           path: tests/api
       - store_test_results:
-          path: tests/api/test-results/report/
+          path: tests/api/api-html-report
     resource_class: large
   test_utils:
     executor: docker-postgres-executor

--- a/tests/api/playwright.config.js
+++ b/tests/api/playwright.config.js
@@ -2,7 +2,9 @@
 const config = {
   testDir: '.',
   outputDir: './test-results',
-  reporter: [['html', { outputFolder: './report', open: 'never' }]],
+  reporter: [
+    ['html', { outputFolder: './test-results/report', outputFile: 'api-report.html', open: 'never' }],
+  ],
   workers: 1,
 };
 

--- a/tests/api/playwright.config.js
+++ b/tests/api/playwright.config.js
@@ -3,7 +3,7 @@ const config = {
   testDir: '.',
   outputDir: './test-results',
   reporter: [
-    ['html', { outputFolder: './api-html-report', outputFile: 'api-report.html', open: 'never' }],
+    ['html', { outputFolder: './api-html-report', open: 'never' }],
   ],
   workers: 1,
 };

--- a/tests/api/playwright.config.js
+++ b/tests/api/playwright.config.js
@@ -3,7 +3,7 @@ const config = {
   testDir: '.',
   outputDir: './test-results',
   reporter: [
-    ['html', { outputFolder: './api-html-report', open: 'never' }],
+    ['html', { outputFolder: './html-report', open: 'never' }],
   ],
   workers: 1,
 };

--- a/tests/api/playwright.config.js
+++ b/tests/api/playwright.config.js
@@ -3,7 +3,7 @@ const config = {
   testDir: '.',
   outputDir: './test-results',
   reporter: [
-    ['html', { outputFolder: './test-results/report', outputFile: 'api-report.html', open: 'never' }],
+    ['html', { outputFolder: './api-html-report', outputFile: 'api-report.html', open: 'never' }],
   ],
   workers: 1,
 };

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -462,7 +462,7 @@ test.describe('Activity Report', () => {
 
     await expect(page.getByText("This goal is used on an activity report, so some fields can't be edited.")).toBeVisible();
     await expect(page.getByText('g2', { exact: true })).toBeVisible();
-    await expect(page.getByText('g2o1')).not.toBeVisible();
+    await expect(page.getByText('g2o1')).toBeVisible();
   });
 
   test('multi recipient goal used on an AR', async ({ page }) => {

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -462,7 +462,7 @@ test.describe('Activity Report', () => {
 
     await expect(page.getByText("This goal is used on an activity report, so some fields can't be edited.")).toBeVisible();
     await expect(page.getByText('g2', { exact: true })).toBeVisible();
-    await expect(page.getByText('g2o1')).toBeVisible();
+    await expect(page.getByText('g2o1')).not.toBeVisible();
   });
 
   test('multi recipient goal used on an AR', async ({ page }) => {

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -15,7 +15,7 @@ const config = {
   fullyParallel: true,
   reporter: [
     ['list'],
-    ['html', { outputFolder: './e2e-html-report', outputFile: 'e2e-report.html', open: 'never' }],
+    ['html', { outputFolder: './e2e-html-report', open: 'never' }],
   ],
   timeout: 300000,
   globalTimeout: 900000,

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -13,7 +13,11 @@ const config = {
     timeout: 20000,
   },
   fullyParallel: true,
-  reporter: [['html', { outputFolder: './report', open: 'never' }]],
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: './report', open: 'never' }],
+    ['json', { outputFolder: './report', outputFile: 'report.json', open: 'never' }],
+  ],
   timeout: 300000,
   globalTimeout: 900000,
   globalSetup: './init/globalSetup.ts',

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -15,8 +15,8 @@ const config = {
   fullyParallel: true,
   reporter: [
     ['list'],
-    ['html', { outputFolder: './report', open: 'never' }],
-    ['json', { outputFolder: './report', outputFile: 'report.json', open: 'never' }],
+    ['html', { outputFolder: './test-results/report', outputFile: 'e2e-report.html', open: 'never' }],
+    ['json', { outputFolder: './test-results/report', outputFile: 'e2e-report.json', open: 'never' }],
   ],
   timeout: 300000,
   globalTimeout: 900000,

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -15,8 +15,7 @@ const config = {
   fullyParallel: true,
   reporter: [
     ['list'],
-    ['html', { outputFolder: './test-results/report', outputFile: 'e2e-report.html', open: 'never' }],
-    ['json', { outputFolder: './test-results/report', outputFile: 'e2e-report.json', open: 'never' }],
+    ['html', { outputFolder: './e2e-html-report', outputFile: 'e2e-report.html', open: 'never' }],
   ],
   timeout: 300000,
   globalTimeout: 900000,

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -15,7 +15,7 @@ const config = {
   fullyParallel: true,
   reporter: [
     ['list'],
-    ['html', { outputFolder: './e2e-html-report', open: 'never' }],
+    ['html', { outputFolder: './html-report', open: 'never' }],
   ],
   timeout: 300000,
   globalTimeout: 900000,


### PR DESCRIPTION
## Description of change

Fix playwright artifacts storage in CI.

## How to test

* Before: Nothing in the "artifacts" tab in CI (test_e2e and test_api jobs).
* After: "artifacts" tab populated in CI (test_e2e and test_api jobs).

In the artifacts tab for one of the jobs, test_e2e for example, find and click on `tests/e2e/html-report/index.html`. A nice UI should be displayed with a video for each test, a trace, and screenshot. Watch a video. Play with the trace.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3279


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
