### PR TITLE
Disabling auto-close of monitoring goals

### DIFF
--- a/src/tools/createMonitoringGoals.js
+++ b/src/tools/createMonitoringGoals.js
@@ -163,6 +163,7 @@ const createMonitoringGoals = async () => {
 
       // 3. Close monitoring goals that no longer have any active citations, un-approved reports,
       // or open Objectives
+      /* Commenting out as temporarily not-needed (See [TTAHUB-4049](https://jira.acf.gov/browse/TTAHUB-4049))
       const goalsToClose = await sequelize.query(`
       WITH
     grants_with_monitoring_goal AS (
@@ -258,6 +259,7 @@ const createMonitoringGoals = async () => {
           context: null,
         })));
       }
+      */
     });
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/tools/createMonitoringGoals.test.js
+++ b/src/tools/createMonitoringGoals.test.js
@@ -2533,11 +2533,11 @@ describe('createMonitoringGoals', () => {
     expect(goalChangeStatus12.userName).toBe('system');
     expect(goalChangeStatus12.reason).toBe('Active monitoring citations');
 
-    // CASE 13: Closes monitoring goal that no longer has any active citations.
+    // CASE 13: Does not auto-close monitoring goal that no longer has any active citations.
     const grant13Goals = await Goal.findAll({ where: { grantId: grantClosedMonitoringGoal13.id } });
     expect(grant13Goals.length).toBe(1);
     expect(grant13Goals[0].goalTemplateId).toBe(goalTemplate.id);
-    expect(grant13Goals[0].status).toBe('Closed');
+    expect(grant13Goals[0].status).toBe('Not started');
 
     // Ensure the correct GoalChangeStatus has been created.
     const goalChangeStatus13 = await GoalStatusChange.findOne({ where: { goalId: goalForClose13.id } });

--- a/src/tools/createMonitoringGoals.test.js
+++ b/src/tools/createMonitoringGoals.test.js
@@ -2433,7 +2433,7 @@ describe('createMonitoringGoals', () => {
     await sequelize.close();
   });
 
-  it('logs an error is the monitoring goal template doesn\'t exist', async () => {
+  it('logs an error if the monitoring goal template does not exist', async () => {
     // Get the current function for the GoalTemplate.findOne method and but it back later.
     const originalFindOne = GoalTemplate.findOne;
     // Mock the GoalTemplate.findOne method to return null.

--- a/src/tools/createMonitoringGoals.test.js
+++ b/src/tools/createMonitoringGoals.test.js
@@ -2539,6 +2539,7 @@ describe('createMonitoringGoals', () => {
     expect(grant13Goals[0].goalTemplateId).toBe(goalTemplate.id);
     expect(grant13Goals[0].status).toBe('Not started');
 
+    /* Commenting out temporarily since we're not auto-closing goals
     // Ensure the correct GoalChangeStatus has been created.
     const goalChangeStatus13 = await GoalStatusChange.findOne({ where: { goalId: goalForClose13.id } });
     expect(goalChangeStatus13).not.toBeNull();
@@ -2547,6 +2548,7 @@ describe('createMonitoringGoals', () => {
     expect(goalChangeStatus13.newStatus).toBe('Closed');
     expect(goalChangeStatus13.userName).toBe('system');
     expect(goalChangeStatus13.reason).toBe('No active monitoring citations');
+    */
 
     // CASE 14: Monitoring goal with no active citations but has a unapproved report (don't close).
     const grant14Goals = await Goal.findAll({ where: { grantId: grantToNotCloseMonitoringGoal14.id } });


### PR DESCRIPTION
## Description of change
Disabling auto-close of monitoring goals.


## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4049


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
