### PR TITLE
[TTAHUB-3788] Communication log form drawers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,7 +787,7 @@ parameters:
     default: "all-eclkc-to-headstart-resource-updates"
     type: string
   sandbox_git_branch: # change to feature branch to test deployment
-    default: "mb/TTAHUB-3808/communication-log-frontend"
+    default: "jp/TTAHUB-3788/comm-log-drawers"
     type: string
   prod_new_relic_app_id:
     default: "877570491"

--- a/frontend/src/components/CommunicationLog/pages/log.js
+++ b/frontend/src/components/CommunicationLog/pages/log.js
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { COMMUNICATION_METHODS, COMMUNICATION_PURPOSES, COMMUNICATION_RESULTS } from '@ttahub/common';
@@ -10,6 +10,8 @@ import {
   Dropdown,
   Textarea,
 } from '@trussworks/react-uswds';
+import Drawer from '../../../components/Drawer';
+import ContentFromFeedByTag from '../../../components/ContentFromFeedByTag';
 import { useFormContext } from 'react-hook-form';
 import IndicatesRequiredField from '../../IndicatesRequiredField';
 import FormItem from '../../FormItem';
@@ -36,6 +38,8 @@ const Log = ({
 
   const { user } = useContext(UserContext);
   const { regionalUsers, standardGoals } = useLogContext();
+  const purposeDrawerRef = useRef(null);
+  const resultDrawerRef = useRef(null);
   const communicationDate = watch('communicationDate');
   const authorName = watch('author.name');
   const isEditing = watch('isEditing');
@@ -156,7 +160,19 @@ const Log = ({
       </div>
       <div className="margin-top-2">
         <FormItem
-          label="Purpose of communication "
+          label={(
+            <>
+              Purpose of communication
+              {' '}
+              <button
+                type="button"
+                className="usa-button usa-button--unstyled margin-left-1"
+                ref={purposeDrawerRef}
+              >
+                Get help choosing a purpose
+              </button>
+            </>
+          )}
           name="purpose"
         >
           <Dropdown
@@ -200,7 +216,19 @@ const Log = ({
       </div>
       <div className="margin-top-2">
         <FormItem
-          label="Result"
+          label={(
+            <>
+              Result
+              {' '}
+              <button
+                type="button"
+                className="usa-button usa-button--unstyled margin-left-1"
+                ref={resultDrawerRef}
+              >
+                Get help choosing a result
+              </button>
+            </>
+          )}
           name="result"
           required
         >
@@ -217,6 +245,24 @@ const Log = ({
           </Dropdown>
         </FormItem>
       </div>
+
+      <Drawer
+        triggerRef={purposeDrawerRef}
+        stickyHeader
+        stickyFooter
+        title="Purpose guidance"
+      >
+        <ContentFromFeedByTag tagName="ttahub-commlog-purpose" />
+      </Drawer>
+
+      <Drawer
+        triggerRef={resultDrawerRef}
+        stickyHeader
+        stickyFooter
+        title="Result guidance"
+      >
+        <ContentFromFeedByTag tagName="ttahub-commlog-results" />
+      </Drawer>
     </>
   );
 };

--- a/frontend/src/components/CommunicationLog/pages/log.js
+++ b/frontend/src/components/CommunicationLog/pages/log.js
@@ -250,7 +250,7 @@ const Log = ({
         triggerRef={purposeDrawerRef}
         stickyHeader
         stickyFooter
-        title="Purpose guidance"
+        title="Purpose of communication"
       >
         <ContentFromFeedByTag tagName="ttahub-commlog-purpose" />
       </Drawer>

--- a/frontend/src/components/CommunicationLog/pages/log.js
+++ b/frontend/src/components/CommunicationLog/pages/log.js
@@ -10,9 +10,9 @@ import {
   Dropdown,
   Textarea,
 } from '@trussworks/react-uswds';
-import Drawer from '../../../components/Drawer';
-import ContentFromFeedByTag from '../../../components/ContentFromFeedByTag';
 import { useFormContext } from 'react-hook-form';
+import Drawer from '../../Drawer';
+import ContentFromFeedByTag from '../../ContentFromFeedByTag';
 import IndicatesRequiredField from '../../IndicatesRequiredField';
 import FormItem from '../../FormItem';
 import ControlledDatePicker from '../../ControlledDatePicker';

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
@@ -183,7 +183,7 @@ describe('CommunicationLogForm', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeView = screen.getAllByText(/purpose of communication/i)[0];
     const purposeDropdown = within(purposeView).getByRole('combobox');
     userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
@@ -239,7 +239,7 @@ describe('CommunicationLogForm', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeView = screen.getAllByText(/purpose of communication/i)[0];
     const purposeDropdown = within(purposeView).getByRole('combobox');
     userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 

--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLogForm/__tests__/index.js
@@ -9,6 +9,7 @@ import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
+import { COMMUNICATION_PURPOSES, COMMUNICATION_RESULTS } from '@ttahub/common';
 import UserContext from '../../../../../UserContext';
 import AppLoadingContext from '../../../../../AppLoadingContext';
 import { NOT_STARTED, COMPLETE } from '../../../../../components/Navigator/constants';
@@ -182,14 +183,16 @@ describe('CommunicationLogForm', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purpose = await screen.findByLabelText(/purpose of communication/i);
-    userEvent.selectOptions(purpose, 'General Check-In');
+    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeDropdown = within(purposeView).getByRole('combobox');
+    userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 
     const notes = await screen.findByLabelText(/notes/i);
     userEvent.type(notes, 'This is a note');
 
-    const result = await screen.findByLabelText(/result/i);
-    userEvent.selectOptions(result, 'Next Steps identified');
+    const resultView = screen.getAllByText(/result/i)[0];
+    const resultDropdown = within(resultView).getByRole('combobox');
+    userEvent.selectOptions(resultDropdown, COMMUNICATION_RESULTS[0]);
 
     const url = `${communicationLogUrl}/region/${REGION_ID}/recipient/${RECIPIENT_ID}`;
     fetchMock.post(url, {
@@ -236,14 +239,16 @@ describe('CommunicationLogForm', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purpose = await screen.findByLabelText(/purpose of communication/i);
-    userEvent.selectOptions(purpose, 'General Check-In');
+    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeDropdown = within(purposeView).getByRole('combobox');
+    userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 
     const notes = await screen.findByLabelText(/notes/i);
     userEvent.type(notes, 'This is a note');
 
-    const result = await screen.findByLabelText(/result/i);
-    userEvent.selectOptions(result, 'Next Steps identified');
+    const resultView = screen.getAllByText(/result/i)[0];
+    const resultDropdown = within(resultView).getByRole('combobox');
+    userEvent.selectOptions(resultDropdown, COMMUNICATION_RESULTS[0]);
 
     const url = `${communicationLogUrl}/region/${REGION_ID}/recipient/${RECIPIENT_ID}`;
     fetchMock.post(url, 500);

--- a/frontend/src/pages/RegionalCommunicationLog/__tests__/index.js
+++ b/frontend/src/pages/RegionalCommunicationLog/__tests__/index.js
@@ -140,7 +140,7 @@ describe('RegionalCommunicationLog', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeView = screen.getAllByText(/purpose of communication/i)[0];
     const purposeDropdown = within(purposeView).getByRole('combobox');
     userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 

--- a/frontend/src/pages/RegionalCommunicationLog/__tests__/index.js
+++ b/frontend/src/pages/RegionalCommunicationLog/__tests__/index.js
@@ -7,6 +7,7 @@ import {
 } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
+import { COMMUNICATION_PURPOSES, COMMUNICATION_RESULTS } from '@ttahub/common';
 import RegionalCommunicationLog from '..';
 import NetworkContext from '../../../NetworkContext';
 import AppLoadingContext from '../../../AppLoadingContext';
@@ -139,14 +140,16 @@ describe('RegionalCommunicationLog', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purpose = await screen.findByLabelText(/purpose of communication/i);
-    userEvent.selectOptions(purpose, 'New TTA request');
+    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeDropdown = within(purposeView).getByRole('combobox');
+    userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 
     const notes = await screen.findByLabelText(/notes/i);
     userEvent.type(notes, 'This is a note');
 
-    const result = await screen.findByLabelText(/result/i);
-    userEvent.selectOptions(result, 'Next Steps identified');
+    const resultView = screen.getAllByText(/result/i)[0];
+    const resultDropdown = within(resultView).getByRole('combobox');
+    userEvent.selectOptions(resultDropdown, COMMUNICATION_RESULTS[0]);
 
     const saveButton = screen.getByRole('button', { name: 'Save and continue' });
     userEvent.click(saveButton);
@@ -181,14 +184,16 @@ describe('RegionalCommunicationLog', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purpose = await screen.findByLabelText(/purpose of communication/i);
-    userEvent.selectOptions(purpose, 'New TTA request');
+    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeDropdown = within(purposeView).getByRole('combobox');
+    userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 
     const notes = await screen.findByLabelText(/notes/i);
     userEvent.type(notes, 'This is a note');
 
-    const result = await screen.findByLabelText(/result/i);
-    userEvent.selectOptions(result, 'Next Steps identified');
+    const resultView = screen.getAllByText(/result/i)[0];
+    const resultDropdown = within(resultView).getByRole('combobox');
+    userEvent.selectOptions(resultDropdown, COMMUNICATION_RESULTS[0]);
 
     const saveButton = screen.getByRole('button', { name: 'Save and continue' });
     userEvent.click(saveButton);

--- a/frontend/src/pages/RegionalCommunicationLog/__tests__/index.js
+++ b/frontend/src/pages/RegionalCommunicationLog/__tests__/index.js
@@ -184,7 +184,7 @@ describe('RegionalCommunicationLog', () => {
     const method = await screen.findByLabelText(/How was the communication conducted/i);
     userEvent.selectOptions(method, 'Phone');
 
-    const purposeView = screen.getByText(/purpose of communication/i);
+    const purposeView = screen.getAllByText(/purpose of communication/i)[0];
     const purposeDropdown = within(purposeView).getByRole('combobox');
     userEvent.selectOptions(purposeDropdown, COMMUNICATION_PURPOSES[0]);
 


### PR DESCRIPTION
## Description of change

Adds help drawers for the "purpose" and "results" form fields to the communication log form (regional and RTR).

## How to test

Open the drawer and make sure the content loads correctly.

https://github.com/user-attachments/assets/ada5151f-06bd-4b91-925e-b68c3da020d1


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3788


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
