### PR TITLE
TTAHUB-4074 - Fix for the number of TR participants

### DIFF
--- a/src/widgets/trOverview.ts
+++ b/src/widgets/trOverview.ts
@@ -107,7 +107,7 @@ export default async function trOverview(
 
       if (deliveryMethod === 'hybrid') {
         sessionParticipants += numberOfParticipantsInPerson + numberOfParticipantsVirtually;
-      } else {
+      } else if (Number(numberOfParticipants)) {
         sessionParticipants += numberOfParticipants;
       }
     });


### PR DESCRIPTION
## Description of change
Fixes the number of participants shown in the participants widget on the Training Report Regional Dashboard.

## How to test
1. Go to the Regional Dashboard, click on the "Training Reports" tab.
2. Notice that the number of participants is now a reasonable number.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4074


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [X] API Documentation updated
- [X] Boundary diagram updated
- [X] Logical Data Model updated
- [X] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
