### PR TITLE
[TTAHUB-3420] Fix two non-validating form fields

### DIFF
--- a/frontend/src/pages/TrainingReportForm/pages/__tests__/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/__tests__/eventSummary.js
@@ -121,6 +121,12 @@ describe('eventSummary', () => {
       userEvent.type(startDate, '01/03/2021');
 
       await selectEvent.select(screen.getByLabelText(/Event region point of contact/i), 'Ted User');
+      await selectEvent.select(screen.getByLabelText(/Event collaborators/i), []);
+      userEvent.tab();
+
+      // confirm the blur event fires and the validation message is present
+      expect(await screen.findByText('Select at least one collaborator')).toBeInTheDocument();
+
       await selectEvent.select(screen.getByLabelText(/Event collaborators/i), ['Tedwina User']);
       await selectEvent.select(screen.getByLabelText(/target populations/i), ['Pregnant Women / Pregnant Persons']);
       await selectEvent.select(screen.getByLabelText(/reasons/i), ['Complaint']);

--- a/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
@@ -181,7 +181,7 @@ const EventSummary = ({
                 <Req />
               </Label>
               <Controller
-                render={({ onChange: controllerOnChange, value: id }) => (
+                render={({ onChange: controllerOnChange, value: id, onBlur }) => (
                   <Select
                     value={(creators || []).find((option) => option.id === id)}
                     inputId="ownerId"
@@ -198,6 +198,7 @@ const EventSummary = ({
                     options={creators || []}
                     getOptionLabel={(option) => option.nameWithNationalCenters}
                     getOptionValue={(option) => option.id}
+                    onBlur={onBlur}
                     required
                   />
                 )}
@@ -274,7 +275,7 @@ const EventSummary = ({
             required
           >
             <Controller
-              render={({ onChange: controllerOnChange, value }) => (
+              render={({ onChange: controllerOnChange, value, onBlur }) => (
                 <Select
                   isMulti
                   value={collaborators.filter((collaborator) => (
@@ -290,6 +291,7 @@ const EventSummary = ({
                   onChange={(s) => {
                     controllerOnChange(s.map((option) => option.id));
                   }}
+                  onBlur={onBlur}
                   inputRef={register({ required: 'Select at least one collaborator' })}
                   getOptionLabel={(option) => option.nameWithNationalCenters}
                   getOptionValue={(option) => option.id}
@@ -320,7 +322,7 @@ const EventSummary = ({
                 <Req />
               </Label>
               <Controller
-                render={({ onChange: controllerOnChange, value }) => (
+                render={({ onChange: controllerOnChange, value, onBlur }) => (
                   <Select
                     value={pointOfContact.filter((option) => (
                       value.includes(option.id)
@@ -339,6 +341,7 @@ const EventSummary = ({
                     getOptionLabel={(option) => option.fullName}
                     getOptionValue={(option) => option.id}
                     options={pointOfContact}
+                    onBlur={onBlur}
                     required
                     isMulti
                   />


### PR DESCRIPTION
## Description of change

Two form fields on the event summary were missing on blur handlers and therefore would not validate. This has been fixed

## How to test
Confirm that event collaborators and regional point of contact fields are validated on blur if a selection was not made

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3420


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
