### PR TITLE
Fix bug with fetching trainers

### DIFF
--- a/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
@@ -79,13 +79,13 @@ describe('sessionSummary', () => {
       id: 1,
       ownerId: null,
       eventId: 'sdfgsdfg',
+      regionId: 1,
+      facilitation: 'regional_tta_staff',
       eventDisplayId: 'event-display-id',
       event: {
         regionId: 1,
-
       },
       eventName: 'Event name',
-      regionId: 1,
       status: 'In progress',
       pageState: {
         1: NOT_STARTED,
@@ -153,7 +153,7 @@ describe('sessionSummary', () => {
         { id: 2, name: 'Complaint' },
       ]);
 
-      fetchMock.get('/api/users/trainers/regional/region/undefined', [
+      fetchMock.get('/api/users/trainers/regional/region/1', [
         { id: 1, fullName: 'Regional Trainer 1' },
         { id: 2, fullName: 'Regional Trainer 2' },
         { id: 3, fullName: 'Regional Trainer 3' },
@@ -161,7 +161,7 @@ describe('sessionSummary', () => {
 
       ]);
 
-      fetchMock.get('/api/users/trainers/national-center/region/undefined', [
+      fetchMock.get('/api/users/trainers/national-center/region/1', [
         { id: 1, fullName: 'National Center Trainer 1' },
         { id: 2, fullName: 'National Center Trainer 2' },
         { id: 3, fullName: 'National Center Trainer 3' },
@@ -185,6 +185,8 @@ describe('sessionSummary', () => {
 
       fetchMock.get('/api/feeds/item?tag=ttahub-topic', mockRSSData());
       fetchMock.get('/api/feeds/item?tag=ttahub-tta-support-type', mockRSSData());
+      fetchMock.get('/api/feeds/item?tag=ttahub-ohs-standard-goals', mockRSSData());
+      fetchMock.get('/api/goal-templates', []);
     });
 
     afterEach(async () => {
@@ -264,7 +266,7 @@ describe('sessionSummary', () => {
         userEvent.click(removeFile);
       });
 
-      const deleteUrl = '/api/files/s/undefined/2';
+      const deleteUrl = '/api/files/s/1/2';
       fetchMock.delete(deleteUrl, 200);
 
       const confirmDelete = await screen.findByRole('button', {
@@ -351,16 +353,21 @@ describe('sessionSummary', () => {
     it('national center event facilitated by national center', async () => {
       const additionalData = {
         status: 'Not started',
+        facilitation: 'national_center',
         event: {
           data: {
             regionId: 1,
-            facilitation: 'national_center',
             eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
           },
         },
       };
 
-      render(<RenderSessionSummary additionalData={additionalData} />);
+      const formValues = {
+        ...defaultFormValues,
+        facilitation: 'national_center',
+      };
+
+      render(<RenderSessionSummary additionalData={additionalData} formValues={formValues} />);
 
       const trainers = await screen.findByLabelText(/Who provided the TTA/i);
       await selectEvent.select(trainers, ['National Center Trainer 4']);
@@ -370,16 +377,45 @@ describe('sessionSummary', () => {
     it('national center event facilitated by regional tta staff', async () => {
       const additionalData = {
         status: 'Not started',
+        facilitation: 'regional_tta_staff',
         event: {
           data: {
             regionId: 1,
-            facilitation: 'regional_tta_staff',
             eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
           },
         },
       };
 
-      render(<RenderSessionSummary additionalData={additionalData} />);
+      const formValues = {
+        ...defaultFormValues,
+        facilitation: 'regional_tta_staff',
+      };
+
+      render(<RenderSessionSummary additionalData={additionalData} formValues={formValues} />);
+
+      const trainers = await screen.findByLabelText(/Who provided the TTA/i);
+      await selectEvent.select(trainers, ['Regional Trainer 1']);
+      expect(await screen.findByText('Regional Trainer 1')).toBeVisible();
+    });
+
+    it('national center event facilitated by both', async () => {
+      const additionalData = {
+        status: 'Not started',
+        facilitation: 'both',
+        event: {
+          data: {
+            regionId: 1,
+            eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
+          },
+        },
+      };
+
+      const formValues = {
+        ...defaultFormValues,
+        facilitation: 'both',
+      };
+
+      render(<RenderSessionSummary additionalData={additionalData} formValues={formValues} />);
 
       const trainers = await screen.findByLabelText(/Who provided the TTA/i);
       await selectEvent.select(trainers, ['Regional Trainer 1']);
@@ -394,7 +430,7 @@ describe('sessionSummary', () => {
         userEvent.click(removeFile);
       });
 
-      const deleteUrl = '/api/files/s/undefined/2';
+      const deleteUrl = '/api/files/s/1/2';
       fetchMock.delete(deleteUrl, 500);
 
       const confirmDelete = await screen.findByRole('button', {

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -65,7 +65,6 @@ const SessionSummary = ({ datePickerKey, event }) => {
   const goalTemplates = useGoalTemplates([]);
 
   const {
-    getValues,
     register,
     watch,
     setValue,
@@ -74,16 +73,14 @@ const SessionSummary = ({ datePickerKey, event }) => {
     setError,
   } = useFormContext();
 
-  const data = getValues();
-
-  const { id, regionId } = data;
+  const id = watch('id');
+  const regionId = watch('regionId');
+  const facilitation = watch('facilitation');
 
   let eventOrganizer = '';
-  let facilitation = '';
 
   if (event && event.data) {
     eventOrganizer = event.data.eventOrganizer;
-    facilitation = event.data.facilitation;
   }
 
   const {
@@ -117,6 +114,11 @@ const SessionSummary = ({ datePickerKey, event }) => {
       }
 
       if (facilitation === 'regional_tta_staff') {
+        optionsForValue = regionalTrainers;
+        return regionalTrainers;
+      }
+
+      if (facilitation === 'both') {
         optionsForValue = [...nationalCenterTrainers, ...regionalTrainers];
         return [
           {


### PR DESCRIPTION
## Description of change

Update code for determining trainers on the session summary (fetch is the same, but I messed up the cases that determined which set of trainers below


## How to test

These are the expected trainers given the event organizer and the facilitation

| Event Organizer      | Facilitation     |  Expected trainers |
| ------------- | ------------- | ------------- |
| National Centers | Region | Regional |
| National Centers | National Centers | National Center Users |
| National Centers | Both | Regional + National Center Users |
| Region | N/A | Regional |

I demonstrate how to test in the video below

https://github.com/user-attachments/assets/d76b17be-8ef2-4d05-9f25-1251ba03aa22




## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4189


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
