### PR TITLE
[Prod] Handle a case in the TTA history graph where a topic is returned from the database but is null in the UI

### DIFF
--- a/src/migrations/20250206180000-eo-close-goals-and-objectives.js
+++ b/src/migrations/20250206180000-eo-close-goals-and-objectives.js
@@ -1,0 +1,154 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      return queryInterface.sequelize.query(`
+        -- This Completes any remaining equity Objectives and Closes any
+        -- remaining equity Goals
+
+        -- Create a list of EO-impacted Goals that are not yet closed
+        DROP TABLE IF EXISTS equity_goals;
+        CREATE TEMP TABLE equity_goals
+        AS
+        SELECT
+          g.id gid,
+          LEFT(name, 30) short_gname,
+          COALESCE(NULLIF(POSITION(' dei' IN LOWER(name)),0),POSITION(' equit' IN LOWER(name))) gissue_loc,
+          status g_status
+        FROM "Goals" g
+        LEFT JOIN "GoalTemplates" gt
+          ON g."goalTemplateId" = gt.id
+        WHERE (
+            LOWER(name) LIKE '% dei%'
+            OR
+            LOWER(name) LIKE '% equit%'
+            OR
+            LOWER(name) LIKE 'dei%'
+            OR
+            LOWER(name) LIKE 'equit%'
+          )
+          AND g.status != 'Closed'
+          AND g."deletedAt" IS NULL
+        ;
+
+        -- Create a list of EO-impacted Objectives that are not yet closed
+        -- and are on a non-deleted Goal. 
+        DROP TABLE IF EXISTS equity_objectives;
+        CREATE TEMP TABLE equity_objectives
+        AS
+        SELECT
+          o.id oid,
+          "goalId" ogid,
+          title full_otitle,
+          LEFT(title, 30) short_otitle,
+          COALESCE(NULLIF(POSITION(' dei' IN LOWER(title)),0),POSITION(' equit' IN LOWER(title))) oissue_loc,
+          o.status o_status
+        FROM "Objectives" o
+        JOIN "Goals" g
+          ON o."goalId" = g.id
+        LEFT JOIN equity_goals
+          ON gid = g.id
+        WHERE
+          (
+          gid IS NOT NULL -- Complete objectives on closing Goals
+          OR
+            ( -- Complete objectives with EO-impacted text
+              LOWER(title) LIKE '% dei%'
+              OR
+              LOWER(title) LIKE '% equit%'
+              OR
+              LOWER(title) LIKE 'dei%'
+              OR
+              LOWER(title) LIKE 'equit%'
+            )
+          )
+          AND o.status NOT IN ('Complete','Suspended')
+          AND o."deletedAt" IS NULL
+          AND g."deletedAt" IS NULL
+        ;
+
+        -- Complete the Objectives
+        DROP TABLE IF EXISTS updated_obj;
+        CREATE TEMP TABLE updated_obj
+        AS
+        WITH nowtime AS (SELECT NOW() nowts)
+        , updater AS (
+        UPDATE "Objectives"
+        SET
+          "updatedAt" = nowts,
+          status = 'Complete'
+        FROM equity_objectives
+        CROSS JOIN nowtime
+        WHERE oid = id
+        RETURNING id completed_oid
+        )
+        SELECT * FROM updater
+        ;
+
+        -- Complete the Goals
+        DROP TABLE IF EXISTS updated_goals;
+        CREATE TEMP TABLE updated_goals
+        AS
+        WITH nowtime AS (SELECT NOW() nowts)
+        , updater AS (
+        UPDATE "Goals"
+        SET
+          "updatedAt" = nowts,
+          status = 'Closed'
+        FROM equity_goals
+        CROSS JOIN nowtime
+        WHERE gid = id
+        RETURNING id closed_gid
+        )
+        SELECT * FROM updater
+        ;
+
+        -- Insert the status changes
+        DROP TABLE IF EXISTS inserted_goal_changes;
+        CREATE TEMP TABLE inserted_goal_changes
+        AS
+        WITH nowtime AS (SELECT NOW() nowts)
+        , updater AS (
+        INSERT INTO "GoalStatusChanges" (
+          "goalId",
+          "oldStatus",
+          "newStatus",
+          reason
+        )
+        SELECT
+          gid,
+          g_status,
+          'Closed',
+          'Regional Office request'
+        FROM equity_goals
+        CROSS JOIN nowtime
+        RETURNING *
+        )
+        SELECT * FROM updater
+        ;
+        
+
+        -- The first two numbers should match and the last should be 0
+        SELECT 1 ord,'equity Objectives' item, COUNT(*) cnt FROM equity_objectives
+        UNION
+        SELECT 2, 'objectives Completed' , COUNT(*)  FROM updated_obj
+        UNION
+        SELECT 3 ,'equity Goals' item, COUNT(*) cnt FROM equity_goals
+        UNION
+        SELECT 4, 'Goals Closed' , COUNT(*)  FROM updated_goals
+        UNION
+        SELECT 5, 'Goal status changes inserted' , COUNT(*)  FROM inserted_goal_changes
+        ORDER BY 1
+        ;
+      `);
+    });
+  },
+
+  async down() {
+    // no rollbacks
+  },
+};

--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -16,8 +16,7 @@ import {
 } from '../models';
 
 export const getAllTopicsForWidget = async () => Topic.findAll({
-  attributes: ['id', 'name', 'deletedAt'],
-  where: { deletedAt: null },
+  attributes: ['id', 'name'],
   order: [['name', 'ASC']],
 });
 

--- a/src/widgets/topicFrequencyGraph.js
+++ b/src/widgets/topicFrequencyGraph.js
@@ -205,10 +205,11 @@ export async function topicFrequencyGraphViaGoals(scopes) {
   topicsAndParticipants?.forEach((goalData) => {
     goalData
       .get('topics')?.forEach(({ topic, reportIds }) => {
-        const topicResponce = topicsResponse
+        const topicResponse = topicsResponse
           .find((t) => t.topic === lookUpTopic.get(topic));
 
-        reportIds?.forEach((id) => topicResponce.reportIds.add(id));
+        if (!topicResponse) return;
+        reportIds?.forEach((id) => topicResponse.reportIds.add(id));
       });
   });
 


### PR DESCRIPTION
## Description of change
Topics are soft deleted, so they will show up in the database through a "raw" query but not in a managed query. This change fixes a bug with the TTA history graph in the recipient record that combines data from two sources: a direct query to our database and a managed query through our database relationship software.

## How to test
The TTA history page loads correctly

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [x] QA review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [x] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
