### PR TITLE
[TTAHUB-3370] Pass the 'createdHere' to the BE so its persisted

### DIFF
--- a/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
@@ -160,6 +160,115 @@ describe('FormDataHelpers', () => {
         },
       ]);
     });
+
+    it('correctly pacakges all objective fields', () => {
+      const grantIds = [1];
+      const packagedGoals = packageGoals(
+        [
+          {
+            ...baseGoal,
+            name: 'goal name',
+            endDate: '09/01/2020',
+            prompts: [{ fieldName: 'prompt' }],
+            objectives: [
+              {
+                id: 1,
+                isNew: false,
+                ttaProvided: 'Not Created Here TTA',
+                title: 'Not Created Here Title',
+                status: 'status',
+                resources: 'resources',
+                topics: 'topics',
+                files: 'files',
+                supportType: 'supportType',
+                courses: 'courses',
+                closeSuspendReason: 'closeSuspendReason',
+                closeSuspendContext: 'closeSuspendContext',
+                createdHere: false,
+              },
+            ],
+          },
+        ],
+        {
+          ...baseGoal,
+          name: 'recipient',
+          endDate: '09/01/2020',
+          isActivelyBeingEditing: true,
+          objectives: [
+            {
+              id: 2,
+              isNew: false,
+              ttaProvided: 'Created Here TTA',
+              title: 'Created Here Title',
+              status: 'status',
+              resources: 'resources',
+              topics: 'topics',
+              files: 'files',
+              supportType: 'supportType',
+              courses: 'courses',
+              closeSuspendReason: 'closeSuspendReason',
+              closeSuspendContext: 'closeSuspendContext',
+              createdHere: true,
+            },
+          ],
+        },
+        grantIds,
+        [{ fieldName: 'prompt2' }],
+      );
+
+      expect(packagedGoals).toEqual([
+        {
+          ...baseGoal,
+          name: 'goal name',
+          endDate: '09/01/2020',
+          prompts: [{ fieldName: 'prompt' }],
+          grantIds,
+          isActivelyBeingEditing: false,
+          objectives: [
+            {
+              id: 1,
+              isNew: false,
+              ttaProvided: 'Not Created Here TTA',
+              title: 'Not Created Here Title',
+              status: 'status',
+              resources: 'resources',
+              topics: 'topics',
+              files: 'files',
+              supportType: 'supportType',
+              courses: 'courses',
+              closeSuspendReason: 'closeSuspendReason',
+              closeSuspendContext: 'closeSuspendContext',
+              createdHere: false,
+            },
+          ],
+        },
+        {
+          ...baseGoal,
+          name: 'recipient',
+          endDate: '09/01/2020',
+          isActivelyBeingEditing: true,
+          grantIds,
+          prompts: [{ fieldName: 'prompt2' }],
+          objectives: [
+            {
+              id: 2,
+              isNew: false,
+              ttaProvided: 'Created Here TTA',
+              title: 'Created Here Title',
+              status: 'status',
+              resources: 'resources',
+              topics: 'topics',
+              files: 'files',
+              supportType: 'supportType',
+              courses: 'courses',
+              closeSuspendReason: 'closeSuspendReason',
+              closeSuspendContext: 'closeSuspendContext',
+              createdHere: true,
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('convertGoalsToFormData', () => {

--- a/frontend/src/pages/ActivityReport/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/formDataHelpers.js
@@ -129,6 +129,7 @@ export const packageGoals = (goals, goal, grantIds, prompts) => {
         courses: objective.courses,
         closeSuspendReason: objective.closeSuspendReason,
         closeSuspendContext: objective.closeSuspendContext,
+        createdHere: objective.createdHere,
       })),
     })),
   ];
@@ -155,6 +156,7 @@ export const packageGoals = (goals, goal, grantIds, prompts) => {
         courses: objective.courses,
         closeSuspendReason: objective.closeSuspendReason,
         closeSuspendContext: objective.closeSuspendContext,
+        createdHere: objective.createdHere,
       })),
       grantIds,
       prompts: grantIds.length < 2 ? prompts : [],


### PR DESCRIPTION
## Description of change

When an objective is created from and AR we populate the database field 'objectiveCreatedHere'. It looks like this was never being passed to the BE, so it was never persisted in the database. When the user clicks save draft on the objective, the value would come back to the FE as undefined. This would intern lock the objective text from being updated (even though it was created on the report).

## How to test

- Review the code
- Make sure creating a new AR with objectives doesn't lock the objective text (also the column 'objectiveCreatedHere' is populated correctly).
- Make sure using objectives on report that were NOT created on the report have the correct value.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3370


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
