### PR TITLE
[TTAHUB-4554] Only return recipients for comm log that have active grants

### DIFF
--- a/src/routes/communicationLog/handlers.ts
+++ b/src/routes/communicationLog/handlers.ts
@@ -105,7 +105,10 @@ async function getAvailableUsersRecipientsAndGoals(req: Request, res: Response) 
         model: Grant,
         as: 'grants',
         attributes: [],
-        where: { regionId },
+        where: {
+          regionId,
+          status: 'Active',
+        },
         required: true,
       },
     ],


### PR DESCRIPTION
## Description of change

We were returning recipients for grants that are no longer active This was the case for all examples given in the JIRA.

## How to test

- Review the code
- Make sure we don't allow the selection of any recipients linked to Inactive grants.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4554


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
