### PR TITLE
increase db restore timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,7 +707,7 @@ commands:
           task_args: '["<< parameters.backup_prefix >>", "<< parameters.rds_service_name >>", "<< parameters.s3_service_name >>"]'
           config: "<< parameters.backup_prefix >>-restore"
           success_message: ':database: "<< parameters.backup_prefix >>" Restored to "<< parameters.rds_service_name >>"'
-          timeout: "900"
+          timeout: "1800"
   cf_process:
     description: "Process database from S3"
     parameters:


### PR DESCRIPTION
## Description of change

Current db restore is failing due to a timeout of 15 minutes.
This appears to have been an arbitrary choice, so I am increasing the timeout to 30 min.

Example run here:
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/27435/workflows/6ad7232e-9675-43a0-aaed-c4a0d544c4a3/jobs/156439?invite=true#step-110-1142917_80

## How to test

This job only runs against the prod branch, so it's not easily testable, but the change is a one-liner increase to a static value

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
