### PR TITLE
[NO-TICKET] Remove unnecessary `src/.eslintrc` and `frontend/src/.eslintrc`

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
+      "ecmaVersion": 2020,
       "project": "./src/tsconfig.json"
     },
     "plugins": [

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "parserOptions": {
-    "ecmaVersion": 2020
-  }
-}


### PR DESCRIPTION
## Description of change

We store our eslint configs in `package.json` and `frontend/package.json`, so we don't also need `src/.eslintrc` and `frontend/src/.eslintrc`. It is safe to remove these.

Further, on my machine at least, it confuses the eslint LSP (`vscode-eslint-language-server`) which apparently prioritizes the discovery of `.eslintrc` over a `package.json` configuration, discovers no configuration (because these files are empty) and therefore provides no diagnostics.

## How to test

Make sure eslint still provides diagnostics in your editor.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
