### PR TITLE
[TTAHUB-4013] Only count recipients once across regions

### DIFF
--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -66,8 +66,10 @@ export function baseTRScopes(scopes) {
 export async function getAllRecipientsFiltered(scopes) {
   return Recipient.findAll({
     attributes: [
-      [sequelize.fn('DISTINCT', sequelize.col('"Recipient"."id"')), 'id'], // This is required for scopes.
-      [sequelize.col('grants.regionId'), 'regionId'],
+      [sequelize.fn('COUNT', sequelize.fn(
+        'DISTINCT',
+        sequelize.col('"activityRecipients->grant->recipient"."id"'),
+      )), 'numRecipients'],
     ],
     raw: true,
     where: {

--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -68,7 +68,7 @@ export async function getAllRecipientsFiltered(scopes) {
     attributes: [
       [sequelize.fn('COUNT', sequelize.fn(
         'DISTINCT',
-        sequelize.col('"activityRecipients->grant->recipient"."id"'),
+        sequelize.col('"Recipient"."id"'),
       )), 'numRecipients'],
     ],
     raw: true,


### PR DESCRIPTION
## Description of change

We were counting recipients with multiple regions as separate recipients in the numerator but not denominator of the dashboard overview widget. This brings the calculations in line.

## How to test

Check with "program types" as a filter while able to see all regions and see that the number remains below 100%.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4013


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
