### PR TITLE
[HOTFIX-3190] Add (and use) grants root cause filter

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -13,7 +13,6 @@ import {
   grantNumberFilter,
   userRolesFilter,
   goalNameFilter,
-  feiRootCauseFilter,
 } from '../../../components/filter/goalFilters';
 
 export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) => [
@@ -24,7 +23,6 @@ export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) => [
   statusFilter,
   topicsFilter,
   userRolesFilter,
-  feiRootCauseFilter,
 ].sort((a, b) => a.display.localeCompare(b.display));
 
 const TTAHISTORY_FILTER_CONFIG = [

--- a/frontend/src/pages/RecipientSearch/constants.js
+++ b/frontend/src/pages/RecipientSearch/constants.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { regionFilter } from '../../components/filter/activityReportFilters';
-import { goalNameFilter } from '../../components/filter/goalFilters';
+import { feiRootCauseFilter, goalNameFilter } from '../../components/filter/goalFilters';
 import { groupsFilter, recipientsWithoutTTA, grantStatusFilter } from '../../components/filter/grantFilters';
 
 const RECIPIENT_SEARCH_FILTER_CONFIG = [
@@ -9,6 +9,7 @@ const RECIPIENT_SEARCH_FILTER_CONFIG = [
   regionFilter,
   recipientsWithoutTTA,
   grantStatusFilter,
+  feiRootCauseFilter,
 ];
 
 // sort by display prop

--- a/src/scopes/grants/goalResponse.ts
+++ b/src/scopes/grants/goalResponse.ts
@@ -1,0 +1,24 @@
+import { filterAssociation } from './utils';
+
+const sql = `
+  WITH unnested_responses AS (
+    SELECT "goalId", unnest("response") AS res
+    FROM "GoalFieldResponses"
+  )
+  SELECT DISTINCT "Grants"."recipientId"
+  FROM "Goals" "Goals"
+  INNER JOIN unnested_responses arr
+    ON arr."goalId" = "Goals"."id"
+  INNER JOIN "Grants" "Grants"
+    ON "Grants"."id" = "Goals"."grantId"
+  INNER JOIN "ActivityRecipients" ar
+    ON ar."grantId" = "Grants"."id"
+  WHERE arr."res"`;
+
+export function withGoalResponse(searchText: string[]) {
+  return filterAssociation(sql, searchText, false);
+}
+
+export function withoutGoalResponse(searchText: string[]) {
+  return filterAssociation(sql, searchText, true);
+}

--- a/src/scopes/grants/goalResponse.ts
+++ b/src/scopes/grants/goalResponse.ts
@@ -7,12 +7,10 @@ function getSql(responses: string[]) {
       SELECT "goalId", unnest("response") AS res
       FROM "GoalFieldResponses"
     )
-    SELECT DISTINCT "Grants"."id"
+    SELECT DISTINCT "Goals"."grantId"
     FROM "Goals" "Goals"
     INNER JOIN unnested_responses arr
       ON arr."goalId" = "Goals"."id"
-    INNER JOIN "Grants" "Grants"
-      ON "Grants"."id" = "Goals"."grantId"
     WHERE arr."res" IN (${responses.map((s) => `'${s}'`).join(', ')})
   )`);
 }

--- a/src/scopes/grants/index.js
+++ b/src/scopes/grants/index.js
@@ -12,6 +12,7 @@ import { withGroup, withoutGroup } from './group';
 import { noActivityWithin } from './recipientsWithoutTTA';
 import { withGoalName, withoutGoalName } from './goalName';
 import { withGrantStatus, withoutGrantStatus } from './grantStatus';
+import { withGoalResponse, withoutGoalResponse } from './goalResponse';
 
 export const topicToQuery = {
   recipient: {
@@ -58,6 +59,10 @@ export const topicToQuery = {
   grantStatus: {
     in: (query) => withGrantStatus(query),
     nin: (query) => withoutGrantStatus(query),
+  },
+  goalResponse: {
+    in: (query) => withGoalResponse(query),
+    nin: (query) => withoutGoalResponse(query),
   },
 };
 

--- a/src/scopes/utils.ts
+++ b/src/scopes/utils.ts
@@ -99,12 +99,16 @@ export function createFiltersToScopes(filters, topicToQuery, options, userId) {
 export function filterAssociation(baseQuery, searchTerms, exclude, callback, comparator = '~*', escape = true) {
   if (exclude) {
     return {
-      [Op.and]: callback(baseQuery, searchTerms, 'NOT IN', comparator, escape),
+      where: {
+        [Op.and]: callback(baseQuery, searchTerms, 'NOT IN', comparator, escape),
+      },
     };
   }
 
   return {
-    [Op.or]: callback(baseQuery, searchTerms, 'IN', comparator, escape),
+    where: {
+      [Op.or]: callback(baseQuery, searchTerms, 'IN', comparator, escape),
+    },
   };
 }
 


### PR DESCRIPTION
## Description of change

I overlooked this in 3190. I looked at the prototype and thought that we wanted this filter on the RTR, and NOT on the RTR **search** page. They want it on the search page. This is an entirely different filter for Grants and not Goals.

In this PR I add a new goalResponse filter for Grants and include it on the search page. It hides the goalResponse filter on the RTR but does not remove the code, because maybe we want it later?

## How to test

Filter tests were added, but you can test by going to the RTR and using the filter.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3190


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
