### PR TITLE
[TTAHUB-3816] A11y review: tooltip should be keyboard accessible

### DIFF
--- a/frontend/src/components/FiltersNotApplicable.js
+++ b/frontend/src/components/FiltersNotApplicable.js
@@ -1,17 +1,21 @@
 import React from 'react';
-import { Tooltip as TrussWorksToolTip } from '@trussworks/react-uswds';
 import {
   faQuestionCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import colors from '../colors';
+import Tooltip from './Tooltip';
 
 const FiltersNotApplicable = () => (
   <>
     <span className="ttahub-filters-not-applicable font-sans-xs margin-right-1"> - Filters not applied</span>
-    <TrussWorksToolTip className="usa-button--unstyled smart-hub--overview-tool-tip" id="filter-not-applicable" label="One or more of the selected filters cannot be applied to this data.">
-      <FontAwesomeIcon icon={faQuestionCircle} color={colors.ttahubMediumBlue} />
-    </TrussWorksToolTip>
+    <Tooltip
+      displayText={<FontAwesomeIcon icon={faQuestionCircle} color={colors.ttahubMediumBlue} size="lg" />}
+      tooltipText="One or more of the selected filters cannot be applied to this data."
+      buttonLabel="Show filter information"
+      hideUnderline
+      className="smart-hub--overview-tool-tip"
+    />
   </>
 );
 

--- a/frontend/src/components/Tooltip.js
+++ b/frontend/src/components/Tooltip.js
@@ -28,7 +28,7 @@ export default function Tooltip({
 
   return (
     <span className={cssClasses} data-testid="tooltip">
-      <div aria-hidden="true" className={`usa-tooltip__body usa-tooltip__body--${position} maxw-card-lg`}>{tooltipText}</div>
+      <div aria-hidden="true" className={`usa-tooltip__body usa-tooltip__body--${position}`}>{tooltipText}</div>
       <button type="button" className={`usa-button usa-button--unstyled ${buttonClassName}`} onClick={onClick}>
         <span className="smart-hub--ellipsis">
           <span aria-hidden={!screenReadDisplayText}>

--- a/frontend/src/components/Tooltip.scss
+++ b/frontend/src/components/Tooltip.scss
@@ -48,8 +48,12 @@
     display: inline-block;
     line-height: 1;
     position: absolute;
-    transform: translateX(-25%);
+    transform: translateX(-50%);
+    left: 50%;
     white-space: normal;
+    min-width: 120px;
+    max-width: 300px;
+    width: max-content;
 
     &.usa-tooltip__body--top {
         bottom: 2.25rem;


### PR DESCRIPTION
## Description of change

We were not using our `<Tooltip>` component in the `<FiltersNotApplicable>` component. Our `<Tooltip>` component provides the behavior expected and outlined in TTAHUB-3816.

Some styles needed to be adjusted to prevent the tooltip body from being too narrow, because it was previously determining its own width based on the width of the trigger element (the icon in this case).

https://github.com/user-attachments/assets/ddc1f100-40eb-4ea6-89f2-d84c240429b0

It should still look good in other places:

https://github.com/user-attachments/assets/1ebcb84a-56b2-463b-9477-247b5d938bf1


## How to test

- Go to the QA dashboard
- Make sure you can toggle the tooltip with just the keyboard as many times as you want
- Make sure the tooltips still look good site-wide

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3816


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
