### PR TITLE
[TTAHUB-4552] add placeholder GHA workflow

### DIFF
--- a/.github/workflows/db_restore.yml
+++ b/.github/workflows/db_restore.yml
@@ -1,0 +1,41 @@
+name: DB Restore
+
+on:
+  workflow_dispath:
+    inputs:
+      source:
+        description: use processed (anonymized) or prod data
+        required: true
+        type: choice
+        options: 
+        - production
+        - processed
+        default: "processed"
+      source_date:
+        description: either "latest" or a date in YYYY-MM-DD format
+        required: true
+        type: string
+        default: "latest"
+      target_db:
+        description: Name of the db to restore into, e.g. "ttahub-dev-blue"
+        required: true
+        type: choice
+        options: 
+        - ttahub-staging
+        - ttahub-dev-blue
+        - ttahub-dev-red
+        - ttahub-dev-green
+        - ttahub-dev-gold
+        - ttahub-dev-pink
+    secrets:
+      github-token:
+        required: true
+
+jobs:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: db-restore
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5


### PR DESCRIPTION
## Description of change

In order to run a manually triggered GH Actions workflow, it must exist on the default branch.  After it exists, it can be run from another branch for testing.  This creates a placeholder workflow file for the in-progress db restore job so that further functionality can be developed and tested on a separate branch.  As it stands now, the workflow will accept some arguments but take no actions other than checking out the repo.

## How to test

No impact

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-4552


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete
