### PR TITLE
[TTAHUB-3960] Standard goals: new backend route for goal cards/RTTAPA page

### DIFF
--- a/src/middleware/canWriteReportsInRegionMiddleware.js
+++ b/src/middleware/canWriteReportsInRegionMiddleware.js
@@ -1,0 +1,28 @@
+import { auditLogger } from '../logger';
+import { currentUserId } from '../services/currentUser';
+import ActivityReportPolicy from '../policies/activityReport';
+import { userById } from '../services/users';
+
+/**
+ * @param {*} req - request
+ * @param {*} res - response
+ * @param {*} next - next middleware
+ */
+export default async function canWriteReportsInRegionMiddleware(req, res, next) {
+  // since auth middleware has already run, we know user ID is present and user has site access
+  const userId = await currentUserId(req, res);
+  const user = await userById(userId);
+
+  // we should only use this middleware after verifying the grant ID param is present
+  const { regionId } = req.params;
+
+  const policy = new ActivityReportPolicy(user, { regionId });
+
+  if (!policy.canWriteInRegion()) {
+    auditLogger.warn(`User ${userId} denied access to region ${regionId}`);
+    res.sendStatus(403);
+    return;
+  }
+
+  next();
+}

--- a/src/middleware/canWriteReportsInRegionMiddleware.test.js
+++ b/src/middleware/canWriteReportsInRegionMiddleware.test.js
@@ -1,0 +1,59 @@
+import canWriteReportsInRegionMiddleware from './canWriteReportsInRegionMiddleware';
+import { auditLogger } from '../logger';
+import { currentUserId } from '../services/currentUser';
+import ActivityReportPolicy from '../policies/activityReport';
+import { userById } from '../services/users';
+
+jest.mock('../logger');
+jest.mock('../services/currentUser');
+jest.mock('../policies/activityReport');
+jest.mock('../services/users');
+
+describe('canWriteReportsInRegionMiddleware', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = {
+      params: {
+        regionId: 1,
+      },
+    };
+    res = {
+      sendStatus: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call next if user can write reports in region', async () => {
+    currentUserId.mockResolvedValue(1);
+    userById.mockResolvedValue({ id: 1 });
+    ActivityReportPolicy.mockImplementation(() => ({
+      canWriteInRegion: () => true,
+    }));
+
+    await canWriteReportsInRegionMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.sendStatus).not.toHaveBeenCalled();
+  });
+
+  it('should send 403 if user cannot write reports in region', async () => {
+    currentUserId.mockResolvedValue(1);
+    userById.mockResolvedValue({ id: 1 });
+    ActivityReportPolicy.mockImplementation(() => ({
+      canWriteInRegion: () => false,
+    }));
+
+    await canWriteReportsInRegionMiddleware(req, res, next);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+    expect(auditLogger.warn).toHaveBeenCalledWith('User 1 denied access to region 1');
+  });
+});

