### PR TITLE
[TTAHUB-3508] Pre-commit lint for docker users

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@ set -e
 
 # Set USE_DOCKER based on whether both backend and frontend containers are running
 USE_DOCKER=false
-if [ "$(docker ps | grep -P "head-start-ttadp-backend|head-start-ttadp-frontend" | wc -l)" -eq 2 ]; then
+if [ "$(docker ps | grep -E "head-start-ttadp-backend|head-start-ttadp-frontend" | wc -l)" -eq 2 ]; then
   USE_DOCKER=true
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
+# Set USE_DOCKER based on whether both backend and frontend containers are running
+USE_DOCKER=false
+if [ "$(docker ps | grep -P "head-start-ttadp-backend|head-start-ttadp-frontend" | wc -l)" -eq 2 ]; then
+  USE_DOCKER=true
+fi
+
+# Ensure node_modules is populated for frontend or backend (only for non-Docker users)
+check_and_run_yarn() {
+  local dir=$1
+  if [ ! -d "$dir/node_modules" ] || [ -z "$(ls -A "$dir/node_modules")" ]; then
+    echo "Installing dependencies in $dir"
+    (cd "$dir" && yarn)
+  fi
+}
+
 common_changed=false
 common_package_json_changed=false
 frontend_yarn_lock_changed=false
@@ -9,7 +24,6 @@ files=$(git diff --cached --name-only)
 
 for f in $files
 do
-
   # check if packages/common/src/index.js was changed
   if [ -e "$f" ] && [[ $f == packages/common/src/index.js ]]; then
     common_changed=true
@@ -37,19 +51,28 @@ do
     git add "$f"
   fi
 
-  # Autolint changed .js files
-  if [ -e "$f" ] && [[ $f == *.js ]]; then
-    yarn lint:fix:single "$f"
-    git add "$f"
-  fi
-
-  # Autolint changed .ts files
-  if [ -e "$f" ] && [[ $f == *.ts ]]; then
-    yarn lint:fix:single "$f"
+  # Autolint changed .js and .ts files
+  if [ -e "$f" ] && ([[ $f == *.js ]] || [[ $f == *.ts ]]); then
+    if [ "$USE_DOCKER" = true ]; then
+      if [[ $f == frontend/* ]]; then
+        yarn docker:yarn:fe lint:fix:single "$f"
+      else
+        yarn docker:yarn:be lint:fix:single "$f"
+      fi
+    else
+      if [[ $f == frontend/* ]]; then
+        check_and_run_yarn frontend
+        yarn lint:fix:single "$f"
+      else
+        check_and_run_yarn "."
+        yarn lint:fix:single "$f"
+      fi
+    fi
     git add "$f"
   fi
 done
 
+# Versioning and lock file checks
 if [ $common_changed = true ]; then
   if [ $common_package_json_changed = false ]; then
     echo "ERROR: common/src/index.js was changed, but common/package.json was not updated. Please make sure to publish a new version."

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,6 +74,7 @@
     "test:ci": "cross-env TZ=America/New_York JEST_JUNIT_OUTPUT_DIR=reports JEST_JUNIT_OUTPUT_NAME=unit.xml CI=true node --expose-gc ./node_modules/.bin/react-scripts test --coverage --silent --reporters=default --detectOpenHandles --forceExit --reporters=jest-junit --logHeapUsage",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
+    "lint:fix:single": "eslint --fix",
     "lint:ci": "eslint -f eslint-formatter-multiple src"
   },
   "resolutions": {


### PR DESCRIPTION
## Description of change

Leverage the docker container when available for linting when available. When docker is not available make sure node_modules is populated before trying to lint.

## How to test
Run changes are normal when pre-commit hook should run, and confirm it runs as expected.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3508


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
