### PR TITLE
more db restore memory

### DIFF
--- a/automation/configs/process.yml
+++ b/automation/configs/process.yml
@@ -1,5 +1,5 @@
 instances: 1
-memory: 512M
+memory: 1G
 disk_quota: 1G
 
 buildpack: "https://github.com/cloudfoundry/nodejs-buildpack#v1.8.36"

--- a/automation/configs/processed-backup.yml
+++ b/automation/configs/processed-backup.yml
@@ -1,5 +1,5 @@
 instances: 1
-memory: 512M
+memory: 1G
 disk_quota: 64M
 
 buildpack: "binary_buildpack"

--- a/automation/configs/processed-restore.yml
+++ b/automation/configs/processed-restore.yml
@@ -1,5 +1,5 @@
 instances: 1
-memory: 512M
+memory: 1G
 disk_quota: 64M
 
 buildpack: "binary_buildpack"

--- a/automation/configs/processed-retention.yml
+++ b/automation/configs/processed-retention.yml
@@ -1,5 +1,5 @@
 instances: 1
-memory: 512M
+memory: 1G
 disk_quota: 64M
 
 buildpack: "binary_buildpack"

--- a/automation/configs/production-backup.yml
+++ b/automation/configs/production-backup.yml
@@ -1,5 +1,5 @@
 instances: 1
-memory: 512M
+memory: 1G
 disk_quota: 64M
 
 buildpack: "binary_buildpack"

--- a/automation/configs/production-restore.yml
+++ b/automation/configs/production-restore.yml
@@ -1,5 +1,5 @@
 instances: 1
-memory: 512M
+memory: 1G
 disk_quota: 64M
 
 buildpack: "binary_buildpack"

--- a/automation/configs/production-retention.yml
+++ b/automation/configs/production-retention.yml
@@ -1,5 +1,5 @@
 instances: 1
-memory: 512M
+memory: 1G
 disk_quota: 64M
 
 buildpack: "binary_buildpack"


### PR DESCRIPTION
## Description of change

* Increases allocated memory for db backup/restore automation jobs from 512 MB to 1GB.  This is intended to address recent failures seen due to OOM while these jobs are running, presumably due to the underlying database increasing in size.  Given that these jobs run in ~5-10 minutes at low-traffic times, the overall impact of increased allocated memory on account total should be minimal.

## How to test

Successful run against dev:
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/29498/workflows/f8df79d9-0ffe-45ed-b5df-357d9e757ee3

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
