### PR TITLE
[SUPPORT] Fix joins to exclude findings without citations

### DIFF
--- a/src/services/monitoring.ts
+++ b/src/services/monitoring.ts
@@ -245,7 +245,6 @@ export async function ttaByReviews(
     citationsOnActivityReports,
     granteeIds,
   } = await extractExternalData(recipientId, regionId);
-
   const reviews = await MonitoringReview.findAll({
     order: [['reportDeliveryDate', 'DESC']],
     where: {
@@ -302,14 +301,17 @@ export async function ttaByReviews(
                   {
                     model: MonitoringFindingStandard,
                     as: 'monitoringFindingStandards',
+                    required: true,
                     include: [
                       {
                         model: MonitoringStandardLink,
                         as: 'standardLink',
+                        required: true,
                         include: [
                           {
                             model: MonitoringStandard,
                             as: 'monitoringStandards',
+                            required: true,
                           },
                         ],
                       },


### PR DESCRIPTION
## Description of change

Fix joins to exclude findings without citations

## How to test

Make sure that 'Santa Clara country office of education' only shows 5 total citations and no empty citations on the RTR monitoring review tab.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-support


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
