### PR TITLE
[TTAHUB-3813] A11y review: checkbox labels on HorizontalTableWidget

### DIFF
--- a/frontend/src/widgets/HorizontalTableWidget.js
+++ b/frontend/src/widgets/HorizontalTableWidget.js
@@ -227,7 +227,7 @@ export default function HorizontalTableWidget(
                 {
                   enableCheckboxes && (
                     <td className="width-8 checkbox-column" data-label="Select report">
-                      <Checkbox id={r.id} label="" value={r.id} checked={checkboxes[r.id] || false} onChange={handleReportSelect} aria-label={`Select ${r.title}`} />
+                      <Checkbox id={r.id} label="" value={r.id} checked={checkboxes[r.id] || false} onChange={handleReportSelect} aria-label={`Select ${r.title || r.heading}`} />
                     </td>
                   )
                 }

--- a/frontend/src/widgets/__tests__/HorizontalTableWidget.js
+++ b/frontend/src/widgets/__tests__/HorizontalTableWidget.js
@@ -446,18 +446,18 @@ describe('Horizontal Table Widget', () => {
             value: '17',
           },
         ],
-      }
+      },
     ];
 
     renderHorizontalTableWidget(
-      headers, 
-      data, 
-      'First Heading', 
-      false, 
-      'Last Heading', 
-      {}, 
-      {}, 
-      true // enableCheckboxes
+      headers,
+      data,
+      'First Heading',
+      false,
+      'Last Heading',
+      {},
+      {},
+      true, // enableCheckboxes
     );
 
     // Check the "select all" checkbox

--- a/frontend/src/widgets/__tests__/HorizontalTableWidget.js
+++ b/frontend/src/widgets/__tests__/HorizontalTableWidget.js
@@ -433,4 +433,39 @@ describe('Horizontal Table Widget', () => {
     expect(screen.getAllByText(/-/i)[0]).toBeInTheDocument();
     expect(screen.getAllByText(/19/i)[0]).toBeInTheDocument();
   });
+
+  it('renders checkboxes with proper aria-labels', async () => {
+    const headers = ['col1'];
+    const data = [
+      {
+        heading: 'Test Recipient',
+        id: '123',
+        data: [
+          {
+            title: 'col1',
+            value: '17',
+          },
+        ],
+      }
+    ];
+
+    renderHorizontalTableWidget(
+      headers, 
+      data, 
+      'First Heading', 
+      false, 
+      'Last Heading', 
+      {}, 
+      {}, 
+      true // enableCheckboxes
+    );
+
+    // Check the "select all" checkbox
+    const selectAllCheckbox = screen.getByLabelText('Select or de-select all');
+    expect(selectAllCheckbox).toBeInTheDocument();
+
+    // Check the row checkbox
+    const rowCheckbox = screen.getByLabelText('Select Test Recipient');
+    expect(rowCheckbox).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Description of change

The HorizontalTableWidget was rendering checkboxes, expecting a `title` property to be provided. This PR just falls back to the `heading` property, which should be provided in all cases.

This also fixes TTAHUB-3814.

## How to test

- Go to http://localhost:3000/dashboards/qa-dashboard/recipients-with-no-tta
- Make sure the checkboxes in the table have valid aria-label values.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3813
* https://jira.acf.gov/browse/TTAHUB-3814


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
