### PR TITLE
Fix overflowing table cells in comm log

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/CommunicationLog.js
+++ b/frontend/src/pages/RecipientRecord/pages/CommunicationLog.js
@@ -203,11 +203,11 @@ export default function CommunicationLog({ regionId, recipientId }) {
             log.recipients && log.recipients.length > 1 ? <UsersIcon /> : null,
           data: [
             { title: 'Date', value: log.data.communicationDate },
-            { title: 'Purpose', value: log.data.purpose },
+            { title: 'Purpose', value: log.data.purpose, tooltip: true },
             { title: 'Goals', value: (log.data.goals || []).map((g) => g.label).join(', '), tooltip: true },
             { title: 'Creator name', value: log.authorName },
             { title: 'Other TTA staff', value: (log.data.otherStaff || []).map((u) => u.label).join(', '), tooltip: true },
-            { title: 'Result', value: log.data.result },
+            { title: 'Result', value: log.data.result, tooltip: true },
             { title: 'Recipient next steps', value: log.data.recipientNextSteps.map((s) => s.note).join(', '), hidden: true },
             { title: 'Specialist next steps', value: log.data.specialistNextSteps.map((s) => s.note).join(', '), hidden: true },
             { title: 'Files', value: log.files.map((f) => f.originalFileName).join(', '), hidden: true },

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/CommunicationLog.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/CommunicationLog.js
@@ -74,7 +74,7 @@ describe('CommunicationLog', () => {
     await act(() => waitFor(() => renderTest()));
     const tableCells = screen.getAllByRole('cell');
     const tableCellContents = tableCells.map((cell) => cell.textContent);
-    expect(tableCellContents).toContain('My purpose');
+    expect(tableCellContents).toContain('My purposeMy purpose');
   });
 
   it('formats the log correctly', async () => {

--- a/frontend/src/pages/RegionalCommunicationLogDashboard/components/RegionalCommLogTable.js
+++ b/frontend/src/pages/RegionalCommunicationLogDashboard/components/RegionalCommLogTable.js
@@ -170,11 +170,11 @@ export default function RegionalCommLogTable({ filters }) {
           data: [
             { title: 'Recipient', value: log.recipients.map((r) => r.name).join(', '), tooltip: true },
             { title: 'Date', value: log.data.communicationDate },
-            { title: 'Purpose', value: log.data.purpose },
+            { title: 'Purpose', value: log.data.purpose, tooltip: true },
             { title: 'Goals', value: (log.data.goals || []).map((g) => g.label).join(', '), tooltip: true },
             { title: 'Creator name', value: log.authorName },
             { title: 'Other TTA staff', value: (log.data.otherStaff || []).map((u) => u.label).join(', '), tooltip: true },
-            { title: 'Result', value: log.data.result },
+            { title: 'Result', value: log.data.result, tooltip: true },
           ],
           actions: log.userId === user.id ? [
             { label: 'View', onClick: () => handleRowActionClick('View', log, Number(log.data.regionId)) },


### PR DESCRIPTION
## Description of change

Fix this:

![screenshot of communication log table with overflowing text](https://github.com/user-attachments/assets/d97fc72f-af9c-4fea-9164-5d8562db97c2)


## How to test
View the comm log table with the "Program specialist or regional office" purpose and confirm that it doesn't overflow into the next cell 

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
