### PR TITLE
[TTAHUB-5136] Allow a single RAN to trigger the recipient spotlight indicator

### DIFF
--- a/src/services/recipientSpotlight.js
+++ b/src/services/recipientSpotlight.js
@@ -114,7 +114,7 @@ export async function getRecipientSpotlightIndicators(
     Note: LTM = Last Twelve Months
 
     Description of the seven indicators:
-    1. Child Incidents (monitoring data): Grants that have more than one child incident
+    1. Child Incidents (monitoring data): Grants that have at least one child incident
     (RAN) monitoring citation in LTM (MonitoringReviews.ReviewType).
     2. Deficiency (monitoring data): Grants that have at least one review > finding > standard
       (citation) that has a MonitoringFindingHistories.determination of Deficiency.
@@ -288,7 +288,7 @@ export async function getRecipientSpotlightIndicators(
     ---------------------------------------
     -- Spotlight indicators ---------------
     ---------------------------------------
-    -- 1. Child Incidents: Grants with more than one RAN citation in the last 12 months
+    -- 1. Child Incidents: Grants with at least one RAN citation in the last 12 months
     child_incidents AS (
       SELECT
         rid incident_rid,
@@ -298,7 +298,6 @@ export async function getRecipientSpotlightIndicators(
         AND review_status = 'Complete'
         AND rdd >= NOW() - INTERVAL '12 months'
       GROUP BY 1,2
-      HAVING COUNT(*) > 1
     ),
     
     -- 2. Deficiency: Recipients with at least one uncorrected deficiency

--- a/src/services/recipientSpotlight.test.js
+++ b/src/services/recipientSpotlight.test.js
@@ -356,23 +356,14 @@ describe('recipientSpotlight service', () => {
 
     // Create monitoring reviews, findings, and other related data
 
-    // 1. Create child incidents (RAN) reviews
+    // 1. Create child incidents (RAN) review — one is sufficient to trigger the indicator
     const childIncidentsReview1Id = faker.unique(
       () => faker.datatype.number({ min: 40000, max: 50000 }),
     ).toString();
-    const childIncidentsReview2Id = faker.unique(
-      () => faker.datatype.number({ min: 50001, max: 60000 }),
-    ).toString();
-      // Add a third incident review to ensure we have more than one (required by the logic)
-    const childIncidentsReview3Id = faker.unique(
-      () => faker.datatype.number({ min: 60001, max: 65000 }),
-    ).toString();
 
-    // Create MonitoringReviewLinks first
+    // Create MonitoringReviewLink first
     await db.MonitoringReviewLink.bulkCreate([
       { reviewId: childIncidentsReview1Id },
-      { reviewId: childIncidentsReview2Id },
-      { reviewId: childIncidentsReview3Id },
     ]);
 
     const childIncidentsReview1 = await MonitoringReview.create({
@@ -385,58 +376,16 @@ describe('recipientSpotlight service', () => {
       sourceUpdatedAt: createDate,
     });
 
-    const childIncidentsReview2 = await MonitoringReview.create({
-      reviewId: childIncidentsReview2Id,
-      contentId: faker.unique(() => faker.datatype.number({ min: 50001, max: 60000 })).toString(),
-      statusId: monitoringReviewStatus.statusId,
-      reviewType: 'RAN',
-      reportDeliveryDate: pastYear,
+    await MonitoringReviewGrantee.create({
+      reviewId: childIncidentsReview1.reviewId,
+      granteeId: childIncidentsRecipient.id.toString(),
+      grantNumber: childIncidentsGrant.number,
+      createTime: createDate,
+      updateTime: createDate,
+      updateBy: 'test-user',
       sourceCreatedAt: createDate,
       sourceUpdatedAt: createDate,
     });
-
-    const childIncidentsReview3 = await MonitoringReview.create({
-      reviewId: childIncidentsReview3Id,
-      contentId: faker.unique(() => faker.datatype.number({ min: 60001, max: 65000 })).toString(),
-      statusId: monitoringReviewStatus.statusId,
-      reviewType: 'RAN',
-      reportDeliveryDate: pastYear,
-      sourceCreatedAt: createDate,
-      sourceUpdatedAt: createDate,
-    });
-
-    await MonitoringReviewGrantee.bulkCreate([
-      {
-        reviewId: childIncidentsReview1.reviewId,
-        granteeId: childIncidentsRecipient.id.toString(),
-        grantNumber: childIncidentsGrant.number, // Use the grant number directly from the grant
-        createTime: createDate,
-        updateTime: createDate,
-        updateBy: 'test-user',
-        sourceCreatedAt: createDate,
-        sourceUpdatedAt: createDate,
-      },
-      {
-        reviewId: childIncidentsReview2.reviewId,
-        granteeId: childIncidentsRecipient.id.toString(),
-        grantNumber: childIncidentsGrant.number, // Use the grant number directly from the grant
-        createTime: createDate,
-        updateTime: createDate,
-        updateBy: 'test-user',
-        sourceCreatedAt: createDate,
-        sourceUpdatedAt: createDate,
-      },
-      {
-        reviewId: childIncidentsReview3.reviewId,
-        granteeId: childIncidentsRecipient.id.toString(),
-        grantNumber: childIncidentsGrant.number, // Use the grant number directly from the grant
-        createTime: createDate,
-        updateTime: createDate,
-        updateBy: 'test-user',
-        sourceCreatedAt: createDate,
-        sourceUpdatedAt: createDate,
-      },
-    ]);
 
     // 2. Create deficiency finding
     const deficiencyReviewId = faker.unique(


### PR DESCRIPTION
## Description of change

There was an update to the recipient Spotlight guidance and this implements it

## How to test

Grant 15141 (06CH012472 on prod) has one RAN that would not have triggered an indicator before but should now

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5136


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
