### PR TITLE
[TTAHUB-4072] disable node inspector pending further review

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deps": "yarn global add node-gyp && yarn install --frozen-lockfile && yarn --cwd frontend install --frozen-lockfile",
     "start:local": "concurrently \"yarn server\" \"yarn client\" \"yarn worker\"",
     "start:ci": "cross-env BYPASS_SOCKETS=true POSTGRES_USERNAME=postgres POSTGRES_DB=ttasmarthub TTA_SMART_HUB_URI=http://localhost:3000 concurrently \"yarn start:web\" \"yarn client\" \"yarn start:testingonly\"",
-    "start:web": "node --inspect=127.0.0.1:9229 ./build/server/src/index.js",
+    "start:web": "node ./build/server/src/index.js",
     "start:worker": "node ./build/server/src/worker.js",
     "start:testingonly": "tsx watch ./src/testingOnly.js",
     "server": "tsx watch src/index.ts",


### PR DESCRIPTION
## Description of change

Reverting change from [2796](https://github.com/HHS/Head-Start-TTADP/pull/2796) merged earlier today.
This will need to go through further compliance review.

## How to test

Smoke tests passing

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4072

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] Staging smoke test completed

### After merge/deploy

- [ ] Update JIRA ticket status
