### PR TITLE
[TTAHUB-3738] Fix bug when removing a goal while editing another

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
+++ b/frontend/src/pages/ActivityReport/Pages/goalsObjectives.js
@@ -103,6 +103,7 @@ const GoalsObjectives = ({
   const activityRecipients = watch('activityRecipients');
   const objectivesWithoutGoals = watch('objectivesWithoutGoals');
   const pageState = getValues('pageState');
+  const goalForEditing = watch('goalForEditing');
 
   const {
     isRecipientReport,
@@ -211,8 +212,9 @@ const GoalsObjectives = ({
     onUpdateGoals(copyOfSelectedGoals);
 
     // if we have no goals, open the form up via the
-    // hander provided by the context
-    if (copyOfSelectedGoals.length === 0) {
+    // handler provided by the context
+    // Unless we are currently editing a goal and removing at the same time.
+    if (copyOfSelectedGoals.length === 0 && !goalForEditing) {
       setValue('goalForEditing', '');
       setValue('goalName', '');
       setValue('goalEndDate', '');


### PR DESCRIPTION
## Description of change

So this appears to have been around for some time. If we remove a goal while actively editing another goal we loose all goals on the screen (reloading refreshes from the db).

## How to test

1. Create a report with two recipients.
2. Add a template goal and obj then save.
3. Add a regular goal and obj then save.
4. Edit the first template goal.
5. With the edit of the goal open, click 'remove' via the ... context menu on the other goal.
6. The current goal you are editing should be preserved and after saving you should no longer see the removed goal.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3738


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
