### PR TITLE
[TTAHUB-3046] AR flags on merged goals need to be set

### DIFF
--- a/src/models/hooks/activityReportGoal.js
+++ b/src/models/hooks/activityReportGoal.js
@@ -160,7 +160,7 @@ const updateOnARAndOnApprovedARForMergedGoals = async (sequelize, instance) => {
     && changed.includes('originalGoalId')
     && changed.includes('goalId')
     && instance.originalGoalId !== null) {
-    const {goalId} = instance;
+    const { goalId } = instance;
 
     // Check if the ActivityReport linked to this ActivityReportGoal has a
     // calculatedStatus of 'approved'

--- a/src/models/hooks/activityReportGoal.js
+++ b/src/models/hooks/activityReportGoal.js
@@ -1,3 +1,4 @@
+const { Op } = require('sequelize');
 const { REPORT_STATUSES } = require('@ttahub/common');
 const { GOAL_COLLABORATORS } = require('../../constants');
 const {
@@ -179,11 +180,11 @@ const updateOnARAndOnApprovedARForMergedGoals = async (sequelize, instance) => {
       {
         where: {
           id: goalId,
-          [sequelize.Op.or]: [
+          [Op.or]: [
             // Update if onAR is not already true
-            { onAR: { [sequelize.Op.ne]: true } },
+            { onAR: { [Op.ne]: true } },
             // Update if onApprovedAR differs
-            { onApprovedAR: { [sequelize.Op.ne]: onApprovedAR } },
+            { onApprovedAR: { [Op.ne]: onApprovedAR } },
           ],
         },
         individualHooks: true, // Ensure individual hooks are triggered

--- a/src/models/hooks/activityReportGoal.js
+++ b/src/models/hooks/activityReportGoal.js
@@ -160,13 +160,14 @@ const updateOnARAndOnApprovedARForMergedGoals = async (sequelize, instance) => {
     && changed.includes('originalGoalId')
     && changed.includes('goalId')
     && instance.originalGoalId !== null) {
-    const goalId = instance.goalId;
+    const {goalId} = instance;
 
-    // Check if the ActivityReport linked to this ActivityReportGoal has a calculatedStatus of 'approved'
+    // Check if the ActivityReport linked to this ActivityReportGoal has a
+    // calculatedStatus of 'approved'
     const approvedActivityReports = await sequelize.models.ActivityReport.count({
       where: {
         calculatedStatus: 'approved',
-        id: instance.activityReportId,  // Use the activityReportId from the instance
+        id: instance.activityReportId, // Use the activityReportId from the instance
       },
     });
 
@@ -179,16 +180,17 @@ const updateOnARAndOnApprovedARForMergedGoals = async (sequelize, instance) => {
         where: {
           id: goalId,
           [sequelize.Op.or]: [
-            { onAR: { [sequelize.Op.ne]: true } },  // Update if onAR is not already true
-            { onApprovedAR: { [sequelize.Op.ne]: onApprovedAR } },  // Update if onApprovedAR differs
+            // Update if onAR is not already true
+            { onAR: { [sequelize.Op.ne]: true } },
+            // Update if onApprovedAR differs
+            { onApprovedAR: { [sequelize.Op.ne]: onApprovedAR } },
           ],
         },
-        individualHooks: true,  // Ensure individual hooks are triggered
-      }
+        individualHooks: true, // Ensure individual hooks are triggered
+      },
     );
   }
 };
-
 
 const afterCreate = async (sequelize, instance, options) => {
   await processForEmbeddedResources(sequelize, instance, options);
@@ -214,7 +216,7 @@ const afterDestroy = async (sequelize, instance, options) => {
 
 const afterUpdate = async (sequelize, instance, options) => {
   await processForEmbeddedResources(sequelize, instance, options);
-  await destroyLinkedSimilarityGroups(sequelize, instance, options); 
+  await destroyLinkedSimilarityGroups(sequelize, instance, options);
   await updateOnARAndOnApprovedARForMergedGoals(sequelize, instance);
 };
 

--- a/src/models/hooks/activityReportGoal.test.js
+++ b/src/models/hooks/activityReportGoal.test.js
@@ -256,11 +256,11 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
       {
         where: {
           id: instance.goalId,
-          [sequelize.Op.or]: [
+          [Op.or]: [
             // Ensure onAR condition is in the where clause
-            { onAR: { [sequelize.Op.ne]: true } },
+            { onAR: { [Op.ne]: true } },
             // Ensure onApprovedAR condition is in the where clause
-            { onApprovedAR: { [sequelize.Op.ne]: true } },
+            { onApprovedAR: { [Op.ne]: true } },
           ],
         },
         individualHooks: true,
@@ -362,9 +362,9 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
       {
         where: {
           id: instance.goalId,
-          [sequelize.Op.or]: [
-            { onAR: { [sequelize.Op.ne]: true } }, // Check if onAR is already true
-            { onApprovedAR: { [sequelize.Op.ne]: true } }, // Check if onApprovedAR is already true
+          [Op.or]: [
+            { onAR: { [Op.ne]: true } }, // Check if onAR is already true
+            { onApprovedAR: { [Op.ne]: true } }, // Check if onApprovedAR is already true
           ],
         },
         individualHooks: true,

--- a/src/models/hooks/activityReportGoal.test.js
+++ b/src/models/hooks/activityReportGoal.test.js
@@ -295,7 +295,15 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
     expect(sequelize.models.Goal.update).toHaveBeenCalledWith(
       { onAR: true, onApprovedAR: false }, // onApprovedAR is false since no approved reports
       {
-        where: { id: instance.goalId },
+        where: {
+          id: instance.goalId,
+          [Op.or]: [
+            // Ensure onAR condition is in the where clause
+            { onAR: { [Op.ne]: true } },
+            // Ensure onApprovedAR condition is in the where clause
+            { onApprovedAR: { [Op.ne]: false } },
+          ],
+        },
         individualHooks: true,
       },
     );

--- a/src/models/hooks/activityReportGoal.test.js
+++ b/src/models/hooks/activityReportGoal.test.js
@@ -369,5 +369,5 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
         individualHooks: true,
       },
     );
-  }); 
+  });
 });

