### PR TITLE
Set event submitted: true when event is being submitted

### DIFF
--- a/frontend/src/pages/TrainingReportForm/index.js
+++ b/frontend/src/pages/TrainingReportForm/index.js
@@ -226,7 +226,10 @@ export default function TrainingReportForm({ match }) {
 
       // PUT it to the backend
       const updatedEvent = await updateEvent(trainingReportId, {
-        data,
+        data: {
+          ...data,
+          eventSubmitted: true,
+        },
         ownerId: ownerId || null,
         pocIds: pocIds || null,
         collaboratorIds,


### PR DESCRIPTION
## Description of change

We need to capture the "eventSubmitted" variable in the data of a Training Report when the owner submits it. The "complete event" functionality depends on it. It seems to have been removed as part of a bug squash.

## How to test

Recreate the issue described in this slack thread
https://adhoc.slack.com/archives/C022R5301L4/p1725032185745969

Once you submit the event in question, you should be able to complete it.

Alternately, confirm "eventSubmitted" is present in the request body when submitting a training report.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
