### PR TITLE
[TTAHUB-3756] Display inactive grants profile data; fix minor alignment issue

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/Profile.js
+++ b/frontend/src/pages/RecipientRecord/pages/Profile.js
@@ -15,7 +15,6 @@ export default function Profile({
   regionId,
   recipientId,
 }) {
-  const activeGrants = (recipientSummary.grants || []).filter((grant) => grant.status === 'Active');
   const { hasMonitoringData, hasClassData } = useGrantData();
 
   return (
@@ -34,7 +33,7 @@ export default function Profile({
           <Grid desktop={{ col: 12 }} tabletLg={{ col: 12 }}>
             <GrantList summary={recipientSummary} />
           </Grid>
-          {activeGrants.map((grant) => (
+          {(recipientSummary.grants || []).map((grant) => (
             <React.Fragment key={grant.number}>
               {hasMonitoringData(grant.number) || hasClassData(grant.number) ? (
                 <Grid desktop={{ col: 12 }}>

--- a/frontend/src/pages/RecipientRecord/pages/Profile.js
+++ b/frontend/src/pages/RecipientRecord/pages/Profile.js
@@ -44,7 +44,11 @@ export default function Profile({
                   </h2>
                 </Grid>
               ) : null}
-              <Grid desktop={{ col: 6 }} tabletLg={{ col: 12 }}>
+              <Grid
+                desktop={{ col: 6 }}
+                tabletLg={{ col: 12 }}
+                hidden={!hasClassData(grant.number)}
+              >
                 <div>
                   <ClassReview
                     grantNumber={grant.number}
@@ -53,7 +57,12 @@ export default function Profile({
                   />
                 </div>
               </Grid>
-              <Grid desktop={{ col: 6 }} tabletLg={{ col: 12 }}>
+
+              <Grid
+                desktop={{ col: 6 }}
+                tabletLg={{ col: 12 }}
+                hidden={!hasMonitoringData(grant.number)}
+              >
                 <div>
                   <MonitoringReview
                     grantNumber={grant.number}
@@ -62,6 +71,7 @@ export default function Profile({
                   />
                 </div>
               </Grid>
+
             </React.Fragment>
           ))}
         </Grid>

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/Profile.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/Profile.js
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react';
 import Profile from '../Profile';
 import UserContext from '../../../../UserContext';
 import { GrantDataProvider } from '../GrantDataContext';
+import { mockRSSData } from '../../../../testHelpers';
 
 describe('Recipient Record - Profile', () => {
   const user = {
@@ -15,10 +16,8 @@ describe('Recipient Record - Profile', () => {
 
   const renderRecipientProfile = (summary) => {
     fetchMock.get('/api/recipient/1/region/1/leadership', []);
-    fetchMock.get('/api/monitoring/1/region/1/grant/asdfsjkfd', {
-      recipientId: 1, regionId: 1, reviewStatus: 'Compliant', reviewDate: '02/02/2024', reviewType: 'Follow-up', grant: 'asdfsjkfd',
-    });
-    fetchMock.get('/api/monitoring/class/1/region/1/grant/asdfsjkfd', {});
+    fetchMock.get('/api/feeds/item?tag=ttahub-class-thresholds', mockRSSData());
+
     render(
       <UserContext.Provider value={{ user }}>
         <GrantDataProvider>
@@ -33,6 +32,10 @@ describe('Recipient Record - Profile', () => {
   });
 
   it('renders the recipient summary approriately', async () => {
+    fetchMock.get('/api/monitoring/1/region/1/grant/asdfsjkfd', {
+      recipientId: 1, regionId: 1, reviewStatus: 'Compliant', reviewDate: '02/02/2024', reviewType: 'Follow-up', grant: 'asdfsjkfd',
+    });
+    fetchMock.get('/api/monitoring/class/1/region/1/grant/asdfsjkfd', {});
     const summary = {
       recipientId: '44',
       grants: [
@@ -55,9 +58,14 @@ describe('Recipient Record - Profile', () => {
 
     expect(fetchMock.called('/api/monitoring/1/region/1/grant/asdfsjkfd')).toBe(true);
     expect(fetchMock.called('/api/monitoring/class/1/region/1/grant/asdfsjkfd')).toBe(true);
+
+    expect(await screen.findByRole('heading', { name: /grant number asdfsjkfd/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /Monitoring review/i })).toBeInTheDocument();
   });
 
   it('doesnt show the class/monitoring review headings if there is no grant data', async () => {
+    fetchMock.get('/api/monitoring/1/region/1/grant/asdfsjkfd', { body: null });
+    fetchMock.get('/api/monitoring/class/1/region/1/grant/asdfsjkfd', {});
     const summary = {
       recipientId: '44',
       grants: [{
@@ -71,5 +79,26 @@ describe('Recipient Record - Profile', () => {
 
     // should not see the heading "Grant number asdf"
     expect(screen.queryByRole('heading', { name: /grant number asdfsjkfd/i })).not.toBeInTheDocument();
+  });
+
+  it('displays class data', async () => {
+    fetchMock.get('/api/monitoring/1/region/1/grant/asdfsjkfd', { body: null });
+    fetchMock.get('/api/monitoring/class/1/region/1/grant/asdfsjkfd', {
+      recipientId: 1, regionId: 1, grantNumber: 'asdfsjkfd', received: '03/30/2023', ES: '5.8611', CO: '5.6296', IS: '3.2037',
+    });
+    const summary = {
+      recipientId: '44',
+      grants: [{
+        id: 1,
+        number: 'asdfsjkfd',
+        status: 'Froglike',
+        endDate: '2021-09-28',
+      }],
+    };
+    renderRecipientProfile(summary);
+
+    // should not see the heading "Grant number asdf"
+    expect(await screen.findByRole('heading', { name: /grant number asdfsjkfd/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /CLASS® review/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/Profile.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/Profile.js
@@ -15,6 +15,10 @@ describe('Recipient Record - Profile', () => {
 
   const renderRecipientProfile = (summary) => {
     fetchMock.get('/api/recipient/1/region/1/leadership', []);
+    fetchMock.get('/api/monitoring/1/region/1/grant/asdfsjkfd', {
+      recipientId: 1, regionId: 1, reviewStatus: 'Compliant', reviewDate: '02/02/2024', reviewType: 'Follow-up', grant: 'asdfsjkfd',
+    });
+    fetchMock.get('/api/monitoring/class/1/region/1/grant/asdfsjkfd', {});
     render(
       <UserContext.Provider value={{ user }}>
         <GrantDataProvider>
@@ -24,11 +28,16 @@ describe('Recipient Record - Profile', () => {
     );
   };
 
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
   it('renders the recipient summary approriately', async () => {
     const summary = {
       recipientId: '44',
       grants: [
         {
+          id: 1,
           number: 'asdfsjkfd',
           status: 'Froglike',
           endDate: '2021-09-28',
@@ -44,14 +53,16 @@ describe('Recipient Record - Profile', () => {
     expect(screen.getByRole('heading', { name: /recipient summary/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /grants/i })).toBeInTheDocument();
 
-    fetchMock.restore();
+    expect(fetchMock.called('/api/monitoring/1/region/1/grant/asdfsjkfd')).toBe(true);
+    expect(fetchMock.called('/api/monitoring/class/1/region/1/grant/asdfsjkfd')).toBe(true);
   });
 
   it('doesnt show the class/monitoring review headings if there is no grant data', async () => {
     const summary = {
       recipientId: '44',
       grants: [{
-        number: 'asdf',
+        id: 1,
+        number: 'asdfsjkfd',
         status: 'Froglike',
         endDate: '2021-09-28',
       }],
@@ -59,8 +70,6 @@ describe('Recipient Record - Profile', () => {
     renderRecipientProfile(summary);
 
     // should not see the heading "Grant number asdf"
-    expect(screen.queryByRole('heading', { name: /grant number asdf/i })).not.toBeInTheDocument();
-
-    fetchMock.restore();
+    expect(screen.queryByRole('heading', { name: /grant number asdfsjkfd/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description of change
In order to synchronize the monitoring tab and the profile tab in the RTR, this PR removes the filter for active grants in the monitoring query and instead retrieves data for all grants listed on a recipient record. 

## How to test
View the profile tab and confirm that all grants have profile data listed, even inactive ones.

## Issue(s)
* https://jira.acf.gov/browse/TTAHUB-3756


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
