### PR TITLE
[TTAHUB-3265] Support request: Reset session completion status

### DIFF
--- a/src/migrations/20240807172716-reset-session-completions.js
+++ b/src/migrations/20240807172716-reset-session-completions.js
@@ -7,12 +7,22 @@ module.exports = {
     async (transaction) => {
       await prepMigration(queryInterface, transaction, __filename);
       await queryInterface.sequelize.query(/* sql */`
-        -- First, set it at the event level.
+        -- Four sessions are not editable because they have already been
+        -- marked complete by POC. A support request has asked us to
+        -- revert this completion status so that they can be edited.
+
+        -- To do this, we set:
+
+        -- * pocComplete to false
+        -- * pocCompleteId to ""
+        -- * pocCompleteDate to ""
+
+        -- ...on both the event and the session
+
         UPDATE "EventReportPilots"
         SET data = jsonb_set(jsonb_set(jsonb_set(data, '{pocComplete}', 'false'), '{pocCompleteId}', '""'), '{pocCompleteDate}', '""')
         WHERE id = 39;
 
-        -- Then, set it at the session level
         UPDATE "SessionReportPilots"
         SET data = jsonb_set(
             jsonb_set(

--- a/src/migrations/20240807172716-reset-session-completions.js
+++ b/src/migrations/20240807172716-reset-session-completions.js
@@ -1,0 +1,36 @@
+const {
+  prepMigration,
+} = require('../lib/migration');
+
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      await queryInterface.sequelize.query(/* sql */`
+        -- First, set it at the event level.
+        UPDATE "EventReportPilots"
+        SET data = jsonb_set(jsonb_set(jsonb_set(data, '{pocComplete}', 'false'), '{pocCompleteId}', '""'), '{pocCompleteDate}', '""')
+        WHERE id = 39;
+
+        -- Then, set it at the session level
+        UPDATE "SessionReportPilots"
+        SET data = jsonb_set(
+            jsonb_set(
+                jsonb_set(data, '{pocCompleteId}', '""'),
+                '{pocCompleteDate}', '""'
+            ),
+            '{event, data, pocComplete}', 'false'
+        )
+        WHERE data ->> 'id' IN ('74', '101', '92', '102');
+        `, { transaction });
+    },
+  ),
+
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      // If we end up needing to revert this, it would be easier to use a separate
+      // migration using the txid (or a similar identifier) after it's already set
+    },
+  ),
+};


### PR DESCRIPTION
## Description of change

Four sessions are not editable because they have already been marked complete by POC. A support request has asked us to revert this completion status so that they can be edited.

To do this, we set:

* `pocComplete` to `false`
* `pocCompleteId` to `""`
* `pocCompleteDate` to `""`

...on both the event and the session

## How to test

* Restore latest prod backup and run migrations.
* Impersonate user 9 and visit the following URLs:
  * http://localhost:3000/training-report/5017/session/102/next-steps 
  * http://localhost:3000/training-report/5017/session/74/participants 
  * http://localhost:3000/training-report/5017/session/92/participants 
  * http://localhost:3000/training-report/5017/session/101/next-steps
* Ensure every form is editable.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3265


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
