### PR TITLE
Only show specialist roles

### DIFF
--- a/src/queries/api/dashboards/qa/dashboard.sql
+++ b/src/queries/api/dashboards/qa/dashboard.sql
@@ -1282,6 +1282,7 @@ WITH
     ON a."creatorRole"::text = r."fullName"
     WHERE a."calculatedStatus" = 'approved'
     AND a."creatorRole" IS NOT NULL
+    AND r."isSpecialist" = true -- We only want to show specialist roles in the role graph.
     GROUP BY COALESCE(r.name, a."creatorRole"::text)
     ORDER BY 1 DESC
   ),


### PR DESCRIPTION
## Description of change

We only want to show "Specialist roles" on the role graph.

## How to test

Make sure we do NOT show non-specialist roles on the role graph like AA.

SELECT * FROM "Roles" WHERE "isSpecialist" = true


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
