### PR TITLE
[TTAHUB-4304] Patch integration for HSES breaking change

### DIFF
--- a/src/lib/updateGrantsRecipients.js
+++ b/src/lib/updateGrantsRecipients.js
@@ -324,7 +324,7 @@ export async function processFiles(hashSumHex) {
           g.grants_specialist_last_name,
         );
 
-        const regionId = parseInt(g.region_id, 10);
+        const regionId = parseInt(g.numeric_region_id, 10);
         const cdi = regionId === 13;
         const id = parseInt(g.grant_award_id, 10);
         // grant belonging to recipient's id 5 is merged under recipient's id 7782  (TTAHUB-705)

--- a/temp/grant_award.xml
+++ b/temp/grant_award.xml
@@ -3,6 +3,9 @@
   <grant_award_id>7842</grant_award_id>
   <agency_id>1335</agency_id>
   <region_id>2</region_id>
+  <numeric_region_id>2</numeric_region_id>
+  <geographic_region_id xsi:nil="true"/>
+  <geographic_region xsi:nil="true"/>
   <grant_number>02CH01105</grant_number>
   <grantee_state>CO</grantee_state>
   <grant_start_date>2014-03-01</grant_start_date>
@@ -18,6 +21,7 @@
   <grant_award_id>8110</grant_award_id>
   <agency_id>1335</agency_id>
   <region_id>2</region_id>
+  <numeric_region_id>2</numeric_region_id>
   <grant_number>02CH01106</grant_number>
   <grantee_state>MS</grantee_state>
   <grant_start_date>2014-07-01</grant_start_date>
@@ -38,6 +42,7 @@
   <grant_award_id>9999</grant_award_id>
   <agency_id>1335</agency_id>
   <region_id>2</region_id>
+  <numeric_region_id>2</numeric_region_id>
   <grant_number>02CH09999</grant_number>
   <grantee_state>MS</grantee_state>
   <grant_start_date>2014-07-01</grant_start_date>
@@ -53,6 +58,7 @@
   <grant_award_id>2591</grant_award_id>
   <agency_id>1335</agency_id>
   <region_id>2</region_id>
+  <numeric_region_id>2</numeric_region_id>
   <grant_number>02CH01107</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>2013-07-01</grant_start_date>
@@ -67,7 +73,8 @@
 <grant_award>
   <grant_award_id>11835</grant_award_id>
   <agency_id>1335</agency_id>
-  <region_id>2</region_id>
+  <region_id>81</region_id>
+  <numeric_region_id>2</numeric_region_id>
   <grant_number>02CH01108</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>2020-05-01</grant_start_date>
@@ -83,7 +90,8 @@
 <grant_award>
   <grant_award_id>10448</grant_award_id>
   <agency_id>1335</agency_id>
-  <region_id>2</region_id>
+  <region_id>81</region_id>
+  <numeric_region_id>2</numeric_region_id>
   <grant_number>02CH01109</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>2018-12-01</grant_start_date>
@@ -100,6 +108,7 @@
   <grant_award_id>6223</grant_award_id>
   <agency_id>1335</agency_id>
   <region_id>2</region_id>
+  <numeric_region_id>2</numeric_region_id>
   <grant_number>02CH01110</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>1992-03-01</grant_start_date>
@@ -114,7 +123,8 @@
 <grant_award>
   <grant_award_id>10567</grant_award_id>
   <agency_id>1335</agency_id>
-  <region_id>2</region_id>
+  <region_id>81</region_id>
+  <numeric_region_id>2</numeric_region_id>
   <grant_number>02CH01111</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>2019-03-01</grant_start_date>
@@ -135,6 +145,7 @@
   <grant_award_id>5151</grant_award_id>
   <agency_id>1119</agency_id>
   <region_id>11</region_id>
+  <numeric_region_id>11</numeric_region_id>
   <grant_number>90CI4444</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>1994-08-01</grant_start_date>
@@ -149,6 +160,7 @@
   <grant_award_id>8564</grant_award_id>
   <agency_id>1119</agency_id>
   <region_id>11</region_id>
+  <numeric_region_id>11</numeric_region_id>
   <grant_number>90CI5555</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>2015-01-01</grant_start_date>
