### PR TITLE
[TTAHUB-2765] Reset page when filter changes

### DIFF
--- a/frontend/src/components/GoalCards/GoalDataController.js
+++ b/frontend/src/components/GoalCards/GoalDataController.js
@@ -167,7 +167,6 @@ function GoalDataController({
     setSortConfig,
     goalsPerPage,
     history.location,
-    setCurrentFilters,
   ]);
 
   useEffect(() => {

--- a/frontend/src/components/GoalCards/GoalDataController.js
+++ b/frontend/src/components/GoalCards/GoalDataController.js
@@ -72,6 +72,7 @@ function GoalDataController({
   const [logs, setLogs] = useState([]);
   const [logsLoaded, setLogsLoaded] = useState(false);
   const { setIsAppLoading, isAppLoading } = useContext(AppLoadingContext);
+  const [currentFilters, setCurrentFilters] = useState(filtersToQueryString(filters));
 
   useEffect(() => {
     let isLoaded = false;
@@ -145,6 +146,17 @@ function GoalDataController({
       }
     }
     const filterQuery = filtersToQueryString(filters);
+
+    // If filters is different from currentFilters, then reset the activePage and Offset.
+    if (filterQuery !== currentFilters) {
+      setSortConfig({
+        ...sortConfig,
+        activePage: 1,
+        offset: 0,
+      });
+      setCurrentFilters(filterQuery);
+    }
+
     fetchGoals(filterQuery);
   }, [
     sortConfig,
@@ -155,6 +167,7 @@ function GoalDataController({
     setSortConfig,
     goalsPerPage,
     history.location,
+    setCurrentFilters,
   ]);
 
   useEffect(() => {

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/GoalsObjectives.js
@@ -223,8 +223,12 @@ describe('Goals and Objectives', () => {
     // Default with 2 Rows.
     const goalsUrl = `/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=5&createDate.win=${yearToDate}`;
     fetchMock.get(goalsUrl,
-      { count: 2, goalRows: noFilterGoals, statuses: defaultStatuses }, { overwriteRoutes: true });
-
+      {
+        count: 2,
+        goalRows: noFilterGoals,
+        statuses: defaultStatuses,
+        allGoalIds: [],
+      }, { overwriteRoutes: true });
     act(() => renderGoalsAndObjectives());
 
     expect(await screen.findByText(/1-2 of 2/i)).toBeVisible();
@@ -245,6 +249,112 @@ describe('Goals and Objectives', () => {
     expect(await screen.findByText(/1-1 of 1/i)).toBeVisible();
     const notStartedStatuses = await screen.findAllByText(/not started/i);
     expect(notStartedStatuses.length).toBe(5);
+  });
+
+  it('resets the page number when filters change', async () => {
+    // CLear all mocks.
+    fetchMock.restore();
+
+    // Default with 2 Rows.
+    let goalsUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=10&status.in[]=Not%20started';
+    fetchMock.get(goalsUrl,
+      {
+        count: 11,
+        allGoalIds: [
+          { id: 1 },
+          { id: 2 },
+          { id: 3 },
+          { id: 4 },
+          { id: 5 },
+          { id: 6 },
+          { id: 7 },
+          { id: 8 },
+          { id: 9 },
+          { id: 10 },
+          { id: 11 }],
+        goalRows: [
+          { ...noFilterGoals[0], id: 1 },
+          { ...noFilterGoals[0], id: 2 },
+          { ...noFilterGoals[0], id: 3 },
+          { ...noFilterGoals[0], id: 4 },
+          { ...noFilterGoals[0], id: 5 },
+          { ...noFilterGoals[0], id: 6 },
+          { ...noFilterGoals[0], id: 7 },
+          { ...noFilterGoals[0], id: 8 },
+          { ...noFilterGoals[0], id: 9 },
+          { ...noFilterGoals[0], id: 10 },
+          { ...noFilterGoals[0], id: 11 },
+        ],
+        statuses: defaultStatuses,
+      },
+      { overwriteRoutes: true });
+
+    act(() => renderGoalsAndObjectives());
+
+    expect(await screen.findByText(/Showing 1-10 of 11 goals/i)).toBeVisible();
+
+    // Go to the next page.
+    goalsUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=10&limit=10&status.in[]=Not%20started';
+    fetchMock.get(goalsUrl,
+      {
+        count: 11,
+        allGoalIds: [
+          { id: 1 },
+          { id: 2 },
+          { id: 3 },
+          { id: 4 },
+          { id: 5 },
+          { id: 6 },
+          { id: 7 },
+          { id: 8 },
+          { id: 9 },
+          { id: 10 },
+          { id: 11 }],
+        goalRows: [
+          { ...noFilterGoals[0], id: 11 },
+        ],
+        statuses: defaultStatuses,
+      }, { overwriteRoutes: true });
+
+    const pageTwo = await screen.findByRole('link', { name: /go to page number 2/i });
+    userEvent.click(pageTwo);
+
+    expect(await screen.findByText(/Showing 11-11 of 11 goals/i)).toBeVisible();
+
+    // Change Filter and Apply.
+    userEvent.click(await screen.findByRole('button', { name: /open filters for this page/i }));
+
+    userEvent.selectOptions(await screen.findByRole('combobox', { name: 'topic' }), 'status');
+    userEvent.selectOptions(await screen.findByRole('combobox', { name: 'condition' }), 'is');
+
+    const statusSelect = await screen.findByLabelText(/select status to filter by/i);
+    await selectEvent.select(statusSelect, ['Draft']);
+
+    goalsUrl = '/api/recipient/401/region/1/goals?sortBy=goalStatus&sortDir=asc&offset=0&limit=10&status.in[]=Not%20started&status.in[]=Draft';
+    fetchMock.get(goalsUrl,
+      {
+        count: 1,
+        allGoalIds: [
+          { id: 1 },
+        ],
+        goalRows: [
+          { ...noFilterGoals[0], id: 11 },
+        ],
+        statuses: defaultStatuses,
+      }, { overwriteRoutes: true });
+
+    const apply = await screen.findByRole('button', { name: /apply filters to goals/i });
+    userEvent.click(apply);
+
+    // Expect the goalsUrl to have been called.
+    expect(fetchMock.called(goalsUrl)).toBe(true);
+
+    // Expect 1 Row.
+    expect(await screen.findByText(/Showing 1-1 of 1 goals/i)).toBeVisible();
+    // Expect go to page number 1 to be visible.
+    expect(await screen.findByRole('link', { name: /go to page number 1/i })).toBeVisible();
+    // expect go to page number 2 to not be visible.
+    expect(screen.queryByRole('link', { name: /go to page number 2/i })).toBeNull();
   });
 
   it('renders correctly when filter is removed', async () => {
@@ -362,6 +472,7 @@ describe('Goals and Objectives', () => {
 
     expect(await screen.findByText(/Unable to fetch goals/i)).toBeVisible();
   });
+  /// 2
 
   it('adjusts items per page', async () => {
     fetchMock.restore();


### PR DESCRIPTION
## Description of change

This was an issue on the RTR goals page. If we go to the second page of goals, then filter a result that only has one page. The user would be stuck on the second page with no results shown (event though the first page had results).

**NOTE:** I'm not sure if this impacts other pages, but we will start here first.

## How to test

- Review the code.
- Test the use case in the jira
CASE: Apply a goal text filter for something common like "class" while on the second or third page.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2765


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
