### PR TITLE
[TTAHUB-4077] Delete unwanted objective

### DIFF
--- a/src/migrations/20250421000000-delete-dupe-objective.js
+++ b/src/migrations/20250421000000-delete-dupe-objective.js
@@ -1,0 +1,26 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      await queryInterface.sequelize.query(/* sql */`
+        -- A user created a new objective as a correction of this one
+        -- It wasn't used but they don't have a way to delete it
+        UPDATE "Objectives" SET "deletedAt" = NOW() WHERE "id" = 256625 AND title LIKE 'TTA Specialists will%';
+    `, { transaction });
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      await queryInterface.sequelize.query(/* sql */`
+        UPDATE "Objectives" SET "deletedAt" = null WHERE "id" = 256625 AND title LIKE 'TTA Specialists will%';
+    `, { transaction });
+    });
+  },
+};


### PR DESCRIPTION
## Description of change

A user who wanted to correct the title of an Objective on a Goal ended up creating a (near) duplicate instead, but they don't currently have a way to remove the extra Objective. This PR is for removing the extra.

## How to test

Before this should get back one Objective, and after zero:
`SELECT COUNT(*) FROM "Objectives" WHERE "deletedAt" IS NULL AND title = 'TTA Specialists will provide foundational information on the Head Start Director role and responsibilities that include leadership development; systems to support program planning and staffing supports; program governance; and the five-year grant application process.';`

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4077

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
