### PR TITLE
[TTAHUB-4417] db restore job optimizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ workflows:
         requires:
         - backup_temp_db
 
-  backup_db_manual:
+  backup_prod_manual:
     # backup prod db, process(anonymize) it, then backup the processed db
     when: pipeline.parameters.action == "backup_prod" and pipeline.trigger_source == "api"
     jobs:
@@ -241,10 +241,9 @@ workflows:
     # restore the anonymized db snapshot to a lower env db and run migrations
     # uses the last production backup, does not interact with prod or modify snapshots
     when: pipeline.parameters.action == "restore_db" and pipeline.trigger_source == "api"
+    jobs:
     - restore_db_job:
         serial-group: tta-automation-lock
-        requires:
-        - backup_temp_db
         target_env: "<< pipeline.parameters.target_env >>"
 
 # ----------------- Jobs -----------------


### PR DESCRIPTION
## Description of change

* split out manual db restore and manual prod backup into two separate jobs
* this enables fast, non-disruptive and on-demand restore to a dev environment when necessary, and additional prod backup can be triggered if/when desired.  note: prod backup & anonymization occurs automatically every night


## How to test

Restore Job:
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/30854/workflows/73c195bb-7c3d-450b-9ead-29ac312fc1ae

Backup Job:
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/30856/workflows/14d7d4b4-9178-4336-a619-5132e1886f2e

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4417

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR
