### PR TITLE
Do not fail deploy on Slack notification error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,6 @@ commands:
 
             if [ "$ok" != "true" ]; then
               echo "Slack notification failed: $error"
-              exit 1
             else
               echo "Slack notification sent successfully"
             fi


### PR DESCRIPTION
## Description of change
During a recent Slack outage, it was noticed that failing to send to Slack will result in a failed deploy
Notification deemed important, but informational, and desire was for it not to fail the deploy
This change removes the explicit exit with non-zero return code which fails the job 
I have kept the error on missing parameters (above), as this indicates a job misconfiguration and can be fixed internally

## How to test
Not sure if possible unless Slack is experiencing an outage, however the change is only 1 line

## Issue(s)
N/A, see conversation [here](https://adhoc.slack.com/archives/C017Z3PC6MS/p1740595640898179)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
