### PR TITLE
[TTAHUB-3326] Fix some mailer bugs

### DIFF
--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -101,11 +101,18 @@ export const onFailedNotification = (job, error) => {
 };
 
 export const onCompletedNotification = (job, result) => {
-  if (result != null) {
-    logger.info(`Successfully sent ${job.name} notification for ${job.data.report.displayId || job.data.report.id}`);
-    logEmailNotification(job, true, result);
+  if (job.data.reports && Array.isArray(job.data.reports)) {
+    job.data.reports.forEach((report) => {
+      if (result != null) {
+        logger.info(`Successfully sent ${job.name} notification for ${report.displayId}`);
+      } else {
+        logger.info(`Did not send ${job.name} notification for ${report.displayId} preferences are not set or marked as "no-send"`);
+      }
+    });
+  } else if (result != null) {
+    logger.info(`Successfully sent ${job.name} notification for ${job.data.report.displayId || job.data}`);
   } else {
-    logger.info(`Did not send ${job.name} notification for ${job.data.report.displayId || job.data.report.id} preferences are not set or marked as "no-send"`);
+    logger.info(`Did not send ${job.name} notification for ${job.data.report.displayId || job.data} preferences are not set or marked as "no-send"`);
   }
 };
 
@@ -872,13 +879,13 @@ export async function recipientApprovedDigest(freq, subjectFreq) {
       const data = {
         user,
         reports,
-        type: EMAIL_ACTIONS.RECIPIENT_APPROVED_DIGEST,
+        type: EMAIL_ACTIONS.RECIPIENT_REPORT_APPROVED_DIGEST,
         freq,
         subjectFreq,
         ...referenceData(),
       };
 
-      notificationQueue.add(EMAIL_ACTIONS.RECIPIENT_APPROVED_DIGEST, data);
+      notificationQueue.add(EMAIL_ACTIONS.RECIPIENT_REPORT_APPROVED_DIGEST, data);
       return data;
     });
 

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-len */
 import { Op, cast, WhereOptions as SequelizeWhereOptions } from 'sequelize';
 import parse from 'csv-parse/lib/sync';
-import { get } from 'lodash';
 import {
   TRAINING_REPORT_STATUSES as TRS,
   REASONS,
@@ -405,6 +404,9 @@ const checkSessionForCompletion = (
   checker: TChecker,
   missingSessionInfo: TRAlertShape[],
 ) => {
+  // this checks to see if the session has been completed
+  // with a lookup in the form data
+  // by the owner or the poc (depending on the checker parameter)
   const sessionValid = !!(session.data[checker]);
 
   if (!sessionValid) {
@@ -418,8 +420,8 @@ const checkSessionForCompletion = (
       ownerId: event.ownerId,
       pocIds: event.pocIds,
       collaboratorIds: event.collaboratorIds,
-      endDate: session.data.startDate,
-      startDate: session.data.endDate,
+      endDate: session.data.endDate,
+      startDate: session.data.startDate,
       sessionId: session.id,
       eventStatus: event.data.status,
     });
@@ -461,6 +463,9 @@ export async function getTrainingReportAlerts(
 
   const today = moment().startOf('day');
 
+  // the following three filters are used to determine if the user is the owner, collaborator, or poc
+  // or if there is no user, in which case the alert is triggered for everyone
+  // this handles both cases: the alerts table in the UI and the email alerts for a given day
   const ownerUserIdFilter = (event: EventShape, user: number | undefined) => {
     if (!user || event.ownerId === user) {
       return true;


### PR DESCRIPTION
## Description of change
- Digests were not correctly logging "onCompleteNotification"
- An invalid constant was used for one of the jobs
- TR notifications had start date and end date backwards

## How to test
- Confirm that digests send without error (this is onerous to set up locally, I apologize)
- Confirm that the correct constant was used the recipient report approved digest job
- Confirm that POC notifications will send for the TR report "missingSessionInfo" job

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3326


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
