### PR TITLE
TTAHUB-4141 - Removing no-longer-desired fields from RTR Monitoring cards

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/Monitoring/components/DescriptionList.css
+++ b/frontend/src/pages/RecipientRecord/pages/Monitoring/components/DescriptionList.css
@@ -37,6 +37,10 @@
   .ttahub-data-card-description-list {
     grid-template-columns: repeat(6, 1fr);
   }
+
+  .ttahub-review-card--finding-within-review-description-list {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .ttahub-data-card-description-list.ttahub-data-card-description-list__vertical

--- a/frontend/src/pages/RecipientRecord/pages/Monitoring/components/FindingWithinReview.js
+++ b/frontend/src/pages/RecipientRecord/pages/Monitoring/components/FindingWithinReview.js
@@ -11,18 +11,12 @@ import './FindingWithinReview.css';
 export default function FindingWithinReview({ finding, regionId }) {
   return (
     <div className="ttahub-review-card--finding-within-review margin-top-4" key={uniqueId('review-card-finding-')}>
-      <DescriptionList>
+      <DescriptionList className="ttahub-review-card--finding-within-review-description-list">
         <DescriptionItem title="Citation">
           <CitationDrawer citationNumber={finding.citation} />
         </DescriptionItem>
-        <DescriptionItem title="Finding status">
-          {finding.status}
-        </DescriptionItem>
         <DescriptionItem title="Finding type">
           {finding.findingType}
-        </DescriptionItem>
-        <DescriptionItem title="Due date (as of review)">
-          {finding.correctionDeadline}
         </DescriptionItem>
         <DescriptionItem title="Category" className="ttahub-review-card--finding-within-review-category">
           {finding.category}


### PR DESCRIPTION
## Description of change

 In the 4/14 roadmap meeting, OHS requested fields to be removed from the RTR's monitoring page due to issues/confusion caused by ITAMS data.

## How to test

1. Load up RTR
2. Select a recipient
3. Go to the monitoring tab
4. Find a review and click "Show TTA Activity"
5. Note that only three fields are present: Citation, Finding Type, Category

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4141


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
