### PR TITLE
[TTAHUB-3190] Add GoalFieldResponses filter to RTR

### DIFF
--- a/frontend/src/components/filter/FilterFEIRootCause.js
+++ b/frontend/src/components/filter/FilterFEIRootCause.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FilterSelect from './FilterSelect';
+
+const options = [
+  'Community partnerships',
+  'Facilities',
+  'Family circumstances',
+  'Other ECE care options',
+  'Unavailable',
+  'Workforce',
+].map((value) => ({ label: value, value }));
+
+export default function FilterFEIRootCause({ onApply, inputId, query }) {
+  const onApplyClick = (selected) => {
+    onApply(selected);
+  };
+
+  return (
+    <FilterSelect
+      onApply={onApplyClick}
+      inputId={inputId}
+      labelText="Select FEI root cause to filter by"
+      options={options}
+      selectedValues={query}
+    />
+  );
+}
+
+FilterFEIRootCause.propTypes = {
+  inputId: PropTypes.string.isRequired,
+  onApply: PropTypes.func.isRequired,
+  query: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]).isRequired,
+};

--- a/frontend/src/components/filter/goalFilters.js
+++ b/frontend/src/components/filter/goalFilters.js
@@ -17,6 +17,7 @@ import FilterSelect from './FilterSelect';
 import FilterInput from './FilterInput';
 import { handleArrayQuery } from './helpers';
 import FilterRoles from './FilterRoles';
+import FilterFEIRootCause from './FilterFEIRootCause';
 
 const LAST_THIRTY_DAYS = formatDateRange({ lastThirtyDays: true, forDateTime: true });
 
