### PR TITLE
Fix sorting on the recipients with no tta widget

### DIFF
--- a/frontend/src/pages/QADashboard/RecipientsWithNoTta/index.js
+++ b/frontend/src/pages/QADashboard/RecipientsWithNoTta/index.js
@@ -87,11 +87,11 @@ export default function RecipientsWithNoTta() {
             data: [
               {
                 title: 'Date_of_Last_TTA',
-                value: dateOfLastTta ? moment(dateOfLastTta).format('MM/DD/YYYY') : '-',
+                value: dateOfLastTta ? moment(dateOfLastTta).format('MM/DD/YYYY') : null,
               },
               {
                 title: 'Days_Since_Last_TTA',
-                value: daysSinceLastTta || '-',
+                value: daysSinceLastTta || null,
               },
             ],
           };

--- a/frontend/src/widgets/HorizontalTableWidget.js
+++ b/frontend/src/widgets/HorizontalTableWidget.js
@@ -26,6 +26,7 @@ export default function HorizontalTableWidget(
     caption,
     footerData,
     selectAllIdPrefix,
+    showDashForNullValue,
   },
 ) {
   // State for select all check box.
@@ -230,9 +231,10 @@ export default function HorizontalTableWidget(
                 {(r.data || []).map((d, cellIndex) => (
                   <td data-label={d.title} key={`horizontal_table_cell_${cellIndex}`} className={d.title.toLowerCase() === 'total' ? 'smarthub-horizontal-table-last-column' : null}>
                     {
+                      // eslint-disable-next-line no-nested-ternary
                       d.isUrl
                         ? handleUrl(d)
-                        : d.value
+                        : showDashForNullValue && !d.value ? '-' : d.value
                     }
                   </td>
                 ))}
@@ -286,6 +288,7 @@ HorizontalTableWidget.propTypes = {
     PropTypes.bool,
     PropTypes.arrayOf(PropTypes.string),
   ]),
+  showDashForNullValue: PropTypes.bool,
 };
 
 HorizontalTableWidget.defaultProps = {
@@ -307,4 +310,5 @@ HorizontalTableWidget.defaultProps = {
   hideFirstColumnBorder: false,
   caption: '',
   selectAllIdPrefix: null,
+  showDashForNullValue: false,
 };

--- a/frontend/src/widgets/RecipientsWithNoTtaWidget.js
+++ b/frontend/src/widgets/RecipientsWithNoTtaWidget.js
@@ -109,6 +109,7 @@ function RecipientsWithNoTtaWidget({
         setCheckboxes={setCheckBoxes}
         showTotalColumn={false}
         hideFirstColumnBorder
+        showDashForNullValue
       />
     </WidgetContainer>
   );

--- a/frontend/src/widgets/__tests__/HorizontalTableWidget.js
+++ b/frontend/src/widgets/__tests__/HorizontalTableWidget.js
@@ -20,6 +20,7 @@ const renderHorizontalTableWidget = (
   requestSort = () => {},
   enableCheckboxes = false,
   showTotalColumn = true,
+  showDashForNullValue = false,
 ) => render(
   <Router history={history}>
     <HorizontalTableWidget
@@ -32,6 +33,7 @@ const renderHorizontalTableWidget = (
       requestSort={requestSort}
       enableCheckboxes={enableCheckboxes}
       showTotalColumn={showTotalColumn}
+      showDashForNullValue={showDashForNullValue}
     />
   </Router>,
 );
@@ -396,5 +398,39 @@ describe('Horizontal Table Widget', () => {
 
     const { container } = renderHorizontalTableWidget(headers, data, 'First Heading', false, 'Last Heading', {}, {}, false, true);
     expect(container.querySelector('.fa-arrow-up-right-from-square')).toBeNull();
+  });
+
+  it('shows a dash when showDashForNullValue is true', async () => {
+    const headers = ['col1', 'col2', 'col3'];
+    const data = [
+      {
+        heading: 'Row 1 Data',
+        isUrl: false,
+        data: [
+          {
+            title: 'col1',
+            value: '17',
+          },
+          {
+            title: 'col2',
+            value: null,
+          },
+          {
+            title: 'col3',
+            value: '19',
+          },
+        ],
+      },
+    ];
+
+    renderHorizontalTableWidget(headers, data, 'First Heading', false, 'Last Heading', {}, {}, false, false, true);
+    expect(screen.getByText(/First Heading/i)).toBeInTheDocument();
+    expect(screen.getByText(/col1/i, { selector: '.usa-sr-only' })).toBeInTheDocument();
+    expect(screen.getByText(/col2/i, { selector: '.usa-sr-only' })).toBeInTheDocument();
+    expect(screen.getByText(/col3/i, { selector: '.usa-sr-only' })).toBeInTheDocument();
+    expect(screen.getByText(/Row 1 Data/i)).toBeInTheDocument();
+    expect(screen.getByText(/17/i)).toBeInTheDocument();
+    expect(screen.getByText(/-/i)).toBeInTheDocument();
+    expect(screen.getByText(/19/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description of change

After merging to staging I noticed sorting on the "Recipients with No TTA" widget stopped working. This fixes the issue by allowing the values to be null but showing them as a '-'.

## How to test

- Make sure sorting works on the No recipients widget.
- Mae sure sorts work on other widgets in the QA dash.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
