### PR TITLE
Other TTA staff should be an optional field on the communication log

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/pages/log.js
@@ -18,7 +18,7 @@ import {
 } from '../constants';
 import ReadOnlyField from '../../../../../components/ReadOnlyField';
 import UserContext from '../../../../../UserContext';
-import { mustBeQuarterHalfOrWhole } from '../../../../../Constants';
+import { mustBeQuarterHalfOrWhole, NOOP } from '../../../../../Constants';
 import MultiSelect from '../../../../../components/MultiSelect';
 import LogContext from '../LogContext';
 
@@ -55,6 +55,7 @@ const Log = ({ datePickerKey }) => {
           name="otherStaff"
           id="otherStaff-label"
           htmlFor="otherStaff"
+          required={false}
         >
           <MultiSelect
             control={control}
@@ -62,9 +63,9 @@ const Log = ({ datePickerKey }) => {
             name="otherStaff"
             id="otherStaff"
             options={otherStaffOptions}
-            required="Select at least one"
             placeholderText="- Select -"
-            onClick={() => {}}
+            onClick={NOOP}
+            required={false}
           />
         </FormItem>
       </div>


### PR DESCRIPTION
## Description of change
We just got a support ticket saying the "other TTA staff" field in the Comm Log is required. It should be optional.


## How to test
Other TTA Staff, a field on the first page of the Communication Log, should be optional.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
