### PR TITLE
[TTAHUB-3661] Update postgres client

### DIFF
--- a/automation/common/scripts/postgrescli_install.sh
+++ b/automation/common/scripts/postgrescli_install.sh
@@ -221,9 +221,9 @@ function cleanup() {
 
 # Main function to control workflow
 function main() {
-    local deb_url="https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.8-0+deb12u1_amd64.deb"
+    local deb_url="https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.10-0+deb12u1_amd64.deb"
     local deb_file="/tmp/postgresql.deb"
-    local deb_sha256="e88cfe7aa8548f8461dcbd56f69a1bb365affcd380469f705aca697fc2146994"
+    local deb_sha256="cb193447c404d85eed93cb0f61d2f189dd1c94c3f1af4d74afe861e06f8b34db"
     local bin_dir="/tmp/local/bin"
     local tools=("pg_dump" "pg_isready" "pg_restore" "psql" "reindexdb" "vacuumdb")
 


### PR DESCRIPTION
## Description of change
Update from postgresql-client-15_15.8 to postgresql-client-15_15.10 as the *.8 version is no longer available.

This client tool us used in the automation app within the production cloud.gov space as part of the DB backup process only. It does not have any effect in any way on the production or lower environments for running the TTA HUB website.


## How to test
Manually trigger a db backup, or check that the following link has succeeded.
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/20578/workflows/8d433144-8e5f-4be2-afd0-a16c6829234a/jobs/132601

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3661


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
