### PR TITLE
extend inactive Grant availability to 90 days

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -1125,7 +1125,7 @@ export async function handleSoftDeleteReport(report) {
  * @returns {*} Grants and Other entities
  */
 export async function possibleRecipients(regionId, activityReportId = null) {
-  const inactiveDayDuration = 61;
+  const inactiveDayDuration = 90;
   const grants = await Recipient.findAll({
     attributes: [
       'id',

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -417,7 +417,7 @@ describe('Activity report service', () => {
         inactivationDate: new Date(new Date().setDate(new Date().getDate() - 60)),
       });
 
-      // Create a inactive grant with a 'inactivationDate' date more than 60 days ago.
+      // Create a inactive grant with a 'inactivationDate' date more than 90 days ago.
       await Grant.create({
         id: INACTIVE_GRANT_ID_TWO,
         number: faker.datatype.number({ min: 9999 }),
@@ -426,7 +426,7 @@ describe('Activity report service', () => {
         status: 'Inactive',
         startDate: new Date(),
         endDate: new Date(),
-        inactivationDate: new Date(new Date().setDate(new Date().getDate() - 62)),
+        inactivationDate: new Date(new Date().setDate(new Date().getDate() - 92)),
       });
 
       await Grant.create({
@@ -453,7 +453,7 @@ describe('Activity report service', () => {
         endDate: new Date(new Date().setDate(new Date().getDate() - 62)),
       });
 
-      // Create a ActivityReport outside of 60 days.
+      // Create a ActivityReport outside of 90 days.
       inactiveActivityReportTwo = await ActivityReport.create({
         ...submittedReport,
         userId: mockUser.id,
@@ -462,8 +462,8 @@ describe('Activity report service', () => {
         calculatedStatus: REPORT_STATUSES.DRAFT,
         activityRecipients: [],
         // Set a start date that will NOT return the inactive grant.
-        startDate: new Date(new Date().setDate(new Date().getDate() + 62)),
-        endDate: new Date(new Date().setDate(new Date().getDate() + 62)),
+        startDate: new Date(new Date().setDate(new Date().getDate() + 92)),
+        endDate: new Date(new Date().setDate(new Date().getDate() + 92)),
       });
 
       // Create a ActivityReport without start date.


### PR DESCRIPTION
## Description of change

Change the availability of expired grants from 61 days to 90

## How to test

You should be able to select the older replaced Grant for the Recipient at https://tta-smarthub-staging.app.cloud.gov/recipient-tta-records/1671/region/2/profile on an AR, then select a citation in it.
Turcotte LLC as of Jul 3

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4301


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
