### PR TITLE
use materialized view for AR goal retrieval

### DIFF
--- a/src/goalServices/goals.js
+++ b/src/goalServices/goals.js
@@ -784,7 +784,10 @@ export async function goalsForGrants(grantIds) {
       name: {
         [Op.ne]: '', // exclude "blank" goals
       },
-      '$grant.id$': ids,
+      [Op.or]: {
+        '$grant.grantRelationships.grantId$': ids,
+        '$grant.grantRelationships.activeGrantId$': ids,
+      },
       status: {
         [Op.notIn]: ['Closed', 'Suspended'],
       },


### PR DESCRIPTION
## Description of change

The handler that grabbed goals for ARs did not use the new materialized view, which means goals from replaced grants were not surfaced in the UI. This simple change fixes that.

The result is that when the old goal is used on the new grant, and the AR is approved, an entirely new goal is created referencing the new grant ID.

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3614


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