--- a/src/models/hooks/activityReportGoal.test.js
+++ b/src/models/hooks/activityReportGoal.test.js
@@ -1,3 +1,4 @@
+const { Op } = require('sequelize'); // Import Sequelize operators
 const { REPORT_STATUSES } = require('@ttahub/common');
 const {
   destroyLinkedSimilarityGroups,

--- a/src/models/hooks/activityReportGoal.test.js
+++ b/src/models/hooks/activityReportGoal.test.js
@@ -232,38 +232,40 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
       activityReportId: 1,
       changed: () => ['originalGoalId', 'goalId'], // Simulate that both columns have changed
     };
-  
+
     const options = {
       transaction: 'mockTransaction',
     };
-  
+
     // Mock the necessary Sequelize methods
-    sequelize.models.ActivityReport.count.mockResolvedValue(1); // Simulate approved ActivityReport exists
-  
+    // Simulate approved ActivityReport exists
+    sequelize.models.ActivityReport.count.mockResolvedValue(1);
+
     await updateOnARAndOnApprovedARForMergedGoals(sequelize, instance, options);
-  
+
     expect(sequelize.models.ActivityReport.count).toHaveBeenCalledWith({
       where: {
         calculatedStatus: 'approved',
         id: instance.activityReportId,
       },
     });
-  
+
     expect(sequelize.models.Goal.update).toHaveBeenCalledWith(
       { onAR: true, onApprovedAR: true },
       {
         where: {
           id: instance.goalId,
           [sequelize.Op.or]: [
-            { onAR: { [sequelize.Op.ne]: true } },  // Ensure onAR condition is in the where clause
-            { onApprovedAR: { [sequelize.Op.ne]: true } },  // Ensure onApprovedAR condition is in the where clause
+            // Ensure onAR condition is in the where clause
+            { onAR: { [sequelize.Op.ne]: true } },
+            // Ensure onApprovedAR condition is in the where clause
+            { onApprovedAR: { [sequelize.Op.ne]: true } },
           ],
         },
         individualHooks: true,
-      }
+      },
     );
   });
-  
 
   it('should update onAR and onApprovedAR with false when there are no approved activity reports', async () => {
     const instance = {
@@ -294,7 +296,7 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
       {
         where: { id: instance.goalId },
         individualHooks: true,
-      }
+      },
     );
   });
 
@@ -341,17 +343,19 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
       activityReportId: 1,
       changed: () => ['originalGoalId', 'goalId'], // Simulate that both columns have changed
     };
-  
+
     const options = {
       transaction: 'mockTransaction',
     };
-  
+
     // Mock the necessary Sequelize methods
-    sequelize.models.ActivityReport.count.mockResolvedValue(1); // Simulate approved ActivityReport exists
-    sequelize.models.Goal.update.mockResolvedValue(0); // Simulate that the update doesn't happen
-  
+    // Simulate approved ActivityReport exists
+    sequelize.models.ActivityReport.count.mockResolvedValue(1);
+    // Simulate that the update doesn't happen
+    sequelize.models.Goal.update.mockResolvedValue(0);
+
     await updateOnARAndOnApprovedARForMergedGoals(sequelize, instance, options);
-  
+
     expect(sequelize.models.Goal.update).toHaveBeenCalledWith(
       { onAR: true, onApprovedAR: true },
       {
@@ -363,8 +367,7 @@ describe('updateOnARAndOnApprovedARForMergedGoals', () => {
           ],
         },
         individualHooks: true,
-      }
+      },
     );
-  });
-  
+  }); 
 });


### PR DESCRIPTION
## Description of change
Adding a hook to populate the onAR and onApprovedAR flags when the merged goal is placed on the ActivityReportGoal records.


## How to test
Merge goals that have been on an AR, the resulting goal has flags set correctly

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3046


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
