### PR TITLE
[TTAHUB-3808] remove irrelevant bullets from supporting attachments

### DIFF
--- a/frontend/src/components/SupportAttachmentsSessionOrCommunication.js
+++ b/frontend/src/components/SupportAttachmentsSessionOrCommunication.js
@@ -16,6 +16,7 @@ const SupportingAttachmentsSessionOrCommunication = ({
   visitedFieldName,
   handleDelete,
   idKey,
+  children,
 }) => {
   const [fileError, setFileError] = useState();
   const { register } = useFormContext();
@@ -31,17 +32,7 @@ const SupportingAttachmentsSessionOrCommunication = ({
       <Fieldset className="smart-hub--report-legend margin-top-4">
         <FormGroup error={fileError}>
           <div id="attachments" />
-          <Label className="margin-top-0" htmlFor="files">
-            Upload any relevant attachments, such as:
-            <ul className="margin-top-0 padding-left-4">
-              <li>meetings agendas</li>
-              <li>services plans</li>
-              <li>sign-in or attendance sheets</li>
-              <li>other items not available online</li>
-              <li>other non-resource items not available online</li>
-            </ul>
-          </Label>
-
+          {children}
           <span className="usa-hint font-sans-3xs">Example: .doc, .pdf, .txt, .csv (max size 30 MB)</span>
           { fileError && (<ErrorMessage>{fileError}</ErrorMessage>)}
           <Controller
@@ -70,6 +61,21 @@ SupportingAttachmentsSessionOrCommunication.propTypes = {
   visitedFieldName: PropTypes.string.isRequired,
   handleDelete: PropTypes.func.isRequired,
   idKey: PropTypes.string.isRequired,
+  children: PropTypes.node,
+};
+
+SupportingAttachmentsSessionOrCommunication.defaultProps = {
+  children: (<Label className="margin-top-0" htmlFor="files">
+    Upload any relevant attachments, such as:
+    <ul className="margin-top-0 padding-left-4">
+      <li>meetings agendas</li>
+      <li>services plans</li>
+      <li>sign-in or attendance sheets</li>
+      <li>other items not available online</li>
+      <li>other non-resource items not available online</li>
+    </ul>
+    {/* eslint-disable-next-line react/jsx-closing-tag-location */}
+  </Label>),
 };
 
 export default SupportingAttachmentsSessionOrCommunication;

--- a/frontend/src/components/SupportAttachmentsSessionOrCommunication.js
+++ b/frontend/src/components/SupportAttachmentsSessionOrCommunication.js
@@ -29,8 +29,8 @@ const SupportingAttachmentsSessionOrCommunication = ({
         <title>Supporting Attachments</title>
       </Helmet>
       <input type="hidden" ref={register()} name={visitedFieldName} />
-      <Fieldset className="smart-hub--report-legend margin-top-4">
-        <FormGroup error={fileError}>
+      <Fieldset className="smart-hub--report-legend">
+        <FormGroup error={fileError} className="margin-top-0">
           <div id="attachments" />
           {children}
           <span className="usa-hint font-sans-3xs">Example: .doc, .pdf, .txt, .csv (max size 30 MB)</span>

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/supportingAttachments.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/supportingAttachments.js
@@ -6,6 +6,7 @@ import {
 import { pageComplete } from '../constants';
 import { deleteLogFile } from '../../../../../fetchers/File';
 import SupportingAttachmentsSessionOrCommunication from '../../../../../components/SupportAttachmentsSessionOrCommunication';
+import IndicatesRequiredField from '../../../../../components/IndicatesRequiredField';
 
 const path = 'supporting-attachments';
 const position = 2;
@@ -32,23 +33,26 @@ export default {
     _onFormSubmit,
     Alert,
   ) => (
-    <div className="padding-x-1">
-      <SupportingAttachmentsSessionOrCommunication
-        reportId={reportId}
-        visitedFieldName={visitedField}
-        handleDelete={deleteLogFile}
-        idKey="communicationLogId"
-      >
-        <Label className="margin-top-0" htmlFor="files">
-          Upload any relevant attachments
-        </Label>
-      </SupportingAttachmentsSessionOrCommunication>
-      <Alert />
-      <div className="display-flex">
-        <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>
-        <Button id={`${path}-back`} outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(position - 1); }}>Back</Button>
+    <>
+      <IndicatesRequiredField />
+      <div className="padding-x-1">
+        <SupportingAttachmentsSessionOrCommunication
+          reportId={reportId}
+          visitedFieldName={visitedField}
+          handleDelete={deleteLogFile}
+          idKey="communicationLogId"
+        >
+          <Label className="margin-top-0" htmlFor="files">
+            Upload any relevant attachments
+          </Label>
+        </SupportingAttachmentsSessionOrCommunication>
+        <Alert />
+        <div className="display-flex">
+          <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>
+          <Button id={`${path}-back`} outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(position - 1); }}>Back</Button>
+        </div>
       </div>
-    </div>
+    </>
   ),
   isPageComplete,
 };

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/supportingAttachments.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/supportingAttachments.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Button,
+  Label,
 } from '@trussworks/react-uswds';
 import { pageComplete } from '../constants';
 import { deleteLogFile } from '../../../../../fetchers/File';
