### PR TITLE
Wrap poc select in error component, event summary on training report

### DIFF
--- a/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
@@ -303,47 +303,50 @@ const EventSummary = ({
         { adminCanEdit ? (
           <>
             <div className="margin-top-2">
-              <Label htmlFor="pocIds">
-                Event region point of contact
-                <Req />
-              </Label>
-              <Controller
-                render={({ onChange: controllerOnChange, value, onBlur }) => (
-                  <Select
-                    value={pointOfContact.filter((option) => (
-                      value.includes(option.id)
-                    ))}
-                    inputId="pocIds"
-                    name="pocIds"
-                    className="usa-select"
-                    styles={selectOptionsReset}
-                    components={{
-                      DropdownIndicator: null,
-                    }}
-                    onChange={(s) => {
-                      controllerOnChange(s.map((option) => option.id));
-                    }}
-                    inputRef={register({ required: 'Select at least one event region point of contact' })}
-                    getOptionLabel={(option) => option.fullName}
-                    getOptionValue={(option) => option.id}
-                    options={pointOfContact}
-                    onBlur={onBlur}
-                    required
-                    isMulti
-                  />
-                )}
-                control={control}
-                rules={{
-                  validate: (value) => {
-                    if (!value || value.length === 0) {
-                      return 'Select at least one event region point of contact';
-                    }
-                    return true;
-                  },
-                }}
+              <FormItem
+                label="Event region point of contact "
                 name="pocIds"
-                defaultValue={[]}
-              />
+                required
+              >
+
+                <Controller
+                  render={({ onChange: controllerOnChange, value, onBlur }) => (
+                    <Select
+                      value={pointOfContact.filter((option) => (
+                        value.includes(option.id)
+                      ))}
+                      inputId="pocIds"
+                      name="pocIds"
+                      className="usa-select"
+                      styles={selectOptionsReset}
+                      components={{
+                        DropdownIndicator: null,
+                      }}
+                      onChange={(s) => {
+                        controllerOnChange(s.map((option) => option.id));
+                      }}
+                      inputRef={register({ required: 'Select at least one event region point of contact' })}
+                      getOptionLabel={(option) => option.fullName}
+                      getOptionValue={(option) => option.id}
+                      options={pointOfContact}
+                      onBlur={onBlur}
+                      required
+                      isMulti
+                    />
+                  )}
+                  control={control}
+                  rules={{
+                    validate: (value) => {
+                      if (!value || value.length === 0) {
+                        return 'Select at least one event region point of contact';
+                      }
+                      return true;
+                    },
+                  }}
+                  name="pocIds"
+                  defaultValue={[]}
+                />
+              </FormItem>
             </div>
             <Fieldset>
               <div className="margin-top-2">


### PR DESCRIPTION
## Description of change

Turned up this during accessibility review. An earlier change fixed the validation on blur but it turns out this component wasn't wrapped in the correct code to actually display an error.

## How to test
You'll need to be an admin.
Blur the poc select field, selecting nothing, and confirm that the error message appears.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
