### PR TITLE
disable trainingReportTaskDueNotifications by requiring env var

### DIFF
--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -44,7 +44,9 @@ const runDailyEmailJob = () => {
       await submittedDigest(EMAIL_DIGEST_FREQ.DAILY, DIGEST_SUBJECT_FREQ.DAILY);
       await approvedDigest(EMAIL_DIGEST_FREQ.DAILY, DIGEST_SUBJECT_FREQ.DAILY);
       await recipientApprovedDigest(EMAIL_DIGEST_FREQ.DAILY, DIGEST_SUBJECT_FREQ.DAILY);
-      await trainingReportTaskDueNotifications(EMAIL_DIGEST_FREQ.DAILY);
+      if (process.env.SEND_TRAININGREPORTTASKDUENOTIFICATION === 'true') {
+        await trainingReportTaskDueNotifications(EMAIL_DIGEST_FREQ.DAILY);
+      }
     } catch (error) {
       auditLogger.error(`Error processing Daily Email Digest job: ${error}`);
       logger.error(`Daily Email Digest Error: ${error}`);


### PR DESCRIPTION
## Description of change

This disables only trainingReportTaskDueNotifications by requiring an env var to be set to `true` for it to execute. This seemed like the minimal version of this.

## How to test

Seems like this would be very hard to test, but it's also a very simple change.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3600

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
