### PR TITLE
Fix monitoring SQL for goal templates

### DIFF
--- a/src/routes/goalTemplates/handlers.ts
+++ b/src/routes/goalTemplates/handlers.ts
@@ -1,9 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { Request, Response } from 'express';
 import { DECIMAL_BASE } from '@ttahub/common';
-import { currentUserId } from '../../services/currentUser';
-import { userById } from '../../services/users';
-import User from '../../policies/user';
 import handleErrors from '../../lib/apiErrorHandler';
 import {
   getCuratedTemplates,
@@ -20,10 +17,7 @@ export async function getGoalTemplates(req: Request, res: Response) {
     const parsedGrantIds = [grantIds].flat().map((id: string) => parseInt(id, DECIMAL_BASE))
       .filter((id: number) => !Number.isNaN(id));
 
-    const userId = await currentUserId(req, res);
-    const user = await userById(userId);
-
-    const templates = await getCuratedTemplates(parsedGrantIds, user);
+    const templates = await getCuratedTemplates(parsedGrantIds);
     res.json(templates);
   } catch (err) {
     await handleErrors(req, res, err, 'goalTemplates.getGoalTemplates');

--- a/src/services/goalTemplates.test.js
+++ b/src/services/goalTemplates.test.js
@@ -121,27 +121,23 @@ describe('goalTemplates services', () => {
       });
     });
 
-    it('returns only non-monitoring templates', async () => {
+    it('returns only regular templates', async () => {
       const templates = await getCuratedTemplates(
-        [monitoringGrant.id, regularGrant.id],
-        { id: 1, name: 'regular user', flags: [] },
+        [regularGrant.id],
       );
 
-      // Make sure the results contain the regular template and NOT the monitoring template.
       const regularTemplateToAssert = templates.find((t) => t.id === regularTemplate.id);
       expect(regularTemplateToAssert).toBeTruthy();
 
       const monitoringTemplateToAssert = templates.find((t) => t.id === monitoringTemplate.id);
-      expect(monitoringTemplateToAssert).toBeFalsy();
+      expect(monitoringTemplateToAssert).not.toBeTruthy();
     });
 
     it('returns both regular and only monitoring templates', async () => {
       const templates = await getCuratedTemplates(
         [monitoringGrant.id, regularGrant.id],
-        { id: 1, name: 'regular user', flags: ['monitoring_integration'] },
       );
 
-      // Make sure the results contain the regular template and NOT the monitoring template.
       const regularTemplateToAssert = templates.find((t) => t.id === regularTemplate.id);
       expect(regularTemplateToAssert).toBeTruthy();
 

--- a/src/services/goalTemplates.ts
+++ b/src/services/goalTemplates.ts
@@ -132,11 +132,23 @@ export async function getCuratedTemplates(
     ],
     where: {
       creationMethod: CREATION_METHOD.CURATED,
-      [Op.or]: [
-        { '$"region.grants"."id"$': { [Op.not]: null } },
-        { regionId: null },
-        { '$goals.id$': monitoringGoalIds },
-        { '$goals.createdVia$': { [Op.not]: 'monitoring' } },
+      [Op.and]: [
+        {
+          [Op.or]: [
+            { '$"region.grants"."id"$': { [Op.not]: null } },
+            { regionId: null },
+          ],
+        },
+        {
+          [Op.or]: [
+            { '$goals.id$': monitoringGoalIds },
+            {
+              standard: {
+                [Op.not]: 'Monitoring',
+              },
+            },
+          ],
+        },
       ],
     },
     order: [['templateName', 'ASC']],


### PR DESCRIPTION
## Description of change
Fix an error in the Sequelize where options that was returning a truncated list of standard goals. 

## How to test
Pre-requisite: Your DB has monitoring goals
 
Create an AR for a grant that has monitoring goals. Confirm that the _full_ list of standard goals appears in the goal dropdown, **including** the monitoring goal.

Create an AR for a grant that does not have a. monitoring goal. Confirm that the _full_ list of standard goals appears in the goal dropdown, **excluding** the monitoring goal.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
