### PR TITLE
[TTAHUB-3858] Also soft-delete goals and objectives when report deleted

### DIFF
--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -589,7 +589,7 @@ export async function softDeleteReport(req, res) {
       return;
     }
 
-    await handleSoftDeleteReport(report, REPORT_STATUSES.DELETED);
+    await handleSoftDeleteReport(report);
     res.sendStatus(204);
   } catch (error) {
     await handleErrors(req, res, error, logContext);

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -24,6 +24,7 @@ import {
   createOrUpdate,
   activityReports,
   setStatus,
+  handleSoftDeleteReport,
   activityReportAlerts,
   activityReportByLegacyId,
   getDownloadableActivityReportsByIds,
@@ -588,7 +589,7 @@ export async function softDeleteReport(req, res) {
       return;
     }
 
-    await setStatus(report, REPORT_STATUSES.DELETED);
+    await handleSoftDeleteReport(report, REPORT_STATUSES.DELETED);
     res.sendStatus(204);
   } catch (error) {
     await handleErrors(req, res, error, logContext);

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -70,6 +70,7 @@ jest.mock('../../services/activityReports', () => ({
   getAllDownloadableActivityReports: jest.fn(),
   getDownloadableActivityReportsByIds: jest.fn(),
   activityReportsForCleanup: jest.fn(),
+  handleSoftDeleteReport: jest.fn(),
 }));
 
 jest.mock('../../services/objectives', () => ({
@@ -694,6 +695,7 @@ describe('Activity Report handlers', () => {
       ActivityReport.mockImplementation(() => ({
         canDelete: () => true,
       }));
+      activityReportAndRecipientsById.mockResolvedValue([report]);
       await softDeleteReport(request, mockResponse);
       expect(mockResponse.sendStatus).toHaveBeenCalledWith(204);
     });
@@ -702,6 +704,7 @@ describe('Activity Report handlers', () => {
       ActivityReport.mockImplementation(() => ({
         canDelete: () => false,
       }));
+      activityReportAndRecipientsById.mockResolvedValue([report]);
       await softDeleteReport(request, mockResponse);
       expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
     });

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -1083,13 +1083,14 @@ export async function handleSoftDeleteReport(report) {
     attributes: ['id'],
     where: {
       createdVia: 'activityReport',
+      id: {
+        [Op.in]: sequelize.literal(`(SELECT "goalId" FROM "ActivityReportGoals" args WHERE args."activityReportId" = ${report.id})`),
+      },
     },
     include: [{
       model: ActivityReportGoal,
       as: 'activityReportGoals',
-      where: {
-        activityReportId: report.id,
-      },
+      attributes: ['id', 'goalId'],
     }],
   })).filter((goal) => goal.activityReportGoals.length === 1).map((goal) => goal.id);
 

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -1078,7 +1078,7 @@ export async function setStatus(report, status) {
   return activityReportAndRecipientsById(report.id);
 }
 
-export async function handleSoftDeleteReport(report, status) {
+export async function handleSoftDeleteReport(report) {
   const goalsToCleanup = (await Goal.findAll({
     attributes: ['id'],
     where: {
@@ -1093,20 +1093,21 @@ export async function handleSoftDeleteReport(report, status) {
     }],
   })).filter((goal) => goal.activityReportGoals.length === 1).map((goal) => goal.id);
 
-  // these goals and objectives will also be soft-deleted
-  await Objective.destroy({
-    where: {
-      goalId: goalsToCleanup,
-    },
-  });
+  if (goalsToCleanup.length) {
+    // these goals and objectives will also be soft-deleted
+    await Objective.destroy({
+      where: {
+        goalId: goalsToCleanup,
+      },
+    });
 
-  await Goal.destroy({
-    where: {
-      id: goalsToCleanup,
-    },
-  });
-
-  return setStatus(report, status);
+    await Goal.destroy({
+      where: {
+        id: goalsToCleanup,
+      },
+    });
+  }
+  return setStatus(report, REPORT_STATUSES.DELETED);
 }
 
 /*

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -15,6 +15,9 @@ import db, {
   Role,
   UserRole,
   Program,
+  Goal,
+  Objective,
+  ActivityReportGoal,
 } from '../models';
 import {
   createOrUpdate,
@@ -33,11 +36,15 @@ import {
   activityReportsChangesRequestedByDate,
   activityReportsSubmittedByDate,
   activityReportsApprovedByDate,
+  handleSoftDeleteReport,
 } from './activityReports';
 import SCOPES from '../middleware/scopeConstants';
 
-import { createReport, destroyReport } from '../testUtils';
+import {
+  createGrant, createRecipient, createReport, destroyReport,
+} from '../testUtils';
 import { auditLogger } from '../logger';
+import { GOAL_STATUS } from '../constants';
 
 const RECIPIENT_ID = 30;
 const RECIPIENT_ID_SORTING = 31;
@@ -1953,6 +1960,79 @@ describe('Activity report service', () => {
         expect(authorDigest).toBeDefined();
         expect(authorDigest.id).toBe(report.id);
       });
+    });
+  });
+  describe('handleSoftDeleteReport', () => {
+    let user;
+    let report;
+    let recipient;
+    let grant;
+    let goal;
+
+    beforeAll(async () => {
+      user = await User.create({
+        ...mockUserFour,
+        hsesUserId: faker.datatype.string(10),
+        id: faker.datatype.number({ min: 90000 }),
+      });
+      recipient = await createRecipient({});
+      grant = await createGrant({ recipientId: recipient.id });
+
+      report = await ActivityReport.create({
+        ...submittedReport,
+        userId: user.id,
+        lastUpdatedById: user.id,
+        submissionStatus: REPORT_STATUSES.APPROVED,
+        calculatedStatus: REPORT_STATUSES.APPROVED,
+        activityRecipients: [{ activityRecipientId: grant.id }],
+      });
+      goal = await Goal.create({
+        name: 'Test Goal',
+        createdVia: 'activityReport',
+        grantId: grant.id,
+        status: GOAL_STATUS.NOT_STARTED,
+      });
+      await Objective.create({
+        title: 'Test Objective',
+        goalId: goal.id,
+        status: GOAL_STATUS.NOT_STARTED,
+      });
+      await ActivityReportGoal.create({
+        activityReportId: report.id,
+        goalId: goal.id,
+      });
+    });
+
+    afterAll(async () => {
+      await ActivityReportGoal.destroy({ where: { activityReportId: report.id }, force: false });
+      await Objective.destroy({ where: { goalId: goal.id }, force: true });
+      await Goal.destroy({ where: { id: goal.id }, force: true });
+      await ActivityReport.destroy({ where: { id: report.id }, force: true });
+      await Grant.destroy({ where: { id: grant.id }, force: true, individualHooks: true });
+      await Recipient.destroy({ where: { id: recipient.id }, force: true });
+      await User.destroy({ where: { id: user.id }, force: true });
+    });
+
+    it('soft deletes goals and objectives associated with the report', async () => {
+      expect(report.submissionStatus).toBe(REPORT_STATUSES.APPROVED);
+      await handleSoftDeleteReport(report);
+
+      const deletedObjectives = await Objective.findAll({
+        where: { goalId: goal.id },
+        paranoid: false,
+      });
+      const deletedGoals = await Goal.findAll({
+        where: { id: goal.id },
+        paranoid: false,
+      });
+
+      expect(report.submissionStatus).toBe(REPORT_STATUSES.DELETED);
+      expect(deletedObjectives.length).toBe(1);
+      const [deletedObjective] = deletedObjectives;
+      expect(deletedObjective.deletedAt).not.toBeNull();
+      expect(deletedGoals.length).toBe(1);
+      const [deletedGoal] = deletedGoals;
+      expect(deletedGoal.deletedAt).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Description of change

Soft delete goals and objectives when report is soft deleted

## How to test
- Create a report, add a goal and objective (create new for both)
- Delete report, confirm goals and objectives are marked as deletedAt in the DB. (Right now, they are simply left hanging)

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3858


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
