### PR TITLE
TTAHUB-4107 - Replacing ellipsis in ContextMenu with the word "Actions"

### DIFF
--- a/frontend/src/components/ContextMenu.js
+++ b/frontend/src/components/ContextMenu.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEllipsisH } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import colors from '../colors';
 import Menu from './Menu';
 
@@ -31,8 +31,14 @@ function ContextMenu({
       menuWidthOffset={menuWidthOffset}
       up={up}
       menuHeightOffset={menuHeightOffset}
-      buttonText={<FontAwesomeIcon color={colors.textInk} icon={faEllipsisH} />}
-      buttonTestId="ellipsis-button"
+      buttonText={(
+        <>
+          <span className="usa-button--unstyled">Actions</span>
+          <span>&nbsp;</span>
+          <FontAwesomeIcon color={colors.textLink} icon={faChevronDown} />
+        </>
+)}
+      buttonTestId="actions-button"
       fixed={fixed}
     />
   );

--- a/frontend/src/components/GoalCards/__tests__/StandardGoalCard.js
+++ b/frontend/src/components/GoalCards/__tests__/StandardGoalCard.js
@@ -248,17 +248,17 @@ describe('StandardGoalCard', () => {
 
   it('shows the goal options by default', () => {
     renderStandardGoalCard();
-    expect(screen.getByTestId('ellipsis-button')).toBeInTheDocument();
+    expect(screen.getByTestId('actions-button')).toBeInTheDocument();
   });
 
   it('hides the goal options when readonly is true', () => {
     renderStandardGoalCard({ ...DEFAULT_PROPS, readonly: true });
-    expect(screen.queryByTestId('ellipsis-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('actions-button')).not.toBeInTheDocument();
   });
 
   it('shows only edit option by default', async () => {
     renderStandardGoalCard();
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const button = await screen.findByText(/Edit/i);
     expect(button).toBeInTheDocument();
   });
@@ -279,7 +279,7 @@ describe('StandardGoalCard', () => {
       ],
     };
     renderStandardGoalCard(DEFAULT_PROPS, { ...goal, onAR: false }, user);
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const button = await screen.findByText(/Edit/i);
     expect(button).toBeInTheDocument();
     const deleteButton = screen.queryByText(/Delete/i);
@@ -302,7 +302,7 @@ describe('StandardGoalCard', () => {
       ],
     };
     renderStandardGoalCard(DEFAULT_PROPS, { ...goal, status: 'Draft' }, user);
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const button = await screen.findByText(/Edit/i);
     expect(button).toBeInTheDocument();
     const deleteButton = screen.queryByText(/Delete/i);
@@ -325,7 +325,7 @@ describe('StandardGoalCard', () => {
       ],
     };
     renderStandardGoalCard(DEFAULT_PROPS, { ...goal, status: 'Draft', onAR: false }, user);
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const button = await screen.findByText(/Edit/i);
     expect(button).toBeInTheDocument();
     const deleteButton = screen.queryByText(/Delete/i);
@@ -348,7 +348,7 @@ describe('StandardGoalCard', () => {
       ],
     };
     renderStandardGoalCard(DEFAULT_PROPS, { ...goal, status: 'Not Started', onAR: false }, user);
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const button = await screen.findByText(/Edit/i);
     expect(button).toBeInTheDocument();
     const deleteButton = screen.queryByText(/Delete/i);
@@ -371,7 +371,7 @@ describe('StandardGoalCard', () => {
       ],
     };
     renderStandardGoalCard(DEFAULT_PROPS, { ...goal, status: 'Draft', onAR: false }, user);
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const button = await screen.findByText(/Edit/i);
     expect(button).toBeInTheDocument();
     const deleteButton = screen.queryByText(/Delete/i);
@@ -394,7 +394,7 @@ describe('StandardGoalCard', () => {
       ],
     };
     renderStandardGoalCard(DEFAULT_PROPS, { ...goal, status: 'Not Started', onAR: false }, user);
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const deleteButton = screen.queryByText(/Delete/i);
     const url = `${goalApi}?goalIds=1`;
     fetchMock.delete(url, {});
@@ -421,7 +421,7 @@ describe('StandardGoalCard', () => {
       ],
     };
     renderStandardGoalCard(DEFAULT_PROPS, { ...goal, status: 'Not Started', onAR: false }, user);
-    userEvent.click(screen.getByTestId('ellipsis-button'));
+    userEvent.click(screen.getByTestId('actions-button'));
     const deleteButton = screen.queryByText(/Delete/i);
     const url = `${goalApi}?goalIds=1`;
     fetchMock.delete(url, 500);

--- a/frontend/src/components/__tests__/ContextMenu.js
+++ b/frontend/src/components/__tests__/ContextMenu.js
@@ -21,7 +21,7 @@ const menuItems = (label = 'one', onClick = () => {}) => [
 describe('ContextMenu', () => {
   it('hides the menu by default', async () => {
     render(<ContextMenu menuItems={menuItems()} label="label" />);
-    const buttons = screen.queryAllByTestId('ellipsis-button');
+    const buttons = screen.queryAllByTestId('actions-button');
     await waitFor(() => expect(buttons.length).toEqual(1));
     expect(await screen.findByLabelText('label')).toBeVisible();
   });
@@ -29,7 +29,7 @@ describe('ContextMenu', () => {
   describe('when the menu is open', () => {
     it('displays all menu items', async () => {
       render(<ContextMenu menuItems={menuItems()} label="label" />);
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
 
       expect(await screen.findByText('one')).toBeVisible();
@@ -39,7 +39,7 @@ describe('ContextMenu', () => {
     it("calls the menu item's onClick", async () => {
       const onClick = jest.fn();
       render(<ContextMenu menuItems={menuItems('one', onClick)} label="label" />);
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
 
       const oneButton = await screen.findByText('one');
@@ -50,7 +50,7 @@ describe('ContextMenu', () => {
     it('can be closed by pressing escape', async () => {
       const onClick = jest.fn();
       render(<ContextMenu menuItems={menuItems('one', onClick)} label="label" />);
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
       expect(await screen.findByText('one')).toBeVisible();
       userEvent.type(button, '{esc}', { skipClick: true });
@@ -59,7 +59,7 @@ describe('ContextMenu', () => {
 
     it('can be shifted right', async () => {
       render(<ContextMenu left={false} menuItems={menuItems('one')} label="label" />);
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
       const menu = await screen.findByTestId('menu');
       expect(menu).not.toHaveClass('smart-hub--menu__left');
@@ -67,7 +67,7 @@ describe('ContextMenu', () => {
 
     it('can be shifted up', async () => {
       render(<ContextMenu up left={false} menuItems={menuItems('one')} label="label" />);
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
       const menu = await screen.findByTestId('menu');
       expect(menu).toHaveClass('smart-hub--menu__up');
@@ -75,7 +75,7 @@ describe('ContextMenu', () => {
 
     it('can be shifted up and left', async () => {
       render(<ContextMenu up menuItems={menuItems('one')} label="label" />);
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
       const menu = await screen.findByTestId('menu');
       expect(menu).toHaveClass('smart-hub--menu__left_and_up');
@@ -84,7 +84,7 @@ describe('ContextMenu', () => {
     it('ignores keypresses that are not escape', async () => {
       const onClick = jest.fn();
       render(<ContextMenu menuItems={menuItems('one', onClick)} label="label" />);
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
       expect(await screen.findByText('one')).toBeVisible();
       userEvent.type(button, 'a', { skipClick: true });
@@ -99,7 +99,7 @@ describe('ContextMenu', () => {
           );
         </>,
       );
-      const button = await screen.findByTestId('ellipsis-button');
+      const button = await screen.findByTestId('actions-button');
       userEvent.click(button);
 
       const other = await screen.findByTestId('other');

--- a/frontend/src/components/__tests__/WidgetContainer.js
+++ b/frontend/src/components/__tests__/WidgetContainer.js
@@ -109,7 +109,7 @@ describe('Widget Container', () => {
     renderWidgetContainer('Widget Container Title', null, [true, false], () => {}, null, false, true, exportRows);
 
     // Click the context menu button.
-    const contextMenuBtn = screen.getByTestId('ellipsis-button');
+    const contextMenuBtn = screen.getByTestId('actions-button');
     userEvent.click(contextMenuBtn);
 
     // Export all rows.

--- a/frontend/src/pages/Landing/__tests__/MyAlerts.js
+++ b/frontend/src/pages/Landing/__tests__/MyAlerts.js
@@ -275,7 +275,7 @@ describe('My Alerts', () => {
 
   test('shows both context menu items when I am creator or collaborator', async () => {
     renderMyAlerts(false);
-    const menuButtons = await screen.findAllByTestId('ellipsis-button');
+    const menuButtons = await screen.findAllByTestId('actions-button');
     userEvent.click(menuButtons[0]);
 
     const viewButton = await screen.findAllByRole('button', {
@@ -346,7 +346,7 @@ describe('My Alerts', () => {
 
     renderMyAlerts(report);
 
-    const menuButtons = await screen.findAllByTestId('ellipsis-button');
+    const menuButtons = await screen.findAllByTestId('actions-button');
     userEvent.click(menuButtons[0]);
 
     const viewButton = await screen.findAllByRole('button', {
@@ -360,7 +360,7 @@ describe('My Alerts', () => {
 
   test('redirects to view activity report when clicked from context menu', async () => {
     const history = renderMyAlerts();
-    const menuButtons = await screen.findAllByTestId('ellipsis-button');
+    const menuButtons = await screen.findAllByTestId('actions-button');
     userEvent.click(menuButtons[0]);
 
     const viewButton = await screen.findByRole('button', {
@@ -433,7 +433,7 @@ describe('My Alerts', () => {
     };
 
     renderMyAlerts(report);
-    const menuButtons = await screen.findAllByTestId('ellipsis-button');
+    const menuButtons = await screen.findAllByTestId('actions-button');
     userEvent.click(menuButtons[0]);
 
     const viewButton = await screen.findByRole('button', {
@@ -441,7 +441,7 @@ describe('My Alerts', () => {
     });
     userEvent.click(viewButton);
 
-    const contextMenu = await screen.findAllByTestId('ellipsis-button');
+    const contextMenu = await screen.findAllByTestId('actions-button');
     expect(contextMenu).toBeTruthy();
     const button = await screen.findByRole('button', { name: /this button will permanently delete the report\./i, hidden: true });
     userEvent.click(button);

--- a/frontend/src/widgets/__tests__/CoursesAssociatedWithActivityReports.js
+++ b/frontend/src/widgets/__tests__/CoursesAssociatedWithActivityReports.js
@@ -402,7 +402,7 @@ describe('iPD Courses Associated with Activity Reports', () => {
     });
 
     // Click the context menu button.
-    let contextMenuBtn = screen.getByTestId('ellipsis-button');
+    let contextMenuBtn = screen.getByTestId('actions-button');
     userEvent.click(contextMenuBtn);
 
     // Export selected rows.
@@ -414,7 +414,7 @@ describe('iPD Courses Associated with Activity Reports', () => {
     expect(downloadLink).not.toBeNull();
 
     // Click the context menu button.
-    contextMenuBtn = screen.getByTestId('ellipsis-button');
+    contextMenuBtn = screen.getByTestId('actions-button');
     userEvent.click(contextMenuBtn);
 
     // Export all rows.

--- a/frontend/src/widgets/__tests__/TRHoursOfTrainingByNationalCenter.js
+++ b/frontend/src/widgets/__tests__/TRHoursOfTrainingByNationalCenter.js
@@ -18,7 +18,7 @@ describe('TRHoursOfTrainingByNationalCenter', () => {
     render(<TRHoursOfTrainingByNationalCenter />);
 
     // Get ellipsis menu and click "display table"
-    const menuButton = screen.getByTestId('ellipsis-button');
+    const menuButton = screen.getByTestId('actions-button');
     fireEvent.click(menuButton);
     const tableButton = screen.getByText('Display table');
     expect(tableButton).toBeInTheDocument();

--- a/frontend/src/widgets/__tests__/TotalHrsAndRecipientGraph.js
+++ b/frontend/src/widgets/__tests__/TotalHrsAndRecipientGraph.js
@@ -128,7 +128,7 @@ describe('Total Hrs And Recipient Graph Widget', () => {
     expect(xAxisTitle).toBeInTheDocument();
 
     // Find the button to show the table
-    const menuButton = screen.getByTestId('ellipsis-button');
+    const menuButton = screen.getByTestId('actions-button');
     fireEvent.click(menuButton);
     const tableButton = screen.getByText('Display table');
     fireEvent.click(tableButton);


### PR DESCRIPTION
## Description of change
Replaces the "ellipsis" symbol with the word "Actions" in the ContextMenu component, most notably used in StandardGoalCards.


## How to test
Spin up, go to RTR->RTTAPA, notice in the Goal Card in the upper right it now says "Actions".

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4107


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