@@ -37,7 +38,11 @@ export default {
         visitedFieldName={visitedField}
         handleDelete={deleteLogFile}
         idKey="communicationLogId"
-      />
+      >
+        <Label className="margin-top-0" htmlFor="files">
+          Upload any relevant attachments
+        </Label>
+      </SupportingAttachmentsSessionOrCommunication>
       <Alert />
       <div className="display-flex">
         <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>Save and continue</Button>

--- a/frontend/src/pages/SessionForm/pages/supportingAttachments.js
+++ b/frontend/src/pages/SessionForm/pages/supportingAttachments.js
@@ -40,7 +40,7 @@ export default {
       />
       <Alert />
       <div className="display-flex">
-        <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>{additionalData.status !== TRAINING_REPORT_STATUSES.COMPLETE ? 'Save and continue' : 'Continue' }</Button>
+        <Button id={`${path}-save-continue`} className="margin-right-1" type="button" disabled={isAppLoading} onClick={onContinue}>{additionalData.status !== TRAINING_REPORT_STATUSES.COMPLETE ? 'Save and continue' : 'Continue'}</Button>
         {
           // if status is 'Completed' then don't show the save draft button.
           additionalData
@@ -48,7 +48,7 @@ export default {
           && additionalData.status !== TRAINING_REPORT_STATUSES.COMPLETE && (
             <Button id={`${path}-save-draft`} className="usa-button--outline" type="button" disabled={isAppLoading} onClick={onSaveDraft}>Save draft</Button>
           )
-        }
+}
         <Button id={`${path}-back`} outline type="button" disabled={isAppLoading} onClick={() => { onUpdatePage(position - 1); }}>Back</Button>
       </div>
     </div>

--- a/frontend/src/pages/SessionForm/pages/supportingAttachments.js
+++ b/frontend/src/pages/SessionForm/pages/supportingAttachments.js
@@ -4,6 +4,7 @@ import { Button } from '@trussworks/react-uswds';
 import { deleteSessionSupportingAttachment } from '../../../fetchers/File';
 import { pageComplete, supportingAttachmentsVisitedField } from '../constants';
 import SupportingAttachmentsSessionOrCommunication from '../../../components/SupportAttachmentsSessionOrCommunication';
+import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
 
 const path = 'supporting-attachments';
 const position = 3;
@@ -32,6 +33,7 @@ export default {
     Alert,
   ) => (
     <div className="padding-x-1">
+      <IndicatesRequiredField />
       <SupportingAttachmentsSessionOrCommunication
         reportId={reportId}
         visitedFieldName={supportingAttachmentsVisitedField}


### PR DESCRIPTION
## Description of change

### Session report
![Screenshot 2025-02-10 at 9 47 04 AM](https://github.com/user-attachments/assets/21b5a15a-75ec-4761-97b5-31e7856d62e1)

### communication log
![Screenshot 2025-02-10 at 9 44 40 AM](https://github.com/user-attachments/assets/aa313d29-ca9a-4c27-a433-35cab07f95b8)

## How to test
- Confirm that the communication log supporting attachments file uploader label reads only "Upload any relevant attachments"
- Confirm that the recipient record supporting  attachments still has the various specific examples of what a support attachment might be

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3808


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
