### PR TITLE
[NO-TICKET] Fix migrations being run against incorrect dev environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,8 +578,8 @@ jobs:
         command: |
           set -x
           TASK_NAME="$(echo "$CIRCLE_JOB" | tr ' ' '_')-<< parameters.target_env >>-${RANDOM}"
-          cf run-task tta-smarthub-${cfg_env} --command "yarn db:migrate:prod" --name ${TASK_NAME} --wait
-          cf logs tta-smarthub-${cfg_env} --recent | grep ${TASK_NAME}
+          cf run-task tta-smarthub-${full_env} --command "yarn db:migrate:prod" --name ${full_env} --wait
+          cf logs tta-smarthub-${full_env} --recent | grep ${TASK_NAME}
     - run:
         name: Alert on migration failure
         when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,7 +578,7 @@ jobs:
         command: |
           set -x
           TASK_NAME="$(echo "$CIRCLE_JOB" | tr ' ' '_')-<< parameters.target_env >>-${RANDOM}"
-          cf run-task tta-smarthub-${full_env} --command "yarn db:migrate:prod" --name ${full_env} --wait
+          cf run-task tta-smarthub-${full_env} --command "yarn db:migrate:prod" --name ${TASK_NAME} --wait
           cf logs tta-smarthub-${full_env} --recent | grep ${TASK_NAME}
     - run:
         name: Alert on migration failure


### PR DESCRIPTION
## Description of change

* After each deploy to cloud.gov, DB migrations are run via a cf "task" that executes in the application space.
* This task was always targeting "dev", when it should have been targeting "dev-green", "dev-blue", etc.
* This would have only happened when the space name doesn't match the app name, so staging and prod were unaffected. 

## How to test

Run a deploy targeting dev environment, verify the correct app/env is being targeted for migrations via log inspection

Before this fix:
`cf run-task ************-dev --command 'yarn db:migrate:prod' --name 'deploy_(dev-pink)`

After:
`cf run-task ************-dev-pink --command 'yarn db:migrate:prod' --name 'deploy_(dev-pink)`

https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/30442/workflows/c865d067-5409-4614-8831-4b2e98a011b6/jobs/181429

## Issue(s)

N/A

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
