### PR TITLE
[TTAHUB-4382] Change restart goal button text

### DIFF
--- a/frontend/src/components/SharedGoalComponents/constants.js
+++ b/frontend/src/components/SharedGoalComponents/constants.js
@@ -18,7 +18,7 @@ export const GOAL_FORM_BUTTON_LABELS = Object.freeze({
   SAVE: 'Save',
   GO_TO_EXISTING: 'Go to existing goal',
   ADD_GOAL: 'Add goal',
-  RESTART: 'Restart goal',
+  RESTART: 'Reopen goal',
 });
 
 export const NEW_GOAL_FORM_PAGES = Object.freeze({

--- a/frontend/src/pages/StandardGoalForm/__tests__/RestartStandardGoal.js
+++ b/frontend/src/pages/StandardGoalForm/__tests__/RestartStandardGoal.js
@@ -84,7 +84,7 @@ describe('RestartStandardGoal', () => {
       expect(fetchMock.called('/api/goal-templates/standard/1/grant/1?status=Closed')).toBe(true);
     });
 
-    expect(await screen.findByRole('button', { name: /Restart/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Reopen/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Cancel/i })).toBeInTheDocument();
   });
 
@@ -108,7 +108,7 @@ describe('RestartStandardGoal', () => {
       expect(fetchMock.called('/api/goal-templates/standard/1/grant/1?status=Closed')).toBe(true);
     });
 
-    const submitButton = await screen.findByRole('button', { name: /Restart/i });
+    const submitButton = await screen.findByRole('button', { name: /Reopen/i });
     await act(async () => {
       userEvent.click(submitButton);
     });
@@ -127,7 +127,7 @@ describe('RestartStandardGoal', () => {
       expect(fetchMock.called('/api/goal-templates/standard/1/grant/1?status=Closed')).toBe(true);
     });
 
-    const submitButton = await screen.findByRole('button', { name: /Restart/i });
+    const submitButton = await screen.findByRole('button', { name: /Reopen/i });
     await act(async () => {
       userEvent.click(submitButton);
     });


### PR DESCRIPTION
## Description of change

Updated the text to say 'Reopen goal' instead of 'Restart goal'.

<img width="662" height="193" alt="image" src="https://github.com/user-attachments/assets/2a495373-1e39-4c92-bbb9-583c1cb12f42" />


## How to test
 
- Review code
- Make sure the button shows correctly.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4382


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
