### PR TITLE
[NO-TICKET] Use the same lock for all db-restore jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,37 +186,37 @@ workflows:
         - process_temp_db
     - restore_db_job:
         name: restore (dev)
-        serial-group: "tta-automation-lock-dev"
+        serial-group: "tta-automation-lock"
         target_env: "dev"
         requires:
         - backup_temp_db
     - restore_db_job:
         name: restore (dev-green)
-        serial-group: "tta-automation-lock-dev-green"
+        serial-group: "tta-automation-lock"
         target_env: "dev-green"
         requires:
         - backup_temp_db
     - restore_db_job:
         name: restore (dev-blue)
-        serial-group: "tta-automation-lock-dev-blue"
+        serial-group: "tta-automation-lock"
         target_env: "dev-blue"
         requires:
         - backup_temp_db
     - restore_db_job:
         name: restore (dev-red)
-        serial-group: "tta-automation-lock-dev-red"
+        serial-group: "tta-automation-lock"
         target_env: "dev-red"
         requires:
         - backup_temp_db
     - restore_db_job:
         name: restore (sandbox)
-        serial-group: "tta-automation-lock-sandbox"
+        serial-group: "tta-automation-lock"
         target_env: "sandbox"
         requires:
         - backup_temp_db
     - restore_db_job:
         name: restore (staging)
-        serial-group: "tta-automation-lock-staging"
+        serial-group: "tta-automation-lock"
         target_env: "staging"
         requires:
         - backup_temp_db


### PR DESCRIPTION
## Description of change

All automated db restore jobs use the '`ta-automation` "app" for running tasks, and only a single instance of the app can be deployed at a time.  I had attempted to split the locking on a per-environment basis, but this results in the tasks failing to run due to the fact that only one can be in the "staging" state at a time in cloud foundry.

Therefore, use the same lock for all jobs.  This resolves the error [which can be seen here](https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/28548/workflows/a5f2e73b-2a50-4ded-ab4d-4012e4691946/jobs/163091):
<img width="765" alt="Screenshot 2025-04-30 at 9 26 17 AM" src="https://github.com/user-attachments/assets/93f86d8f-436a-4ceb-86b9-e330407bd7db" />

## How to test

Ran the manual db restore job, however the only way to really test is via the cron itself.
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/28596/workflows/117e72cc-910a-46c3-9f2f-d87894b2cda1

## Issue(s)

N/A

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
