### PR TITLE
[TTAHUB-3904] delete or update dupe and erroneous Goal stat changes

### DIFF
--- a/src/migrations/20250213000000-clean-false-status-changes.js
+++ b/src/migrations/20250213000000-clean-false-status-changes.js
@@ -1,0 +1,129 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      return queryInterface.sequelize.query(`
+        -- Remove extra GoalStatusChange entiries that:
+        --  - were inserted when Goals didn't actually change status
+        --  - are duplicate insertions of the same status change
+        -- Also update Goals that have the incorrect "oldStatus" value.
+        -- This appears to occur most often on the initial status change
+        -- for a Goal when an associated Objective is designated as
+        -- In Progress. Potentially that is also when the Goal was created
+
+        DROP TABLE IF EXISTS marked_changes;
+        CREATE TEMP TABLE marked_changes
+        AS
+        SELECT
+          id gscid,
+          "oldStatus" oldstat,
+          "newStatus" newstat,
+          LAG("newStatus") OVER (
+              PARTITION BY "goalId"
+              ORDER BY "createdAt", id
+          ) real_previous_status,
+          "newStatus" != COALESCE(
+            LAG("newStatus") OVER (
+              PARTITION BY "goalId"
+              ORDER BY "createdAt", id
+            ), 'NULL'
+          ) isrealchange
+        FROM "GoalStatusChanges" g
+        ORDER BY "createdAt"
+        ;
+
+        -- Complete the Objectives
+        DROP TABLE IF EXISTS deleted_gsc;
+        CREATE TEMP TABLE deleted_gsc
+        AS
+        WITH updater AS (
+        DELETE FROM "GoalStatusChanges"
+        USING marked_changes
+        WHERE id = gscid
+          AND NOT isrealchange
+        RETURNING id deleted_gscid
+        )
+        SELECT * FROM updater
+        ;
+
+        -- Complete the Goals
+        DROP TABLE IF EXISTS updated_gsc;
+        CREATE TEMP TABLE updated_gsc
+        AS
+        WITH nowtime AS (SELECT NOW() nowts)
+        , updater AS (
+        UPDATE "GoalStatusChanges"
+        SET
+          "updatedAt" = nowts,
+          "oldStatus" = real_previous_status
+        FROM marked_changes
+        CROSS JOIN nowtime
+        WHERE id = gscid
+          AND COALESCE("oldStatus",'NULL') != COALESCE(real_previous_status,'NULL')
+        RETURNING id updated_gscid
+        )
+        SELECT * FROM updater
+        ;
+
+        DROP TABLE IF EXISTS remarked_changes;
+        CREATE TEMP TABLE remarked_changes
+        AS
+        SELECT
+          id gscid,
+          "oldStatus" oldstat,
+          "newStatus" newstat,
+          LAG("newStatus") OVER (
+              PARTITION BY "goalId"
+              ORDER BY "createdAt", id
+          ) real_previous_status,
+          "newStatus" != COALESCE(
+            LAG("newStatus") OVER (
+              PARTITION BY "goalId"
+              ORDER BY "createdAt", id
+            ), 'NULL'
+          ) isrealchange
+        FROM "GoalStatusChanges" g
+        ORDER BY "createdAt"
+        ;
+        
+
+        -- Check the math in the total_records column. same_statuses is just context.
+        -- needs_update and needs_delete should also match up and end 0
+        SELECT
+          1 ord,
+          COUNT(*) total_records,
+          COUNT(*) FILTER (WHERE oldstat = newstat) same_statuses,
+          COUNT(*) FILTER (WHERE isrealchange AND COALESCE(oldstat,'NULL') != COALESCE(real_previous_status,'NULL')) needs_update,
+          COUNT(*) FILTER (WHERE NOT isrealchange) needs_delete
+        FROM marked_changes
+        GROUP BY 1
+        UNION
+        SELECT
+          2 ord,
+          -(SELECT COUNT(*) FROM deleted_gsc),
+          NULL,
+          -(SELECT COUNT(*) FROM updated_gsc),
+          -(SELECT COUNT(*) FROM deleted_gsc)
+        UNION
+        SELECT
+          3 ord,
+          COUNT(*) total_records,
+          COUNT(*) FILTER (WHERE oldstat = newstat) same_statuses,
+          COUNT(*) FILTER (WHERE isrealchange AND COALESCE(oldstat,'NULL') != COALESCE(real_previous_status,'NULL'))  needs_update,
+          COUNT(*) FILTER (WHERE NOT isrealchange) needs_delete
+        FROM remarked_changes
+        GROUP BY 1
+        ORDER BY 1
+        ;
+      `);
+    });
+  },
+
+  async down() {
+    // no rollbacks
+  },
+};


### PR DESCRIPTION
## Description of change

This checks what the actual previous `newStatus` was prior to each `GoalStatusChanges` record to determine: 
 - if the record is a duplicate and
 - if `GoalStatusChanges.oldstatus` accurately reflects the previous status.
 
Duplicates are deleted and inaccurate non-duplicates are updated

## How to test

There are temp tables to inspect and a validation query at the end where the number math should balance and look something like:
```
 ord | total_records | same_statuses | needs_update | needs_delete
-----+---------------+---------------+--------------+--------------
   1 |        242489 |         76541 |        29104 |        77609
   2 |        -77609 |               |       -29104 |       -77609
   3 |        164880 |             0 |            0 |            0
   ```

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3904


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
