### PR TITLE
[NO-TICKET] Fix typo in production approver name in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,7 @@
 - [ ] PR created as **Draft**
 - [ ] Staging smoke test completed
 - [ ] PR transitioned to **Open**
-- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparish` is the authorized approver under normal circumstances)_
+- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
   - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
   - _Confirm that Slack notification was sent after reviewer was added_
 


### PR DESCRIPTION
## Description of change

Fixes a typo in the authorized approver name in the production deploy section of the PR template.

## How to test

1. Open [.github/pull_request_template.md](/Users/krystyna/Head-Start-TTADP/.github/pull_request_template.md).
2. Verify the production deploy section now references `elainaparrish` instead of `elainaparish`.
3. Confirm no code paths or runtime behavior changed.

## Issue(s)

* https://jira.acf.gov/browse/NO-TICKET

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [n/a] Meets issue criteria
- [n/a] JIRA ticket status updated
- [n/a] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [n/a] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
