### PR TITLE
[NO-TICKET] fix zap image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,7 +533,7 @@ jobs:
         command: ./bin/ping-server 9100 localhost /openapi.json
     - run:
         name: Pull OWASP ZAP docker image
-        command: docker pull softwaresecurityproject/zap-stable:latest
+        command: docker pull softwaresecurityproject/zap-stable:2.16.0
     - run:
         name: Run OWASP ZAP scan for Node.js server
         command: ./bin/run-owasp-scan --target http://server:8080 --full


### PR DESCRIPTION
## Description of change

zap "stable" docker repo no longer has a `latest` tag.
* there are two versions of this repo, [stable](https://hub.docker.com/r/softwaresecurityproject/zap-stable/tags) and [bare](https://hub.docker.com/r/softwaresecurityproject/zap-bare/tags).
* the `latest` tag only exists in the `bare` repo, so I have opted to use the latest explicit version from the stable repo.

## How to test

Successful run:
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/30293/workflows/1e45b254-a936-48c6-aa71-1d4f5be478e7

## Issue(s)

* N/A

