### PR TITLE
[TTAHUB-3750] macos does not like tee

### DIFF
--- a/bin/latest_backup.sh
+++ b/bin/latest_backup.sh
@@ -235,12 +235,14 @@ download_and_verify() {
     local checksum_sha256=$(curl -s "$sha256_url")
     local checksum_md5=$(curl -s "$md5_url")
 
-    # Download file and generate hashes simultaneously
-    echo "Downloading file and generating hashes..."
-    $downloader "$backup_url" |\
-      tee >(sha256sum | awk '{print $1}' > "${backup_file_name}.sha256") \
-          >(md5sum | awk '{print $1}' > "${backup_file_name}.md5") \
-          > "$backup_file_name"
+   # Download file
+    echo "Downloading file..."
+    $downloader "$backup_url" > "$backup_file_name"
+
+    # Calculate hashes
+    echo "Calculating hashes..."
+    sha256sum "$backup_file_name" | awk '{print $1}' > "${backup_file_name}.sha256"
+    md5sum "$backup_file_name" | awk '{print $1}' > "${backup_file_name}.md5"
 
     # Verify SHA-256 checksum
     echo "Verifying SHA-256 checksum..."


### PR DESCRIPTION
## Description of change

refactor to not use tee, slower, but macos will be happy

## How to test
```./bin/latest_backup.sh -d```

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3750


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
