### PR TITLE
[TTAHUB-3528] Do not deduplicate on objectiveCreatedHere

### DIFF
--- a/src/goalServices/reduceGoals.ts
+++ b/src/goalServices/reduceGoals.ts
@@ -139,21 +139,22 @@ export function reduceObjectivesForActivityReport(
       ? objective.activityReportObjectives[0].supportType : null;
 
     const objectiveCreatedHere = objective.activityReportObjectives
-        && objective.activityReportObjectives[0]
-        && objective.activityReportObjectives[0].objectiveCreatedHere
-      ? objective.activityReportObjectives[0].objectiveCreatedHere : null;
+        && objective.activityReportObjectives.some((aro) => aro.objectiveCreatedHere) ? true : null;
 
     // objectives represent the accumulator in the find below
     // objective is the objective as it is returned from the API
     const exists = objectives.find((o) => (
       o.title.trim() === objective.title.trim()
       && o.status === objectiveStatus
-      && o.objectiveCreatedHere === objectiveCreatedHere
     ));
 
     if (exists) {
       const { id } = objective;
       exists.ids = [...exists.ids, id];
+
+      if (objectiveCreatedHere && !exists.objectiveCreatedHere) {
+        exists.objectiveCreatedHere = true;
+      }
 
       // we can dedupe these using lodash
       exists.resources = reduceRelationThroughActivityReportObjectives(


### PR DESCRIPTION
## Description of change
I'm not sure how obectiveCreatedHere would diverge across activity report objectives but we do not need to use it as a key for deduplicating objectives; if one ARO within an objective is set to true, they should all be true. This is only used as one factor as to whether the objective's text is editable so the risk of changing this is extremely low.

## How to test
Download the latest prod backup, impersonate the user and view the report from the support case, and confirm that none of the open objectives are duplicated. There are objectives duplicated across the goals but that looks to be intentional.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3528


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
