### PR TITLE
[TTAHUB-3452] Fix comm date validation

### DIFF
--- a/src/services/communicationLog.test.js
+++ b/src/services/communicationLog.test.js
@@ -9,6 +9,7 @@ import {
   updateLog,
   createLog,
   orderLogsBy,
+  formatCommunicationDateWithJsonData,
 } from './communicationLog';
 import { createRecipient, createUser } from '../testUtils';
 
@@ -142,6 +143,32 @@ describe('communicationLog services', () => {
       const result = orderLogsBy(undefined, sortDir);
 
       expect(result).toEqual([['data.communicationDate', 'asc']]);
+    });
+  });
+
+  describe('formatCommunicationDateWithJsonData', () => {
+    const badDatesLong = [
+      '08/16/24',
+      '8/16/24',
+      '8/16/2024',
+      '08/16//24',
+      '8-16-24',
+      '08/16/20240.75',
+    ];
+
+    const badDatesShort = [
+      '08/4/2024',
+      '8/4/24',
+      '8/4/2024',
+      '08/4/24',
+    ];
+
+    it.each(badDatesLong)('should return 08/16/2024 when the date is %s', (date) => {
+      expect(formatCommunicationDateWithJsonData({ communicationDate: date })).toEqual({ communicationDate: '08/16/2024' });
+    });
+
+    it.each(badDatesShort)('should return 08/04/2024 when the date is %s', (date) => {
+      expect(formatCommunicationDateWithJsonData({ communicationDate: date })).toEqual({ communicationDate: '08/04/2024' });
     });
   });
 });

--- a/src/services/communicationLog.ts
+++ b/src/services/communicationLog.ts
@@ -6,16 +6,18 @@ import { communicationLogToCsvRecord } from '../lib/transform';
 
 const { sequelize, CommunicationLog } = db;
 
+interface CommLogData {
+  communicationDate?: string;
+  purpose?: string;
+  result?: string;
+}
+
 interface CommLog {
   files: unknown[];
   recipientId: number;
   userId: number;
   id: number;
-  data: {
-    communicationDate: string;
-    purpose: string;
-    result: string;
-  };
+  data: CommLogData;
   authorName: string;
   author: {
     id: number;
@@ -23,7 +25,7 @@ interface CommLog {
   }
 }
 
-export const formatCommunicationDateWithJsonData = (data: { communicationDate: string }) => {
+export const formatCommunicationDateWithJsonData = (data: CommLogData): CommLogData => {
   if (data.communicationDate) {
     const formattedCommunicationDate = moment(data.communicationDate, 'MM/DD/YYYY').format('MM/DD/YYYY');
 
@@ -232,7 +234,7 @@ const updateLog = async (id: number, logData: CommLog) => {
     ...data
   } = logData;
   const log = await CommunicationLog.findOne(LOG_WHERE_OPTIONS(id));
-  return log.update({ data: formatCommunicationDateWithJsonData(data) });
+  return log.update({ data: formatCommunicationDateWithJsonData(data as CommLogData) });
 };
 
 export {


### PR DESCRIPTION
## Description of change
The issue here is that the validation on the frontend (can we parse a valid date from what the user enters using the momentjs library?) normally combines with postgres date columns to standardize the saved format. Since we are saving the date here to a JSON field, the date field can contain any arbitrary value that moment can figure out. This change preempts the save and create communication log services to use moment's formatting to save whatever date it has parsed from user input.

## How to test
Save a date in a non MM/DD/YYYY format  in the communication date field in the comm log. Save: the value in the UI and the database is corrected.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3452


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
