### PR TITLE
[TTAHUB-3967] Temporarily disable restoring processed database to staging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1888,12 +1888,13 @@ workflows:
       - process_backup:
           requires:
             - process_production
-      - restore_processed_to_staging:
-          requires:
-            - process_backup
+      # - restore_processed_to_staging:
+      #     requires:
+      #       - process_backup
       - restore_processed_to_sandbox:
           requires:
-            - restore_processed_to_staging
+            - process_backup
+            # - restore_processed_to_staging
       - restore_processed_to_dev:
           requires:
             - restore_processed_to_sandbox
@@ -1976,11 +1977,11 @@ workflows:
       - process_backup:
           requires:
             - process_production
-  manual_restore_staging:
-    when:
-      equal: [true, << pipeline.parameters.manual-restore-staging >>]
-    jobs:
-      - restore_processed_to_staging
+  # manual_restore_staging:
+  #   when:
+  #     equal: [true, << pipeline.parameters.manual-restore-staging >>]
+  #   jobs:
+  #     - restore_processed_to_staging
   manual_restore_sandbox:
     when:
       equal: [true, << pipeline.parameters.manual-restore-sandbox >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1670,26 +1670,26 @@ jobs:
           rds_service_name: ttahub-process
           s3_service_name: ttahub-db-backups
           backup_prefix: processed
-  restore_processed_to_staging:
-    docker:
-      - image: cimg/base:2024.05
-    steps:
-    - sparse_checkout:
-          directories: 'automation'
-          branch: << pipeline.git.branch >>
-    - cf_restore:
-          auth_client_secret: PROD_AUTH_CLIENT_SECRET
-          cloudgov_username: CLOUDGOV_PROD_USERNAME
-          cloudgov_password: CLOUDGOV_PROD_PASSWORD
-          cloudgov_space: CLOUDGOV_PROD_SPACE
-          rds_service_name: ttahub-staging
-          s3_service_name: ttahub-db-backups
-          backup_prefix: processed
-    - cf_migrate:
-          app_name: tta-smarthub-staging
-          cloudgov_username: CLOUDGOV_STAGING_USERNAME
-          cloudgov_password: CLOUDGOV_STAGING_PASSWORD
-          cloudgov_space: CLOUDGOV_STAGING_SPACE
+  # restore_processed_to_staging:
+  #   docker:
+  #     - image: cimg/base:2024.05
+  #   steps:
+  #   - sparse_checkout:
+  #         directories: 'automation'
+  #         branch: << pipeline.git.branch >>
+  #   - cf_restore:
+  #         auth_client_secret: PROD_AUTH_CLIENT_SECRET
+  #         cloudgov_username: CLOUDGOV_PROD_USERNAME
+  #         cloudgov_password: CLOUDGOV_PROD_PASSWORD
+  #         cloudgov_space: CLOUDGOV_PROD_SPACE
+  #         rds_service_name: ttahub-staging
+  #         s3_service_name: ttahub-db-backups
+  #         backup_prefix: processed
+  #   - cf_migrate:
+  #         app_name: tta-smarthub-staging
+  #         cloudgov_username: CLOUDGOV_STAGING_USERNAME
+  #         cloudgov_password: CLOUDGOV_STAGING_PASSWORD
+  #         cloudgov_space: CLOUDGOV_STAGING_SPACE
   restore_processed_to_sandbox:
     docker:
       - image: cimg/base:2024.05


### PR DESCRIPTION
## Description of change
This change temporarily disables the restore of the processed database to staging to allow for penetration testing setup and execution.


## How to test
Look at the change. This will be tested once merged.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3967


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [n/a] QA review complete

### Before merge to main

- [n/a] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
