### PR TITLE
[TTAHUB-4330]Treat "Elevated Deficiency" as Active status for Findings

### DIFF
--- a/docs/it-ams-monitoring-data.md
+++ b/docs/it-ams-monitoring-data.md
@@ -138,7 +138,7 @@ A: If the automatic import fails, an engineer must manually run an import comman
 A: The intent is for citations to be available to select within the time period that TTA is being provided and ARs written. So:
 - As a prerequisite, a **Review** needs to reach a `Complete` status while being linked an `Active` **Finding** so a **Monitoring Goal** is created and available for use in ARs
 - The **Finding** must be linked through a **MonitoringFindingStandards** record to a **MonitoringStandards** record, which contains the citation text
-- As long as the **Finding** remains in `Active` status, it will remain selectable on ARs using the monitoring goal.
+- As long as the **Finding** remains in `Active` or `Elevated Deficiency` status, it will remain selectable on ARs using the monitoring goal.
 - Regardless of **Finding** status, if the _most recent_ **Review** has not reached a `Complete` state with a `reportDeliveryDate` prior to the AR `startDate`, then the citation will remain selectable
 - Once _both_ the most recent **Review** is `Complete` with a `reportDeliveryDate` prior to the AR `startDate` _and_ the **Finding** reaches one of the terminal states (`Corrected`,`Withdrawn`,`Closed`), then the citation will not appear or be selectable.
 

--- a/docs/monitoring-tech.md
+++ b/docs/monitoring-tech.md
@@ -106,7 +106,7 @@ A new goal is created if:
 * The review is Complete
 * It is of a type like 'AIAN-DEF', 'RAN', 'FA-1', 'Follow-up', 'FA1-FR',
           'FA-2', 'FA2-CR', 'Special'
-* There is at least one finding with a status name of 'Active' linked to the grant.
+* There is at least one finding with a status name of 'Active' linked to the grant
 * The grant has no existing goal linked to the Monitoring goal template
 
 In short:

--- a/docs/monitoring-tech.md
+++ b/docs/monitoring-tech.md
@@ -106,7 +106,7 @@ A new goal is created if:
 * The review is Complete
 * It is of a type like 'AIAN-DEF', 'RAN', 'FA-1', 'Follow-up', 'FA1-FR',
           'FA-2', 'FA2-CR', 'Special'
-* There is at least one active finding linked to the grant
+* There is at least one finding with a status name of 'Active' linked to the grant.
 * The grant has no existing goal linked to the Monitoring goal template
 
 In short:

--- a/src/services/citations.ts
+++ b/src/services/citations.ts
@@ -55,7 +55,7 @@ export async function getCitationsByGrantIds(
       FROM "MonitoringFindings" mf
       JOIN "MonitoringFindingStatuses" mfs
         ON mf."statusId" = mfs."statusId"
-      WHERE mfs.name = 'Active'
+      WHERE mfs.name IN ('Active', 'Elevated Deficiency')
         AND mf."sourceDeletedAt" IS NULL
       ),
       -- get the order and status of reviews associated with citations

--- a/src/tools/createMonitoringGoals.js
+++ b/src/tools/createMonitoringGoals.js
@@ -223,7 +223,7 @@ const createMonitoringGoals = async () => {
       ON mfh."findingId" = mf."findingId"
       JOIN "MonitoringFindingStatuses" mfs
       ON mf."statusId" = mfs."statusId"
-      AND mfs.name = 'Active'
+      AND mfs.name in ('Active', 'Elevated Deficiency')
       JOIN "MonitoringFindingGrants" mfg
       ON mf."findingId" = mfg."findingId"
       AND mrg."granteeId" = mfg."granteeId"


### PR DESCRIPTION
## Description of change

IT-AMS started using "Elevated Deficiency" as a status for Findings that should be treated as equivalent to "Active"

## How to test

Recipient 6301 (Caldwell Parish on prod) should show selectable citations. Use this link to easily find them:
https://tta-smarthub-staging.app.cloud.gov/recipient-tta-records/6301/region/6/profile

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4330

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
