### PR TITLE
[TTAHUB-4064] allow citations on reviews that close after AR startDate

### DIFF
--- a/docs/it-ams-monitoring-data.md
+++ b/docs/it-ams-monitoring-data.md
@@ -55,8 +55,8 @@ A: The intent is for citations to be available to select within the time period 
 - As a prerequisite, a **Review** needs to reach a `Complete` status while being linked an `Active` **Finding** so a **Monitoring Goal** is created and available for use in ARs
 - The **Finding** must be linked through a **MonitoringFindingStandards** record to a **MonitoringStandards** record, which contains the citation text
 - As long as the **Finding** remains in `Active` status, it will remain selectable on ARs using the monitoring goal.
-- Regardless of **Finding** status, if the _most recent_ **Review** has not reached a `Complete` state, then the citation will remain selectable
-- Once _both_ the most recent **Review** is `Complete` _and_ the **Finding** reaches one of the terminal states (`Corrected`,`Withdrawn`,`Closed`), then the citation will not appear or be selectable.
+- Regardless of **Finding** status, if the _most recent_ **Review** has not reached a `Complete` state with a `reportDeliveryDate` prior to the AR `startDate`, then the citation will remain selectable
+- Once _both_ the most recent **Review** is `Complete` with a `reportDeliveryDate` prior to the AR `startDate` _and_ the **Finding** reaches one of the terminal states (`Corrected`,`Withdrawn`,`Closed`), then the citation will not appear or be selectable.
 
 ## 📎 Additional Documentation
 For developer details, see: [Technical Documentation](monitoring-tech.md)

--- a/src/services/citations.test.js
+++ b/src/services/citations.test.js
@@ -582,7 +582,9 @@ describe('citations service', () => {
     const citationsToAssert = await getCitationsByGrantIds([grant1.id, grant1a.id, grant2.id, grant3.id], reportStartDate);
 
     // Assert correct number of citations.
-    expect(citationsToAssert.length).toBe(3);
+    // This will be all four now because the AR date is also the reportDeliveryDate
+    // which means that all citations will be considered valid for that time
+    expect(citationsToAssert.length).toBe(4);
 
     // Assert the citations.
     // Get the citation with the text 'Grant 1 - Citation 1 - Good'.

--- a/src/services/citations.ts
+++ b/src/services/citations.ts
@@ -63,6 +63,7 @@ export async function getCitationsByGrantIds(
         mfh."findingId" fid,
         mfh."reviewId" rid,
         mrs.name review_status,
+        mr."reportDeliveryDate" rdd,
         ROW_NUMBER() OVER (
           PARTITION BY mfh."findingId"
           ORDER BY mr."startDate" DESC, mr."sourceCreatedAt" DESC, mr.id DESC
@@ -81,7 +82,11 @@ export async function getCitationsByGrantIds(
       UNION
       SELECT fid FROM ordered_citation_reviews
       WHERE recency_rank = 1
-        AND review_status != 'Complete'
+        AND (
+          review_status != 'Complete'
+          OR
+          '${reportStartDate}'::date BETWEEN '${cutOffStartDate}' AND rdd
+        )
       ),
       -- Subquery ensures only the most recent history for each finding-grant combination
       "RecentMonitoring" AS ( 


### PR DESCRIPTION
## Description of change

We have been relying on the time gap between when TTA is provided addressing a Finding/citation and when the final follow-up review closes to ensure that the AR has already been written and approved, but while the latest fix was working its way through, at least one user has gotten outside that window. This expands the logic so that as long as the `reportDeliveryDate` of the latest review is after the start date of the AR, the citation can still be selected. 

## How to test

This actually impacts the same user as https://github.com/HHS/Head-Start-TTADP/pull/2777 if you update to May data.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4064

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
