### PR TITLE
[TTAHUB-3741] set deletedAt for objectives created on ARs but not on an AR

### DIFF
--- a/src/migrations/20250107000000-clean-orphan-objectives.js
+++ b/src/migrations/20250107000000-clean-orphan-objectives.js
@@ -1,0 +1,60 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      return queryInterface.sequelize.query(`
+        -- This marks as deleted any objectives for which all of the following are true:
+        -- - created within an AR
+        -- - Is currently linked to no AR
+        -- - Is not already marked as deleted
+
+        DROP TABLE IF EXISTS orphan_obj;
+        CREATE TEMP TABLE orphan_obj AS
+        SELECT o.id oid
+        FROM "Objectives" o
+        LEFT JOIN "ActivityReportObjectives" aro
+          ON o.id = aro."objectiveId"
+        WHERE o."createdVia" = 'activityReport'
+          AND o."deletedAt" IS NULL
+          AND aro.id IS NULL
+        ORDER BY 1;
+
+        DROP TABLE IF EXISTS updated_obj;
+        CREATE TEMP TABLE updated_obj
+        AS
+        WITH nowtime AS (SELECT NOW() nowts)
+        , updater AS (
+        UPDATE "Objectives"
+        SET "deletedAt" = nowts
+        FROM orphan_obj
+        CROSS JOIN nowtime
+        WHERE oid = id
+        RETURNING id deleted_oid
+        )
+        SELECT * FROM updater
+        ;
+
+        -- The first two numbers should match and the last should be 0
+        SELECT 1 ord,'orphaned objectives' item, COUNT(*) cnt FROM orphan_obj
+        UNION
+        SELECT 2, 'objectives marked deleted' , COUNT(*)  FROM updated_obj
+        UNION
+        SELECT 3, 'remaining orphaned objectives', COUNT(*) FROM (
+          SELECT * FROM orphan_obj
+          EXCEPT
+          SELECT * FROM updated_obj
+        ) a
+        ORDER BY 1
+        ;
+      `);
+    });
+  },
+
+  async down() {
+    // no rollbacks
+  },
+};


### PR DESCRIPTION
## Description of change

This soft-deletes all Objectives that were created on an AR but aren't on an AR. @AdamAdHocTeam fixed a bug that caused a lot of these to be created and this is the cleanup. However, this doesn't limit itself to only recipient objectives, because other-entity Objectives that are not connected to any AR are even more useless because they can't even connect to a Goal.

## How to test

There's a bit at the end confirming the orphan objectives are all removed that should look like:
```
 ord |             item              | cnt
-----+-------------------------------+------
   1 | orphaned objectives           | 9008
   2 | objectives marked deleted     | 9008
   3 | remaining orphaned objectives |    0
 ```

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3741


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested

### Before merge to main

- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
