### PR TITLE
[TTAHUB-4371] Add script for connecting to replica DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,15 @@ Our project includes four deployed Postgres databases, one to interact with each
    You will need to have the pg/redis client installed locally and findable in your $PATH.
    Production instances are generally inaccessible for direct connection, although this can be disabled when necessary.
 
+   Note: This plugin will not work for connecting to a replica database.  
+   Instead, use the script `./bin/replica-connect.sh` from this repo.
+   ```
+   ./bin/replica-connect.sh tta-smarthub-dev-blue
+    Establishing SSH tunnel with PID: 38115
+    Connecting to db replica for tta-smarthub-dev-blue on port 5432...
+    cgawsbrokerprodbt584djy6n6cnuz=> 
+    ```
+
 ##### Option B: Run script as task
 
 1. Use [cf run-task][cf-run-task] command

--- a/bin/replica-connect.sh
+++ b/bin/replica-connect.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 app_name"
+    echo "Example: $0 tta-smarthub-prod"
+    exit 1
+fi
+
+APP_NAME="$1"
+
+RAW_DATA=$(cf ssh $APP_NAME -c 'echo $VCAP_SERVICES')
+
+# parse
+REPLICA_HOST=$(echo $RAW_DATA | jq --raw-output '.["aws-rds"][0] | .credentials | .replica_host')
+
+PORT=$(echo $RAW_DATA | jq --raw-output '.["aws-rds"][0] | .credentials | .port')
+USER=$(echo $RAW_DATA | jq --raw-output '.["aws-rds"][0] | .credentials | .username')
+PASSWD=$(echo $RAW_DATA | jq --raw-output '.["aws-rds"][0] | .credentials | .password')
+DB_NAME=$(echo $RAW_DATA | jq --raw-output '.["aws-rds"][0] | .credentials | .db_name')
+
+# Ensure the port is available, kill any other process using it
+lsof -t -i ":${PORT}" | xargs kill 2>/dev/null || true
+
+cleanup() {
+    echo "Cleaning up..."
+    if [ -n "$SSH_PID" ]; then
+        kill $SSH_PID
+        echo "SSH tunnel closed."
+    fi
+    exit 0
+}
+
+trap 'cleanup' EXIT
+
+tunnel_cmd="cf ssh -N -L ${PORT}:${REPLICA_HOST}:${PORT} $APP_NAME"
+$tunnel_cmd &
+SSH_PID=$!
+echo "Establishing SSH tunnel with PID: $SSH_PID"
+sleep 3  # Wait for the SSH tunnel to establish
+
+echo "Connecting to db replica for ${APP_NAME} on port ${PORT}..."
+PGPASSWORD=$PASSWD; psql -h localhost -p ${PORT} -U ${USER} -d ${DB_NAME}
+
+

--- a/bin/replica-connect.sh
+++ b/bin/replica-connect.sh
@@ -41,6 +41,5 @@ echo "Establishing SSH tunnel with PID: $SSH_PID"
 sleep 3  # Wait for the SSH tunnel to establish
 
 echo "Connecting to db replica for ${APP_NAME} on port ${PORT}..."
+echo "Password: ${PASSWD}"
 PGPASSWORD=$PASSWD; psql -h localhost -p ${PORT} -U ${USER} -d ${DB_NAME}
-
-

--- a/bin/replica-connect.sh
+++ b/bin/replica-connect.sh
@@ -41,5 +41,5 @@ echo "Establishing SSH tunnel with PID: $SSH_PID"
 sleep 3  # Wait for the SSH tunnel to establish
 
 echo "Connecting to db replica for ${APP_NAME} on port ${PORT}..."
-echo "Password: ${PASSWD}"
-PGPASSWORD=$PASSWD; psql -h localhost -p ${PORT} -U ${USER} -d ${DB_NAME}
+#echo "Password: ${PASSWD}" # Uncomment if password prompt is triggered
+export PGPASSWORD=$PASSWD; psql -h localhost -p ${PORT} -U ${USER} -d ${DB_NAME}


### PR DESCRIPTION
## Description of change

* This is a workaround script for connecting to a replica DB in cloud.gov.  We currently have a replica running in prod and in dev-pink
* The usual `connect-to-service` plugin does not work for replica databases unfortunately, so I have created something equivalent.  This script gets the db info via VCAP_SERVICES on the app host, sets up an SSH tunnel through host in a background process, then starts a psql connection to this given address.  
* It will catch exit signals to the main process and attempt to close the SSH tunnel.  I have validated this works in a variety of cases myself, but just in case it doesn't it will a) print the PID of the tunnel process when created b) cleanup any previous zombie processes it finds on startup
* We still need more for TTAHUB-4371, but this is an important first step.

## How to test

```
> ./bin/replica-connect.sh tta-smarthub-dev-pink
Establishing SSH tunnel with PID: 38115
Connecting to db replica for tta-smarthub-dev-pink on port 5432...
psql (14.18 (Homebrew), server 15.12)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.

cgawsbrokerprodbt584djy6n6cnuz=>
\q
Cleaning up...
SSH tunnel closed.
```

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4371

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- N/A Meets accessibility standards (WCAG 2.1 Levels A, AA)
- N/A API Documentation updated
- N/A Boundary diagram updated
- N/A Logical Data Model updated
- N/A [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- N/A UI review complete
- N/A QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR
