### PR TITLE
[TTAHUB-3500] Monitoring Import Cadence adjustment to bypass minor issues

### DIFF
--- a/src/migrations/20241030114000-monitoring-import-cadence.js
+++ b/src/migrations/20241030114000-monitoring-import-cadence.js
@@ -1,0 +1,27 @@
+const { prepMigration } = require('../lib/migration');
+
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+
+      await queryInterface.sequelize.query(/* sql */`
+        UPDATE public."Imports"
+        SET schedule = '30 2,8,14,20 * * *'
+        WHERE id = 1;
+      `, { transaction });
+    },
+  ),
+
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+
+      await queryInterface.sequelize.query(/* sql */`
+        UPDATE public."Imports"
+        SET schedule = '30 8 * * *'
+        WHERE id = 1;
+      `, { transaction });
+    },
+  ),
+};


### PR DESCRIPTION
## Description of change
Through observation some days miss the window to get the latest monitoring data due to dns failures or system reboots. This change will trigger the collection 4 times per 24 hours in an attempt to recover before the next day should the intended window be missed. Nothing happens if it is triggered and no work needs to be done.

was 8:30 am every day, now 2:30 AM, 8:30 AM, 2:30 PM, 8:30 PM

## How to test
Validate the new cron schedule.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3500


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
