### PR TITLE
Remove extra hours from start date, end date filters

### DIFF
--- a/src/scopes/activityReport/index.test.js
+++ b/src/scopes/activityReport/index.test.js
@@ -125,7 +125,6 @@ describe('filtersToScopes', () => {
   let includedUser2;
   let includedUser3;
   let excludedUser;
-  let client;
 
   beforeAll(async () => {
     await User.create(mockUser);

--- a/src/scopes/utils.ts
+++ b/src/scopes/utils.ts
@@ -1,5 +1,6 @@
 import { Op, WhereOptions } from 'sequelize';
 import { map, pickBy } from 'lodash';
+import moment from 'moment';
 import { DECIMAL_BASE } from '@ttahub/common';
 
 /**
@@ -16,7 +17,7 @@ export function compareDate(dates: string[], property: string, operator: string)
     ...acc,
     {
       [property]: {
-        [operator]: new Date(date),
+        [operator]: date,
       },
     },
   ], []);
@@ -45,8 +46,8 @@ export function withinDateRange(dates: string[], property: string): WhereOptions
       ...acc,
       {
         [property]: {
-          [Op.gte]: new Date(startDate),
-          [Op.lte]: new Date(endDate),
+          [Op.gte]: startDate,
+          [Op.lte]: endDate,
         },
       },
     ];

--- a/src/scopes/utils.ts
+++ b/src/scopes/utils.ts
@@ -1,6 +1,5 @@
 import { Op, WhereOptions } from 'sequelize';
 import { map, pickBy } from 'lodash';
-import moment from 'moment';
 import { DECIMAL_BASE } from '@ttahub/common';
 
 /**


### PR DESCRIPTION
## Description of change
Using a date constructor appends a UTC offset for some reason; we don't need it as the date in the URL params are already in an acceptable YYYY-MM-DD ISO format

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
