### PR TITLE
Monitoring goals should show flag and "system-generated" message

### DIFF
--- a/frontend/src/components/GoalCards/StandardGoalCard.js
+++ b/frontend/src/components/GoalCards/StandardGoalCard.js
@@ -49,9 +49,10 @@ export default function StandardGoalCard({
     onAR,
     grant = { number: 'N/A' },
     previousStatus,
+    standard,
   } = goal;
 
-  const isMonitoringGoal = goal.createdVia === 'monitoring';
+  const isMonitoringGoal = standard === 'Monitoring';
   const { user } = useContext(UserContext);
   const { setIsAppLoading } = useContext(AppLoadingContext);
   const [localStatus, setLocalStatus] = useState(status);

--- a/frontend/src/components/GoalCards/__tests__/StandardGoalCard.js
+++ b/frontend/src/components/GoalCards/__tests__/StandardGoalCard.js
@@ -136,7 +136,7 @@ describe('StandardGoalCard', () => {
   });
 
   it('shows the monitoring flag when the goal createdVia is monitoring', () => {
-    renderStandardGoalCard({ }, { ...goal, createdVia: 'monitoring' });
+    renderStandardGoalCard({ }, { ...goal, standard: 'Monitoring' });
     const monitoringToolTip = screen.getByRole('button', {
       name: /reason for flag on goal g-1 is monitoring\. click button to visually reveal this information\./i,
     });

--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -910,11 +910,21 @@ export async function standardGoalsForRecipient(
         )`),
         'latestStatusChangeDate',
       ],
+      [
+        sequelize.literal('"goalTemplate"."standard"'),
+        'standard',
+      ],
     ],
     where: {
       id: ids,
     },
     include: [
+      {
+        model: GoalTemplate,
+        as: 'goalTemplate',
+        attributes: [],
+        required: true,
+      },
       {
         model: GoalStatusChange,
         as: 'statusChanges',


### PR DESCRIPTION
## Description of change

<img width="1387" height="424" src="https://github.com/user-attachments/assets/46ecaa4c-4209-4627-af46-077c84faa546" />

## How to test
Confirm that the monitoring goals display on the RTR, show the little red flag, and the correct "OHS" label with the "system-generated" tooltip.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4384


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
