### PR TITLE
correct rollback, allow dupe deletedAt

### DIFF
--- a/src/migrations/20250424000000-mark-source-deleted-records.js
+++ b/src/migrations/20250424000000-mark-source-deleted-records.js
@@ -38,17 +38,18 @@ module.exports = {
         SELECT 1/(LEAST(SUM(beforecount),1) - 1 ) FROM beforecounts;
 
         -- The actual marking of the records as deleted
-        UPDATE "MonitoringClassSummaries" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingGrants" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringReviewGrantees" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingHistories" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringReviews" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingHistoryStatuses" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringReviewStatuses" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindings" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;\
-        UPDATE "MonitoringFindingStandards" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringStandards" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingStatuses" SET "deletedAt" = NOW() WHERE "sourceDeletedAt" IS NOT NULL;
+        -- The millisecond additions are so that multiple duplicates aren't deleted at quite the same time
+        UPDATE "MonitoringClassSummaries" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingGrants" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringReviewGrantees" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingHistories" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringReviews" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingHistoryStatuses" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringReviewStatuses" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindings" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingStandards" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringStandards" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingStatuses" SET "deletedAt" = NOW() + TRUNC(RANDOM()*999 +1) * (interval '1 ms') WHERE "sourceDeletedAt" IS NOT NULL;
 
         -- Count the marked-deleted records
         DROP TABLE IF EXISTS aftercounts;
@@ -96,17 +97,17 @@ module.exports = {
       const sessionSig = __filename;
       await prepMigration(queryInterface, transaction, sessionSig);
       await queryInterface.sequelize.query(/* sql */`
-        UPDATE "MonitoringClassSummaries" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingGrants" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringReviewGrantees" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingHistories" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringReviews" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingHistoryStatuses" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringReviewStatuses" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindings" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingStandards" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringStandards" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
-        UPDATE "MonitoringFindingStatuses" SET "deletedAt" = NOW() WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringClassSummaries" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingGrants" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringReviewGrantees" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingHistories" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringReviews" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingHistoryStatuses" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringReviewStatuses" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindings" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingStandards" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringStandards" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
+        UPDATE "MonitoringFindingStatuses" SET "deletedAt" = NULL WHERE "deletedAt" IS NOT NULL;
     `, { transaction });
     });
   },


### PR DESCRIPTION
## Description of change

Basically a correction of https://github.com/HHS/Head-Start-TTADP/pull/2772, which is failing that migration and any subsequent migrations (none yet) due to identical `deletedAt` timestamps.

## How to test

Evidently you can't see the issue if you run locally, so we'll need to look in a deployed environment

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4039

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
