### PR TITLE
[TTAHUB-3925] Restore previous status for suspended goals

### DIFF
--- a/src/migrations/20250224000000-bring-back-status-for-suspended.js
+++ b/src/migrations/20250224000000-bring-back-status-for-suspended.js
@@ -1,0 +1,30 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      return queryInterface.sequelize.query(`
+        -- As a result of the previous migration, we lost the ability to track
+        -- the status of Goals that are suspended. This migration will bring
+        -- that back for the suspended goals by correcting the status changes that were removed.
+
+        UPDATE "GoalStatusChanges" gsc
+        SET "oldStatus" = zal.old_row_data->>'oldStatus'
+        FROM "ZALGoalStatusChanges" zal
+        WHERE gsc.id = zal."data_id"
+          AND zal.old_row_data->>'oldStatus' IS NOT NULL
+          AND gsc."oldStatus" IS NULL
+          AND gsc."newStatus" = 'Suspended'
+          AND gsc."updatedAt" >= '2025-02-14 00:00:00'::timestamp
+          AND gsc."updatedAt" < '2025-02-15 00:00:00'::timestamp;
+      `);
+    });
+  },
+
+  async down() {
+    // no rollbacks
+  },
+};


### PR DESCRIPTION
## Description of change
A migration update on 2/14/25 inadvertently removed the ability to transition suspended goals back to their previous status. This also caused an issue where objectives could no longer be added to goals.

This PR resolves the issue by restoring the previous status from the audit log (ZALGoalStatusChanges), making sure that suspended goals can be correctly transitioned back.


## How to test
Without first running the migration and with the recent production snapshot, e.g. one from 2/21/25 available in keybase:
- impersonate the user mentioned in the JIRA
- navigate to the RTR and look for goal 94772
- note that the goal cannot be moved to "Not Started"
- run the migration
- verify that the goal can now be moved to "In Progress", it's previous status.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3925


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [n/a] QA review complete

### Before merge to main

- [n/a] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