@@ -163,7 +175,8 @@
 <grant_award>
   <grant_award_id>11628</grant_award_id>
   <agency_id>7709</agency_id>
-  <region_id>11</region_id>
+  <region_id>85</region_id>
+  <numeric_region_id>11</numeric_region_id>
   <grant_number>90CI090022</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>2020-01-01</grant_start_date>
@@ -178,7 +191,8 @@
 <grant_award>
   <grant_award_id>11630</grant_award_id>
   <agency_id>1119</agency_id>
-  <region_id>13</region_id>
+  <region_id>84</region_id>
+  <numeric_region_id>13</numeric_region_id>
   <grant_number>13CDI0001</grant_number>
   <grantee_state>CT</grantee_state>
   <grant_start_date>2020-01-01</grant_start_date>
@@ -194,6 +208,7 @@
   <grant_award_id>9957</grant_award_id>
   <agency_id>5</agency_id>
   <region_id>6</region_id>
+  <numeric_region_id>6</numeric_region_id>
   <grant_number>06HP000089</grant_number>
   <grantee_state>AR</grantee_state>
   <grant_start_date>2017-03-01</grant_start_date>
@@ -208,7 +223,8 @@
 <grant_award>
   <grant_award_id>14495</grant_award_id>
   <agency_id>7782</agency_id>
-  <region_id>6</region_id>
+  <region_id>83</region_id>
+  <numeric_region_id>6</numeric_region_id>
   <grant_number>06HP000499</grant_number>
   <grantee_state>AR</grantee_state>
   <grant_start_date>2021-09-01</grant_start_date>
@@ -223,7 +239,8 @@
 <grant_award>
   <grant_award_id>12297</grant_award_id>
   <agency_id>628</agency_id>
-  <region_id>5</region_id>
+  <region_id>83</region_id>
+  <numeric_region_id>5</numeric_region_id>
   <grant_number>05CH011591</grant_number>
   <grantee_state>MN</grantee_state>
   <grant_start_date>2020-08-01</grant_start_date>
@@ -239,6 +256,7 @@
   <grant_award_id>8317</grant_award_id>
   <agency_id>628</agency_id>
   <region_id>5</region_id>
+  <numeric_region_id>5</numeric_region_id>
   <grant_number>05CH8398</grant_number>
   <grantee_state>MN</grantee_state>
   <grant_start_date>2014-08-01</grant_start_date>
@@ -254,6 +272,7 @@
   <grant_award_id>12128</grant_award_id>
   <agency_id>628</agency_id>
   <region_id>5</region_id>
+  <numeric_region_id>5</numeric_region_id>
   <grant_number>05CH011696</grant_number>
   <grantee_state>PA</grantee_state>
   <grant_start_date>2020-07-01</grant_start_date>
@@ -268,6 +287,7 @@
   <grant_award_id>12129</grant_award_id>
   <agency_id>628</agency_id>
   <region_id>4</region_id>
+  <numeric_region_id>4</numeric_region_id>
   <grant_number>04CH011636</grant_number>
   <grantee_state>TN</grantee_state>
   <grant_start_date>2020-07-01</grant_start_date>
@@ -281,6 +301,7 @@
   <grant_award_id>10291</grant_award_id>
   <agency_id>628</agency_id>
   <region_id>9</region_id>
+  <numeric_region_id>9</numeric_region_id>
   <grant_number>09CH010707</grant_number>
   <grantee_state>FC</grantee_state>
   <grant_start_date>2018-08-01</grant_start_date>
@@ -297,6 +318,7 @@
   <grant_award_id>14869</grant_award_id>
   <agency_id>628</agency_id>
   <region_id>9</region_id>
+  <numeric_region_id>9</numeric_region_id>
   <grant_number>09CH012355</grant_number>
   <grantee_state>FC</grantee_state>
   <grant_start_date>2023-08-01</grant_start_date>


### PR DESCRIPTION
## Description of change
Updates our integration to use numeric_region_id in place of region_id, reflecting recent changes in the HSES data feed. Maintains compatibility with the latest HSES response format.


## How to test
Look at the code. No tests are needed.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4304


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [n/a] QA review complete

### Before merge to main

- [n/a] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
