### PR TITLE
Fix for misaligned support drawer link

### DIFF
--- a/frontend/src/components/ObjectiveSupportType.js
+++ b/frontend/src/components/ObjectiveSupportType.js
@@ -20,7 +20,7 @@ export default function ObjectiveSupportType({
       <SupportTypeDrawer
         drawerTriggerRef={supportTypeDrawerTriggerRef}
       />
-      <div className="display-flex">
+      <div className="display-flex flex-align-start">
         <Label htmlFor={inputName}>
           Support type
           <Req />


### PR DESCRIPTION
## Description of change
Fixes a misaligned link for the "Get help choosing a support type" drawer on the Goals and Objectives page of an Activity Report form. Only appeared misaligned when in an error state.

## How to test
* Pick an Activity Report to edit
* Go to the Goals and Objectives page
* Scroll down to the Support Type select, click it, but do not select any of the options
* This should put this form element into an error state, but the drawer link should remain aligned with the "Support Type" label.

## Screenshots
Before:
![support-type-field-error](https://github.com/user-attachments/assets/03e39df6-159f-46a2-902a-f7b185c936d8)
After:
![Screenshot 2025-04-21 at 10 46 48 AM](https://github.com/user-attachments/assets/9df1ba78-72dc-441b-b83f-25e841b9fb0b)

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3290


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [X] API Documentation updated
- [X] Boundary diagram updated
- [X] Logical Data Model updated
- [X] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
