### PR TITLE
[NO-TICKET] add tta-automation to the list of envs for cache clear

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,8 @@ workflows:
     - clear_cache_job:
         target_env: "tta-smarthub-staging"
     - clear_cache_job:
+        target_env: "tta-automation"
+    - clear_cache_job:
         target_env: "tta-smarthub-dev-blue" 
     - clear_cache_job:
         target_env: "tta-smarthub-dev-green" 


### PR DESCRIPTION
## Description of change

add tta-automation to the list of envs for cache clear.  tta-automation is a dedicated environment for running tasks like backing up the db and processing the db files

## How to test

one line change, other envs work, validated locally
