### PR TITLE
[TTAHUB-3450] Update "recipients with no TTA" filter to not use overlaps

### DIFF
--- a/src/scopes/grants/index.test.js
+++ b/src/scopes/grants/index.test.js
@@ -227,6 +227,13 @@ describe('grant filtersToScopes', () => {
         startDate: new Date('01/01/2021'),
         endDate: new Date('03/01/2021'),
       }),
+      // Just outside of range by one day. Not included in results for recipientsWithoutTTA.
+      ActivityReport.create({
+        ...draftReport,
+        userId: mockUser.id,
+        startDate: new Date('04/01/2022'),
+        endDate: new Date('04/02/2022'),
+      }),
     ]);
 
     // Create Activity Report Goals.

--- a/src/scopes/grants/recipientsWithoutTTA.js
+++ b/src/scopes/grants/recipientsWithoutTTA.js
@@ -20,10 +20,11 @@ const grantsMissingActivitySql = (beginActivityDate, finishActivityDate) => sequ
       WHERE
         ar."startDate" < DATE ${sequelize.escape(finishActivityDate)} + 1
         AND ar."endDate" > DATE ${sequelize.escape(beginActivityDate)} - 1
-      SELECT
-        g."id"
-      FROM "Grants" g
-      WHERE g."recipientId" NOT IN (SELECT used_recipient_id FROM  activity))
+    )
+    SELECT
+      g."id"
+    FROM "Grants" g
+    WHERE g."recipientId" NOT IN (SELECT used_recipient_id FROM activity))
     `,
 );
 

--- a/src/scopes/grants/recipientsWithoutTTA.js
+++ b/src/scopes/grants/recipientsWithoutTTA.js
@@ -18,10 +18,8 @@ const grantsMissingActivitySql = (beginActivityDate, finishActivityDate) => sequ
       JOIN "ActivityReports" ar
         ON arr."activityReportId" = ar.id
       WHERE
-        (ar."startDate", ar."endDate")
-          OVERLAPS
-        (DATE ${sequelize.escape(beginActivityDate)} - 1, DATE ${sequelize.escape(finishActivityDate)} + 1)
-      )
+        ar."startDate" < DATE ${sequelize.escape(finishActivityDate)} + 1
+        AND ar."endDate" > DATE ${sequelize.escape(beginActivityDate)} - 1
       SELECT
         g."id"
       FROM "Grants" g

--- a/src/scopes/grants/recipientsWithoutTTA.js
+++ b/src/scopes/grants/recipientsWithoutTTA.js
@@ -18,8 +18,8 @@ const grantsMissingActivitySql = (beginActivityDate, finishActivityDate) => sequ
       JOIN "ActivityReports" ar
         ON arr."activityReportId" = ar.id
       WHERE
-        ar."startDate" < DATE ${sequelize.escape(finishActivityDate)} + 1
-        AND ar."endDate" > DATE ${sequelize.escape(beginActivityDate)} - 1
+        ar."startDate" <= ${sequelize.escape(finishActivityDate)}
+        AND ar."endDate" >= ${sequelize.escape(beginActivityDate)}
     )
     SELECT
       g."id"


### PR DESCRIPTION
## Description of change

The filter used to look like this:

```sql
      WHERE
        (ar."startDate", ar."endDate")
          OVERLAPS
        (DATE ${sequelize.escape(beginActivityDate)} - 1, DATE ${sequelize.escape(finishActivityDate)} + 1)
      )
```

so if you filter for 3/20/2024 -> 3/20/2024, ARs from 3/19/2024 and 3/21/2024 would be included because of the `OVERLAPS`. The query now looks like this:

```sql
      WHERE
        ar."startDate" <= ${sequelize.escape(finishActivityDate)}
        AND ar."endDate" >= ${sequelize.escape(beginActivityDate)}
```


## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3450


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
