### PR TITLE
[TTAHUB-3449] Only send e-mails to active users

### DIFF
--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -539,7 +539,7 @@ export const trCollaboratorAdded = async (
 ) => {
   if (process.env.CI) return;
   try {
-    const collaborator = await userById(newCollaboratorId);
+    const collaborator = await userById(newCollaboratorId, true);
     if (!collaborator) {
       throw new Error(`Unable to notify user with ID ${newCollaboratorId} that they were added as a collaborator to TR ${report.id}, a user with that ID does not exist`);
     }
@@ -587,7 +587,7 @@ export const trOwnerAdded = async (
 ) => {
   if (process.env.CI) return;
   try {
-    const owner = await userById(ownerId);
+    const owner = await userById(ownerId, true);
 
     // due to the way sequelize sends the JSON column :(
     const parsedData = safeParse(report); // parse the JSON string
@@ -881,7 +881,7 @@ export async function recipientApprovedDigest(freq, subjectFreq) {
     specialists = specialists.filter((s) => s !== null);
 
     const users = await Promise.all(
-      specialists.map(async (s) => userById(s.id)),
+      specialists.map(async (s) => userById(s.id, true)),
     );
 
     const records = users.map((user) => {
@@ -1064,7 +1064,7 @@ export async function trainingReportTaskDueNotifications(freq) {
       const { userId } = mail;
       let user = userMap.get(userId);
       if (!user) {
-        user = await userById(userId);
+        user = await userById(userId, true);
 
         if (!user) {
           return null;

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -500,7 +500,7 @@ export const trSessionCreated = async (event, sessionId) => {
     const reportPath = `${process.env.TTA_SMART_HUB_URI}/training-report/${eId}/session/${sessionId}`;
 
     await Promise.all(event.pocIds.map(async (id) => {
-      const user = await userById(id);
+      const user = await userById(id, true);
       const emailTo = filterAndDeduplicateEmails([user.email]);
 
       if (emailTo.length === 0) {
@@ -633,7 +633,7 @@ export const trEventComplete = async (
     const reportPath = `${process.env.TTA_SMART_HUB_URI}/training-report/view/${eId}`;
 
     const emails = await Promise.all(userIds.map(async (id) => {
-      const user = await userById(id);
+      const user = await userById(id, true);
       if (!user) return null;
       return user.email;
     }));

--- a/src/lib/mailer/index.test.js
+++ b/src/lib/mailer/index.test.js
@@ -28,6 +28,7 @@ import {
   trEventComplete,
   sendEmailVerificationRequestWithToken,
   recipientApprovedDigest,
+  frequencyToInterval,
 } from '.';
 import {
   EMAIL_ACTIONS,
@@ -1653,6 +1654,14 @@ describe('mailer tests', () => {
       await programSpecialistRecipientReportApprovedNotification(mockProgramSpecialist, mockReport);
       expect(auditLogger.error).toHaveBeenCalledTimes(1);
       expect(auditLogger.error.mock.calls[0][0].message).toContain('Error adding to queue');
+    });
+  });
+
+  describe('frequencyToInterval', () => {
+    it('returns the correct interval for every frequency', () => {
+      expect(frequencyToInterval(EMAIL_DIGEST_FREQ.DAILY)).toBe('NOW() - INTERVAL \'1 DAY\'');
+      expect(frequencyToInterval(EMAIL_DIGEST_FREQ.WEEKLY)).toBe('NOW() - INTERVAL \'1 WEEK\'');
+      expect(frequencyToInterval(EMAIL_DIGEST_FREQ.MONTHLY)).toBe('NOW() - INTERVAL \'1 MONTH\'');
     });
   });
 });

--- a/src/lib/mailer/trainingReportTaskDueNotifications.test.js
+++ b/src/lib/mailer/trainingReportTaskDueNotifications.test.js
@@ -896,8 +896,8 @@ describe('trainingReportTaskDueNotifications', () => {
     const emails = await trainingReportTaskDueNotifications(EMAIL_DIGEST_FREQ.DAILY);
 
     expect(emails).toEqual([null, null]);
-    expect(userById).toHaveBeenCalledWith(1);
-    expect(userById).toHaveBeenCalledWith(3);
+    expect(userById).toHaveBeenCalledWith(1, true);
+    expect(userById).toHaveBeenCalledWith(3, true);
   });
 
   it('return null if the user email is not found', async () => {
@@ -923,7 +923,7 @@ describe('trainingReportTaskDueNotifications', () => {
     const emails = await trainingReportTaskDueNotifications(EMAIL_DIGEST_FREQ.DAILY);
 
     expect(emails).toEqual([null, null]);
-    expect(userById).toHaveBeenCalledWith(1);
-    expect(userById).toHaveBeenCalledWith(3);
+    expect(userById).toHaveBeenCalledWith(1, true);
+    expect(userById).toHaveBeenCalledWith(3, true);
   });
 });

--- a/src/services/userSettings.js
+++ b/src/services/userSettings.js
@@ -165,8 +165,10 @@ export const usersWithSetting = async (key, values) => {
             required: false,
           },
         ],
-        where: { '$userSettingOverrides.id$': null },
-        '$permissions.scopeId$': SITE_ACCESS,
+        where: {
+          '$userSettingOverrides.id$': null,
+          '$permissions.scopeId$': SITE_ACCESS,
+        },
       });
     } else {
       // this is an override.

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -30,7 +30,19 @@ export const userAttributes = [
   'createdAt',
 ];
 
-export async function userById(userId) {
+export async function userById(userId, onlyActiveUsers = false) {
+  let permissionInclude = {
+    model: Permission,
+    as: 'permissions',
+    attributes: ['userId', 'scopeId', 'regionId'],
+  };
+
+  if (onlyActiveUsers) {
+    permissionInclude = {
+      ...permissionInclude,
+      where: { scopeId: SITE_ACCESS },
+    };
+  }
   return User.findOne({
     attributes: userAttributes,
     where: {
@@ -39,7 +51,9 @@ export async function userById(userId) {
       },
     },
     include: [
-      { model: Permission, as: 'permissions', attributes: ['userId', 'scopeId', 'regionId'] },
+      {
+        ...permissionInclude,
+      },
       { model: Role, as: 'roles' },
       { model: UserValidationStatus, as: 'validationStatus', attributes: ['userId', 'type', 'validatedAt'] },
     ],

--- a/src/services/users.test.js
+++ b/src/services/users.test.js
@@ -36,16 +36,63 @@ describe('Users DB service', () => {
         hsesUserId: '55',
         lastLogin: new Date(),
       });
+
+      // Active user.
+      await User.create({
+        id: 56,
+        name: 'user 56',
+        hsesUsername: 'user.56',
+        hsesUserId: '56',
+        lastLogin: new Date(),
+      });
+
+      await Permission.create({
+        userId: 56,
+        regionId: 14,
+        scopeId: SCOPES.SITE_ACCESS,
+      });
+
+      await Permission.create({
+        userId: 56,
+        regionId: 1,
+        scopeId: SCOPES.READ_REPORTS,
+      });
+
+      // In-active users.
+      await User.create({
+        id: 57,
+        name: 'user 57',
+        hsesUsername: 'user.57',
+        hsesUserId: '57',
+      });
+
+      await Permission.create({
+        userId: 57,
+        regionId: 1,
+        scopeId: SCOPES.READ_REPORTS,
+      });
     });
 
     afterEach(async () => {
-      await User.destroy({ where: { id: [54, 55] } });
+      await Permission.destroy({ where: { userId: [56, 57] } });
+      await User.destroy({ where: { id: [54, 55, 56, 57] } });
     });
 
     it('retrieves the correct user', async () => {
       const user = await userById(54);
       expect(user.id).toBe(54);
       expect(user.name).toBe('user 54');
+    });
+
+    it('retrieves user if they are active', async () => {
+      const user = await userById(56, true);
+      expect(user.id).toBe(56);
+      expect(user.name).toBe('user 56');
+    });
+
+    it('does not retrieve user if they are inactive', async () => {
+      const user = await userById(57, true);
+      expect(user).toBe(null);
     });
   });
 


### PR DESCRIPTION
## Description of change

This PR fixes a bug for the retrieval of the active users. It also ensures that the getUserById() only returns active users for the TR alerts.

## How to test

- Review the code
- Test e-mail sending for active / inactive user (for a variety of cases).

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3449


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
