### PR TITLE
Remove scheduled env shutdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1941,24 +1941,6 @@ workflows:
           env_state: "<< pipeline.parameters.env_state >>"
           env_list: "<< pipeline.parameters.env_list >>"
   monitor_and_shutdown_envs:
-    triggers:
-      # Every 15 minutes from 11 AM to 11:59 PM UTC (6 AM to 6:59 PM EST, 3 AM to 3:59 PM PST), Monday to Friday
-      - schedule:
-          cron: "0,15,30,45 11-23 * * 1-5"
-          filters:
-            branches:
-              only:
-                - main
-                - TTAHUB-3071/shutdown-unutilized-envs
-
-      # Every 15 minutes from 12 AM to 12:45 AM UTC (7 PM to 8:45 PM EST, 4 PM to 5:45 PM PST), Monday to Friday
-      - schedule:
-          cron: "0,15,30,45 0-3 * * 2-6"
-          filters:
-            branches:
-              only:
-                - main
-                - TTAHUB-3071/shutdown-unutilized-envs
     jobs:
       - manage_env_apps:
           env_state: "stop"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1941,6 +1941,8 @@ workflows:
           env_state: "<< pipeline.parameters.env_state >>"
           env_list: "<< pipeline.parameters.env_list >>"
   monitor_and_shutdown_envs:
+    when:
+      equal: [true, << pipeline.parameters.manual-trigger >>]
     jobs:
       - manage_env_apps:
           env_state: "stop"


### PR DESCRIPTION
## Description of change

Remove the scheduled shutdown of environments (at least for now).  Currently, lower-level environments are checked for inactivity and shut down automatically each day.  This has resulted in an engineer needing to go in and manually spin up sandbox and/or staging environments almost every day, as they are still being requested for use in testing by others.

After potentially reworking the current dev environment deploy approach, may want to revisit automated shutdown, but for now it seems to be causing more problems than it solves.  The current job can still be run manually via CircleCI if desired.

## How to test

Open to suggestions.  I only just realized that while I have read access in CircleCI, I am lacking ability to trigger pipelines manually or view parameters, so my visibility is limited.

## Issue(s)

N/A

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
