### PR TITLE
[NO-TICKET] Remove commlog feature flag guards for release

### DIFF
--- a/frontend/src/Routes.js
+++ b/frontend/src/Routes.js
@@ -311,9 +311,7 @@ export default function Routes({
           path="/communication-log"
           render={() => (
             <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
-              <FeatureFlag flag="multirecipient_communication_log" renderNotFound>
-                <RegionalCommunicationLogDashboard />
-              </FeatureFlag>
+              <RegionalCommunicationLogDashboard />
             </AppWrapper>
           )}
         />
@@ -371,9 +369,7 @@ export default function Routes({
           path="/communication-log/region/:regionId/log/:logId/view"
           render={({ match }) => (
             <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
-              <FeatureFlag flag="multirecipient_communication_log" renderNotFound>
-                <ViewRegionalCommunicationLog match={match} />
-              </FeatureFlag>
+              <ViewRegionalCommunicationLog match={match} />
             </AppWrapper>
           )}
         />
@@ -381,11 +377,9 @@ export default function Routes({
           exact
           path="/communication-log/region/:regionId/log/:logId/:currentPage?"
           render={() => (
-            <FeatureFlag flag="multirecipient_communication_log" renderNotFound>
-              <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
-                <RegionalCommunicationLog />
-              </AppWrapper>
-            </FeatureFlag>
+            <AppWrapper authenticated logout={logout} hasAlerts={!!(alert)}>
+              <RegionalCommunicationLog />
+            </AppWrapper>
           )}
         />
         <Route

--- a/frontend/src/components/SiteNav.js
+++ b/frontend/src/components/SiteNav.js
@@ -128,16 +128,14 @@ const SiteNav = ({
                       Activity Reports
                     </NavLink>
                   </li>
-                  <FeatureFlag flag="multirecipient_communication_log">
-                    <li>
-                      <NavLink
-                        withinDisclosure
-                        to="/communication-log"
-                      >
-                        Communication Log
-                      </NavLink>
-                    </li>
-                  </FeatureFlag>
+                  <li>
+                    <NavLink
+                      withinDisclosure
+                      to="/communication-log"
+                    >
+                      Communication Log
+                    </NavLink>
+                  </li>
                   <li>
                     <NavLink
                       withinDisclosure


### PR DESCRIPTION
## Description of change

We're releasing the communication log globally, so the feature flag guards can be removed.

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
