### PR TITLE
[TTAHUB-3718] Prevent and log error saving ARO topics

### DIFF
--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -134,7 +134,7 @@ export default function Objective({
     rules: {
       validate: {
         notEmpty: (value) => (value && value.length) || OBJECTIVE_TOPICS,
-        noNullId: (value) => value.every((topic) => topic.id !== null) || OBJECTIVE_TOPICS,
+        noNullId: (value) => value.every((topic) => topic.id) || OBJECTIVE_TOPICS,
       },
     },
     defaultValue: objective.topics,

--- a/frontend/src/pages/ActivityReport/Pages/components/Objective.js
+++ b/frontend/src/pages/ActivityReport/Pages/components/Objective.js
@@ -134,6 +134,7 @@ export default function Objective({
     rules: {
       validate: {
         notEmpty: (value) => (value && value.length) || OBJECTIVE_TOPICS,
+        noNullId: (value) => value.every((topic) => topic.id !== null) || OBJECTIVE_TOPICS,
       },
     },
     defaultValue: objective.topics,

--- a/src/services/reportCache.js
+++ b/src/services/reportCache.js
@@ -1,6 +1,7 @@
 import {
   processActivityReportObjectiveForResourcesById,
 } from './resource';
+import { auditLogger } from '../logger';
 
 const { Op } = require('sequelize');
 const {
@@ -107,7 +108,13 @@ export const cacheCourses = async (objectiveId, activityReportObjectiveId, cours
 };
 
 const cacheTopics = async (objectiveId, activityReportObjectiveId, topics = []) => {
-  const topicIds = topics.map((topic) => topic.id);
+  const topicIds = topics.map((topic) => {
+    if (!topic.id) {
+      auditLogger.error(`Error saving ARO topics: ${JSON.stringify(topics)} for objectiveId: ${objectiveId} and activityReportObjectiveId: ${activityReportObjectiveId}`);
+    }
+    return topic.id;
+  });
+
   const topicsSet = new Set(topicIds);
   const originalAROTopics = await ActivityReportObjectiveTopic.findAll({
     where: { activityReportObjectiveId },

--- a/src/services/reportCache.test.js
+++ b/src/services/reportCache.test.js
@@ -29,6 +29,7 @@ import {
   cacheGoalMetadata,
   cacheCourses,
   cacheCitations,
+  cacheTopics,
 } from './reportCache';
 import {
   createReport,
@@ -38,6 +39,7 @@ import {
   createGoal,
 } from '../testUtils';
 import { GOAL_STATUS } from '../constants';
+import { auditLogger } from '../logger';
 
 describe('cacheCourses', () => {
   let courseOne;
@@ -115,6 +117,21 @@ describe('cacheCourses', () => {
 
     expect(aroCourses).toHaveLength(1);
     expect(aroCourses[0].courseId).toEqual(courseTwo.id);
+  });
+});
+
+describe('cacheTopics', () => {
+  let mockAuditLoggerError;
+  beforeAll(() => {
+    mockAuditLoggerError = jest.spyOn(auditLogger, 'error').mockImplementation();
+  });
+  afterAll(() => {
+    mockAuditLoggerError.mockRestore();
+  });
+
+  it('logs and error when topics are missing ids', async () => {
+    await expect(cacheTopics(1, 1, [{ name: 'Topic 1', id: null }])).rejects.toThrow();
+    expect(mockAuditLoggerError).toHaveBeenCalledWith('Error saving ARO topics: [{"name":"Topic 1","id":null}] for objectiveId: 1 and activityReportObjectiveId: 1');
   });
 });
 


### PR DESCRIPTION
## Description of change

I was unable to reproduce this error so I think for now we can do two things:

1. Prevent submitting objective topics if the ID is null.
2. Log a more detailed error message in the terminal if it occurs again.

Hopefully these will let us narrow down if its a FE or BE issue.

## How to test

- Review the code
- Make sure you cant save an objective if the topic id is null (you might need to modify the FE options).
- Ensure there is no other info we should add to the audit logger.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3718


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
