### PR TITLE
[TTAHUB-4222] explicit nodejs buildpack version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
     strategy: rolling
     stack: cflinuxfs4
     buildpacks:
-      - https://github.com/cloudfoundry/nodejs-buildpack/tree/v1.8.36
+      - https://github.com/cloudfoundry/nodejs-buildpack.git#v1.8.36
     env:
       AUTH_BASE: ((AUTH_BASE))
       AUTH_CLIENT_ID: ((AUTH_CLIENT_ID))


### PR DESCRIPTION
## Description of change

Set nodejs buildpack version to `1.8.36`.
This fixes the immediate issue encountered when pulling down the latest node.js buildpack, as it no longer supports the version of node we are running `20.18.2`
`Unable to install node: no match found for 20.18.2 in [18.20.7 18.20.8 20.19.0 20.19.2 22.14.0 22.16.0]"`

Attempting to upgrade to a later version of node (20.19.2) resulted in e2e test errors, which will take some more digging to resolve.

Reference:
https://github.com/cloudfoundry/nodejs-buildpack/releases
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#buildpacks


## How to test

Got a successful deploy to dev environment: 
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/29224/workflows/02b63aa8-3879-4c71-8cb7-0399505335c4

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4222

## Checklists

### Every PR

N/A

### Before merge to main

- [x] Ready to create production PR

