### PR TITLE
[TTAHUB-3422] Update display of "Entered by" value on goal card

### DIFF
--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -30,7 +30,7 @@ import GoalStatusChangeAlert from './components/GoalStatusChangeAlert';
 import useObjectiveStatusMonitor from '../../hooks/useObjectiveStatusMonitor';
 import DataCard from '../DataCard';
 import Tag from '../Tag';
-import Tooltip from '../Tooltip';
+import SpecialistTags from '../../pages/RecipientRecord/pages/Monitoring/components/SpecialistTags';
 
 export const ObjectiveSwitch = ({
   objective,
@@ -254,127 +254,45 @@ export default function GoalCard({
   };
 
   const renderEnteredBy = () => {
-    const tags = [];
+    let specialists = [];
 
     if (isMonitoringGoal) {
-      // monitoring goals: show a single "System-generated" tag with "OHS" role
-      tags.push(
-        <Tag key="system-generated-tag" clickable>
-          <Tooltip
-            displayText="OHS"
-            screenReadDisplayText={false}
-            buttonLabel="reveal the full name of this user"
-            tooltipText="System-generated"
-            hideUnderline
-            buttonClassName="display-flex"
-            className="ttahub-goal-card__entered-by-tooltip"
-          />
-        </Tag>,
-      );
+      specialists = [
+        {
+          name: 'System-generated',
+          roles: ['OHS'],
+        },
+      ];
     } else if (collaborators && collaborators.length > 0) {
       const creatorsWithName = collaborators.filter((c) => c.goalCreatorName);
 
       if (creatorsWithName.length > 0) {
-        creatorsWithName.forEach((c) => {
+        specialists = creatorsWithName.map((c) => {
+          let roles = [];
+
           if (c.goalCreatorRoles) {
             // convert roles to array, handling different possible formats
-            let rolesArray = [];
-
             if (typeof c.goalCreatorRoles === 'string') {
               // e.g. "GS, ECS"
-              rolesArray = c.goalCreatorRoles.split(',').map((r) => r.trim());
+              roles = c.goalCreatorRoles.split(',').map((r) => r.trim());
             } else if (Array.isArray(c.goalCreatorRoles)) {
               // already an array
-              rolesArray = c.goalCreatorRoles;
+              roles = c.goalCreatorRoles;
             } else {
               // something else, try to flatten it
-              rolesArray = [c.goalCreatorRoles].flat().filter(Boolean);
+              roles = [c.goalCreatorRoles].flat().filter(Boolean);
             }
-
-            // separate tag for each role
-            if (rolesArray.length > 0) {
-              rolesArray.forEach((role) => {
-                tags.push(
-                  <Tag key={`${c.goalCreatorName}-${role}`} clickable>
-                    <Tooltip
-                      displayText={role}
-                      screenReadDisplayText={false}
-                      buttonLabel="reveal the full name of this user"
-                      tooltipText={c.goalCreatorName}
-                      hideUnderline
-                      buttonClassName="display-flex"
-                      className="ttahub-goal-card__entered-by-tooltip"
-                    />
-                  </Tag>,
-                );
-              });
-            } else {
-              // roles array is empty after processing
-              tags.push(
-                <Tag key={`${c.goalCreatorName}-unavailable`} clickable>
-                  <Tooltip
-                    displayText="Unavailable"
-                    screenReadDisplayText={false}
-                    buttonLabel="reveal the full name of this user"
-                    tooltipText={c.goalCreatorName}
-                    hideUnderline
-                    buttonClassName="display-flex"
-                    className="ttahub-goal-card__entered-by-tooltip"
-                  />
-                </Tag>,
-              );
-            }
-          } else {
-            // user has no roles
-            tags.push(
-              <Tag key={`${c.goalCreatorName}-unavailable`} clickable>
-                <Tooltip
-                  displayText="Unavailable"
-                  screenReadDisplayText={false}
-                  buttonLabel="reveal the full name of this user"
-                  tooltipText={c.goalCreatorName}
-                  hideUnderline
-                  buttonClassName="display-flex"
-                  className="ttahub-goal-card__entered-by-tooltip"
-                />
-              </Tag>,
-            );
           }
+
+          return {
+            name: c.goalCreatorName,
+            roles,
+          };
         });
-      } else {
-        // legacy goal, no creator data
-        tags.push(
-          <Tag key="unknown-unavailable" clickable>
-            <Tooltip
-              displayText="Unavailable"
-              screenReadDisplayText={false}
-              buttonLabel="reveal the full name of this user"
-              tooltipText="Unknown"
-              hideUnderline
-              buttonClassName="display-flex"
-              className="ttahub-goal-card__entered-by-tooltip"
-            />
-          </Tag>,
-        );
       }
-    } else {
-      // legacy goal, no collaborators data
-      tags.push(
-        <Tag key="unknown-unavailable" clickable>
-          <Tooltip
-            displayText="Unavailable"
-            screenReadDisplayText={false}
-            buttonLabel="reveal the full name of this user"
-            tooltipText="Unknown"
-            hideUnderline
-            buttonClassName="display-flex"
-            className="ttahub-goal-card__entered-by-tooltip"
-          />
-        </Tag>,
-      );
     }
 
-    return <>{tags}</>;
+    return <SpecialistTags specialists={specialists} />;
   };
 
   return (

--- a/frontend/src/components/GoalCards/GoalCard.js
+++ b/frontend/src/components/GoalCards/GoalCard.js
@@ -30,7 +30,7 @@ import GoalStatusChangeAlert from './components/GoalStatusChangeAlert';
 import useObjectiveStatusMonitor from '../../hooks/useObjectiveStatusMonitor';
 import DataCard from '../DataCard';
 import Tag from '../Tag';
-import SpecialistTags from '../../pages/RecipientRecord/pages/Monitoring/components/SpecialistTags';
+import Tooltip from '../Tooltip';
 
 export const ObjectiveSwitch = ({
   objective,
@@ -254,23 +254,127 @@ export default function GoalCard({
   };
 
   const renderEnteredBy = () => {
-    let specialists;
+    const tags = [];
+
     if (isMonitoringGoal) {
-      specialists = [
-        {
-          name: 'System-generated',
-          roles: ['OHS'],
-        },
-      ];
-    } else if (collaborators) {
-      specialists = collaborators
-        .filter((c) => c.goalCreatorName)
-        .map((c) => ({
-          name: c.goalCreatorName,
-          roles: [c.goalCreatorRoles].flat(),
-        }));
+      // monitoring goals: show a single "System-generated" tag with "OHS" role
+      tags.push(
+        <Tag key="system-generated-tag" clickable>
+          <Tooltip
+            displayText="OHS"
+            screenReadDisplayText={false}
+            buttonLabel="reveal the full name of this user"
+            tooltipText="System-generated"
+            hideUnderline
+            buttonClassName="display-flex"
+            className="ttahub-goal-card__entered-by-tooltip"
+          />
+        </Tag>,
+      );
+    } else if (collaborators && collaborators.length > 0) {
+      const creatorsWithName = collaborators.filter((c) => c.goalCreatorName);
+
+      if (creatorsWithName.length > 0) {
+        creatorsWithName.forEach((c) => {
+          if (c.goalCreatorRoles) {
+            // convert roles to array, handling different possible formats
+            let rolesArray = [];
+
+            if (typeof c.goalCreatorRoles === 'string') {
+              // e.g. "GS, ECS"
+              rolesArray = c.goalCreatorRoles.split(',').map((r) => r.trim());
+            } else if (Array.isArray(c.goalCreatorRoles)) {
+              // already an array
+              rolesArray = c.goalCreatorRoles;
+            } else {
+              // something else, try to flatten it
+              rolesArray = [c.goalCreatorRoles].flat().filter(Boolean);
+            }
+
+            // separate tag for each role
+            if (rolesArray.length > 0) {
+              rolesArray.forEach((role) => {
+                tags.push(
+                  <Tag key={`${c.goalCreatorName}-${role}`} clickable>
+                    <Tooltip
+                      displayText={role}
+                      screenReadDisplayText={false}
+                      buttonLabel="reveal the full name of this user"
+                      tooltipText={c.goalCreatorName}
+                      hideUnderline
+                      buttonClassName="display-flex"
+                      className="ttahub-goal-card__entered-by-tooltip"
+                    />
+                  </Tag>,
+                );
+              });
+            } else {
+              // roles array is empty after processing
+              tags.push(
+                <Tag key={`${c.goalCreatorName}-unavailable`} clickable>
+                  <Tooltip
+                    displayText="Unavailable"
+                    screenReadDisplayText={false}
+                    buttonLabel="reveal the full name of this user"
+                    tooltipText={c.goalCreatorName}
+                    hideUnderline
+                    buttonClassName="display-flex"
+                    className="ttahub-goal-card__entered-by-tooltip"
+                  />
+                </Tag>,
+              );
+            }
+          } else {
+            // user has no roles
+            tags.push(
+              <Tag key={`${c.goalCreatorName}-unavailable`} clickable>
+                <Tooltip
+                  displayText="Unavailable"
+                  screenReadDisplayText={false}
+                  buttonLabel="reveal the full name of this user"
+                  tooltipText={c.goalCreatorName}
+                  hideUnderline
+                  buttonClassName="display-flex"
+                  className="ttahub-goal-card__entered-by-tooltip"
+                />
+              </Tag>,
+            );
+          }
+        });
+      } else {
+        // legacy goal, no creator data
+        tags.push(
+          <Tag key="unknown-unavailable" clickable>
+            <Tooltip
+              displayText="Unavailable"
+              screenReadDisplayText={false}
+              buttonLabel="reveal the full name of this user"
+              tooltipText="Unknown"
+              hideUnderline
+              buttonClassName="display-flex"
+              className="ttahub-goal-card__entered-by-tooltip"
+            />
+          </Tag>,
+        );
+      }
+    } else {
+      // legacy goal, no collaborators data
+      tags.push(
+        <Tag key="unknown-unavailable" clickable>
+          <Tooltip
+            displayText="Unavailable"
+            screenReadDisplayText={false}
+            buttonLabel="reveal the full name of this user"
+            tooltipText="Unknown"
+            hideUnderline
+            buttonClassName="display-flex"
+            className="ttahub-goal-card__entered-by-tooltip"
+          />
+        </Tag>,
+      );
     }
-    return <SpecialistTags specialists={specialists} />;
+
+    return <>{tags}</>;
   };
 
   return (

--- a/frontend/src/components/GoalCards/__tests__/GoalCard.js
+++ b/frontend/src/components/GoalCards/__tests__/GoalCard.js
@@ -174,7 +174,7 @@ describe('GoalCard', () => {
     expect(status.tagName).toEqual('DIV');
   });
 
-  it('shows entered by', () => {
+  it('shows entered by with a single role', () => {
     renderGoalCard();
     expect(screen.getByText(/entered by/i)).toBeInTheDocument();
     expect(screen.getByText(/ECS/i)).toBeInTheDocument();
@@ -182,6 +182,109 @@ describe('GoalCard', () => {
     const tooltip = screen.getByTestId('tooltip');
     expect(tooltip).toBeInTheDocument();
     expect(tooltip.textContent).toContain('Test User');
+  });
+
+  it('shows entered by with multiple roles as separate tags', () => {
+    const goalWithMultipleRoles = {
+      ...goal,
+      collaborators: [
+        {
+          goalNumber: 'G-1',
+          goalCreatorRoles: ['ECS', 'GS'],
+          goalCreatorName: 'Test User',
+        },
+      ],
+    };
+
+    renderGoalCard({}, goalWithMultipleRoles);
+    expect(screen.getByText(/entered by/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/ECS/i)).toBeInTheDocument();
+    expect(screen.getByText(/GS/i)).toBeInTheDocument();
+
+    const tooltips = screen.getAllByTestId('tooltip');
+    expect(tooltips.length).toBe(2);
+    tooltips.forEach((tooltip) => {
+      expect(tooltip.textContent).toContain('Test User');
+    });
+  });
+
+  it('shows entered by with multiple roles as separate tags when roles are a comma-separated string', () => {
+    const goalWithMultipleRolesAsString = {
+      ...goal,
+      collaborators: [
+        {
+          goalNumber: 'G-1',
+          goalCreatorRoles: 'ECS, GS',
+          goalCreatorName: 'Test User',
+        },
+      ],
+    };
+
+    renderGoalCard({}, goalWithMultipleRolesAsString);
+    expect(screen.getByText(/entered by/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/ECS/i)).toBeInTheDocument();
+    expect(screen.getByText(/GS/i)).toBeInTheDocument();
+
+    const tooltips = screen.getAllByTestId('tooltip');
+    expect(tooltips.length).toBe(2);
+    tooltips.forEach((tooltip) => {
+      expect(tooltip.textContent).toContain('Test User');
+    });
+  });
+
+  it('shows "Unavailable" when goal creator has no roles', () => {
+    const goalWithNoRoles = {
+      ...goal,
+      collaborators: [
+        {
+          goalNumber: 'G-1',
+          goalCreatorRoles: [],
+          goalCreatorName: 'Test User',
+        },
+      ],
+    };
+
+    renderGoalCard({}, goalWithNoRoles);
+    expect(screen.getByText(/entered by/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unavailable/i)).toBeInTheDocument();
+
+    const tooltip = screen.getByTestId('tooltip');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip.textContent).toContain('Test User');
+  });
+
+  it('shows "Unavailable" for legacy goal with no creator data', () => {
+    const legacyGoal = {
+      ...goal,
+      collaborators: [],
+    };
+
+    renderGoalCard({}, legacyGoal);
+    expect(screen.getByText(/entered by/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unavailable/i)).toBeInTheDocument();
+
+    const tooltip = screen.getByTestId('tooltip');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip.textContent).toContain('Unknown');
+  });
+
+  it('shows "Unavailable" for goal with collaborators but no creator name', () => {
+    const goalWithNoCreatorName = {
+      ...goal,
+      collaborators: [
+        {
+          goalNumber: 'G-1',
+          goalCreatorRoles: 'ECS',
+          goalCreatorName: '',
+        },
+      ],
+    };
+
+    renderGoalCard({}, goalWithNoCreatorName);
+    expect(screen.getByText(/entered by/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unavailable/i)).toBeInTheDocument();
   });
 
   it('shows the goal options by default', () => {

--- a/frontend/src/pages/RecipientRecord/pages/Monitoring/components/SpecialistTags.js
+++ b/frontend/src/pages/RecipientRecord/pages/Monitoring/components/SpecialistTags.js
@@ -1,27 +1,86 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { uniqueId } from 'lodash';
 import Tag from '../../../../../components/Tag';
 import Tooltip from '../../../../../components/Tooltip';
 
 export default function SpecialistTags({ specialists }) {
-  return specialists.map((specialist) => {
-    if (!specialist.name) return null;
+  const tags = [];
 
-    return (
-      <Tag key={uniqueId('specialist-tag-')} clickable>
+  if (!specialists || specialists.length === 0) {
+    // legacy goal, no collaborators data
+    tags.push(
+      <Tag key="unknown-unavailable" clickable>
         <Tooltip
-          displayText={specialist.roles.join(', ')}
+          displayText="Unavailable"
           screenReadDisplayText={false}
           buttonLabel="reveal the full name of this user"
-          tooltipText={specialist.name}
+          tooltipText="Unknown"
           hideUnderline
           buttonClassName="display-flex"
           className="ttahub-goal-card__entered-by-tooltip"
         />
-      </Tag>
+      </Tag>,
     );
-  });
+  } else {
+    specialists.forEach((specialist) => {
+      if (!specialist.name) return;
+
+      // monitoring goals: show a single "System-generated" tag with "OHS" role
+      if (specialist.name === 'System-generated') {
+        tags.push(
+          <Tag key="system-generated-tag" clickable>
+            <Tooltip
+              displayText={specialist.roles[0] || 'Unavailable'}
+              screenReadDisplayText={false}
+              buttonLabel="reveal the full name of this user"
+              tooltipText="System-generated"
+              hideUnderline
+              buttonClassName="display-flex"
+              className="ttahub-goal-card__entered-by-tooltip"
+            />
+          </Tag>,
+        );
+        return;
+      }
+
+      // handle specialists with roles
+      if (specialist.roles && specialist.roles.length > 0) {
+        // separate tag for each role
+        specialist.roles.forEach((role) => {
+          tags.push(
+            <Tag key={`${specialist.name}-${role}`} clickable>
+              <Tooltip
+                displayText={role}
+                screenReadDisplayText={false}
+                buttonLabel="reveal the full name of this user"
+                tooltipText={specialist.name}
+                hideUnderline
+                buttonClassName="display-flex"
+                className="ttahub-goal-card__entered-by-tooltip"
+              />
+            </Tag>,
+          );
+        });
+      } else {
+        // user has no roles
+        tags.push(
+          <Tag key={`${specialist.name}-unavailable`} clickable>
+            <Tooltip
+              displayText="Unavailable"
+              screenReadDisplayText={false}
+              buttonLabel="reveal the full name of this user"
+              tooltipText={specialist.name}
+              hideUnderline
+              buttonClassName="display-flex"
+              className="ttahub-goal-card__entered-by-tooltip"
+            />
+          </Tag>,
+        );
+      }
+    });
+  }
+
+  return <>{tags}</>;
 }
 
 SpecialistTags.propTypes = {
@@ -30,5 +89,9 @@ SpecialistTags.propTypes = {
       name: PropTypes.string,
       roles: PropTypes.arrayOf(PropTypes.string),
     }),
-  ).isRequired,
+  ),
+};
+
+SpecialistTags.defaultProps = {
+  specialists: [],
 };


### PR DESCRIPTION
## Description of change

- When the creator has a single role, there is a single "Entered by" tag for that role.
- When the creator has multiple roles, there is an "Entered by" tag for each role.
- When the creator has no roles, there is a single "Unavailable" tag.

## How to test

- Visit the RTR
- Validate the tests
- Add/remove roles for yourself to test behavior

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-3422


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
