### PR TITLE
[TTAHUB-4114] Remove reason from TTA History

### DIFF
--- a/frontend/src/widgets/FrequencyGraph.js
+++ b/frontend/src/widgets/FrequencyGraph.js
@@ -1,7 +1,6 @@
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from '@trussworks/react-uswds';
-import { capitalize } from 'lodash';
 import withWidgetData from './withWidgetData';
 import Container from '../components/Container';
 import AccessibleWidgetData from './AccessibleWidgetData';
@@ -19,53 +18,34 @@ function sortData(data, isTabular) {
 }
 
 const TOPIC_STR = 'topics';
-const REASON_STR = 'reasons';
 
 const HEADINGS = {
   [TOPIC_STR]: ['Topic', 'Count'],
-  [REASON_STR]: ['Reason', 'Count'],
 };
 
 export function FreqGraph({ data, loading }) {
   // whether to show the data as accessible widget data or not
   const [showAccessibleData, updateShowAccessibleData] = useState(false);
-  const [selectedGraph, updateSelectedGraph] = useState(TOPIC_STR);
   const widgetRef = useRef(null);
 
-  const selectedData = data[selectedGraph];
+  const selectedData = data[TOPIC_STR];
   const sortedData = sortData(selectedData, showAccessibleData);
   const accessibleRows = sortedData.map((row) => ({ data: [row.category, row.count] }));
 
-  const columnHeadings = HEADINGS[selectedGraph];
-  const toggleGraphLabel = selectedGraph === TOPIC_STR ? REASON_STR : TOPIC_STR;
-
-  function toggleSelectedGraph() {
-    updateSelectedGraph((current) => (current === TOPIC_STR ? REASON_STR : TOPIC_STR));
-  }
+  const columnHeadings = HEADINGS[TOPIC_STR];
 
   return (
-    <Container className="ttahub--frequency-graph position-relative" loading={loading} loadingLabel={`${selectedGraph} frequency loading`}>
+    <Container className="ttahub--frequency-graph position-relative" loading={loading} loadingLabel="Topics frequency loading">
       <Grid row className="position-relative margin-bottom-2">
         <Grid className="flex-align-self-center desktop:display-flex flex-align-center" desktop={{ col: 'auto' }} mobileLg={{ col: 10 }}>
           <h2 className="display-inline desktop:margin-y-0 margin-left-1" aria-live="polite">
-            {capitalize(selectedGraph)}
-            {' '}
-            in activity reports
+            Topics in activity reports
           </h2>
-          <button
-            type="button"
-            className="usa-button--unstyled margin-left-2"
-            aria-label={`display number of activity reports by ${toggleGraphLabel}`}
-            onClick={toggleSelectedGraph}
-          >
-            {capitalize(toggleGraphLabel)}
-            {' '}
-            in activity reports
-          </button>
         </Grid>
         <Grid desktop={{ col: 'auto' }} className="ttahub--show-accessible-data-button flex-align-self-center">
           <DisplayTableToggle
-            title={`number of activity reports by ${selectedGraph}`}
+            displayTable={showAccessibleData}
+            title="number of activity reports by topics"
             setDisplayTable={updateShowAccessibleData}
           />
         </Grid>
@@ -73,7 +53,7 @@ export function FreqGraph({ data, loading }) {
       { showAccessibleData
         ? (
           <AccessibleWidgetData
-            caption={`Number of Activity Reports by ${selectedGraph} Table`}
+            caption="Number of Activity Reports by Topics Table"
             columnHeadings={columnHeadings}
             rows={accessibleRows}
           />
@@ -81,7 +61,7 @@ export function FreqGraph({ data, loading }) {
         : (
           <BarGraph
             data={sortedData}
-            xAxisLabel={capitalize(selectedGraph)}
+            xAxisLabel="Topics"
             widgetRef={widgetRef}
           />
         )}
@@ -102,7 +82,7 @@ FreqGraph.propTypes = {
 };
 
 FreqGraph.defaultProps = {
-  data: { [TOPIC_STR]: [], [REASON_STR]: [] },
+  data: { [TOPIC_STR]: [] },
 };
 
 export default withWidgetData(FreqGraph, 'frequencyGraph');

--- a/frontend/src/widgets/__tests__/FrequencyGraph.js
+++ b/frontend/src/widgets/__tests__/FrequencyGraph.js
@@ -22,20 +22,6 @@ const TEST_DATA = {
       count: 0,
     },
   ],
-  reasons: [
-    {
-      category: 'one',
-      count: 1,
-    },
-    {
-      category: 'two',
-      count: 2,
-    },
-    {
-      category: 'three',
-      count: 0,
-    },
-  ],
 };
 
 const renderFrequencyGraph = async () => (
@@ -43,17 +29,9 @@ const renderFrequencyGraph = async () => (
 );
 
 describe('Frequency Graph', () => {
-  it('shows topics by default', async () => {
+  it('shows topics', async () => {
     renderFrequencyGraph();
     const topics = await screen.findByRole('heading', { name: /topics in activity reports/i });
-    expect(topics).toBeInTheDocument();
-  });
-
-  it('can switch to show reasons', async () => {
-    renderFrequencyGraph();
-    const toggleGraphButton = await screen.findByRole('button', { name: /display number of activity reports by reasons/i });
-    userEvent.click(toggleGraphButton);
-    const topics = await screen.findByRole('heading', { name: /reasons in activity reports/i });
     expect(topics).toBeInTheDocument();
   });
 
@@ -62,5 +40,22 @@ describe('Frequency Graph', () => {
     const accessibleBtn = await screen.findByText('Display table');
     userEvent.click(accessibleBtn);
     expect(await screen.findByText('first category')).toBeInTheDocument();
+  });
+
+  it('can toggle back to graph view', async () => {
+    renderFrequencyGraph();
+    // First toggle to table view
+    const tableBtn = await screen.findByText('Display table');
+    userEvent.click(tableBtn);
+
+    // Verify we're in table view first
+    expect(screen.queryByRole('table')).toBeInTheDocument();
+
+    // Then toggle back to graph view
+    const graphBtn = await screen.findByText('Display graph');
+    userEvent.click(graphBtn);
+
+    // After toggling back to graph view, the table should no longer be visible
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 });

--- a/src/widgets/frequencyGraph.js
+++ b/src/widgets/frequencyGraph.js
@@ -1,13 +1,9 @@
-import { REASONS } from '@ttahub/common';
-import { countOccurrences } from './helpers';
 import { topicFrequencyGraphViaGoals } from './topicFrequencyGraph';
 
 export default async function frequencyGraph(scopes) {
-  const reasons = await countOccurrences(scopes.activityReport, 'reason', REASONS);
   const topicsViaGoals = await topicFrequencyGraphViaGoals(scopes);
 
   return {
     topics: topicsViaGoals.map((t) => ({ category: t.topic, count: t.count })),
-    reasons,
   };
 }

--- a/src/widgets/frequencyGraph.test.js
+++ b/src/widgets/frequencyGraph.test.js
@@ -206,17 +206,6 @@ describe('frequency graph widget', () => {
     expect(topics.find((r) => r.category === 'Nutrition').count).toBe(0);
   });
 
-  it('returns count of reasons', async () => {
-    const res = await frequencyGraph(scopes);
-
-    const { reasons } = res;
-
-    expect(reasons.find((r) => r.category === 'Change in Scope').count).toBe(3);
-    expect(reasons.find((r) => r.category === 'Complaint').count).toBe(1);
-    expect(reasons.find((r) => r.category === 'Child Incident').count).toBe(2);
-    expect(reasons.find((r) => r.category === 'Full Enrollment').count).toBe(0);
-  });
-
   it('returns count of topics with additional associated report', async () => {
     const res = await frequencyGraph(scopes);
 

--- a/tests/api/widgets.spec.ts
+++ b/tests/api/widgets.spec.ts
@@ -119,14 +119,8 @@ test.describe('widgets', () => {
       count: Joi.number().integer().required()
     });
 
-    const reasonsSchema = Joi.object({
-      category: Joi.string().required(),
-      count: Joi.number().integer().required()
-    });
-
     const schema = Joi.object({
-      topics: Joi.array().items(topicSchema).required(),
-      reasons: Joi.array().items(reasonsSchema).required()
+      topics: Joi.array().items(topicSchema).required()
     });
 
     await validateSchema(response, schema, expect);


### PR DESCRIPTION
## Description of change

This ticket is simply the removal of the reasons widget from the TTA History (we only show topics now).

## How to test

- Review the code.
- Make sure the topics widget still works and we don't allow the reasons widget to be displayed.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4114


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
