### PR TITLE
[TTAHUB-3714] Push CLASS score cutoffs back two years

### DIFF
--- a/src/queries/api/dashboards/qa/class.sql
+++ b/src/queries/api/dashboards/qa/class.sql
@@ -607,11 +607,14 @@ BEGIN
             WHERE json_values.value = (
             CASE
               -- Get the max reportDeliveryDate for the instructionalSupport domain
+              -- These dates are set by OHS policy and were delayed by two years in July 2024:
+              -- Final Rule to Delay Effective Date for Increasing the CLASS Instructional Support Domain Competitive Threshold
+              -- https://eclkc.ohs.acf.hhs.gov/policy/pi/acf-ohs-pi-24-07
               WHEN (ARRAY_AGG(mcs."instructionalSupport" ORDER BY mcs."reportDeliveryDate" DESC))[1] >= 3 THEN 'Above all thresholds'
-              WHEN (MAX(mcs."reportDeliveryDate") >= '2025-08-01'
+              WHEN (MAX(mcs."reportDeliveryDate") >= '2027-08-01'
               AND (ARRAY_AGG(mcs."instructionalSupport" ORDER BY mcs."reportDeliveryDate" DESC))[1] < 2.5)
               THEN 'Below competitive'
-              WHEN (MAX(mcs."reportDeliveryDate") BETWEEN '2020-11-09' AND '2025-07-31'
+              WHEN (MAX(mcs."reportDeliveryDate") BETWEEN '2020-11-09' AND '2027-07-31'
               AND (ARRAY_AGG(mcs."instructionalSupport" ORDER BY mcs."reportDeliveryDate" DESC))[1] < 2.3)
               THEN 'Below competitive'
               ELSE 'Below quality'

--- a/src/queries/api/dashboards/qa/class.sql
+++ b/src/queries/api/dashboards/qa/class.sql
@@ -606,7 +606,7 @@ BEGIN
             ) AS json_values
             WHERE json_values.value = (
             CASE
-              -- Get the max reportDeliveryDate for the instructionalSupport domain
+              -- Get the max reportDeliveryDate for the instructionalSupport domain to apply the correct threshold logic
               -- These dates are set by OHS policy and were delayed by two years in July 2024:
               -- Final Rule to Delay Effective Date for Increasing the CLASS Instructional Support Domain Competitive Threshold
               -- https://eclkc.ohs.acf.hhs.gov/policy/pi/acf-ohs-pi-24-07


### PR DESCRIPTION
## Description of change

OHS changed the cutoff date for the change in CLASS score cutoffs from 2025 to the same date in 2027 per https://eclkc.ohs.acf.hhs.gov/policy/pi/acf-ohs-pi-24-07, so this just updates the SSDI query to reflect that in advance.

## How to test

There aren't really any report delivery dates out that far, though this is a small enough change to where if there isn't a typo it should be safe.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3714

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested

### Before merge to main

- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
