### PR TITLE
Revert "[NO-TICKET] Add dependabot cooldown"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 5
-      semver-major-days: 30


### PR DESCRIPTION
Reverts HHS/Head-Start-TTADP#3157

Creating a dependabot file with cooldown had the unintended consequence of enabling version checking on all node packages, not just those with security vulnerabilities.  This results in a flood of dependabot updates as many of our packages are significantly behind.  For this reason I think it is best to revert the change, perhaps it could be revisited at another time.