### PR TITLE
[TTAHUB-3611] recover missing Goals.createdVia values

### DIFF
--- a/src/migrations/20241125000000-fix-missing-goal-source.js
+++ b/src/migrations/20241125000000-fix-missing-goal-source.js
@@ -1,0 +1,77 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      return queryInterface.sequelize.query(`
+        -- This restores Goal.createdVia values that were not being set at creation time
+        -- We considered also trying to restore Goal.source but decided that it it wasn't
+        -- worth the ambiguity
+
+        DROP TABLE IF EXISTS cv_modifications;
+        CREATE TEMP TABLE cv_modifications AS
+        SELECT
+          g.id gid,
+          CASE
+            WHEN zd.descriptor IN ('createGoals','createGoalsFromTemplate') THEN 'rtr'::"enum_Goals_createdVia"
+            WHEN zd.descriptor IN ('saveReport','createGoalsForReport') THEN 'activityReport'::"enum_Goals_createdVia"
+          END new_created_via
+        FROM "GoalTemplates" gt
+        JOIN "Goals" g
+          ON gt.id = g."goalTemplateId"
+        JOIN "ZALGoals" zg
+          ON g.id = zg.data_id
+          AND zg.dml_type = 'INSERT'
+        JOIN "ZADescriptor" zd
+          ON zg.descriptor_id = zd.id
+        WHERE gt."creationMethod" = 'Curated'
+          AND g."createdAt" > '2024-10-31'
+          AND g."createdVia" IS NULL
+          AND zd.descriptor IN ('createGoals','saveReport','createGoalsForReport','createGoalsFromTemplate')
+        ORDER BY 1;
+
+        DROP TABLE IF EXISTS updated_goals;
+        CREATE TEMP TABLE updated_goals
+        AS
+        WITH updater AS (
+        UPDATE "Goals"
+        SET "createdVia" = new_created_via
+        FROM cv_modifications
+        WHERE id = gid
+          AND "createdVia" IS NULL -- just here for extra safety
+        RETURNING id gid
+        )
+        SELECT * FROM updater
+        ;
+
+        -- These numbers should add up
+        SELECT 'goals to be updated' item, COUNT(*) cnt FROM cv_modifications
+        UNION
+        SELECT
+          'new rtr',
+          COUNT(*)
+        FROM "Goals"
+        JOIN updated_goals
+          ON id = gid
+        WHERE "createdVia" = 'rtr'
+        UNION
+        SELECT
+          'new activityReport',
+          COUNT(*)
+        FROM "Goals"
+        JOIN updated_goals
+          ON id = gid
+        WHERE "createdVia" = 'activityReport'
+        ORDER BY 1
+        ;
+      `);
+    });
+  },
+
+  async down() {
+    // no rollbacks
+  },
+};


### PR DESCRIPTION
## Description of change

Uses the events that created the goals to infer the proper Goals.createdVia values. After discussing different less satisfactory possibilities for inferring Goals.source values, the decision was to not try to do so.

## How to test

There's a small diagnostic query at the end that should look like:
```
        item         | cnt
---------------------+-----
 goals to be updated | 195
 new activityReport  | 191
 new rtr             |   4
```


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3611

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
