### PR TITLE
[TTAHUB-4013] only count recipients once across regions

### DIFF
--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -32,7 +32,6 @@ export default async function overview(scopes) {
       [sequelize.fn('COUNT', sequelize.fn(
         'DISTINCT',
         sequelize.fn('CONCAT', sequelize.col('"activityRecipients->grant->recipient"."id"')),
-        sequelize.col('"activityRecipients->grant"."regionId"'),
       )), 'numRecipients'],
     ],
     raw: true,


### PR DESCRIPTION
## Description of change

We were counting recipients with multiple regions as separate recipients in the numerator but not denominator of the dashboard overview widget. This brings the calculations in line.

## How to test

Check the main tta dashboard with "program types" as a filter while able to see all regions and see that the number remains below 100%.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
