### PR TITLE
[TTAHUB-3838] Buffer the min and max range on the horizontal bar chart

### DIFF
--- a/frontend/src/widgets/BarGraph.js
+++ b/frontend/src/widgets/BarGraph.js
@@ -54,7 +54,7 @@ function BarGraph({
 
   // We need to buffer the min range/scale otherwise we will cut off the smallest value.
   const minRange = Math.min(...counts);
-  const range = [minRange === 0 || minRange - 2 === 0 ? 0 : minRange - 2, Math.max(...counts) + 2];
+  const range = [minRange === 0 || minRange - 2 <= 0 ? 0 : minRange - 2, Math.max(...counts) + 2];
 
   const trace = {
     type: 'bar',

--- a/frontend/src/widgets/BarGraph.js
+++ b/frontend/src/widgets/BarGraph.js
@@ -52,9 +52,8 @@ function BarGraph({
     counts.push(dataPoint.count);
   });
 
-  // We need to buffer the min range/scale otherwise we will cut off the smallest value.
-  const minRange = Math.min(...counts);
-  const range = [minRange === 0 || minRange - 2 <= 0 ? 0 : minRange - 2, Math.max(...counts) + 2];
+  // Always start the bar at 0 so smaller values aren't hidden.
+  const range = [0, Math.max(...counts) + 2];
 
   const trace = {
     type: 'bar',

--- a/frontend/src/widgets/BarGraph.js
+++ b/frontend/src/widgets/BarGraph.js
@@ -52,7 +52,9 @@ function BarGraph({
     counts.push(dataPoint.count);
   });
 
-  const range = [Math.min(...counts), Math.max(...counts)];
+  // We need to buffer the min range/scale otherwise we will cut off the smallest value.
+  const minRange = Math.min(...counts);
+  const range = [minRange === 0 || minRange - 2 === 0 ? 0 : minRange - 2, Math.max(...counts) + 2];
 
   const trace = {
     type: 'bar',


### PR DESCRIPTION
## Description of change

The smallest value on the QA FEI root cause bar chart was being cutoff. The issue is that if we set the min value for this range to be the smallest value in the set it will never show that value. I have added a small buffer for the start and end of the range.

## How to test

- Review the code
- Ensure the smallest value in the graph shows a bar
- Check other widgets that use this component make sure we didn't break them

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3838


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
