### PR TITLE
[TTAHUB-3380] add dupe constraint to ARO

### DIFF
--- a/src/migrations/20250121000000-add-aro-constraint.js
+++ b/src/migrations/20250121000000-add-aro-constraint.js
@@ -1,0 +1,23 @@
+const { prepMigration, removeTables } = require('../lib/migration');
+
+module.exports = {
+  up: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      await queryInterface.sequelize.query(`
+        DROP INDEX IF EXISTS "activity_report_objectives_activity_report_id_objective_id";
+        CREATE UNIQUE INDEX  "activity_report_objectives_activity_report_id_objective_id_unique" ON "ActivityReportObjectives" ("activityReportId","objectiveId");
+      `, { transaction });
+    },
+  ),
+
+  down: async (queryInterface) => queryInterface.sequelize.transaction(
+    async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      await queryInterface.sequelize.query(`
+        DROP INDEX IF EXISTS "activity_report_objectives_activity_report_id_objective_id_unique";
+        CREATE INDEX "activity_report_objectives_activity_report_id_objective_id" ON "ActivityReportObjectives" ("activityReportId","objectiveId");
+      `, { transaction });
+    },
+  ),
+};

--- a/src/services/dashboards/course.test.js
+++ b/src/services/dashboards/course.test.js
@@ -284,7 +284,7 @@ describe('Course dashboard', () => {
     aroNoCourses = await ActivityReportObjective.create({
       objectiveId: objective.id,
       activityReportId: reportThree.id,
-      ttaProvided: 'course resource widget 3',
+      ttaProvided: 'course resource widget 4',
       status: 'In Progress',
     });
 
@@ -298,7 +298,7 @@ describe('Course dashboard', () => {
     // Report 4 ARO 1.
     aroOnlyCourseOne = await ActivityReportObjective.create({
       objectiveId: objective.id,
-      activityReportId: reportThree.id,
+      activityReportId: reportFour.id,
       ttaProvided: 'course resource widget 3',
       status: 'In Progress',
     });


### PR DESCRIPTION
## Description of change

Adds constraint on the ActivityReportObjectives table so there can only be one record linking a given AR and Objective at a time, and fixes the tests that broke. The other 'broken' tests seem to just be unrelated flaky tests.

## How to test

There's really nothing to test; this is just to prevent future duplicate AROs. No duplicate AROs have been seen recently. There's also an ARO dupe merge in https://github.com/HHS/Head-Start-TTADP/pull/2596, so the database should be totally clean even if somehow new dupe AROs sneak in between now and deployment.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3380

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Logical Data Model updated

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
