### PR TITLE
[TTAHUB-3630] Remove unneeded grant scope merge

### DIFF
--- a/src/scopes/grants/activeWithin.js
+++ b/src/scopes/grants/activeWithin.js
@@ -14,7 +14,6 @@ export function activeBefore(dates) {
     where: {
       [Op.or]: scopes,
     },
-    include: [],
   };
 }
 

--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -9,7 +9,6 @@ import {
   Topic,
   sequelize,
 } from '../models';
-import { mergeIncludes } from '../scopes';
 
 export const getAllTopicsForWidget = async () => Topic.findAll({
   attributes: ['id', 'name', 'deletedAt'],
@@ -81,14 +80,17 @@ export async function getAllRecipientsFiltered(scopes) {
         as: 'grants',
         required: true,
         attributes: [],
-        where: scopes.grant.where,
-        include: mergeIncludes(scopes.grant.include, [
+        where: {
+          ...scopes.grant.where,
+          deleted: { [Op.ne]: true },
+        },
+        include: [
           {
             model: GrantReplacements,
             as: 'replacedGrantReplacements',
             attributes: [],
           },
-        ]),
+        ],
       },
     ],
   });

--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -80,10 +80,7 @@ export async function getAllRecipientsFiltered(scopes) {
         as: 'grants',
         required: true,
         attributes: [],
-        where: {
-          ...scopes.grant.where,
-          deleted: { [Op.ne]: true },
-        },
+        where: scopes.grant.where,
         include: [
           {
             model: GrantReplacements,


### PR DESCRIPTION
## Description of change
There was a bug within a function for combining arbitrary scopes with scopes needed for grant replacement. A typo meant that Sequelize was attempting to treat an empty array as scope (i.e. ```[[]]```).

Since no scopes actually pass an include except the buggy one with the empty array, I removed the use of that function in this spot entirely.

## How to test
You can apply the Date Started (AR) _on or before_ or _is within_ conditions on the regional dashboard and all the graphs load.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3630


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
