### PR TITLE
[NO-TICKET] Don't always prepend tta-smarthub to cache clear job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ workflows:
     when: pipeline.parameters.action == "clear_cache" and pipeline.trigger_source == "api"
     jobs:
     - clear_cache_job:
-        target_env: << pipeline.parameters.target_env >> 
+        target_env: "tta-smarthub-<< pipeline.parameters.target_env >>"
 
   clear_buildcache_cron:
     # the build cache grows over time, causing deploys to fail.  this job will clear it weekly
@@ -685,7 +685,7 @@ jobs:
     - run:
         name: Clear build cache
         command: |
-          app_name="tta-smarthub-<< parameters.target_env >>"
+          app_name="<< parameters.target_env >>"
           echo "Clearing build cache for ${app_name}"
           app_guid=$(cf app --guid ${app_name})
           cf curl -X POST /v3/apps/${app_guid}/actions/clear_buildpack_cache


### PR DESCRIPTION
## Description of change

* There are two CircleCI jobs to clear the CloudGov build cache: cron and manually triggered.  When run manually, the env name is passed via env selection and has a short convenient name (ie dev-blue).  When run via scheduled cron, all envs are passed as a full string including some env names not prepended with tta-smarthub (ie tta-automation).
* Therefore, prepend names in the manual job with "tta-automation" and use the string as passed in the shared base job.

## How to test

Successful manual run:
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/32342/workflows/2e8f593a-7d68-45ef-86e1-24e8f3d8c042

## Issue(s)

N/A

