### PR TITLE
[TTAHBU-3815] Update color of remove 'x' to meet accessibility contrast

### DIFF
--- a/frontend/src/components/MultiSelect.js
+++ b/frontend/src/components/MultiSelect.js
@@ -86,6 +86,12 @@ export const styles = (singleRowInput = null) => ({
     ...provided,
     zIndex: 2,
   }),
+  multiValueRemove: (provided) => ({
+    ...provided,
+    '&:hover': {
+      color: '#1B1B1B',
+    },
+  }),
 });
 function MultiSelect({
   name,

--- a/frontend/src/components/selectOptionsReset.js
+++ b/frontend/src/components/selectOptionsReset.js
@@ -50,6 +50,12 @@ const selectOptionsReset = {
   valueContainer: (provided) => ({
     ...provided,
   }),
+  multiValueRemove: (provided) => ({
+    ...provided,
+    '&:hover': {
+      color: '#1B1B1B',
+    },
+  }),
 };
 
 export default selectOptionsReset;


### PR DESCRIPTION
## Description of change

This ticket updates the color of the remove 'x' for individual items in react select.

New color should be: #1B1B1B

![image](https://github.com/user-attachments/assets/015ddb6a-668e-4f6e-b475-c80aa399ec50)


## How to test

- Review the change
- Test it on various pages AR summary, objectives, TR, etc.
- Make sure we didn't miss any locations


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3815


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [x] Update JIRA ticket status
