### PR TITLE
[TTAHUB-4197] do not return findings/citations deleted at source

### DIFF
--- a/src/services/citations.test.js
+++ b/src/services/citations.test.js
@@ -75,6 +75,7 @@ const createMonitoringData = async (
   // MonitoringFindingHistory (this is the primary finding table and the relationship to citation is 1<>1).
   // If we wanted one grant to have multiple citations, we would need to create multiple findings here and below.
   await Promise.all(citationsArray.map(async (citation) => {
+    const sourceDeletedAt = citation.sourceDeletedAt || null;
     const findingId = citation.findingId || uuidv4();
     const findingStatusId = faker.datatype.number({ min: 9999 });
     await MonitoringFindingHistory.create({
@@ -88,7 +89,7 @@ const createMonitoringData = async (
       hash: faker.datatype.uuid(),
       sourceCreatedAt: new Date(),
       sourceUpdatedAt: new Date(),
-      sourceDeletedAt: null,
+      sourceDeletedAt,
     }, { individualHooks: true });
 
     // MonitoringFinding.
@@ -100,6 +101,7 @@ const createMonitoringData = async (
       source: 'Internal Controls',
       sourceCreatedAt: new Date(),
       sourceUpdatedAt: new Date(),
+      sourceDeletedAt,
     }, { individualHooks: true });
 
     // MonitoringFindingStatus.
@@ -421,6 +423,14 @@ describe('citations service', () => {
         monitoringFindingType: 'Citation 3 Monitoring Finding Type',
         monitoringFindingStatusName: 'Active',
         monitoringFindingGrantFindingType: 'Corrective Action',
+      },
+      {
+        citationText: 'Grant 1 - Citation 4 - Deleted',
+        monitoringFindingType: 'Citation 4 Monitoring Finding Type',
+        monitoringFindingStatusName: 'Active',
+        monitoringFindingGrantFindingType: 'Corrective Action',
+        // This should make this citation not show up in counts
+        sourceDeletedAt: new Date(),
       },
     ];
 

--- a/src/services/citations.ts
+++ b/src/services/citations.ts
@@ -76,7 +76,7 @@ export async function getCitationsByGrantIds(
         ON mr."statusId" = mrs."statusId"
       -- This works without bringing in MonitoringFindings because when MonitoringFindings
       -- are deleted in IT-AMS data, so are all linking MonitoringFindingHistories records
-      WHERE mfh."sourceDeletedAt" IS NOT NULL
+      WHERE mfh."sourceDeletedAt" IS NULL
       ),
       -- union together active citations with those whose most recent linked
       -- review is not complete, yielding the list of citations on which TTA

--- a/src/services/citations.ts
+++ b/src/services/citations.ts
@@ -56,6 +56,7 @@ export async function getCitationsByGrantIds(
       JOIN "MonitoringFindingStatuses" mfs
         ON mf."statusId" = mfs."statusId"
       WHERE mfs.name = 'Active'
+        AND mf."sourceDeletedAt" IS NULL
       ),
       -- get the order and status of reviews associated with citations
       ordered_citation_reviews AS (
@@ -73,6 +74,9 @@ export async function getCitationsByGrantIds(
         ON mfh."reviewId" = mr."reviewId"
       JOIN "MonitoringReviewStatuses" mrs
         ON mr."statusId" = mrs."statusId"
+      -- This works without bringing in MonitoringFindings because when MonitoringFindings
+      -- are deleted in IT-AMS data, so are all linking MonitoringFindingHistories records
+      WHERE mfh."sourceDeletedAt" IS NOT NULL
       ),
       -- union together active citations with those whose most recent linked
       -- review is not complete, yielding the list of citations on which TTA


### PR DESCRIPTION
## Description of change

This excludes any findings where the MonitoringFinding and MonitoringFindingHistory records have been deleted at the source, i.e. in IT-AMS.

## How to test

There's a Finding/citation ANC marked deleted at https://tta-smarthub-staging.app.cloud.gov/recipient-tta-records/1027/region/5/monitoring/review and so there should only be one non-compliance citation showing instead of 2.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4197


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
