### PR TITLE
[TTAHUB-4308]set submissionstatus on deleted ars

### DIFF
--- a/src/migrations/20250901000000-close_prestandard_goals_etc.js
+++ b/src/migrations/20250901000000-close_prestandard_goals_etc.js
@@ -132,6 +132,7 @@ module.exports = {
         UPDATE "ActivityReports"
         SET
           "calculatedStatus" = 'deleted',
+          "submissionStatus" = 'deleted',
           "updatedAt" = NOW()
         WHERE "calculatedStatus" IS NULL
           OR "calculatedStatus" NOT IN ('deleted','approved')


### PR DESCRIPTION
## Description of change

A small fix to the migration so the ARs are actually deleted. Not sure if this will really work or if (very likely) it will need a new migration.

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4308


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
