### PR TITLE
Rename Content group to content_group for google analytics

### DIFF
--- a/frontend/src/hooks/__tests__/useGaPageView.js
+++ b/frontend/src/hooks/__tests__/useGaPageView.js
@@ -22,14 +22,14 @@ describe('useGaPageView', () => {
 
     expect(window.dataLayer).toHaveLength(1);
     expect(window.dataLayer[0].event).toBe(CONTENT_GROUP_EVENT);
-    expect(window.dataLayer[0]['Content Group']).toBe('/test-path');
+    expect(window.dataLayer[0].content_group).toBe('/test-path');
   });
 
   test('should push new event when pathname changes', () => {
     const { rerender } = renderHook(() => useGaPageView());
 
     expect(window.dataLayer).toHaveLength(1);
-    expect(window.dataLayer[0]['Content Group']).toBe('/test-path');
+    expect(window.dataLayer[0].content_group).toBe('/test-path');
 
     // Simulate pathname change
     useLocation.mockReturnValue({ pathname: '/new-path' });
@@ -37,7 +37,7 @@ describe('useGaPageView', () => {
 
     expect(window.dataLayer).toHaveLength(2);
     expect(window.dataLayer[1].event).toBe(CONTENT_GROUP_EVENT);
-    expect(window.dataLayer[1]['Content Group']).toBe('/new-path');
+    expect(window.dataLayer[1].content_group).toBe('/new-path');
   });
 
   test('should not push event if dataLayer is missing', () => {

--- a/frontend/src/hooks/useGaPageView.js
+++ b/frontend/src/hooks/useGaPageView.js
@@ -14,7 +14,7 @@ export default function useGaPageView() {
       if (window.dataLayer && Array.isArray(window.dataLayer)) {
         const event = {
           event: CONTENT_GROUP_EVENT,
-          'Content Group': location.pathname,
+          content_group: location.pathname,
         };
 
         window.dataLayer.push(event);


### PR DESCRIPTION
## Description of change
Request from our analytic team


## How to test
Confirm that the variable was renamed from 'Content Group' to 'content_group'. Unit tests verify this

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
