### PR TITLE
[TTAHUB-2264] include ghost goal in standard goal closures

### DIFF
--- a/src/migrations/20250915000000-close-ghost-goal.js
+++ b/src/migrations/20250915000000-close-ghost-goal.js
@@ -1,0 +1,146 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      await queryInterface.sequelize.query(/* sql */`
+        ---------- The steps -------------------------------------------------
+        -- 1: Make sure it's the correct ghost goal
+        -- 2: Complete any In Progress Objectives on that Goal
+        -- 3: actually close the ghost goal
+        --    "true", but all future records "false" by default.
+        ----------------------------------------------------------------------
+
+        -- Just here for validation convenience
+        DROP TABLE IF EXISTS beforestats;
+        CREATE TEMP TABLE beforestats
+        AS
+        SELECT
+          'goals' entity,
+          COUNT(*) FILTER (WHERE status = 'Closed') closed,
+          COUNT(*) FILTER (WHERE status != 'Closed') open
+        FROM "Goals"
+        WHERE "deletedAt" IS NULL
+        UNION
+        SELECT
+          'objectives',
+          COUNT(*) FILTER (WHERE status = 'Complete'),
+          COUNT(*) FILTER (WHERE status != 'Complete')
+        FROM "Objectives"
+        WHERE "deletedAt" IS NULL
+        ORDER BY 1
+        ;
+
+        -- 1: Make sure it's the correct ghost goal
+        DROP TABLE IF EXISTS goals_to_close;
+        CREATE TEMP TABLE goals_to_close
+        AS
+        SELECT DISTINCT
+          g.id gid
+        FROM "Goals" g
+        JOIN "Grants" gr
+          ON g."grantId" = gr.id
+        WHERE g.id = 103372
+          AND gr.number = '90CI010132'
+        ;
+
+        -- 2: Complete any In Progress Objectives on that Goal
+        DROP TABLE IF EXISTS obj_to_complete;
+        CREATE TEMP TABLE obj_to_complete
+        AS
+        SELECT DISTINCT
+          o.id oid,
+          o."otherEntityId" IS NOT NULL other_entity
+        FROM "Objectives" o
+        JOIN goals_to_close
+          ON o."goalId" = gid
+        ;
+        
+        UPDATE "Objectives" o
+        SET
+          status = 'Complete',
+          "updatedAt" = NOW()
+        FROM obj_to_complete
+        WHERE id = oid
+        ;
+
+        -- 3: actually close the ghost goal
+        DROP TABLE IF EXISTS inserted_goal_closures;
+        CREATE TEMP TABLE inserted_goal_closures
+        AS
+        WITH updater AS (
+        INSERT INTO "GoalStatusChanges" (
+          "goalId",
+          "oldStatus",
+          "newStatus",
+          reason
+        )
+        SELECT
+          id,
+          status,
+          'Closed',
+          'Autoclosure in preparation for Standard Goals'
+        FROM "Goals"
+        JOIN goals_to_close
+          ON id = gid
+        RETURNING *
+        )
+        SELECT * FROM updater
+        ;
+
+        UPDATE "Goals"
+        SET
+          status = 'Closed',
+          prestandard = TRUE,
+          "updatedAt" = NOW()
+        FROM goals_to_close
+        WHERE id = gid
+        ;
+
+        -- Final query for validation convenience
+        DROP TABLE IF EXISTS afterstats;
+        CREATE TEMP TABLE afterstats
+        AS
+        SELECT
+          'goals' entity,
+          COUNT(*) FILTER (WHERE status = 'Closed') closed,
+          COUNT(*) FILTER (WHERE status != 'Closed') open,
+          (SELECT COUNT(*) FROM goals_to_close) AS close_updates,
+          (SELECT COUNT(*) FROM inserted_goal_closures) AS closures_inserted
+        FROM "Goals"
+        WHERE "deletedAt" IS NULL
+        UNION
+        SELECT
+          'objectives',
+          COUNT(*) FILTER (WHERE status = 'Complete'),
+          COUNT(*) FILTER (WHERE status != 'Complete'),
+          (SELECT COUNT(*) FROM obj_to_complete),
+          NULL
+        FROM "Objectives"
+        WHERE "deletedAt" IS NULL
+        ORDER BY 1
+        ;
+
+        SELECT
+          b.entity,
+          b.open orig_open,
+          b.closed orig_closed,
+          a.close_updates closed,
+          a.open new_open,
+          a.closed new_closed,
+          a.closures_inserted
+        FROM beforestats b
+        JOIN afterstats a
+          ON a.entity=b.entity
+        ;
+    `, { transaction });
+    });
+  },
+
+  async down() {
+    // no rollbacks of data fixes
+  },
+};


### PR DESCRIPTION
## Description of change

There was a ghost FEI goal that otherwise met the criteria for retention. This applies the same closure logic used for other prestandard goals.

## How to test

It has a convenience validation query

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-2264


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
