### PR TITLE
[BUG] Null reference when accessing recipient grant for OE report

### DIFF
--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -355,7 +355,8 @@ export async function activityReportAndRecipientsById(activityReportId) {
       activityRecipientId, // Create or Update Report Expect's this Field.
       name,
       // We need the actual id of the recipient to narrow down what grants are selected on the FE.
-      recipientIdForLookUp: recipient.grant.recipientId,
+      // Viewing legacy OE reports will have a null grant.
+      recipientIdForLookUp: recipient.grant ? recipient.grant.recipientId : null,
     };
   });
 


### PR DESCRIPTION
## Description of change
 
This fixes a bug that was coming up in new relic when viewing a legacy OE report.

<img width="1577" height="146" alt="image" src="https://github.com/user-attachments/assets/b8d5165e-0a1b-4974-addc-fd3b8994eccc" />

## How to test

- Review the change.
- View a legacy OE report and ensure there are no 500 errors.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
