### PR TITLE
[TTAHUB-3938] Prevent accessing non existent relation

### DIFF
--- a/src/goalServices/getGoalsForReport.ts
+++ b/src/goalServices/getGoalsForReport.ts
@@ -127,8 +127,10 @@ export default async function getGoalsForReport(reportId: number) {
                 required: false,
                 include: [
                   {
+                    attributes: ['id', 'name', 'mapsTo'],
                     model: Topic,
                     as: 'topic',
+                    paranoid: false,
                   },
                 ],
               },

--- a/src/goalServices/reduceGoals.test.ts
+++ b/src/goalServices/reduceGoals.test.ts
@@ -3,12 +3,6 @@ import {
   reduceRelationThroughActivityReportObjectives,
 } from './reduceGoals';
 
-import {
-  IObjectiveModelInstance,
-} from './types';
-
-type IAcceptableModelParameter = { [key: string]: any };
-
 describe('reduceGoals', () => {
   const goals = [
     {
@@ -367,20 +361,22 @@ describe('reduceGoals', () => {
     ]);
   });
   describe('reduceRelationThroughActivityReportObjectives', () => {
-    it('should merge existing relations with new ones while ensuring uniqueness', () => {
-      const objective: IObjectiveModelInstance = {
-        id: 101,
-        title: 'Test Objective',
-        status: 'Active',
-        goalId: 10,
-        onApprovedAR: false,
-        onAR: false,
-        rtrOrder: 1,
+    it('should handle null topic values without crashing', () => {
+      // Mock objective with an activity report that has a null topic
+      const objective = {
+        id: 243577,
         otherEntityId: null,
-        topics: [],
-        resources: [],
-        files: [],
-        courses: [],
+        goalId: 94169,
+        title: 'Objective Title',
+        status: 'In Progress',
+        objectiveTemplateId: 44484,
+        onAR: true,
+        onApprovedAR: true,
+        createdVia: 'activityReport',
+        rtrOrder: 1,
+        createdAt: new Date('2025-01-15T14:24:08.065Z'),
+        updatedAt: new Date('2025-01-15T14:48:11.857Z'),
+        deletedAt: null,
         activityReportObjectives: [
           {
             id: 1,
@@ -399,29 +395,44 @@ describe('reduceGoals', () => {
             ttaProvided: 'Training',
             closeSuspendReason: 'Completed',
             closeSuspendContext: 'Closed due to completion',
-            activityReportObjectiveResources: [
-              { key: 1, resource: { value: 'R1' } },
-              { key: 2, resource: { value: 'R2' } },
+            activityReportObjectiveResources: [],
+            activityReportObjectiveTopics: [
+              { topic: null }, // This simulates a topic that is null
+              { topic: { dataValues: { id: 73, name: 'Family Support Services' }, id: 73, name: 'Family Support Services' } }, // Valid topic
             ],
-            activityReportObjectiveTopics: [],
             activityReportObjectiveFiles: [],
             activityReportObjectiveCourses: [],
             activityReportObjectiveCitations: [],
             toJSON() { return this; },
+            dataValues: this,
           },
         ],
+        resources: [],
+        topics: [
+          { id: 82, name: 'Parent and Family Engagement' },
+        ],
+        files: [],
+        courses: [],
       };
-      const existingRelation = [{ value: 'R1' }];
+
+      const exists = {
+        topics: [
+          { id: 82, name: 'Parent and Family Engagement' }, // Pre-existing topic
+        ],
+      };
+
+      // Call the function
       const result = reduceRelationThroughActivityReportObjectives(
         objective,
-        'activityReportObjectiveResources',
-        'resource',
-        { resource: existingRelation },
-        'value',
+        'activityReportObjectiveTopics',
+        'topic',
+        exists,
       );
+
+      // Expected result should exclude null topics
       expect(result).toEqual([
-        { value: 'R1' }, // Existing
-        { value: 'R2' }, // New and Unique
+        { id: 82, name: 'Parent and Family Engagement' }, // Existing
+        { id: 73, name: 'Family Support Services' }, // From objective
       ]);
     });
   });

--- a/src/goalServices/reduceGoals.test.ts
+++ b/src/goalServices/reduceGoals.test.ts
@@ -1,6 +1,6 @@
 import {
   reduceGoals, reduceObjectivesForActivityReport,
-  reduceRelationThroughActivityReportObjectives
+  reduceRelationThroughActivityReportObjectives,
 } from './reduceGoals';
 
 import {
@@ -407,7 +407,7 @@ describe('reduceGoals', () => {
             activityReportObjectiveFiles: [],
             activityReportObjectiveCourses: [],
             activityReportObjectiveCitations: [],
-            toJSON: function () { return this; },
+            toJSON() { return this; },
           },
         ],
       };

--- a/src/goalServices/reduceGoals.test.ts
+++ b/src/goalServices/reduceGoals.test.ts
@@ -1,4 +1,13 @@
-import { reduceGoals, reduceObjectivesForActivityReport } from './reduceGoals';
+import {
+  reduceGoals, reduceObjectivesForActivityReport,
+  reduceRelationThroughActivityReportObjectives
+} from './reduceGoals';
+
+import {
+  IObjectiveModelInstance,
+} from './types';
+
+type IAcceptableModelParameter = { [key: string]: any };
 
 describe('reduceGoals', () => {
   const goals = [
@@ -356,5 +365,64 @@ describe('reduceGoals', () => {
         name: 'ANC - Citation 3 - Source 3',
       },
     ]);
+  });
+  describe('reduceRelationThroughActivityReportObjectives', () => {
+    it('should merge existing relations with new ones while ensuring uniqueness', () => {
+      const objective: IObjectiveModelInstance = {
+        id: 101,
+        title: 'Test Objective',
+        status: 'Active',
+        goalId: 10,
+        onApprovedAR: false,
+        onAR: false,
+        rtrOrder: 1,
+        otherEntityId: null,
+        topics: [],
+        resources: [],
+        files: [],
+        courses: [],
+        activityReportObjectives: [
+          {
+            id: 1,
+            objectiveId: 101,
+            activityReportId: 500,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            name: 'Activity Report Objective 1',
+            status: 'In Progress',
+            endDate: '2025-01-01',
+            isActivelyEdited: false,
+            source: 'Some Source',
+            arOrder: 1,
+            objectiveCreatedHere: false,
+            supportType: 'Technical Assistance',
+            ttaProvided: 'Training',
+            closeSuspendReason: 'Completed',
+            closeSuspendContext: 'Closed due to completion',
+            activityReportObjectiveResources: [
+              { key: 1, resource: { value: 'R1' } },
+              { key: 2, resource: { value: 'R2' } },
+            ],
+            activityReportObjectiveTopics: [],
+            activityReportObjectiveFiles: [],
+            activityReportObjectiveCourses: [],
+            activityReportObjectiveCitations: [],
+            toJSON: function () { return this; },
+          },
+        ],
+      };
+      const existingRelation = [{ value: 'R1' }];
+      const result = reduceRelationThroughActivityReportObjectives(
+        objective,
+        'activityReportObjectiveResources',
+        'resource',
+        { resource: existingRelation },
+        'value',
+      );
+      expect(result).toEqual([
+        { value: 'R1' }, // Existing
+        { value: 'R2' }, // New and Unique
+      ]);
+    });
   });
 });

--- a/src/goalServices/reduceGoals.test.ts
+++ b/src/goalServices/reduceGoals.test.ts
@@ -9,7 +9,6 @@ import {
 
 type IAcceptableModelParameter = { [key: string]: any };
 
-
 describe('reduceGoals', () => {
   const goals = [
     {

--- a/src/goalServices/reduceGoals.test.ts
+++ b/src/goalServices/reduceGoals.test.ts
@@ -9,6 +9,7 @@ import {
 
 type IAcceptableModelParameter = { [key: string]: any };
 
+
 describe('reduceGoals', () => {
   const goals = [
     {

--- a/src/goalServices/reduceGoals.ts
+++ b/src/goalServices/reduceGoals.ts
@@ -103,7 +103,7 @@ export function reduceObjectives(
    * @returns {Array} - The reduced relation array.
    */
 type IAcceptableModelParameter = ITopic | IResource | ICourse;
-const reduceRelationThroughActivityReportObjectives = (
+export const reduceRelationThroughActivityReportObjectives = (
   objective: IObjectiveModelInstance,
   join: string,
   relation: string,
@@ -111,16 +111,20 @@ const reduceRelationThroughActivityReportObjectives = (
   uniqueBy = 'id',
 ) => {
   const existingRelation = exists[relation] || [];
-  return uniqBy([
-    ...existingRelation,
-    ...(objective.activityReportObjectives
-        && objective.activityReportObjectives.length > 0
-      ? objective.activityReportObjectives[0][join]
-        .map((t: IAcceptableModelParameter) => t[relation].dataValues)
-        .filter((t: IAcceptableModelParameter) => t)
-      : []),
-  ], (e: string) => e[uniqueBy]);
-};
+  const newRelations = objective.activityReportObjectives?.[0]?.[join]
+    ? objective.activityReportObjectives[0][join]
+      .map((t: { [x: string]: any; }) => {
+        const extracted = t[relation];
+
+        return extracted?.dataValues ?? extracted;
+      })
+      .filter((t: any) => t)
+    : [];
+
+  const result = uniqBy([...existingRelation, ...newRelations], (e: any) => e?.[uniqueBy]);
+
+  return result;
+}
 
 export function reduceObjectivesForActivityReport(
   newObjectives: IObjectiveModelInstance[],

--- a/src/goalServices/reduceGoals.ts
+++ b/src/goalServices/reduceGoals.ts
@@ -124,7 +124,7 @@ export const reduceRelationThroughActivityReportObjectives = (
   const result = uniqBy([...existingRelation, ...newRelations], (e: any) => e?.[uniqueBy]);
 
   return result;
-}
+};
 
 export function reduceObjectivesForActivityReport(
   newObjectives: IObjectiveModelInstance[],

--- a/src/goalServices/reduceGoals.ts
+++ b/src/goalServices/reduceGoals.ts
@@ -97,11 +97,14 @@ export function reduceObjectives(
    * Reduces the relation through activity report objectives.
    *
    * This function extracts and deduplicates related entities (e.g., topics, resources, courses)
-   * from an `IObjectiveModelInstance` by traversing through its `activityReportObjectives` associations.
+   * from an `IObjectiveModelInstance` by traversing through its `activityReportObjectives`
+   * associations.
    * It ensures that both existing and newly found relations are merged while removing duplicates.
    *
-   * @param {IObjectiveModelInstance} objective - The objective containing activity report objectives.
-   * @param {string} join - The table name that joins the activity report objectives with the relation.
+   * @param {IObjectiveModelInstance} objective - The objective containing activity report
+   *                                              objectives.
+   * @param {string} join - The table name that joins the activity report objectives with the
+   *                        relation.
    *                        Example: 'activityReportObjectiveResources'.
    * @param {string} relation - The specific relation to extract. Example: 'resource'.
    * @param {Object} [exists={}] - The existing relations object.
@@ -117,17 +120,17 @@ export const reduceRelationThroughActivityReportObjectives = (
   uniqueBy = 'id',
 ) => {
   // Retrieve existing relation array (defaults to empty array)
-  const existingRelation = exists[relation] || [];
+  const existingRelation = exists[`${relation}s`] || [];
 
   // Extract new relations from the first activity report objective, if available.
   // Ensures the expected association (join) exists before mapping.
   const newRelations = objective.activityReportObjectives?.[0]?.[join]
     ? objective.activityReportObjectives[0][join]
-      .map((t: IAcceptableModelParameter) => t[relation]?.dataValues) // Extracts dataValues if present
+      .map((t: IAcceptableModelParameter) => t[relation]?.dataValues) // Gets dataValues if exist
       .filter((t: IAcceptableModelParameter) => t) // Removes null/undefined values
     : [];
 
-  // Combine existing and new relations while ensuring uniqueness based on the specified key.
+  // Combine existing and new relations ensuring uniqueness based on the specified key.
   const result = uniqBy([...existingRelation, ...newRelations], (e: string) => e?.[uniqueBy]);
 
   return result;


### PR DESCRIPTION
## Description of change
Addresses the errors in production related to the relation being undefined.


## How to test
Look at the code; make sure the tests pass

On main branch:
- restore any recent production backup. e.g. the one on 2/21/25 from Keybase or newer
- filter for report 51003
- observe that clicking on that report generates the error and that the goals are not loaded
- switch to this branch
- confirm that error is no longer happening and the goals section is visible

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3938


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [n/a] QA review complete

### Before merge to main

- [n/a] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
