### PR TITLE
[TTAHUB-4308]close all merged goals

### DIFF
--- a/src/migrations/20250901000000-close_prestandard_goals_etc.js
+++ b/src/migrations/20250901000000-close_prestandard_goals_etc.js
@@ -54,6 +54,7 @@ module.exports = {
           AND gt.standard IN ('Monitoring','FEI','CLASS Monitoring')
           AND g.status != 'Closed'
           AND g."deletedAt" IS NULL
+          AND g."mapsToParentGoalId" IS NULL
         ;
 
         -- 2: Complete any In Progress Objectives not on those Goals

--- a/src/migrations/20250901000000-close_prestandard_goals_etc.js
+++ b/src/migrations/20250901000000-close_prestandard_goals_etc.js
@@ -46,7 +46,7 @@ module.exports = {
         DROP TABLE IF EXISTS retained_goals;
         CREATE TEMP TABLE retained_goals
         AS
-        SELECT DISTINCT ON (g."grantId") g.id gid
+        SELECT DISTINCT ON (g."grantId", g."goalTemplateId") g.id gid
         FROM "Goals" g
         JOIN "GoalTemplates" gt
           ON g."goalTemplateId" = gt.id
@@ -55,7 +55,7 @@ module.exports = {
           AND g.status != 'Closed'
           AND g."deletedAt" IS NULL
           AND g."mapsToParentGoalId" IS NULL
-        ORDER BY g."grantId", g.id DESC
+        ORDER BY g."grantId", g."goalTemplateId", g.id DESC
         ;
 
         -- 2: Complete any In Progress Objectives not on those Goals

--- a/src/migrations/20250901000000-close_prestandard_goals_etc.js
+++ b/src/migrations/20250901000000-close_prestandard_goals_etc.js
@@ -46,7 +46,7 @@ module.exports = {
         DROP TABLE IF EXISTS retained_goals;
         CREATE TEMP TABLE retained_goals
         AS
-        SELECT DISTINCT g.id gid
+        SELECT DISTINCT ON (g."grantId") g.id gid
         FROM "Goals" g
         JOIN "GoalTemplates" gt
           ON g."goalTemplateId" = gt.id
@@ -55,6 +55,7 @@ module.exports = {
           AND g.status != 'Closed'
           AND g."deletedAt" IS NULL
           AND g."mapsToParentGoalId" IS NULL
+        ORDER BY g."grantId", g.id DESC
         ;
 
         -- 2: Complete any In Progress Objectives not on those Goals


### PR DESCRIPTION
## Description of change

Merged goals are not necessarily closed in the process of being merged, meaning that there is a crop of effectively duplicate goals that causes problems for constraints we want to apply in the standard Goal era. This makes it so those merged-away goals also get Closed 

## How to test

This should allow the follow-on migration to apply successfully.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4308
* https://jira.acf.gov/browse/TTAHUB-4005

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
