### PR TITLE
[TTAHUB-3917] Support case: objective endDate comparison bug

### DIFF
--- a/src/services/recipient.js
+++ b/src/services/recipient.js
@@ -433,8 +433,8 @@ export function reduceObjectivesForRecipientRecord(
           endDate: !accumulated.endDate
             || (currentReport.endDate
               && new Date(currentReport.endDate) < new Date(accumulated.endDate))
-            ? currentReport.endDate
-            : accumulated.endDate,
+            ? accumulated.endDate
+            : currentReport.endDate,
         }),
         { reportTopics: [], reportReasons: [], endDate: null },
       );


### PR DESCRIPTION
## Description of change

This PR:

https://github.com/HHS/Head-Start-TTADP/pull/2591/files#diff-c7f2b62c6b1b387d70a5955d99b5044f83b2feaddf7662b8c1321294440a5177R428

Accidentally flipped the assignment to endDate in the date comparison. This PR just flips it back. The way this bug presents itself is with an incorrect endDate in the goal card on the RTR, as outlined in the support request.

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3917


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
