### PR TITLE
[TTAHUB-3996] Support case: session cannot be marked complete

### DIFF
--- a/src/models/hooks/sessionReportPilot.js
+++ b/src/models/hooks/sessionReportPilot.js
@@ -162,14 +162,10 @@ export const checkIfBothIstAndPocAreComplete = async (sequelize, instance, optio
       const previous = instance.previous('data') || null;
       const current = JSON.parse(instance.data.val) || null;
 
-      // Get vars in case they are not present.
       const currentOwnerComplete = current.ownerComplete || false;
       const currentPocComplete = current.pocComplete || false;
-      const previousOwnerComplete = previous.ownerComplete || false;
-      const previousPocComplete = previous.pocComplete || false;
 
-      if ((currentOwnerComplete && currentPocComplete)
-        && (!previousOwnerComplete || !previousPocComplete)) {
+      if (currentOwnerComplete && currentPocComplete && current.status !== TRAINING_REPORT_STATUSES.COMPLETE) {
         sequelize.models.SessionReportPilot.update({
           data: {
             ...current,

--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -133,7 +133,7 @@ describe('sessionReportPilot hooks', () => {
       }, { transaction: mockOptions.transaction });
     });
 
-    it('sets the SessionReportPilot status to complete if both owner and poc are complete', async () => {
+    it('does not set status to complete if only ownerComplete is true', async () => {
       const mockSessionUpdate = jest.fn();
       const mockSequelize = {
         models: {
@@ -143,36 +143,115 @@ describe('sessionReportPilot hooks', () => {
             })),
           },
           SessionReportPilot: {
-            // add a mock for update.
             update: mockSessionUpdate,
           },
         },
       };
       const instance = {
+        id: 123,
         eventId: 1,
         changed: jest.fn(() => ['data']),
         previous: jest.fn(() => ({
-          ownerComplete: true,
+          ownerComplete: false,
           pocComplete: false,
         })),
         data: {
           val: JSON.stringify({
             ownerComplete: true,
-            pocComplete: true,
+            pocComplete: false,
+            status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
           }),
         },
       };
 
       await checkIfBothIstAndPocAreComplete(mockSequelize, instance, mockOptions);
 
-      // Assert the data portion of the update call contains the correct status.
+      // Assert that update was not called since only ownerComplete is true
+      expect(mockSessionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does not set status to complete if already complete', async () => {
+      const mockSessionUpdate = jest.fn();
+      const mockSequelize = {
+        models: {
+          EventReportPilot: {
+            findOne: jest.fn(() => ({
+              update: mockUpdate,
+            })),
+          },
+          SessionReportPilot: {
+            update: mockSessionUpdate,
+          },
+        },
+      };
+      const instance = {
+        id: 123,
+        eventId: 1,
+        changed: jest.fn(() => ['data']),
+        // In this case, previous data is irrelevant, because...
+        previous: jest.fn(() => ({
+          ownerComplete: true,
+          pocComplete: false,
+          status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
+        })),
+        // ...the current data is authoritative.
+        data: {
+          val: JSON.stringify({
+            ownerComplete: true,
+            pocComplete: true,
+            status: TRAINING_REPORT_STATUSES.COMPLETE, // Already complete
+          }),
+        },
+      };
+
+      await checkIfBothIstAndPocAreComplete(mockSequelize, instance, mockOptions);
+
+      // Assert that update was not called since status is already COMPLETE
+      expect(mockSessionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('sets status to complete when both conditions are met and status is not complete', async () => {
+      const mockSessionUpdate = jest.fn();
+      const mockSequelize = {
+        models: {
+          EventReportPilot: {
+            findOne: jest.fn(() => ({
+              update: mockUpdate,
+            })),
+          },
+          SessionReportPilot: {
+            update: mockSessionUpdate,
+          },
+        },
+      };
+      const instance = {
+        id: 123,
+        eventId: 1,
+        changed: jest.fn(() => ['data']),
+        previous: jest.fn(() => ({
+          ownerComplete: false,
+          pocComplete: true,
+          status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
+        })),
+        data: {
+          val: JSON.stringify({
+            ownerComplete: true,
+            pocComplete: true,
+            status: TRAINING_REPORT_STATUSES.IN_PROGRESS, // Not complete yet
+          }),
+        },
+      };
+
+      await checkIfBothIstAndPocAreComplete(mockSequelize, instance, mockOptions);
+
+      // Assert that update was called to set status to COMPLETE
       expect(mockSessionUpdate).toHaveBeenCalledWith({
         data: {
           ownerComplete: true,
           pocComplete: true,
           status: TRAINING_REPORT_STATUSES.COMPLETE,
         },
-      }, { transaction: {}, where: { id: undefined } });
+      }, { transaction: {}, where: { id: 123 } });
     });
   });
 


### PR DESCRIPTION
## Description of change

The condition in the afterUpdate hook was a bit strange, and it has been improved.

## How to test

Tests were added to validate expected behavior, but...

- Get a processed data dump
- Try to submit the session in the linked issue
- Ensure it is marked 'Complete'
- Also, ensure you can still mark not-previously-submitted sessions as 'Complete'

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3996


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
