### PR TITLE
[TTAHUB-4443] Monitoring goal fixes for tool tip and goal details 

### DIFF
--- a/frontend/src/components/GoalCards/StandardGoalCard.js
+++ b/frontend/src/components/GoalCards/StandardGoalCard.js
@@ -261,7 +261,7 @@ export default function StandardGoalCard({
   };
 
   const renderEnteredBy = () => {
-    if (isMonitoringGoal) {
+    if (isMonitoringGoal && (!lastStatusChange || !lastStatusChange.user)) {
       return (
         <SpecialistTags
           specialists={[{

--- a/frontend/src/components/GoalCards/__tests__/StandardGoalCard.js
+++ b/frontend/src/components/GoalCards/__tests__/StandardGoalCard.js
@@ -184,6 +184,32 @@ describe('StandardGoalCard', () => {
     expect(tooltip.textContent).toContain('System-generated');
   });
 
+  // New test: monitoring "Started by" overrides any user-based tags/tooltips
+  it('monitoring goals show System-generated and hide user tags/tooltips in Started by', () => {
+    const monitoringWithUser = {
+      ...goal,
+      standard: 'Monitoring',
+      statusChanges: [],
+    };
+
+    renderStandardGoalCard({}, monitoringWithUser);
+    expect(screen.getByText(/started by/i)).toBeInTheDocument();
+
+    // Should show system generated indicators
+    expect(screen.getByText(/System-generated/i)).toBeInTheDocument();
+    expect(screen.getByText(/OHS/i)).toBeInTheDocument();
+
+    // Should not show user role tags when monitoring
+    expect(screen.queryByText(/ECS/i)).not.toBeInTheDocument();
+
+    // Tooltip should reflect System-generated, not user
+    const tooltips = screen.getAllByTestId('tooltip');
+    const enteredByTooltip = tooltips.find((t) => t.classList.contains('ttahub-goal-card__entered-by-tooltip'));
+    expect(enteredByTooltip).toBeInTheDocument();
+    expect(enteredByTooltip.textContent).toContain('System-generated');
+    expect(enteredByTooltip.textContent).not.toContain('Test User');
+  });
+
   it('renders nothing when statusChanges has no user data', () => {
     const goalWithEmptyStatusChanges = {
       ...goal,

--- a/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/__tests__/index.js
@@ -455,4 +455,19 @@ describe('ViewGoalDetails', () => {
     expect(updates).toHaveLength(1);
     expect(updates[0]).toHaveTextContent(`Added on ${formatDate('2024-10-01T00:00:00.000Z')} by Pizza Man`);
   });
+
+  test('renders by ohs tool tip if goal is monitoring and status is Not Started', async () => {
+    const monitoringGoal = {
+      id: 6,
+      name: 'G-6',
+      status: 'Not Started',
+      standard: 'Monitoring',
+    };
+
+    fetchMock.get(goalHistoryUrl, [monitoringGoal, ...mockGoalHistory]);
+    await act(async () => {
+      renderViewGoalDetails();
+    });
+    expect(screen.getByText(/by ohs/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/index.js
@@ -198,6 +198,16 @@ export default function ViewGoalDetails({
 
     const objectives = goal.objectives || [];
 
+    const getUserByFromStatus = (update) => {
+      if (goal.standard === 'Monitoring' && update.newStatus === 'Not Started') {
+        return ' by OHS';
+      }
+      if (update.user) {
+        return ` by ${update.user.name}, ${update.user.roles.map(({ name }) => name).join(', ')}`;
+      }
+      return '';
+    };
+
     return {
       id: `goal-${goal.id}`,
       title: `G-${goal.id} | ${goal.status}`,
@@ -239,7 +249,7 @@ export default function ViewGoalDetails({
                       <strong>
                         {update.performedAt}
                       </strong>
-                      {update.user ? ` by ${update.user.name}, ${update.user.roles.map(({ name }) => name).join(', ')}` : ''}
+                      {getUserByFromStatus(update)}
                       {(update.newStatus === GOAL_STATUS.SUSPENDED
                       && updateIndex !== statusUpdates.length - 1)
                         ? (


### PR DESCRIPTION
## Description of change

We were not correctly handling the display of 'added on' and 'started on' for a monitoring goal in both the goal card and goal details.

## How to test

- Review the code.
- Make sure the goal card displays the name of the person who started the monitoring goal (use on report)
- Make sure the 'Added on' in goal details shows 'by OHS'

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4443


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
