### PR TITLE
Fix delivery method graph order on QA dash

### DIFF
--- a/frontend/src/widgets/DeliveryMethodGraph.js
+++ b/frontend/src/widgets/DeliveryMethodGraph.js
@@ -121,14 +121,14 @@ export default function DeliveryMethodGraph({ data }) {
     const tableData = [];
     // use a map for quick lookup
     const traceMap = new Map();
+    traceMap.set('Virtual', {
+      x: [], y: [], name: 'Virtual', traceOrder: 0,
+    });
     traceMap.set('In person', {
       x: [], y: [], name: 'In person', traceOrder: 1,
     });
-    traceMap.set('Virtual', {
-      x: [], y: [], name: 'Virtual', traceOrder: 2,
-    });
     traceMap.set('Hybrid', {
-      x: [], y: [], name: 'Hybrid', traceOrder: 3,
+      x: [], y: [], name: 'Hybrid', traceOrder: 2,
     });
 
     (records || []).forEach((dataset, index) => {
@@ -180,7 +180,9 @@ export default function DeliveryMethodGraph({ data }) {
       traceMap.get('Hybrid').y.push(dataset.hybrid_percentage);
     });
     setShowFiltersNotApplicable(showDashboardFiltersNotApplicableProp);
-    setTraces(Array.from(traceMap.values()));
+    const traceArray = Array.from(traceMap.values());
+    traceArray.sort((a, b) => a.traceOrder - b.traceOrder);
+    setTraces(traceArray);
     setDisplayFilteredReports(filteredReports);
     setTabularData(tableData);
     setTotals({
@@ -260,10 +262,10 @@ export default function DeliveryMethodGraph({ data }) {
             label: 'In person', selected: true, shape: 'circle', id: 'show-in-person-checkbox',
           },
           {
-            label: 'Hybrid', selected: true, shape: 'square', id: 'show-hybrid-checkbox',
+            label: 'Virtual', selected: true, shape: 'triangle', id: 'show-virtual-checkbox',
           },
           {
-            label: 'Virtual', selected: true, shape: 'triangle', id: 'show-virtual-checkbox',
+            label: 'Hybrid', selected: true, shape: 'square', id: 'show-hybrid-checkbox',
           },
         ]}
         tableConfig={tableConfig}


### PR DESCRIPTION
## Description of change

Referring to the delivery method graph on the QA dashboard: virtual data was showing up under in-person and vice-versa. Hybrid was correct.

## How to test
Confirm (easiest way to do that is view the response from the network tab and comparing it to the graph) that the data is correct

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
