### PR TITLE
[NO-TICKET] owasp_zap_similarity command update

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -86,7 +86,7 @@ services:
       - full_stack
     platform: linux/arm64
     user: zap
-    command: zap-api-scan.py -t http://similarity:8080/openapi.json -f openapi -I -i -r owasp_api_report.html
+    command: zap-api-scan.py -t http://similarity_api:8080/openapi.json -f openapi -I -i -r owasp_api_report.html
     volumes:
       - ./zap.conf:/zap/wrk/zap.conf:ro
       - ./reports:/zap/wrk:rw


### PR DESCRIPTION
## Description of change

OWASP artifacts aren't being saved. I think it's because the scan fails because the hostname is wrong. Changing this hostname locally works for me, and the scan generates a report. Let's see if this fixes CI as well.

`similarity` changed to `similarity_api` in `docker-compose.override.yml`.

Before:

```yml
    command: zap-api-scan.py -t http://similarity:8080/openapi.json -f openapi -I -i -r owasp_api_report.html
```

After:

```yml
    command: zap-api-scan.py -t http://similarity_api:8080/openapi.json -f openapi -I -i -r owasp_api_report.html
```

Because the service is defined like this:

```yml
  similarity_api:
    build:
      context: ./similarity_api
    profiles:
      - minimal_required
    ports:
      - "9100:8080"
    env_file: .env
    depends_on:
      - db
    volumes:
      - "./similarity_api/src:/app:rw"
```


## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
