### PR TITLE
make ssdi results more accurate for early ARs

### DIFF
--- a/src/queries/dataRequests/ohs/standard-goal-activity-reports.sql
+++ b/src/queries/dataRequests/ohs/standard-goal-activity-reports.sql
@@ -90,7 +90,11 @@ WITH
   ),
   "DistinctIDs" AS (
     SELECT DISTINCT
-      a.id
+      CASE
+	WHEN a.id > 9999 THEN a.id::text
+	WHEN a."legacyId" IS NOT NULL THEN "legacyId"
+        ELSE '-' || a.id::text || '$'
+      END AS id
     FROM "Goals" g
     JOIN "ActivityReportGoals" arg
     ON g.id = arg."goalId"

--- a/src/queries/dataRequests/ohs/standard-goal-activity-reports.sql
+++ b/src/queries/dataRequests/ohs/standard-goal-activity-reports.sql
@@ -91,8 +91,8 @@ WITH
   "DistinctIDs" AS (
     SELECT DISTINCT
       CASE
-	WHEN a.id > 9999 THEN a.id::text
-	WHEN a."legacyId" IS NOT NULL THEN "legacyId"
+        WHEN a.id > 9999 THEN a.id::text
+        WHEN a."legacyId" IS NOT NULL THEN "legacyId"
         ELSE '-' || a.id::text || '$'
       END AS id
     FROM "Goals" g


### PR DESCRIPTION
## Description of change

Low-number ARs could hit on other ARs with IDs that contain the same IDs, and also legacy ARs use their own IDs that don't use our table pkey. This makes queries that include ARs from before July 31st, 2021 likely to be inaccurate.

## How to test

It should give the same results the old query game, except for old ARs. Including old ARs will usually reduce the maximum number of ARs per URL because the max string length is longer.

## Issue(s)

Non Jira fix

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code is meaningfully tested

### Before merge to main

- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