@@ -103,6 +104,21 @@ export const userRolesFilter = {
   renderInput: (id, condition, query, onApplyQuery) => (
     <FilterRoles
       inputId={`user-role-${condition}-${id}`}
+      onApply={onApplyQuery}
+      query={query}
+    />
+  ),
+};
+
+export const feiRootCauseFilter = {
+  id: 'goalResponse',
+  display: 'FEI root cause',
+  conditions: FILTER_CONDITIONS,
+  defaultValues: EMPTY_MULTI_SELECT,
+  displayQuery: handleArrayQuery,
+  renderInput: (id, condition, query, onApplyQuery) => (
+    <FilterFEIRootCause
+      inputId={`fei-root-cause-${condition}-${id}`}
       onApply={onApplyQuery}
       query={query}
     />

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -13,6 +13,7 @@ import {
   grantNumberFilter,
   userRolesFilter,
   goalNameFilter,
+  feiRootCauseFilter,
 } from '../../../components/filter/goalFilters';
 
 export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) => [
@@ -23,6 +24,7 @@ export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) => [
   statusFilter,
   topicsFilter,
   userRolesFilter,
+  feiRootCauseFilter,
 ].sort((a, b) => a.display.localeCompare(b.display));
 
 const TTAHISTORY_FILTER_CONFIG = [

--- a/src/scopes/goals/goalResponse.ts
+++ b/src/scopes/goals/goalResponse.ts
@@ -1,0 +1,20 @@
+import { filterAssociation } from './utils';
+
+const sql = `
+  WITH unnested_responses AS (
+    SELECT "goalId", unnest("response") AS res
+    FROM "GoalFieldResponses"
+  )
+  SELECT DISTINCT "Goals"."id"
+  FROM "Goals" "Goals"
+  INNER JOIN unnested_responses arr
+    ON arr."goalId" = "Goals"."id"
+  WHERE arr."res"`;
+
+export function withGoalResponse(searchText: string[]) {
+  return filterAssociation(sql, searchText, false);
+}
+
+export function withoutGoalResponse(searchText: string[]) {
+  return filterAssociation(sql, searchText, true);
+}

--- a/src/scopes/goals/index.js
+++ b/src/scopes/goals/index.js
@@ -26,6 +26,7 @@ import { withResourceUrl, withoutResourceUrl } from './resouceUrl';
 import { withResourceAttachment, withoutResourceAttachment } from './resourceAttachment';
 import { withEnteredByRole, withoutEnteredByRole } from './enteredByRole';
 import { withGoalName, withoutGoalName } from './goalName';
+import { withGoalResponse, withoutGoalResponse } from './goalResponse';
 
 export const topicToQuery = {
   createDate: {
@@ -133,6 +134,10 @@ export const topicToQuery = {
   goalName: {
     ctn: (query) => withGoalName(query),
     nctn: (query) => withoutGoalName(query),
+  },
+  goalResponse: {
+    in: (query) => withGoalResponse(query),
+    nin: (query) => withoutGoalResponse(query),
   },
 };
 

--- a/src/scopes/goals/index.test.js
+++ b/src/scopes/goals/index.test.js
@@ -24,6 +24,8 @@ import db, {
   NextStepResource,
   ActivityReportFile,
   ActivityReportObjectiveFile,
+  GoalTemplateFieldPrompt,
+  GoalFieldResponse,
   GroupCollaborator,
   File,
 } from '../../models';
@@ -1410,6 +1412,107 @@ describe('goal filtersToScopes', () => {
       expect(found.length).toEqual(1);
       expect(found[0].id).not.toEqual(includedGoal.id);
       expect(found[0].id).toEqual(excludedGoal.id);
+    });
+  });
+
+  describe('goalFieldResponse', () => {
+    let prompt;
+    let goal1;
+    let goal2;
+    let goal3;
+    let response1;
+    let response2;
+    let response3;
+
+    beforeAll(async () => {
+      prompt = await GoalTemplateFieldPrompt.findOne({
+        where: { title: 'FEI root cause' },
+      });
+
+      goal1 = await Goal.create({
+        name: 'Goal 6',
+        status: 'In Progress',
+        timeframe: '12 months',
+        isFromSmartsheetTtaPlan: false,
+        createdAt: new Date('2021-01-20'),
+        grantId: goalGrant.id,
+        createdVia: 'rtr',
+      });
+
+      goal2 = await Goal.create({
+        name: 'Goal 7',
+        status: 'In Progress',
+        timeframe: '12 months',
+        isFromSmartsheetTtaPlan: false,
+        createdAt: new Date('2021-01-20'),
+        grantId: goalGrant.id,
+        createdVia: 'rtr',
+      });
+
+      goal3 = await Goal.create({
+        name: 'Goal 8',
+        status: 'In Progress',
+        timeframe: '12 months',
+        isFromSmartsheetTtaPlan: false,
+        createdAt: new Date('2021-01-20'),
+        grantId: goalGrant.id,
+        createdVia: 'rtr',
+      });
+
+      response1 = await GoalFieldResponse.create({
+        goalId: goal1.id,
+        goalTemplateFieldPromptId: prompt.id,
+        response: ['Community Partnerships'],
+      });
+
+      response2 = await GoalFieldResponse.create({
+        goalId: goal2.id,
+        goalTemplateFieldPromptId: prompt.id,
+        response: ['Workforce', 'Family circumstances'],
+      });
+
+      response2 = await GoalFieldResponse.create({
+        goalId: goal3.id,
+        goalTemplateFieldPromptId: prompt.id,
+        response: ['Facilities'],
+      });
+    });
+
+    afterAll(async () => {
+      await GoalFieldResponse.destroy({
+        where: {
+          id: [response1.id, response2.id, response3.id],
+        },
+      });
+
+      await Goal.destroy({
+        where: {
+          id: [goal1.id, goal2.id, goal3.id],
+        },
+        individualHooks: true,
+      });
+    });
+
+    it('finds goals with responses', async () => {
+      const filters = { 'goalResponse.in': ['Workforce'] };
+      const { goal: scope } = await filtersToScopes(filters, 'goal');
+      const found = await Goal.findAll({
+        where: { [Op.and]: [scope, { id: [goal1.id, goal2.id, goal3.id] }] },
+      });
+      expect(found.length).toBe(1);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([goal2.id]));
+    });
+
+    it('finds goals without responses', async () => {
+      const filters = { 'goalResponse.nin': ['Workforce'] };
+      const { goal: scope } = await filtersToScopes(filters, 'goal');
+      const found = await Goal.findAll({
+        where: { [Op.and]: [scope, { id: [goal1.id, goal2.id, goal3.id] }] },
+      });
+      expect(found.length).toBe(2);
+      expect(found.map((f) => f.id))
+        .toEqual(expect.arrayContaining([goal1.id, goal3.id]));
     });
   });
 


### PR DESCRIPTION
## Description of change

Adds an FEI root cause/GoalFieldResponses filter to the RTR using basically the same query from the AR's `activityReportGoalResponse` filter.

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3190


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
