### PR TITLE
[TTAHUB-3776] Update the meta data url for resource scrape

### DIFF
--- a/src/lib/resource.js
+++ b/src/lib/resource.js
@@ -385,8 +385,9 @@ const getResourceMetaDataJob = async (job) => {
   } = job.data;
 
   try {
-    // Determine if this is an ECLKC resource.
-    const isEclkc = resourceUrl.includes('headstart.gov');
+    // Determine if this is an ECLKC or HeadStart resource.
+    const isEclkc = resourceUrl.includes('eclkc.ohs.acf.hhs.gov');
+    const isHeadStart = resourceUrl.includes('headstart.gov');
 
     let statusCode;
     let mimeType;
@@ -411,8 +412,8 @@ const getResourceMetaDataJob = async (job) => {
       return { status: statusCode || 500, data: { url: resourceUrl } };
     }
 
-    // If it is an ECLKC resource, get the metadata values.
-    if (isEclkc) {
+    // If it is an ECLKC or HeadStart resource, get the metadata values.
+    if (isEclkc || isHeadStart) {
       ({ title, statusCode } = await getMetadataValues(resourceUrl));
       if (statusCode !== httpCodes.OK) {
         auditLogger.error(`Resource Queue: Warning, unable to retrieve metadata or resource TITLE for resource '${resourceUrl}', received status code '${statusCode || 500}'.`);

--- a/src/lib/resource.js
+++ b/src/lib/resource.js
@@ -107,7 +107,7 @@ const getMetadataValuesFrommJson = async (url) => {
   let result;
   try {
     // Attempt to get the resource metadata (if valid ECLKC resource).
-    // Sample: https://eclkc.ohs.acf.hhs.gov/mental-health/article/head-start-heals-campaign?_format=json
+    // Sample: https://headstart.gov/mental-health/article/head-start-heals-campaign?_format=json
     let metadataUrl;
 
     // Check if the URL already contains query parameters
@@ -386,7 +386,7 @@ const getResourceMetaDataJob = async (job) => {
 
   try {
     // Determine if this is an ECLKC resource.
-    const isEclkc = resourceUrl.includes('eclkc.ohs.acf.hhs.gov');
+    const isEclkc = resourceUrl.includes('headstart.gov');
 
     let statusCode;
     let mimeType;

--- a/src/lib/resource.test.js
+++ b/src/lib/resource.test.js
@@ -206,6 +206,75 @@ describe('resource worker tests', () => {
     );
   });
 
+  it('tests a clean resource metadata get when url is eclkc.ohs.acf.hhs.gov', async () => {
+    // Metadata.
+    mockAxios.mockImplementationOnce(() => Promise.resolve({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      data: metadata,
+    }));
+    mockAxiosHead.mockImplementationOnce(() => Promise.resolve(axiosCleanMimeResponse));
+    mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
+
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+    expect(got.status).toBe(200);
+    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov' });
+
+    expect(mockUpdate).toBeCalledTimes(2);
+
+    // Check the update call.
+    expect(mockUpdate).toHaveBeenLastCalledWith(
+      {
+        metadata: {
+          changed: [
+            {
+              value: '2023-05-26T18:57:15+00:00',
+            },
+          ],
+          created: [
+            {
+              value: '2020-04-21T15:20:23+00:00',
+            },
+          ],
+          field_context: [
+            {
+              value: '<p><img alt=\"Two pairs of hands holding a heart.</p>',
+            },
+          ],
+          field_taxonomy_national_centers: [
+            {
+              target_type: 'taxonomy_term',
+            },
+          ],
+          field_taxonomy_topic: [
+            {
+              target_type: 'taxonomy_term',
+            },
+          ],
+          langcode: [
+            {
+              value: 'en',
+            },
+          ],
+          title: [
+            {
+              value: 'Head Start Heals Campaign',
+            },
+          ],
+        },
+        metadataUpdatedAt: expect.anything(),
+        title: 'Head Start Heals Campaign',
+        lastStatusCode: 200,
+      },
+      {
+        individualHooks: true,
+        where: {
+          url: 'http://www.eclkc.ohs.acf.hhs.gov',
+        },
+      },
+    );
+  });
+
   it('tests a clean resource metadata get with a url that has params', async () => {
     // Metadata.
     mockAxios.mockImplementationOnce(() => Promise.resolve({

--- a/src/lib/resource.test.js
+++ b/src/lib/resource.test.js
@@ -19,8 +19,8 @@ const urlReturn = `
 <meta name="node-id" content="7858" />
 <meta name="exclude-from-dynamic-view" content="False" />
 <script>window.dataLayer = window.dataLayer || []; window.dataLayer.push({"language":"en","country":"US","siteName":"ECLKC","entityLangcode":"en","entityVid":"326638","entityCreated":"1490966152","entityStatus":"1","entityName":"leraa","entityType":"node","entityBundle":"page_front","entityId":"2212","entityTitle":"Head Start","userUid":0});</script>
-<link rel="canonical" href="https://eclkc.ohs.acf.hhs.gov/" />
-<link rel="image_src" href="https://eclkc.ohs.acf.hhs.gov/themes/gesso/images/site-logo.png" />
+<link rel="canonical" href="https://headstart.gov/" />
+<link rel="image_src" href="https://headstart.gov/themes/gesso/images/site-logo.png" />
 <title>Head Start | ECLKC</title>
 <body>
 test
@@ -147,9 +147,9 @@ describe('resource worker tests', () => {
     mockAxiosHead.mockImplementationOnce(() => Promise.resolve(axiosCleanMimeResponse));
     mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
 
-    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.headstart.gov' } });
     expect(got.status).toBe(200);
-    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov' });
+    expect(got.data).toStrictEqual({ url: 'http://www.headstart.gov' });
 
     expect(mockUpdate).toBeCalledTimes(2);
 
@@ -200,7 +200,7 @@ describe('resource worker tests', () => {
       {
         individualHooks: true,
         where: {
-          url: 'http://www.eclkc.ohs.acf.hhs.gov',
+          url: 'http://www.headstart.gov',
         },
       },
     );
@@ -216,14 +216,14 @@ describe('resource worker tests', () => {
     mockAxiosHead.mockImplementationOnce(() => Promise.resolve(axiosCleanMimeResponse));
     mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
 
-    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov/activity-reports?region.in[]=1' } });
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.headstart.gov/activity-reports?region.in[]=1' } });
     expect(got.status).toBe(200);
-    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov/activity-reports?region.in[]=1' });
+    expect(got.data).toStrictEqual({ url: 'http://www.headstart.gov/activity-reports?region.in[]=1' });
 
     expect(mockUpdate).toBeCalledTimes(2);
 
     expect(mockAxios).toBeCalledWith(
-      'http://www.eclkc.ohs.acf.hhs.gov/activity-reports?region.in[]=1&_format=json',
+      'http://www.headstart.gov/activity-reports?region.in[]=1&_format=json',
       {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
         maxRedirects: 25,
@@ -278,7 +278,7 @@ describe('resource worker tests', () => {
       {
         individualHooks: true,
         where: {
-          url: 'http://www.eclkc.ohs.acf.hhs.gov/activity-reports?region.in[]=1',
+          url: 'http://www.headstart.gov/activity-reports?region.in[]=1',
         },
       },
     );
@@ -294,15 +294,15 @@ describe('resource worker tests', () => {
     mockAxiosHead.mockImplementationOnce(() => Promise.resolve(axiosCleanMimeResponse));
     mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
 
-    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov/section#2' } });
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.headstart.gov/section#2' } });
     expect(got.status).toBe(200);
-    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov/section#2' });
+    expect(got.data).toStrictEqual({ url: 'http://www.headstart.gov/section#2' });
 
     expect(mockUpdate).toBeCalledTimes(2);
 
     // Expect axios get to have been called with the correct url.
     expect(mockAxios).toBeCalledWith(
-      'http://www.eclkc.ohs.acf.hhs.gov/section?_format=json',
+      'http://www.headstart.gov/section?_format=json',
       {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
         maxRedirects: 25,
@@ -357,7 +357,7 @@ describe('resource worker tests', () => {
       {
         individualHooks: true,
         where: {
-          url: 'http://www.eclkc.ohs.acf.hhs.gov/section#2',
+          url: 'http://www.headstart.gov/section#2',
         },
       },
     );
@@ -373,9 +373,9 @@ describe('resource worker tests', () => {
     mockAxiosHead.mockImplementationOnce(() => Promise.resolve(axiosCleanMimeResponse));
     mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
 
-    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.headstart.gov' } });
     expect(got.status).toBe(500);
-    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov' });
+    expect(got.data).toStrictEqual({ url: 'http://www.headstart.gov' });
 
     expect(mockUpdate).toBeCalledTimes(2);
   });
@@ -388,7 +388,7 @@ describe('resource worker tests', () => {
     mockAxiosHead.mockImplementationOnce(() => Promise.resolve(axiosCleanMimeResponse));
     mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
 
-    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.headstart.gov' } });
 
     // Verify auditlogger.error was called with the message we expect.
     expect(auditLogger.error).toBeCalledTimes(3);
@@ -412,9 +412,9 @@ describe('resource worker tests', () => {
     mockAxios.mockImplementationOnce(() => Promise.resolve(axiosCleanResponse));
     mockUpdate.mockImplementationOnce(() => Promise.resolve([1]));
 
-    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.headstart.gov' } });
     expect(got.status).toBe(200);
-    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov' });
+    expect(got.data).toStrictEqual({ url: 'http://www.headstart.gov' });
 
     expect(mockUpdate).toBeCalledTimes(2);
 
@@ -426,7 +426,7 @@ describe('resource worker tests', () => {
       },
       {
         individualHooks: true,
-        where: { url: 'http://www.eclkc.ohs.acf.hhs.gov' },
+        where: { url: 'http://www.headstart.gov' },
       },
     );
 
@@ -473,7 +473,7 @@ describe('resource worker tests', () => {
       {
         individualHooks: true,
         where: {
-          url: 'http://www.eclkc.ohs.acf.hhs.gov',
+          url: 'http://www.headstart.gov',
         },
       },
     );
@@ -504,9 +504,9 @@ describe('resource worker tests', () => {
   it('eclkc resource url not found', async () => {
     mockAxiosHead.mockImplementationOnce(() => Promise.resolve({ headers: { 'content-type': 'text/html; charset=utf-8' }, status: 404 }));
     mockAxios.mockImplementationOnce(() => Promise.resolve(axiosResourceNotFound));
-    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.eclkc.ohs.acf.hhs.gov' } });
+    const got = await getResourceMetaDataJob({ data: { resourceUrl: 'http://www.headstart.gov' } });
     expect(got.status).toBe(404);
-    expect(got.data).toStrictEqual({ url: 'http://www.eclkc.ohs.acf.hhs.gov' });
+    expect(got.data).toStrictEqual({ url: 'http://www.headstart.gov' });
     expect(mockAxiosHead).toBeCalled();
     expect(mockAxios).not.toBeCalled();
     expect(mockUpdate).toBeCalled();


### PR DESCRIPTION
## Description of change

Update the ECKLC URL to the new HeadStart.gov for the resource metadata scrape.

## How to test

- Review the code.
- Make sure we didn't miss anything.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3776


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
