### PR TITLE
[No Ticket] - Fixing typo for goal category filter label

### DIFF
--- a/frontend/src/components/filter/communicationLogFilters.js
+++ b/frontend/src/components/filter/communicationLogFilters.js
@@ -174,7 +174,7 @@ export const myReportsFilter = {
 
 export const goalFilter = {
   id: 'goal',
-  display: 'Goal',
+  display: 'Goal category',
   conditions: FILTER_CONDITIONS,
   defaultValues: EMPTY_MULTI_SELECT,
   displayQuery: handleArrayQuery,


### PR DESCRIPTION
## Description of change

Fixing the display label for the "Goal category" comm log filter so it says "Goal category" instead of just "Goal".

## How to test

1. Fire up the app
2. Go to the comm log page, select filters
3. Verify that the label says "Goal category"

## Issue(s)

* No Ticket, just a hotfix


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] JIRA ticket status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [X] API Documentation updated
- [X] Boundary diagram updated
- [X] Logical Data Model updated
- [X] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [X] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
