### PR TITLE
Revert OWASP ZAP fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1243,7 +1243,7 @@ jobs:
           command: ./bin/prod-style-server
       - run:
           name: Wait for Node.js server to start
-          command: ./bin/ping-server 8080 localhost /alive
+          command: ./bin/ping-server 8080
       - run:
           name: Wait for similarity_api to start
           command: ./bin/ping-server 9100 localhost /openapi.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,7 +787,7 @@ parameters:
     default: "all-eclkc-to-headstart-resource-updates"
     type: string
   sandbox_git_branch: # change to feature branch to test deployment
-    default: "TTAHUB-3772/TTAHUB-3773/TTAHUB-3774/TTAHUB-3775/commlog"
+    default: "jp/revert-owasp"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/src/app.js
+++ b/src/app.js
@@ -106,11 +106,7 @@ app.get(oauth2CallbackPath, cookieSession, async (req, res) => {
 });
 
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'dss') {
-  // Define an endpoint to be used in CI for healthcheck purposes.
-  // In other words, this is a way for us to tell if the server is up.
-  app.use('/alive', (req, res) => {
-    res.status(200).end();
-  });
+  app.use('*', serveIndex);
 }
 
 runCronJobs();


### PR DESCRIPTION
This reverts commit a11310fe17e5850e69f2be145c72c1370807c860, reversing changes made to 7219e2740dc35795f5450e0b14231769bb5ced15.

## Description of change

We need to rethink how to handle resolving this OWASP finding. The way I implemented it works fine locally and in CI, but breaks in higher environments.

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
