### PR TITLE
[TTAHUB-2549] Operation warp speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
 FROM node:18.20.3
 WORKDIR /app
 RUN apt-get update && apt-get install lcov -y
+RUN \
+    mkdir -p /home/node/.cache/yarn \
+    && chown -R node:node /home/node/.cache/yarn \
+    && mkdir -p /app/node_modules \
+    && chown -R node:node /app/node_modules
+
+

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -28,6 +28,8 @@ services:
       - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
     volumes:
       - ".:/app:rw"
+      - "node_modules-backend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
     deploy:
       resources:
         limits:
@@ -43,6 +45,8 @@ services:
     volumes:
       - "./frontend:/app:rw"
       - "./scripts:/app/scripts"
+      - "node_modules-frontend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
     environment:
       - BACKEND_PROXY=http://backend:8080
   worker:
@@ -59,3 +63,5 @@ services:
       - SMTP_HOST=mailcatcher
     volumes:
       - ".:/app:rw"
+      - "node_modules-backend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"

--- a/docker-compose.dss.yml
+++ b/docker-compose.dss.yml
@@ -22,7 +22,6 @@ services:
       - BYPASS_SOCKETS="true"
     volumes:
       - ".:/app:rw"
-      - "yarn-cache:/home/node/.cache/yarn:rw"
   db:
     image: postgres:15.6
     container_name: postgres_docker

--- a/docker-compose.dss.yml
+++ b/docker-compose.dss.yml
@@ -22,6 +22,7 @@ services:
       - BYPASS_SOCKETS="true"
     volumes:
       - ".:/app:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
   db:
     image: postgres:15.6
     container_name: postgres_docker

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -28,6 +28,8 @@ services:
       - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
     volumes:
       - ".:/app:rw"
+      - "node_modules-backend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
   frontend:
     build:
       context: .
@@ -40,6 +42,8 @@ services:
       - "./frontend:/app:rw"
       - "./scripts:/app/scripts"
       - "./packages:/packages:ro"
+      - "node_modules-frontend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
     environment:
       - BACKEND_PROXY=http://backend:8080
       - REACT_APP_WEBSOCKET_URL
@@ -57,6 +61,8 @@ services:
       - SMTP_HOST=mailcatcher
     volumes:
       - ".:/app:rw"
+      - "node_modules-backend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
   owasp_zap_backend:
     image: softwaresecurityproject/zap-stable:latest
     platform: linux/arm64

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,6 +15,8 @@ services:
       - "${ITAMS_MD_HOST:-sftp.itams.ohs.acf.hhs.gov}:0.0.0.0"
     volumes:
       - ".:/app:rw"
+      - "node_modules-backend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
     networks:
       - ttadp-test
   test-frontend:
@@ -27,6 +29,8 @@ services:
     volumes:
       - "./frontend:/app:rw"
       - "./scripts:/app/scripts"
+      - "node_modules-frontend:/app/node_modules:rw"
+      - "yarn-cache:/home/node/.cache/yarn:rw"
     environment:
       - BACKEND_PROXY=http://test-backend:8080
       - REACT_APP_WEBSOCKET_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,3 +83,6 @@ services:
 volumes:
   dbdata: {}
   minio-data: {}
+  yarn-cache: {}
+  node_modules-backend: {}
+  node_modules-frontend: {}


### PR DESCRIPTION
## Description of change

- yarn cache and node_modules are now in volumns to support sharing across containers and reuse between rebuilds of containers.

- side effect, (which is also good) host os architecture node_modules are now not loaded into the container for execution or deps 


## How to test

- delete all node containers
- run yarn docker:deps

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2549


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
