### PR TITLE
[TTAHUB-4323] Fix goal card sorting

### DIFF
--- a/src/migrations/20231213210654-goalusers.js
+++ b/src/migrations/20231213210654-goalusers.js
@@ -521,7 +521,7 @@ module.exports = {
         and new_row_data ->> 'mapsToParentGoalId' IS NOT null
         GROUP BY 1,2
         `,
-        GOAL_COLLABORATORS.MERGE_DEPRECATOR,
+        'Merge-Deprecator',
       );
 
       const collectGoalCollaboratorsAsMergeCreator = () => collectGoalCollaborators(
@@ -542,7 +542,7 @@ module.exports = {
         AND new_row_data -> 'name' IS NOT NULL
         GROUP BY 1,2
         `,
-        GOAL_COLLABORATORS.MERGE_CREATOR,
+        'Merge-Creator',
       );
 
       const collectGoalCollaboratorsForMerged = () => /* sql */`
@@ -565,7 +565,7 @@ module.exports = {
             JOIN "Goals" pg
             ON g."mapsToParentGoalId" = pg.id
             WHERE g."mapsToParentGoalId" IS NOT NULL
-            AND ct.name NOT IN ('${GOAL_COLLABORATORS.MERGE_CREATOR}', '${GOAL_COLLABORATORS.MERGE_DEPRECATOR}')
+            AND ct.name NOT IN ('Merge-Creator', 'Merge-Deprecator')
           ),
           unrolled as (
             SELECT

--- a/src/services/standardGoalSorting.test.js
+++ b/src/services/standardGoalSorting.test.js
@@ -1,0 +1,194 @@
+import { GOAL_STATUS } from '../constants';
+import { standardGoalsForRecipient } from './standardGoals';
+import db from '../models';
+import { createRecipient, createGrant } from '../testUtils';
+
+const {
+  Goal,
+  GoalTemplate,
+  CollaboratorType,
+  GoalCollaborator,
+  User,
+  Grant,
+} = db;
+
+describe('standardGoalsForRecipient sorting tests', () => {
+  let recipient;
+  let grant;
+  let templateNotStarted;
+  let templateInProgress;
+  let templateSuspended;
+  let templateClosed;
+  let notStartedGoal;
+  let inProgressGoal;
+  let suspendedGoal;
+  let closedGoal;
+  let user;
+  let creatorType;
+
+  beforeAll(async () => {
+    // Create recipient and grant
+    recipient = await createRecipient();
+    grant = await createGrant({ recipientId: recipient.id, regionId: 1 });
+
+    // Create a goal template
+    // Create goal templates for each goal
+    templateNotStarted = await GoalTemplate.create({
+      templateName: 'Not Started Test Template',
+      creationMethod: 'Curated',
+    });
+
+    templateInProgress = await GoalTemplate.create({
+      templateName: 'In Progress Test Template',
+      creationMethod: 'Curated',
+    });
+
+    templateSuspended = await GoalTemplate.create({
+      templateName: 'Suspended Test Template',
+      creationMethod: 'Curated',
+    });
+
+    templateClosed = await GoalTemplate.create({
+      templateName: 'Closed Test Template',
+      creationMethod: 'Curated',
+    });
+
+    // Find a user to use as creator
+    user = await User.findOne();
+    if (!user) {
+      throw new Error('No user found for test');
+    }
+
+    // Create collaborator type for 'Creator'
+    const [creatorTypeFound] = await CollaboratorType.findOrCreate({
+      where: { name: 'Creator' },
+      defaults: { name: 'Creator' },
+    });
+    creatorType = creatorTypeFound;
+
+    // Create goals with different statuses
+    notStartedGoal = await Goal.create({
+      name: 'Not Started Goal',
+      status: GOAL_STATUS.NOT_STARTED,
+      grantId: grant.id,
+      goalTemplateId: templateNotStarted.id,
+      createdVia: 'rtr',
+    });
+
+    inProgressGoal = await Goal.create({
+      name: 'In Progress Goal',
+      status: GOAL_STATUS.IN_PROGRESS,
+      grantId: grant.id,
+      goalTemplateId: templateInProgress.id,
+      createdVia: 'rtr',
+    });
+
+    suspendedGoal = await Goal.create({
+      name: 'Suspended Goal',
+      status: GOAL_STATUS.SUSPENDED,
+      grantId: grant.id,
+      goalTemplateId: templateSuspended.id,
+      createdVia: 'rtr',
+    });
+
+    closedGoal = await Goal.create({
+      name: 'Closed Goal',
+      status: GOAL_STATUS.CLOSED,
+      grantId: grant.id,
+      goalTemplateId: templateClosed.id,
+      createdVia: 'rtr',
+    });
+
+    // Add collaborators to the goals
+    const goalIds = [
+      notStartedGoal?.id,
+      inProgressGoal?.id,
+      suspendedGoal?.id,
+      closedGoal?.id,
+    ].filter(Boolean);
+
+    if (goalIds.length > 0 && user?.id && creatorType?.id) {
+      await Promise.all(
+        goalIds.map((goalId) => (
+          GoalCollaborator.create({
+            goalId,
+            userId: user.id,
+            collaboratorTypeId: creatorType.id,
+          })
+        )),
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await GoalCollaborator.destroy({
+      where: {
+        goalId: [
+          notStartedGoal.id,
+          inProgressGoal.id,
+          suspendedGoal.id,
+          closedGoal.id,
+        ],
+      },
+      force: true,
+    });
+
+    // Clean up goals
+    await Goal.destroy({
+      where: {
+        id: [
+          notStartedGoal.id,
+          inProgressGoal.id,
+          suspendedGoal.id,
+          closedGoal.id,
+        ],
+      },
+      individualHooks: true,
+      force: true,
+    });
+
+    // Clean up goal template if it was created
+    await GoalTemplate.destroy({
+      where: {
+        id: [
+          templateNotStarted.id,
+          templateInProgress.id,
+          templateSuspended.id,
+          templateClosed.id],
+      },
+      individualHooks: true,
+      force: true,
+    });
+
+    // Clean up grant if it was created
+    await Grant.destroy({
+      where: {
+        id: grant.id,
+      },
+      individualHooks: true,
+      force: true,
+    });
+  });
+
+  it('sorts goals by status with ASC direction showing Not Started first', async () => {
+    // Call the function with the recipient and region from the grant
+    const result = await standardGoalsForRecipient(
+      recipient.id,
+      grant.regionId,
+      { sortBy: 'goalStatus', sortDir: 'asc' },
+    );
+
+    // Verify we have goals in the result
+    expect(result.goalRows.length).toBe(4);
+
+    // Assert the order of the goals by status
+    const expectedOrder = [
+      GOAL_STATUS.NOT_STARTED,
+      GOAL_STATUS.IN_PROGRESS,
+      GOAL_STATUS.CLOSED,
+      GOAL_STATUS.SUSPENDED,
+    ];
+    const actualOrder = result.goalRows.map((goal) => goal.status);
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+});

--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -875,7 +875,6 @@ export async function standardGoalsForRecipient(
       ],
     }
     : {};
-
   const goalRows = await Goal.findAll({
     attributes: [
       'id',
@@ -883,14 +882,7 @@ export async function standardGoalsForRecipient(
       'status',
       'createdAt',
       'goalTemplateId',
-      [
-        sequelize.literal(`(
-          SELECT MAX("createdAt")
-          FROM "GoalStatusChanges"
-          WHERE "goalId" = "Goal"."id"
-        )`),
-        'latestStatusChangeDate',
-      ],
+      // The underlying sort expect the status_sort column to be the first column _0.
       [sequelize.literal(`
         CASE
           WHEN COALESCE("Goal"."status",'')  = '' OR "Goal"."status" = 'Needs Status' THEN 1
@@ -901,6 +893,14 @@ export async function standardGoalsForRecipient(
           WHEN "Goal"."status" = 'Suspended' THEN 6
           ELSE 7 END`),
       'status_sort'],
+      [
+        sequelize.literal(`(
+          SELECT MAX("createdAt")
+          FROM "GoalStatusChanges"
+          WHERE "goalId" = "Goal"."id"
+        )`),
+        'latestStatusChangeDate',
+      ],
     ],
     where: {
       id: ids,


### PR DESCRIPTION
## Description of change

Looks like we moved to order of the status sort column that broke the sorting. I have fixed the order and added a test to ensure we get alerted to the change going forward. I also hard coded some enum values we removed in an older migration to hopefully fix an issue where the goal creator collaborator type would some times not be created.

## How to test

- Review the code
- Test the goal card sort order on RTR


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4323


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [x] Update JIRA ticket status
