### PR TITLE
[TTAHUB-3770] - cf_migrate in circleci config needs to lock the env's app, not automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,7 +455,7 @@ commands:
           command: |
             chmod +x ./automation/ci/scripts/*-lock.sh
             ./automation/ci/scripts/acquire-lock.sh \
-              "tta-automation" \
+              "<< parameters.app_name >>" \
               "<< pipeline.git.branch >>" \
               "<< pipeline.number >>" \
               "$CIRCLE_JOB"
@@ -470,7 +470,7 @@ commands:
           command: |
             chmod +x ./automation/ci/scripts/*-lock.sh
             ./automation/ci/scripts/release-lock.sh \
-              "tta-automation" \
+              "<< parameters.app_name >>" \
               "<< pipeline.git.branch >>" \
               "<< pipeline.number >>" \
               "$CIRCLE_JOB"


### PR DESCRIPTION
## Description of change

- Small logic error in the new cf_migrate job in circleci config file. Other steps leverage the automation app in production, but the migrate needs to be aligned with the app in the environment. This means the lock needs to be on the app being used for the app running the migration. 

## How to test
Trigger a restore on an environment, set manual-restore-staging or manual-restore-sandbox or manual-restore-dev to true.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3770


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
