### PR TITLE
[TTAHUB-4451] Fix monitoring created via

### DIFF
--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -351,6 +351,7 @@ export async function saveStandardGoalsForReport(goals, userId, report) {
     // eslint-disable-next-line implicit-arrow-linebreak
     const goalTemplate = await GoalTemplate.findByPk(goal.goalTemplateId);
     const isMonitoring = goalTemplate.standard === 'Monitoring';
+    const createdVia = isMonitoring ? 'monitoring' : 'activityReport';
     return Promise.all(goal.grantIds.map(async (grantId) => {
       let newOrUpdatedGoal = existingGoals.find((existingGoal) => (
         existingGoal.grantId === grantId && existingGoal.goalTemplateId === goal.goalTemplateId
@@ -372,7 +373,7 @@ export async function saveStandardGoalsForReport(goals, userId, report) {
       if (!newOrUpdatedGoal) {
         newOrUpdatedGoal = await Goal.create({
           goalTemplateId: goalTemplate.id,
-          createdVia: 'activityReport',
+          createdVia,
           name: goalTemplate.templateName,
           grantId,
           status: GOAL_STATUS.NOT_STARTED,
@@ -643,12 +644,16 @@ export async function newStandardGoal(
     throw new Error('Standard goal has already been utilized');
   }
 
+  const isMonitoring = standard.standard === 'Monitoring';
+
+  const createdVia = isMonitoring ? 'monitoring' : 'rtr';
+
   const newGoal = await Goal.create({
     status,
     name: standard.templateName,
     grantId,
     goalTemplateId: standard.id,
-    createdVia: 'rtr',
+    createdVia,
   });
 
   // a new goal does not require objectives, but may include them


### PR DESCRIPTION
## Description of change
Fix the createdVia attributes for monitoring goals when reopened.


## How to test
Close a monitoring goal (admins can). Must be "prestandard: false"
Reopen monitoring goal
Confirm goal can be used on AR

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4451


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
