### PR TITLE
Fix build and run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,15 @@ executors:
       environment:
         DATABASE_URL: postgresql://postgres@localhost/ttasmarthub
         REDIS_HOST: localhost
-        REDIS_PASS: ""
+        REDIS_PASS: secretpass
     - image: cimg/postgres:15.12
       environment:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: secretpass
         POSTGRES_DB: ttasmarthub
     - image: cimg/redis:6.2.17
+      environment:
+        REDIS_PASS: secretpass
   docker-python-executor:
     docker:
     - image: cimg/python:3.9.21

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
         POSTGRES_DB: ttasmarthub
     - image: cimg/redis:6.2.17
       environment:
-        REDIS_PASS: secretpass
+        REDIS_PASSWORD: secretpass
   docker-python-executor:
     docker:
     - image: cimg/python:3.9.21

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "sinon": "^15.0.0",
     "supertest": "^6.1.3",
     "tsx": "^3.12.2",
-    "typescript": "^5.8.0",
+    "typescript": "~5.2.0",
     "umzug": "^3.2.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "sinon": "^15.0.0",
     "supertest": "^6.1.3",
     "tsx": "^3.12.2",
-    "typescript": "~5.2.0",
+    "typescript": "^5.8.0",
     "umzug": "^3.2.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "sinon": "^15.0.0",
     "supertest": "^6.1.3",
     "tsx": "^3.12.2",
-    "typescript": "^4.9.0",
+    "typescript": "^5.8.0",
     "umzug": "^3.2.1"
   },
   "dependencies": {
@@ -379,7 +379,7 @@
     "sequelize": "^6.29.0",
     "sequelize-cli": "^6.2.0",
     "simple-git": "3.19.1",
-    "smartsheet": "^4.0.2",
+    "smartsheet": "^4.3.0",
     "ssh2": "^1.15.0",
     "throng": "^5.0.0",
     "through2": "^4.0.2",

--- a/src/lib/dataObjectUtils.ts
+++ b/src/lib/dataObjectUtils.ts
@@ -184,8 +184,8 @@ const remap = (
     let sourcePath:string;
     if (reverse) {
       sourcePath = Array.isArray(remappingDefinition[key])
-        ? remappingDefinition[key].slice(-1) as string
-        : remappingDefinition[key] as string;
+        ? (remappingDefinition[key].slice(-1) as unknown as string)
+        : (remappingDefinition[key] as string);
     } else {
       sourcePath = key;
     }

--- a/src/lib/queue.js
+++ b/src/lib/queue.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import Queue from 'bull';
 import { auditLogger } from '../logger';
+import { formatLogObject } from '../processHandler';
 
 const generateRedisConfig = (enableRateLimiter = false) => {
   if (process.env.VCAP_SERVICES) {
@@ -124,7 +125,7 @@ function handleShutdown(queue) {
 
 function handleException(queue) {
   return (err) => {
-    auditLogger.error('Uncaught exception:', err);
+    auditLogger.error('Uncaught exception:', formatLogObject(err));
     // queue.close().then(() => {
     //   auditLogger.error('Queue closed after uncaught exception.');
     //   removeQueueEventHandlers(queue);

--- a/src/routes/admin/redis.ts
+++ b/src/routes/admin/redis.ts
@@ -23,15 +23,13 @@ const logContext = { namespace };
 export async function getRedisInfo(req: Request, res: Response) {
   // admin access is already checked in the middleware
   try {
-    const {
-      uri: redisUrl,
-      tlsEnabled,
-    } = generateRedisConfig();
+    const { uri: redisUrl, tlsEnabled } = generateRedisConfig();
 
     redisClient = new Redis(redisUrl, {
       tls: tlsEnabled ? { rejectUnauthorized: false } : undefined,
     });
 
+    await redisClient.connect();
     const info = await redisClient.info();
 
     await redisClient.quit();
@@ -41,27 +39,25 @@ export async function getRedisInfo(req: Request, res: Response) {
   }
 }
 /**
-   * Runs flush all and then returns info on the redis instance
-   * as if you'd run the two commands
-   *
-   * https://redis.io/commands/flushall/
-   * https://redis.io/commands/info/
-   *
-   * @param {Request} _req - request
-   * @param {Response} res - response
-   */
+ * Runs flush all and then returns info on the redis instance
+ * as if you'd run the two commands
+ *
+ * https://redis.io/commands/flushall/
+ * https://redis.io/commands/info/
+ *
+ * @param {Request} _req - request
+ * @param {Response} res - response
+ */
 export async function flushRedis(req: Request, res: Response) {
   // admin access is already checked in the middleware
   try {
-    const {
-      uri: redisUrl,
-      tlsEnabled,
-    } = generateRedisConfig();
+    const { uri: redisUrl, tlsEnabled } = generateRedisConfig();
 
     redisClient = new Redis(redisUrl, {
       tls: tlsEnabled ? { rejectUnauthorized: false } : undefined,
     });
 
+    await redisClient.connect();
     const flush = await redisClient.flushall();
     auditLogger.info(`Redis cache flushAll with response ${flush}`);
 

--- a/src/routes/admin/ss.ts
+++ b/src/routes/admin/ss.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import express from 'express';
-import smartsheet from 'smartsheet';
+import { createClient } from 'smartsheet';
 import transactionWrapper from '../transactionWrapper';
 import handleErrors from '../../lib/apiErrorHandler';
 import { auditLogger as logger } from '../../logger';
@@ -25,7 +25,7 @@ const router = express.Router();
 
 // Function to create and return the Smartsheet client
 function createSmartsheetClient() {
-  return smartsheet.createClient({
+  return createClient({
     accessToken: process.env.SMARTSHEET_ACCESS_TOKEN,
     baseUrl: process.env.SMARTSHEET_ENDPOINT,
     logLevel: 'info',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11799,10 +11799,10 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-smartsheet@^4.0.2:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/smartsheet/-/smartsheet-4.2.3.tgz#7177c3cd68dfe0f7122dbd10dc20114c8da00186"
-  integrity sha512-Q18e+rWf4Ogbm/GGSENvuQKQs2f9bO+ANWmt5ejX9V+fcLqV08hhaDMX2qIUpAsTnTHzqpCnaGS3BO8U3VwbwA==
+smartsheet@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/smartsheet/-/smartsheet-4.3.0.tgz#53dde11cdd54243fe2753cbfb490eefb6c27cd86"
+  integrity sha512-f3CnpyPqGG17Ys6pNA1YAmK+eFNz3J7h7qwkkn8WIqvH2T98nIgWQOAtUJsiKTg3OnzBP65MktZiDiTC+6LiKA==
   dependencies:
     axios "^1.4.0"
     bluebird "^3.5.0"
@@ -12822,10 +12822,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.9.0:
-  version "4.9.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@~5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 uc.micro@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12822,10 +12822,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@~5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@^5.8.0:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 uc.micro@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## Description of change

* Set typescript version to 5.8.0, fixes `can't use default exports` errors from old js packages
* Set a password for redis during CI
* Await connection to redis when starting up
* Use named import for smartsheet and update the version
* Add stacktrace logging for uncaught exceptions