### PR TITLE
[TTAHUB-4482] Ffix reopen goal header

### DIFF
--- a/frontend/src/components/GoalForm/GoalFormTitle.js
+++ b/frontend/src/components/GoalForm/GoalFormTitle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const GoalFormTitle = ({ goalNumbers, isReopenedGoal }) => {
-  const formTitle = goalNumbers && goalNumbers.length ? `Goal ${goalNumbers.join(', ')}${isReopenedGoal ? '-R' : ''}` : 'Recipient TTA goal';
+  const formTitle = goalNumbers && goalNumbers.length && !isReopenedGoal ? `Goal ${goalNumbers.join(', ')}` : 'Recipient TTA goal';
   return (
     <h2 className="font-serif-xl margin-0">{formTitle}</h2>
   );

--- a/frontend/src/components/GoalForm/__tests__/GoalFormTitle.js
+++ b/frontend/src/components/GoalForm/__tests__/GoalFormTitle.js
@@ -13,7 +13,15 @@ describe('GoalFormTitle', () => {
 
   test('renders the correct form title when goalNumbers is empty', () => {
     const goalNumbers = [];
-    const isReopenedGoal = false;
+    const isReopenedGoal = true;
+    render(<GoalFormTitle goalNumbers={goalNumbers} isReopenedGoal={isReopenedGoal} />);
+    const formTitle = screen.getByText('Recipient TTA goal');
+    expect(formTitle).toBeInTheDocument();
+  });
+
+  test('renders the correct form title when goalNumbers not empty on a reopen', () => {
+    const goalNumbers = ['1', '2', '3'];
+    const isReopenedGoal = true;
     render(<GoalFormTitle goalNumbers={goalNumbers} isReopenedGoal={isReopenedGoal} />);
     const formTitle = screen.getByText('Recipient TTA goal');
     expect(formTitle).toBeInTheDocument();
@@ -21,9 +29,9 @@ describe('GoalFormTitle', () => {
 
   test('renders the correct form title when isReopenedGoal is true', () => {
     const goalNumbers = ['1', '2', '3'];
-    const isReopenedGoal = true;
+    const isReopenedGoal = false;
     render(<GoalFormTitle goalNumbers={goalNumbers} isReopenedGoal={isReopenedGoal} />);
-    const formTitle = screen.getByText('Goal 1, 2, 3-R');
+    const formTitle = screen.getByText('Goal 1, 2, 3');
     expect(formTitle).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/SharedGoalComponents/GoalFormUpdateOrRestart.js
+++ b/frontend/src/components/SharedGoalComponents/GoalFormUpdateOrRestart.js
@@ -31,7 +31,7 @@ export default function GoalFormUpdateOrRestart({
       <GoalFormNavigationLink recipient={recipient} regionId={regionId} />
       <GoalFormHeading recipient={recipient} regionId={regionId} />
       <GoalFormContainer>
-        <GoalFormTitleGroup status={GOAL_STATUS.NOT_STARTED} goalNumbers={[`G-${goal.id}`]} />
+        <GoalFormTitleGroup status={GOAL_STATUS.NOT_STARTED} goalNumbers={[`G-${goal.id}`]} isReopenedGoal={isRestart} />
         <ReadOnlyField label="Recipient grant numbers">
           {goal.grant.numberWithProgramTypes}
         </ReadOnlyField>

--- a/frontend/src/pages/RecipientRecord/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/__tests__/index.js
@@ -302,7 +302,7 @@ describe('recipient record page', () => {
     memoryHistory.push('/recipient-tta-records/1/region/45/standard-goals/10/grant/10/restart');
     act(() => renderRecipientRecord());
     await waitFor(() => expect(screen.queryByText(/loading.../)).toBeNull());
-    expect(await screen.findByText(/Goal G-1234/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Recipient TTA goal/i)).toBeInTheDocument();
   });
 
   it('navigates to the update standard goal', async () => {


### PR DESCRIPTION
## Description of change

We were incorrectly showing the old goal numbers on the header of the RTR goal re-open page. It looks like the param was never being passed down. It also looks like it displayed a bad value '-r' if we had goal numbers.

## How to test

- Review the code
- Ensure we only show the generic header on a reopen 'Recipient TTA Goal'. (see https://www.figma.com/design/L3LrqOhOWCpFsYHRrbupyA/Standard-Goals?node-id=422-21024&m=dev)

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4482


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
