### PR TITLE
Remove monitoring dashboard feature flag gating

### DIFF
--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -62,7 +62,6 @@ export const links = [
   {
     to: '/dashboards/regional-dashboard/monitoring',
     label: 'Monitoring',
-    featureFlag: 'monitoring-regional-dashboard',
   },
   {
     to: '/dashboards/regional-dashboard/recipient-spotlight',


### PR DESCRIPTION
## Description of change

Allow users to access the monitoring regional dashboard
Leaving the feature flag in place in the database as it will work to hide additional pieces of the dashboard as they are developed

## How to test

Confirm users without the feature flag can see the monitoring dashboard

## Issue(s)



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