--- a/src/routes/goalTemplates/handlers.test.js
+++ b/src/routes/goalTemplates/handlers.test.js
@@ -9,6 +9,7 @@ import {
   getStandardGoal,
   useStandardGoal,
   updateStandardGoal,
+  getStandardGoalsByRecipientId,
 } from './handlers';
 import {
   getCuratedTemplates,
@@ -20,6 +21,7 @@ import {
   goalForRtr,
   newStandardGoal,
   updateExistingStandardGoal,
+  standardGoalsForRecipient,
 } from '../../services/standardGoals';
 import { GOAL_STATUS } from '../../constants';
 
@@ -130,6 +132,51 @@ describe('goalTemplates handlers', () => {
       newStandardGoal.mockRejectedValue(new Error('error'));
 
       await useStandardGoal(req, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe('getStandardGoalsByRecipientId', () => {
+    it('handles success', async () => {
+      const req = {
+        params: {
+          regionId: 1,
+          recipientId: 1,
+        },
+        query: {
+          limit: 10,
+          offset: 0,
+          sortBy: 'createdAt',
+          sortDir: 'desc',
+        },
+      };
+
+      const goals = [{ id: 1, name: 'Goal 1' }];
+      standardGoalsForRecipient.mockResolvedValue(goals);
+
+      await getStandardGoalsByRecipientId(req, mockResponse);
+
+      expect(mockResponse.json).toHaveBeenCalledWith(goals);
+    });
+
+    it('handles errors', async () => {
+      const req = {
+        params: {
+          regionId: 1,
+          recipientId: 1,
+        },
+        query: {
+          limit: 10,
+          offset: 0,
+          sortBy: 'createdAt',
+          sortDir: 'desc',
+        },
+      };
+
+      standardGoalsForRecipient.mockRejectedValue(new Error('error'));
+
+      await getStandardGoalsByRecipientId(req, mockResponse);
 
       expect(mockResponse.status).toHaveBeenCalledWith(INTERNAL_SERVER_ERROR);
     });

--- a/src/routes/goalTemplates/handlers.ts
+++ b/src/routes/goalTemplates/handlers.ts
@@ -12,6 +12,7 @@ import {
   newStandardGoal,
   updateExistingStandardGoal,
   goalForRtr,
+  standardGoalsForRecipient,
 } from '../../services/standardGoals';
 
 export async function getStandardGoal(req: Request, res: Response) {
@@ -86,7 +87,7 @@ export async function updateStandardGoal(req: Request, res: Response) {
 
     res.json(standards);
   } catch (err) {
-    await handleErrors(req, res, err, 'goalTemplates.useStandardGoal');
+    await handleErrors(req, res, err, 'goalTemplates.updateStandardGoal');
   }
 }
 
@@ -145,5 +146,28 @@ export async function getOptionsByPromptName(req: Request, res: Response) {
     res.json(prompts);
   } catch (err) {
     await handleErrors(req, res, err, 'goalTemplates.getOptionsByPromptName');
+  }
+}
+
+export async function getStandardGoalsByRecipientId(req: Request, res: Response) {
+  try {
+    const { regionId, recipientId } = req.params;
+    const {
+      limit,
+      offset,
+      sortBy,
+      sortDir,
+    } = req.query;
+    const goals = await standardGoalsForRecipient(
+      Number(recipientId),
+      Number(regionId),
+      Number(limit),
+      Number(offset),
+      sortBy as 'createdOn' | 'goalStatus',
+      sortDir as 'ASC' | 'DESC',
+    );
+    res.json(goals);
+  } catch (err) {
+    await handleErrors(req, res, err, 'goalTemplates.getStandardGoalsByRecipientId');
   }
 }

--- a/src/routes/goalTemplates/handlers.ts
+++ b/src/routes/goalTemplates/handlers.ts
@@ -161,10 +161,12 @@ export async function getStandardGoalsByRecipientId(req: Request, res: Response)
     const goals = await standardGoalsForRecipient(
       Number(recipientId),
       Number(regionId),
-      Number(limit),
-      Number(offset),
-      sortBy as 'createdOn' | 'goalStatus',
-      sortDir as 'ASC' | 'DESC',
+      {
+        limit: Number(limit),
+        offset: Number(offset),
+        sortBy: sortBy as 'createdOn' | 'goalStatus',
+        sortDir: sortDir as 'ASC' | 'DESC',
+      },
     );
     res.json(goals);
   } catch (err) {

--- a/src/routes/goalTemplates/index.js
+++ b/src/routes/goalTemplates/index.js
@@ -9,8 +9,9 @@ import {
   useStandardGoal,
   updateStandardGoal,
   getStandardGoal,
+  getStandardGoalsByRecipientId,
 } from './handlers';
-import { checkGoalTemplateIdParam, checkGrantIdParam } from '../../middleware/checkIdParamMiddleware';
+import { checkGoalTemplateIdParam, checkGrantIdParam, checkRecipientIdParam, checkRegionIdParam } from '../../middleware/checkIdParamMiddleware';
 import canWriteReportsInGrantRegionMiddleware from '../../middleware/canWriteReportsInGrantRegionMiddleware';
 
 const router = express.Router();
@@ -33,6 +34,6 @@ router.put('/standard/:goalTemplateId/grant/:grantId', authMiddleware, checkGoal
 
 // eslint-disable-next-line max-len
 // future PR: get standard goals by recipient ID for the goal cards
-// router.get('/standard/recipient/:recipientId');
+router.get('/standard/recipient/:recipientId/region/regionId'), authMiddleware, checkRecipientIdParam, checkRegionIdParam, transactionWrapper(getStandardGoalsByRecipientId);
 
 export default router;

--- a/src/routes/goalTemplates/index.js
+++ b/src/routes/goalTemplates/index.js
@@ -11,8 +11,14 @@ import {
   getStandardGoal,
   getStandardGoalsByRecipientId,
 } from './handlers';
-import { checkGoalTemplateIdParam, checkGrantIdParam, checkRecipientIdParam, checkRegionIdParam } from '../../middleware/checkIdParamMiddleware';
+import {
+  checkGoalTemplateIdParam,
+  checkGrantIdParam,
+  checkRecipientIdParam,
+  checkRegionIdParam,
+} from '../../middleware/checkIdParamMiddleware';
 import canWriteReportsInGrantRegionMiddleware from '../../middleware/canWriteReportsInGrantRegionMiddleware';
+import canWriteReportsInRegionMiddleware from '../../middleware/canWriteReportsInRegionMiddleware';
 
 const router = express.Router();
 // get templates with goal usage for activity reports and for the "new goal" form in the RTR
@@ -33,7 +39,6 @@ router.post('standard/:goalTemplateId/grant/:grantId', authMiddleware, checkGoal
 router.put('/standard/:goalTemplateId/grant/:grantId', authMiddleware, checkGoalTemplateIdParam, checkGrantIdParam, canWriteReportsInGrantRegionMiddleware, transactionWrapper(updateStandardGoal));
 
 // eslint-disable-next-line max-len
-// future PR: get standard goals by recipient ID for the goal cards
-router.get('/standard/recipient/:recipientId/region/regionId'), authMiddleware, checkRecipientIdParam, checkRegionIdParam, transactionWrapper(getStandardGoalsByRecipientId);
+router.get('/standard/recipient/:recipientId/region/regionId', authMiddleware, checkRecipientIdParam, checkRegionIdParam, canWriteReportsInRegionMiddleware, transactionWrapper(getStandardGoalsByRecipientId));
 
 export default router;

--- a/src/services/standardGoal.test.js
+++ b/src/services/standardGoal.test.js
@@ -852,6 +852,8 @@ describe('standardGoal service', () => {
 
       const [goalOne, goalTwo] = goalRows;
 
+      // ======
+
       expect(goalOne.id).toBe(secondGoalForSecondTemplate.id);
       expect(goalOne.name).toBe(secondGoalTemplate.templateName);
       expect(goalOne.status).toBe(GOAL_STATUS.IN_PROGRESS);

--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { REPORT_STATUSES } from '@ttahub/common'; 
+import { REPORT_STATUSES } from '@ttahub/common';
 import { CREATION_METHOD, GOAL_STATUS } from '../constants';
 import db from '../models';
 import orderGoalsBy from '../lib/orderGoalsBy';

--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -1,13 +1,31 @@
 import { Op } from 'sequelize';
-import { GOAL_STATUS } from '../constants';
+import { REPORT_STATUSES } from '@ttahub/common'; 
+import { CREATION_METHOD, GOAL_STATUS } from '../constants';
 import db from '../models';
+import orderGoalsBy from '../lib/orderGoalsBy';
+import filtersToScopes from '../scopes';
+import goalStatusByGoalName from '../widgets/goalStatusByGoalName';
+
+const GOALS_PER_PAGE = 10;
 
 const {
+  sequelize,
   GoalTemplate,
   GoalTemplateFieldPrompt,
   GoalFieldResponse,
   Goal,
   Objective,
+  Grant,
+  ActivityReport,
+  ActivityReportObjective,
+  ActivityReportObjectiveCitation,
+  Topic,
+  GoalStatusChange,
+  User,
+  UserRole,
+  Role,
+  CollaboratorType,
+  GoalCollaborator,
 } = db;
 
 interface IObjective {
@@ -240,4 +258,202 @@ export async function updateExistingStandardGoal(
     grantId,
     standardGoalId,
   );
+}
+
+export async function standardGoalsForRecipient(
+  recipientId: number,
+  regionId: number,
+  {
+    sortBy = 'goalStatus',
+    sortDir = 'desc',
+    offset = 0,
+    limit = GOALS_PER_PAGE,
+    goalIds = [],
+    ...filters
+  },
+) {
+  const { goal: scopes } = await filtersToScopes(filters, {});
+
+  const { rows, count } = await Goal.findAndCountAll({
+    logging: console.log,
+    attributes: [
+      'id',
+      'name',
+      'status',
+      'createdAt',
+      [sequelize.literal(`
+        CASE
+          WHEN COALESCE("Goal"."status",'')  = '' OR "Goal"."status" = 'Needs Status' THEN 1
+          WHEN "Goal"."status" = 'Draft' THEN 2
+          WHEN "Goal"."status" = 'Not Started' THEN 3
+          WHEN "Goal"."status" = 'In Progress' THEN 4
+          WHEN "Goal"."status" = 'Closed' THEN 5
+          WHEN "Goal"."status" = 'Suspended' THEN 6
+          ELSE 7 END`),
+      'status_sort'],
+    ],
+    where: {
+      [Op.and]: [
+        ...scopes,
+        sequelize.where(
+          sequelize.col('Goal.id'),
+          'IN',
+          sequelize.literal(`(
+            SELECT MAX(g2.id)
+            FROM "Goals" g2
+            INNER JOIN "Grants" gr2 ON g2."grantId" = gr2.id
+            INNER JOIN "GoalTemplates" gt2 ON g2."goalTemplateId" = gt2.id
+            WHERE gr2."recipientId" = ${recipientId}
+            AND gr2."regionId" = ${regionId}
+            GROUP BY g2."goalTemplateId", g2."grantId"
+          )`),
+        ),
+      ],
+    },
+    include: [
+      {
+        model: GoalStatusChange,
+        as: 'statusChanges',
+        attributes: ['oldStatus'],
+        required: false,
+      },
+      {
+        model: GoalCollaborator,
+        as: 'goalCollaborators',
+        attributes: [],
+        required: false,
+        include: [
+          {
+            model: CollaboratorType,
+            as: 'collaboratorType',
+            required: true,
+            where: {
+              name: 'Creator',
+            },
+            attributes: ['name'],
+          },
+          {
+            model: User,
+            as: 'user',
+            attributes: ['name'],
+            required: true,
+            include: [
+              {
+                model: UserRole,
+                as: 'userRoles',
+                required: true,
+                include: [
+                  {
+                    model: Role,
+                    as: 'role',
+                    attributes: ['name'],
+                    required: true,
+                  },
+                ],
+                attributes: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        model: GoalFieldResponse,
+        as: 'responses',
+        required: false,
+        attributes: ['response', 'goalId'],
+      },
+      {
+        model: GoalTemplate,
+        as: 'goalTemplate',
+        attributes: [],
+        required: true,
+        where: {
+          creationMethod: CREATION_METHOD.CURATED,
+        },
+      },
+      {
+        required: true,
+        model: Grant,
+        as: 'grant',
+        attributes: [
+          'id',
+          'recipientId',
+          'regionId',
+          'number',
+        ],
+        where: {
+          regionId,
+          recipientId,
+        },
+      },
+      {
+        attributes: [
+          'id',
+          'title',
+          'status',
+          'goalId',
+          'onApprovedAR',
+        ],
+        model: Objective,
+        as: 'objectives',
+        required: false,
+        include: [
+          {
+            model: ActivityReportObjective,
+            as: 'activityReportObjectives',
+            attributes: ['id', 'objectiveId'],
+            required: false,
+            include: [
+              {
+                attributes: [
+                  'id',
+                  'endDate',
+                  'calculatedStatus',
+                  'regionId',
+                  'displayId',
+                ],
+                model: ActivityReport,
+                as: 'activityReport',
+                required: false,
+                where: {
+                  calculatedStatus: REPORT_STATUSES.APPROVED,
+                },
+              },
+              {
+                model: Topic,
+                as: 'topics',
+                attributes: ['name'],
+                required: false,
+              },
+              {
+                model: ActivityReportObjectiveCitation,
+                as: 'activityReportObjectiveCitations',
+                attributes: [
+                  'citation',
+                  'monitoringReferences',
+                ],
+                required: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    order: orderGoalsBy(sortBy, sortDir),
+  });
+
+  const ids = rows.map((r) => r.id);
+
+  const statuses = await goalStatusByGoalName({
+    goal: {
+      id: ids,
+    },
+  });
+
+  return {
+    count,
+    goalRows: rows,
+    statuses,
+    allGoalIds: ids,
+  };
 }


### PR DESCRIPTION
## Description of change
This is the new backend route that fetches data for the RTTAPA page. It is a partial rewrite of the existing function, streamlined to not rely on JavaScript. Note that I have changed the field names and data structure of what will be the goal cards, so when we attach it to a frontend, we will have to rework how the data is accessed.

## How to test
Confirm that all fields required by the design are present, that the test makes sense, and that the logic for fetching the goals is correct.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3960


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
