### PR TITLE
[TTAHUB-3423] Use separate labels for table data on Horizontal Table Widget

### DIFF
--- a/frontend/src/pages/ResourcesDashboard/__tests__/index.js
+++ b/frontend/src/pages/ResourcesDashboard/__tests__/index.js
@@ -54,7 +54,10 @@ const resourcesDefault = {
     },
   },
   resourcesUse: {
-    headers: ['Jan-22'],
+    headers: [{
+      displayName: 'Jan-22',
+      name: 'January 2022',
+    }],
     resources: [
       {
         heading: 'https://test1.gov',
@@ -73,7 +76,20 @@ const resourcesDefault = {
     ],
   },
   topicUse: {
-    headers: ['Oct-22', 'Nov-22', 'Dec-22'],
+    headers: [
+      {
+        displayName: 'Oct-22',
+        name: 'October 2022',
+      },
+      {
+        displayName: 'Nov-22',
+        name: 'November 2022',
+      },
+      {
+        displayName: 'Dec-22',
+        name: 'December 2022',
+      },
+    ],
     topics: [{
       heading: 'https://official1.gov',
       isUrl: true,
@@ -124,7 +140,10 @@ const resourcesRegion1 = {
     },
   },
   resourcesUse: {
-    headers: ['Jan-22'],
+    headers: [{
+      displayName: 'Jan-22',
+      name: 'January 2022',
+    }],
     resources: [
       {
         heading: 'https://test2.gov',
@@ -143,7 +162,20 @@ const resourcesRegion1 = {
     ],
   },
   topicUse: {
-    headers: ['Oct-22', 'Nov-22', 'Dec-22'],
+    headers: [
+      {
+        displayName: 'Oct-22',
+        name: 'October 2022',
+      },
+      {
+        displayName: 'Nov-22',
+        name: 'November 2022',
+      },
+      {
+        displayName: 'Dec-22',
+        name: 'December 2022',
+      },
+    ],
     topics: [{
       heading: 'https://official2.gov',
       isUrl: true,
@@ -194,7 +226,10 @@ const resourcesRegion2 = {
     },
   },
   resourcesUse: {
-    headers: ['Jan-22'],
+    headers: [{
+      displayName: 'Jan-22',
+      name: 'January 2022',
+    }],
     resources: [
       {
         heading: 'https://test3.gov',
@@ -213,7 +248,20 @@ const resourcesRegion2 = {
     ],
   },
   topicUse: {
-    headers: ['Oct-22', 'Nov-22', 'Dec-22'],
+    headers: [
+      {
+        displayName: 'Oct-22',
+        name: 'October 2022',
+      },
+      {
+        displayName: 'Nov-22',
+        name: 'November 2022',
+      },
+      {
+        displayName: 'Dec-22',
+        name: 'December 2022',
+      },
+    ],
     topics: [{
       heading: 'https://official3.gov',
       isUrl: true,

--- a/frontend/src/widgets/HorizontalTableWidget.js
+++ b/frontend/src/widgets/HorizontalTableWidget.js
@@ -30,8 +30,8 @@ export default function HorizontalTableWidget(
     itemsArr.reduce((obj, d) => ({ ...obj, [d.id]: checked }), {})
   );
 
-  const renderSortableColumnHeader = (displayName, name, classValues) => {
-    const sortClassName = getClassNamesFor(name);
+  const renderSortableColumnHeader = (displayName, key, name, classValues) => {
+    const sortClassName = getClassNamesFor(key);
     let fullAriaSort;
     switch (sortClassName) {
       case 'asc':
@@ -46,15 +46,15 @@ export default function HorizontalTableWidget(
     }
 
     return (
-      <th key={displayName.replace(' ', '_')} className={classValues || 'bg-white text-left data-header'} scope="col" aria-sort={fullAriaSort}>
+      <th key={key} className={classValues || 'bg-white text-left data-header'} scope="col" aria-sort={fullAriaSort}>
         <button
           type="button"
           tabIndex={0}
           onClick={() => {
-            requestSort(name);
+            requestSort(key);
           }}
           className={`usa-button usa-button--unstyled sortable ${sortClassName}`}
-          aria-label={`${displayName}. Activate to sort ${sortClassName === 'asc' ? 'descending' : 'ascending'
+          aria-label={`${name}. Activate to sort ${sortClassName === 'asc' ? 'descending' : 'ascending'
           }`}
         >
           {displayName}
@@ -107,6 +107,43 @@ export default function HorizontalTableWidget(
     }
   };
 
+  const Header = ({ header, sortingEnabled }) => {
+    let displayName = header;
+    let name = header;
+
+    if (header.displayName) {
+      displayName = header.displayName;
+    }
+
+    if (header.name) {
+      name = header.name;
+    }
+
+    const key = displayName.replaceAll(' ', '_');
+
+    if (sortingEnabled) {
+      return renderSortableColumnHeader(displayName, key, name);
+    }
+
+    return (
+      <th key={key} scope="col" className="text-left data-header">
+        <span className="usa-sr-only">{name}</span>
+        <span aria-hidden="true">{displayName}</span>
+      </th>
+    );
+  };
+
+  Header.propTypes = {
+    sortingEnabled: PropTypes.bool.isRequired,
+    header: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        displayName: PropTypes.string,
+        name: PropTypes.string,
+      }),
+    ]).isRequired,
+  };
+
   return (
     <div className="smarthub-horizontal-table-widget usa-table-container--scrollable margin-top-0 margin-bottom-0">
       <Table stackedStyle="default" fullWidth striped bordered={false}>
@@ -128,7 +165,7 @@ export default function HorizontalTableWidget(
             }
             {
               enableSorting
-                ? renderSortableColumnHeader(firstHeading, firstHeading.replaceAll(' ', '_'), `smarthub-horizontal-table-first-column ${enableCheckboxes ? 'left-with-checkbox' : 'left-0'}`)
+                ? renderSortableColumnHeader(firstHeading, firstHeading.replaceAll(' ', '_'), firstHeading, `smarthub-horizontal-table-first-column ${enableCheckboxes ? 'left-with-checkbox' : 'left-0'}`)
                 : (
                   <th className={`smarthub-horizontal-table-first-column data-header ${enableCheckboxes ? 'left-with-checkbox' : 'left-0'}`}>
                     {firstHeading}
@@ -136,9 +173,7 @@ export default function HorizontalTableWidget(
                 )
             }
             {
-            headers.map((h) => (enableSorting
-              ? renderSortableColumnHeader(h, h.replaceAll(' ', '_'))
-              : <th key={h.replace(' ', '_')} scope="col" className="text-left data-header">{h}</th>))
+            headers.map((h) => (<Header header={h} sortingEnabled={enableSorting} />))
             }
             {
             enableSorting
@@ -158,7 +193,7 @@ export default function HorizontalTableWidget(
                 {
                   enableCheckboxes && (
                     <td className="width-8 checkbox-column" data-label="Select report">
-                      <Checkbox id={r.id} label="" value={r.id} checked={checkboxes[r.id] || false} onChange={handleReportSelect} aria-label={`Select ${r.id}`} />
+                      <Checkbox id={r.id} label="" value={r.id} checked={checkboxes[r.id] || false} onChange={handleReportSelect} aria-label={`Select ${r.title}`} />
                     </td>
                   )
                 }
@@ -167,7 +202,7 @@ export default function HorizontalTableWidget(
                     r.isUrl
                       ? handleUrl(r)
                       : r.heading
-                      }
+                  }
                 </td>
                 {r.data.map((d, cellIndex) => (
                   <td data-label={d.title} key={`horizontal_table_cell_${cellIndex}`} className={d.title.toLowerCase() === 'total' ? 'smarthub-horizontal-table-last-column' : null}>
@@ -190,6 +225,7 @@ HorizontalTableWidget.propTypes = {
       PropTypes.shape({
         name: PropTypes.string,
         count: PropTypes.number,
+        label: PropTypes.string,
       }),
     ), PropTypes.shape({}),
   ]),

--- a/frontend/src/widgets/ResourceUseSparklineGraph.js
+++ b/frontend/src/widgets/ResourceUseSparklineGraph.js
@@ -45,7 +45,7 @@ LegendIndicator.propTypes = {
 };
 
 export default function ResourceUseSparklineGraph({ data }) {
-  const headings = data.headers.map((header) => <span key={uniqueId('resource-use-sparkline-headings-')} className="ttahub-resource-use-sparkline__heading usa-prose display-flex flex-justify-center flex-align-center">{header}</span>);
+  const headings = data.headers.map((header) => <span key={uniqueId('resource-use-sparkline-headings-')} className="ttahub-resource-use-sparkline__heading usa-prose display-flex flex-justify-center flex-align-center" aria-label={header.name}><span aria-hidden="true">{header.displayName}</span></span>);
 
   return (
     <>
@@ -97,7 +97,10 @@ export default function ResourceUseSparklineGraph({ data }) {
 
 ResourceUseSparklineGraph.propTypes = {
   data: PropTypes.shape({
-    headers: PropTypes.arrayOf(PropTypes.string),
+    headers: PropTypes.arrayOf(PropTypes.shape({
+      displayName: PropTypes.string,
+      name: PropTypes.string,
+    })),
     resources: PropTypes.arrayOf(PropTypes.shape({
       data: PropTypes.arrayOf(PropTypes.shape({
         title: PropTypes.string,

--- a/frontend/src/widgets/__tests__/HorizontalTableWidget.js
+++ b/frontend/src/widgets/__tests__/HorizontalTableWidget.js
@@ -54,9 +54,9 @@ describe('Horizontal Table Widget', () => {
 
     renderHorizontalTableWidget(headers, data);
     expect(screen.getByText(/First Heading/i)).toBeInTheDocument();
-    expect(screen.getByText(/col1/i)).toBeInTheDocument();
-    expect(screen.getByText(/col2/i)).toBeInTheDocument();
-    expect(screen.getByText(/col3/i)).toBeInTheDocument();
+    expect(screen.getByText(/col1/i, { selector: '.usa-sr-only' })).toBeInTheDocument();
+    expect(screen.getByText(/col2/i, { selector: '.usa-sr-only' })).toBeInTheDocument();
+    expect(screen.getByText(/col3/i, { selector: '.usa-sr-only' })).toBeInTheDocument();
     expect(screen.getByText(/Row 1 Data/i)).toBeInTheDocument();
     expect(screen.getByText(/17/i)).toBeInTheDocument();
     expect(screen.getByText(/18/i)).toBeInTheDocument();

--- a/frontend/src/widgets/__tests__/ResourceUse.js
+++ b/frontend/src/widgets/__tests__/ResourceUse.js
@@ -4,8 +4,23 @@ import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ResourceUse from '../ResourceUse';
 
+const headers = [
+  {
+    name: 'January 2022',
+    displayName: 'Jan-22',
+  },
+  {
+    name: 'February 2022',
+    displayName: 'Feb-22',
+  },
+  {
+    name: 'March 2022',
+    displayName: 'Mar-22',
+  },
+];
+
 const testData = {
-  headers: ['Jan-22', 'Feb-22', 'Mar-22'],
+  headers,
   resources: [
     {
       heading: 'https://eclkc.ohs.acf.hhs.gov/school-readiness/effective-practice-guides/effective-practice-guides',
@@ -87,7 +102,7 @@ const renderResourceUse = (data) => {
 
 describe('Resource Use Widget', () => {
   it('renders correctly without data', async () => {
-    const data = { headers: ['Jan-22', 'Feb-22', 'Mar-22'], resources: [] };
+    const data = { headers, resources: [] };
     renderResourceUse(data);
 
     const button = await screen.findByRole('button', { name: /Display Resource use as table/i });

--- a/src/services/dashboards/course.js
+++ b/src/services/dashboards/course.js
@@ -1,6 +1,6 @@
-/* eslint-disable import/prefer-default-export */
 /* eslint-disable max-len */
 import { Op, QueryTypes } from 'sequelize';
+import moment from 'moment';
 import { REPORT_STATUSES } from '@ttahub/common';
 import {
   ActivityReport,
@@ -58,7 +58,10 @@ export async function rollUpCourseUrlData(data) {
   headers.sort((h1, h2) => h1.date - h2.date);
 
   // Return the headers and rolled up data.
-  const sortedHeaders = headers.map((h) => h.rollUpDate);
+  const sortedHeaders = headers.map((h) => ({
+    name: moment(h.rollUpDate, 'MMM-YY').format('MMMM YYYY'),
+    displayName: h.rollUpDate,
+  }));
 
   return { headers: sortedHeaders, courses: rolledUpCourseData };
 }

--- a/src/services/dashboards/course.test.js
+++ b/src/services/dashboards/course.test.js
@@ -477,7 +477,7 @@ describe('Course dashboard', () => {
 
     expect(headers).not.toBeNull();
     expect(headers.length).toBe(2);
-    expect(headers[0]).toStrictEqual({ displayName: 'Jan-25', name: 'January 2025' });
+    expect(headers[0]).toStrictEqual({ displayName: 'Jan-21', name: 'January 2021' });
     expect(headers[1]).toStrictEqual({ displayName: 'Feb-21', name: 'February 2025' });
 
     expect(courses).not.toBeNull();

--- a/src/services/dashboards/course.test.js
+++ b/src/services/dashboards/course.test.js
@@ -478,7 +478,7 @@ describe('Course dashboard', () => {
     expect(headers).not.toBeNull();
     expect(headers.length).toBe(2);
     expect(headers[0]).toStrictEqual({ displayName: 'Jan-21', name: 'January 2021' });
-    expect(headers[1]).toStrictEqual({ displayName: 'Feb-21', name: 'February 2025' });
+    expect(headers[1]).toStrictEqual({ displayName: 'Feb-21', name: 'February 2021' });
 
     expect(courses).not.toBeNull();
     expect(courses.length).toBe(3);

--- a/src/services/dashboards/course.test.js
+++ b/src/services/dashboards/course.test.js
@@ -376,7 +376,7 @@ describe('Course dashboard', () => {
 
     expect(headers).not.toBeNull();
     expect(headers.length).toBe(1);
-    expect(headers[0]).toBe('Jan-25');
+    expect(headers[0]).toBe({ displayName: 'Jan-25', name: 'January 2025' });
 
     const expectedResults = [
       {
@@ -477,8 +477,8 @@ describe('Course dashboard', () => {
 
     expect(headers).not.toBeNull();
     expect(headers.length).toBe(2);
-    expect(headers[0]).toBe('Jan-21');
-    expect(headers[1]).toBe('Feb-21');
+    expect(headers[0]).toBe({ displayName: 'Jan-25', name: 'January 2025' });
+    expect(headers[1]).toBe({ displayName: 'Feb-21', name: 'February 2025' });
 
     expect(courses).not.toBeNull();
     expect(courses.length).toBe(3);
@@ -561,8 +561,8 @@ describe('Course dashboard', () => {
     const { headers, courses } = result;
 
     expect(headers.length).toBe(2);
-    expect(headers[0]).toBe('Mar-24');
-    expect(headers[1]).toBe('Apr-24');
+    expect(headers[0]).toBe({ displayName: 'Mar-24', name: 'March 2024' });
+    expect(headers[1]).toBe({ displayName: 'Apr-24', name: 'April 2024' });
 
     expect(courses).not.toBeNull();
     expect(courses.length).toBe(1);

--- a/src/services/dashboards/course.test.js
+++ b/src/services/dashboards/course.test.js
@@ -376,7 +376,7 @@ describe('Course dashboard', () => {
 
     expect(headers).not.toBeNull();
     expect(headers.length).toBe(1);
-    expect(headers[0]).toBe({ displayName: 'Jan-25', name: 'January 2025' });
+    expect(headers[0]).toStrictEqual({ displayName: 'Jan-25', name: 'January 2025' });
 
     const expectedResults = [
       {
@@ -477,8 +477,8 @@ describe('Course dashboard', () => {
 
     expect(headers).not.toBeNull();
     expect(headers.length).toBe(2);
-    expect(headers[0]).toBe({ displayName: 'Jan-25', name: 'January 2025' });
-    expect(headers[1]).toBe({ displayName: 'Feb-21', name: 'February 2025' });
+    expect(headers[0]).toStrictEqual({ displayName: 'Jan-25', name: 'January 2025' });
+    expect(headers[1]).toStrictEqual({ displayName: 'Feb-21', name: 'February 2025' });
 
     expect(courses).not.toBeNull();
     expect(courses.length).toBe(3);
@@ -561,8 +561,8 @@ describe('Course dashboard', () => {
     const { headers, courses } = result;
 
     expect(headers.length).toBe(2);
-    expect(headers[0]).toBe({ displayName: 'Mar-24', name: 'March 2024' });
-    expect(headers[1]).toBe({ displayName: 'Apr-24', name: 'April 2024' });
+    expect(headers[0]).toStrictEqual({ displayName: 'Mar-24', name: 'March 2024' });
+    expect(headers[1]).toStrictEqual({ displayName: 'Apr-24', name: 'April 2024' });
 
     expect(courses).not.toBeNull();
     expect(courses.length).toBe(1);

--- a/src/services/dashboards/resource.js
+++ b/src/services/dashboards/resource.js
@@ -2,6 +2,7 @@
 import { Sequelize, Op, QueryTypes } from 'sequelize';
 import { REPORT_STATUSES } from '@ttahub/common';
 import { v4 as uuidv4 } from 'uuid';
+import moment from 'moment';
 import {
   ActivityReport,
   ActivityReportGoal,
@@ -2161,7 +2162,11 @@ export async function resourceDashboardFlat(scopes) {
   const rolledUpTopicUse = await rollUpTopicUse(data);
 
   // Date headers.
-  const dateHeadersArray = data.dateHeaders.map((date) => date.rollUpDate);
+  const dateHeadersArray = data.dateHeaders.map((date) => ({
+    name: moment(date.rollUpDate, 'MMM-YY').format('MMMM YYYY'),
+    displayName: date.rollUpDate,
+  }));
+
   return {
     resourcesDashboardOverview: dashboardOverview,
     resourcesUse: { headers: dateHeadersArray, resources: rolledUpResourceUse },


### PR DESCRIPTION
## Description of change
Horizontal table widget was using nondescript aria-labels for its contents and also truncated date strings. Both of these are either hard to understand or inconsistent for screen-readers. This PR modifies those values so that they are more easily understood.

## How to test
- Confirm hidden labels on Horizontal Table Widget for select row checkboxes and table headers are human-understandable

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3423


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
