### PR TITLE
[TTAHUB-3390] removeQueueEventHandlers undefined listeners

### DIFF
--- a/src/lib/queue.js
+++ b/src/lib/queue.js
@@ -98,18 +98,20 @@ export async function increaseListeners(queue, num = 1) {
 }
 
 // Remove event handlers
-function removeQueueEventHandlers(
+export function removeQueueEventHandlers(
   queue,
   errorListener,
   shutdownListener,
   exceptionListener,
   rejectionListener,
 ) {
-  queue.removeListener('error', errorListener);
-  process.removeListener('SIGINT', shutdownListener);
-  process.removeListener('SIGTERM', shutdownListener);
-  process.removeListener('uncaughtException', exceptionListener);
-  process.removeListener('unhandledRejection', rejectionListener);
+  if (errorListener) queue.removeListener('error', errorListener);
+  if (shutdownListener) {
+    process.removeListener('SIGINT', shutdownListener);
+    process.removeListener('SIGTERM', shutdownListener);
+  }
+  if (exceptionListener) process.removeListener('uncaughtException', exceptionListener);
+  if (rejectionListener) process.removeListener('unhandledRejection', rejectionListener);
 }
 
 // Define the handlers so they can be added and removed

--- a/src/lib/queue.test.js
+++ b/src/lib/queue.test.js
@@ -197,3 +197,28 @@ describe('newQueue', () => {
     );
   });
 });
+
+describe('removeQueueEventHandlers', () => {
+  it('safely handles removing event listeners when some are undefined', () => {
+    const mockQueue = {
+      removeListener: jest.fn(),
+    };
+
+    const originalProcessRemoveListener = process.removeListener;
+    process.removeListener = jest.fn();
+
+    // eslint-disable-next-line global-require
+    const { removeQueueEventHandlers } = require('./queue');
+
+    const errorListener = jest.fn();
+
+    // Call with some undefined listeners
+    removeQueueEventHandlers(mockQueue, errorListener, undefined, undefined, undefined);
+
+    // Verify it removes the defined listener but doesn't try to remove undefined ones
+    expect(mockQueue.removeListener).toHaveBeenCalledWith('error', errorListener);
+    expect(process.removeListener).not.toHaveBeenCalled();
+
+    process.removeListener = originalProcessRemoveListener;
+  });
+});


### PR DESCRIPTION
## Description of change

The function removeQueueEventHandlers was throwing TypeError [ERR_INVALID_ARG_TYPE] when called without listener arguments. This happened because queue closing functionality is intentionally disabled (commented out) in our handler functions, but we still need to safely remove event listeners in other parts of the code.

This change adds null checks before removing each listener, ensuring we don't try to remove undefined listeners. A test was also added to verify this behavior.

## How to test

A test was written for this behavior.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3390


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
