### PR TITLE
TTAHUB-4601 - Fix for QA Dashboard drawers

### DIFF
--- a/frontend/src/pages/QADashboard/RecipientsWithClassScoresAndGoals/index.js
+++ b/frontend/src/pages/QADashboard/RecipientsWithClassScoresAndGoals/index.js
@@ -219,7 +219,7 @@ export default function RecipientsWithClassScoresAndGoals() {
         stickyFooter
         title="QA dashboard filters"
       >
-        <ContentFromFeedByTag tagName="ttahub-qa-dash-class-filters" />
+        <ContentFromFeedByTag tagName="ttahub-qa-dash-filters" />
       </Drawer>
       <RecipientsWithClassScoresAndGoalsWidget
         data={recipientsWithClassScoresAndGoalsData}

--- a/frontend/src/pages/QADashboard/RecipientsWithNoTta/index.js
+++ b/frontend/src/pages/QADashboard/RecipientsWithNoTta/index.js
@@ -160,7 +160,7 @@ export default function RecipientsWithNoTta() {
         stickyFooter
         title="QA dashboard filters"
       >
-        <ContentFromFeedByTag tagName="ttahub-qa-dash-recipients-no-tta-filter" />
+        <ContentFromFeedByTag tagName="ttahub-qa-dash-filters" />
       </Drawer>
       <RecipientsWithNoTtaWidget
         data={recipientsWithNoTTA}

--- a/frontend/src/pages/QADashboard/RecipientsWithOhsStandardFeiGoal/index.js
+++ b/frontend/src/pages/QADashboard/RecipientsWithOhsStandardFeiGoal/index.js
@@ -200,7 +200,7 @@ export default function RecipientsWithOhsStandardFeiGoal() {
         stickyFooter
         title="QA dashboard filters"
       >
-        <ContentFromFeedByTag tagName="ttahub-qa-dash-fei-filters" />
+        <ContentFromFeedByTag tagName="ttahub-qa-dash-filters" />
       </Drawer>
       <RecipientsWithOhsStandardFeiGoalWidget
         data={recipientsWithOhsStandardFeiGoal}


### PR DESCRIPTION
## Description of change

Fixing it so that QA Dashboard "Help with Filters" drawers all pull from the same feed.

## How to test

1. Go to QA dashboard
2. Select "Display details" from one of the widgets at the top
3. Click on the "Learn more about filters" link near the top left
4. Verify that the QA Dashboard Help drawer loads

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4601


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [X] API Documentation updated
- [X] Boundary diagram updated
- [X] Logical Data Model updated
- [X] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
