### PR TITLE
[TTAHUB-3588] startDate filter bugfix

### DIFF
--- a/src/scopes/goals/endDate.ts
+++ b/src/scopes/goals/endDate.ts
@@ -18,7 +18,7 @@ function getDateSql(dates: string[], operator: string) {
 export function beforeEndDate(date: string): WhereOptions {
   return {
     id: {
-      [Op.in]: getDateSql([`'${date}'`], '<='),
+      [Op.in]: getDateSql([`'${new Date(date).toISOString()}'`], '<='),
     },
   };
 }
@@ -26,7 +26,7 @@ export function beforeEndDate(date: string): WhereOptions {
 export function afterEndDate(date: string): WhereOptions {
   return {
     id: {
-      [Op.in]: getDateSql([`'${date}'`], '>='),
+      [Op.in]: getDateSql([`'${new Date(date).toISOString()}'`], '>='),
     },
   };
 }

--- a/src/scopes/goals/endDate.ts
+++ b/src/scopes/goals/endDate.ts
@@ -1,25 +1,43 @@
-import { filterAssociation } from './utils';
+import { Op, WhereOptions } from 'sequelize';
+import { sequelize } from '../../models';
 
-const goalIds = `
-  SELECT DISTINCT
-    "ActivityReportGoals"."goalId"
-  FROM "ActivityReportGoals"
-  INNER JOIN "ActivityReports"
-  ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
-  WHERE "ActivityReports"."endDate"`;
+function getDateSql(dates: string[], operator: string) {
+  const dateClause = (operator === 'BETWEEN')
+    ? `${dates[0]} AND ${dates[1]}`
+    : dates[0];
 
-export function beforeEndDate(date) {
-  return filterAssociation(goalIds, date, false, '<=');
+  return sequelize.literal(`(
+    SELECT DISTINCT "goalId"
+    FROM "ActivityReportGoals"
+    INNER JOIN "ActivityReports"
+    ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
+    WHERE "ActivityReports"."endDate" ${operator} ${dateClause}
+  )`);
 }
 
-export function afterEndDate(date) {
-  return filterAssociation(goalIds, date, false, '>=');
+export function beforeEndDate(date: string): WhereOptions {
+  return {
+    id: {
+      [Op.in]: getDateSql([`'${date}'`], '<='),
+    },
+  };
 }
 
-export function withinEndDates(dates: string[]) {
-  // got: [ '2022/11/23-2023/02/22' ]
-  // need: [ '2022/11/23', '2023/02/22']
-  const escapedDateStrings = dates[0].split('-').map((d) => `'${d}'`);
-  // now: "'2022/11/23'", "'2023/02/22'"
-  return filterAssociation(goalIds, escapedDateStrings, false, 'BETWEEN');
+export function afterEndDate(date: string): WhereOptions {
+  return {
+    id: {
+      [Op.in]: getDateSql([`'${date}'`], '>='),
+    },
+  };
+}
+
+export function withinEndDates(dates: string[]): WhereOptions {
+  const escapedDates = dates[0]
+    .split('-')
+    .map((d) => `'${new Date(d).toISOString()}'`);
+  return {
+    id: {
+      [Op.in]: getDateSql(escapedDates, 'BETWEEN'),
+    },
+  };
 }

--- a/src/scopes/goals/startDate.ts
+++ b/src/scopes/goals/startDate.ts
@@ -1,25 +1,43 @@
-import { filterAssociation } from './utils';
+import { Op, WhereOptions } from 'sequelize';
+import { sequelize } from '../../models';
 
-const goalIds = `
-  SELECT DISTINCT
-    "ActivityReportGoals"."goalId"
-  FROM "ActivityReportGoals"
-  INNER JOIN "ActivityReports"
-  ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
-  WHERE "ActivityReports"."startDate"`;
+function getDateSql(dates: string[], operator: string) {
+  const dateClause = (operator === 'BETWEEN')
+    ? `${dates[0]} AND ${dates[1]}`
+    : dates[0];
 
-export function beforeStartDate(date) {
-  return filterAssociation(goalIds, date, false, '<=');
+  return sequelize.literal(`(
+    SELECT DISTINCT "goalId"
+    FROM "ActivityReportGoals"
+    INNER JOIN "ActivityReports"
+    ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
+    WHERE "ActivityReports"."startDate" ${operator} ${dateClause}
+  )`);
 }
 
-export function afterStartDate(date) {
-  return filterAssociation(goalIds, date, false, '>=');
+export function beforeStartDate(date: string): WhereOptions {
+  return {
+    id: {
+      [Op.in]: getDateSql([`'${date}'`], '<='),
+    },
+  };
 }
 
-export function withinStartDates(dates: string[]) {
+export function afterStartDate(date: string): WhereOptions {
+  return {
+    id: {
+      [Op.in]: getDateSql([`'${date}'`], '>='),
+    },
+  };
+}
+
+export function withinStartDates(dates: string[]): WhereOptions {
   // got: [ '2022/11/23-2023/02/22' ]
-  // need: [ '2022/11/23', '2023/02/22']
-  const escapedDateStrings = dates[0].split('-').map((d) => `'${d}'`);
-  // now: "'2022/11/23'", "'2023/02/22'"
-  return filterAssociation(goalIds, escapedDateStrings, false, 'BETWEEN');
+  // need: [ '2022-11-23', '2023-02-22']
+  const escapedDates = dates[0].split('-').map((d) => `'${d.replace(/\//g, '-')}'`);
+  return {
+    id: {
+      [Op.in]: getDateSql(escapedDates, 'BETWEEN'),
+    },
+  };
 }

--- a/src/scopes/goals/startDate.ts
+++ b/src/scopes/goals/startDate.ts
@@ -18,7 +18,7 @@ function getDateSql(dates: string[], operator: string) {
 export function beforeStartDate(date: string): WhereOptions {
   return {
     id: {
-      [Op.in]: getDateSql([`'${date}'`], '<='),
+      [Op.in]: getDateSql([`'${new Date(date).toISOString()}'`], '<='),
     },
   };
 }
@@ -26,7 +26,7 @@ export function beforeStartDate(date: string): WhereOptions {
 export function afterStartDate(date: string): WhereOptions {
   return {
     id: {
-      [Op.in]: getDateSql([`'${date}'`], '>='),
+      [Op.in]: getDateSql([`'${new Date(date).toISOString()}'`], '>='),
     },
   };
 }

--- a/src/scopes/goals/startDate.ts
+++ b/src/scopes/goals/startDate.ts
@@ -32,9 +32,9 @@ export function afterStartDate(date: string): WhereOptions {
 }
 
 export function withinStartDates(dates: string[]): WhereOptions {
-  // got: [ '2022/11/23-2023/02/22' ]
-  // need: [ '2022-11-23', '2023-02-22']
-  const escapedDates = dates[0].split('-').map((d) => `'${d.replace(/\//g, '-')}'`);
+  const escapedDates = dates[0]
+    .split('-')
+    .map((d) => `'${new Date(d).toISOString()}'`);
   return {
     id: {
       [Op.in]: getDateSql(escapedDates, 'BETWEEN'),


### PR DESCRIPTION
## Description of change

Update the `startDate` filter to have valid date syntax in the query.

- Invalid: BETWEEN 2020/02/22 AND 2020/02/23
- Valid: BETWEEN 2020-02-22 AND 2020-02-23

To take this a little further and be a little more safe, we call `new Date('2020/02/22').toISOString()`.

Also updated the `endDate` filter to use this same method.

## How to test

Go to the TTA history tab under the RTR and make sure the "Topics in activity reports" widget loads correctly.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3588


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
