### PR TITLE
Fix typo in local storage hook + collab report dates

### DIFF
--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -174,7 +174,7 @@ export const DATE_DISPLAY_FORMAT = 'MM/DD/YYYY';
 export const DATEPICKER_VALUE_FORMAT = 'YYYY-MM-DD';
 export const EARLIEST_INC_FILTER_DATE = moment('2020-08-31');
 
-const LOCAL_STORAGE_CACHE_NUMBER = '0.4';
+const LOCAL_STORAGE_CACHE_NUMBER = '0.5';
 export const LOCAL_STORAGE_AR_DATA_KEY = (id) => `ar-form-data-${id}-${LOCAL_STORAGE_CACHE_NUMBER}`;
 export const LOCAL_STORAGE_CR_DATA_KEY = (id) => `cr-form-data-${id}-${LOCAL_STORAGE_CACHE_NUMBER}`;
 export const LOCAL_STORAGE_AR_ADDITIONAL_DATA_KEY = (id) => `ar-additional-data-${id}-${LOCAL_STORAGE_CACHE_NUMBER}`;

--- a/frontend/src/__tests__/localStorageCleanup.js
+++ b/frontend/src/__tests__/localStorageCleanup.js
@@ -59,12 +59,12 @@ describe('localStorageCleanup', () => {
 
       const calls = [
         '__storage_test__',
-        'ar-form-data-2-0.4',
-        'ar-additional-data-2-0.4',
-        'ar-can-edit-2-0.4',
-        'ar-form-data-3-0.4',
-        'ar-additional-data-3-0.4',
-        'ar-can-edit-3-0.4',
+        'ar-form-data-2-0.5',
+        'ar-additional-data-2-0.5',
+        'ar-can-edit-2-0.5',
+        'ar-form-data-3-0.5',
+        'ar-additional-data-3-0.5',
+        'ar-can-edit-3-0.5',
       ];
 
       calls.forEach((call) => {

--- a/frontend/src/pages/CollaborationReportForm/formDataHelpers.js
+++ b/frontend/src/pages/CollaborationReportForm/formDataHelpers.js
@@ -2,6 +2,12 @@ import { isEqual } from 'lodash';
 import moment from 'moment';
 
 /**
+ * @param string
+ * @returns isValid bool
+ */
+export const isDateValid = (date) => !(!date || !moment(date, 'MM/DD/YYYY').isValid());
+
+/**
  * compares two objects using lodash "isEqual" and returns the difference
  * @param {*} object
  * @param {*} base
@@ -18,7 +24,7 @@ export const findWhatsChanged = (object, base) => {
 
   function reduction(accumulator, current) {
     if (current === 'startDate' || current === 'endDate') {
-      if (!object[current] || !moment(object[current], 'MM/DD/YYYY').isValid()) {
+      if (!isDateValid(object[current])) {
         delete accumulator[current];
         return accumulator;
       }

--- a/frontend/src/pages/CollaborationReportForm/index.js
+++ b/frontend/src/pages/CollaborationReportForm/index.js
@@ -19,7 +19,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import pages from './Pages';
 import Navigator from '../../components/Navigator';
 import { NOT_STARTED } from './constants';
-import { convertReportToFormData, findWhatsChanged } from './formDataHelpers';
+import { convertReportToFormData, isDateValid, findWhatsChanged } from './formDataHelpers';
 import {
   LOCAL_STORAGE_CR_DATA_KEY,
   LOCAL_STORAGE_CR_ADDITIONAL_DATA_KEY,
@@ -401,8 +401,18 @@ function CollaborationReport({ match, location }) {
   const onSave = async (data, forceUpdate = false) => {
     try {
       if (reportId.current === 'new') {
+        const fields = data;
+
+        if (!isDateValid(fields.startDate)) {
+          delete fields.startDate;
+        }
+
+        if (!isDateValid(fields.endDate)) {
+          delete fields.endDate;
+        }
+
         const savedReport = await createReport({
-          ...data,
+          ...fields,
           regionId: formData.regionId,
           version: 2,
         });


### PR DESCRIPTION
## Description of change
Two bugs. One: backend not handling invalid start/end dates and Two: local storage not being cleaned up properly

## How to test
To repro in staging,
1. Save a collab report with no fields filled out
2. DB error for start/end date being invalid on create
3. Fill out start and end date, the report will save
4. Return to collab report landing, click new report
5. Save again after filling out start and end date. Another DB error, this time because the ID was submitted

## Issue(s)



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
