### PR TITLE
[TTAHUB-3676] update cf cli tools for deployment from v7 to v8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1125,8 +1125,14 @@ jobs:
       - run:
           name: Install Cloud Foundry
           command: |
-            curl -v -L -o cf-cli_amd64.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=v7&source=github'
-            sudo dpkg -i cf-cli_amd64.deb
+            # Install Cloud Foundry CLI
+            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+            echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            sudo apt-get update
+            sudo apt-get install -y cf8-cli
+            # Install plugin needed for connect-to-service
+            cf install-plugin -f https://github.com/cloud-gov/cf-service-connect/releases/download/v1.1.3/cf-service-connect_linux_amd64
+
       - when: # sandbox: for short-term feature development, see README.md
           condition:
             and:


### PR DESCRIPTION
## Description of change
The URL to download v7 https://packages.cloudfoundry.org/stable?release=debian64&version=v7&source=github now results in a 404, switching to v8 which has been in use for automation tasks.


## How to test
deploy works

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3676


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
