### PR TITLE
Fix approver not submitted view on collab report

### DIFF
--- a/frontend/src/pages/CollaborationReportForm/Pages/components/Review.js
+++ b/frontend/src/pages/CollaborationReportForm/Pages/components/Review.js
@@ -116,7 +116,7 @@ const Review = ({
   author,
   approvers,
 }) => {
-  const FormComponent = (isApprover) ? ApproverReview : CreatorSubmit;
+  const FormComponent = (isApprover && isSubmitted) ? ApproverReview : CreatorSubmit;
 
   const { watch, getValues } = useFormContext();
   const { user } = useContext(UserContext);

--- a/frontend/src/pages/CollaborationReportForm/Pages/components/__tests__/Review.js
+++ b/frontend/src/pages/CollaborationReportForm/Pages/components/__tests__/Review.js
@@ -135,9 +135,15 @@ describe('Review Component', () => {
 
   describe('Component Selection', () => {
     it('renders ApproverReview component when isApprover is true', () => {
-      renderTest({ isApprover: true });
+      renderTest({ isApprover: true, isSubmitted: true });
       expect(screen.getByTestId('approver-review')).toBeInTheDocument();
       expect(screen.queryByTestId('creator-submit')).not.toBeInTheDocument();
+    });
+
+    it('renders CreatorSubmit component when isApprover is true and isSubmitted is false', () => {
+      renderTest({ isApprover: true, isSubmitted: false });
+      expect(screen.queryByTestId('approver-review')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('creator-submit')).toBeInTheDocument();
     });
 
     it('renders CreatorSubmit component when isApprover is false', () => {
@@ -259,7 +265,7 @@ describe('Review Component', () => {
         { user: { id: 2 }, status: 'needs_action', note: 'Other note' },
       ];
 
-      renderTest({ approverStatusList, isApprover: true }, { id: 1 });
+      renderTest({ approverStatusList, isApprover: true, isSubmitted: true }, { id: 1 });
       expect(screen.getByTestId('approver-review')).toBeInTheDocument();
     });
   });

--- a/src/services/collabReports.ts
+++ b/src/services/collabReports.ts
@@ -66,7 +66,7 @@ export const collabReportScopes = async (filters, userId, status) => {
       },
       {
         id: {
-          [Op.in]: sequelize.literal(`(SELECT cra."collabReportId" FROM "CollabReportApprovers" cra WHERE cra."userId" = ${userId})`),
+          [Op.in]: sequelize.literal(`(SELECT cra."collabReportId" FROM "CollabReportApprovers" cra INNER JOIN "CollabReports" cr ON cr.id = cra."collabReportId" WHERE cra."userId" = ${userId} AND cr."calculatedStatus" = 'submitted' AND cr."deletedAt" IS NULL)`),
         },
       },
     ];


### PR DESCRIPTION
## Description of change

Two bugs on collab report: 

1. If an creator is also an approver, saves draft without submitting, the creator/approver is presented with an approval status select and is unable to submit. 
2. Revise the getAlerts query for collab reports so that approvers only see submitted reports

## How to test

Confirm that the cases above are fixed

## Issue(s)



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
