### PR TITLE
[NO-TICKET] Auto-retry CircleCI from failed step 3x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ workflows:
     # It will build the app, run all tests, then deploy if the branch matches
     # autodeploy: main->staging, production->prod
     when: pipeline.parameters.action == "build_test_deploy"
+    max_auto_reruns: 3
     jobs:
     - build_and_lint
     - build_similarity_api
@@ -159,6 +160,7 @@ workflows:
     # backup temp db to snapshot
     # restore temp snapshot to lower env dbs
     # run migrations
+    max_auto_reruns: 3
     triggers:
     - schedule:
         cron: "0 4 * * *" # 4AM UTC = 12AM EST


### PR DESCRIPTION
## Description of change

Noticed that CircleCI released a new feature: auto-retries.  Due to the fact that our backend tests are still somewhat flaky, I have enabled 3 automatic retries on this job and the db restore job.  This will function the same as "retry from failed" behavior, which is what we would usually click when the normal build_test_deploy job.

Reference:
https://circleci.com/changelog/automatic-retry-of-workflows-released/

## How to test

Validated job runs as normal, and that jobs will retry as expected.

## Issue(s)

N/A
