### PR TITLE
[Prod] Remove monitoring dashboard feature flag, allow single RAN to trigger spotlight indicator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,7 @@
 - [ ] PR created as **Draft**
 - [ ] Staging smoke test completed
 - [ ] PR transitioned to **Open**
-- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparish` is the authorized approver under normal circumstances)_
+- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
   - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
   - _Confirm that Slack notification was sent after reviewer was added_
 

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -62,7 +62,6 @@ export const links = [
   {
     to: '/dashboards/regional-dashboard/monitoring',
     label: 'Monitoring',
-    featureFlag: 'monitoring-regional-dashboard',
   },
   {
     to: '/dashboards/regional-dashboard/recipient-spotlight',

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8209,9 +8209,9 @@ prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, 
     react-is "^16.13.1"
 
 protocol-buffers-schema@^3.3.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz#77bc75a48b2ff142c1ad5b5b90c94cd0fa2efd03"
-  integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz#fd9a58a5c4e96385b964808f3ddd58f9ef18c3c8"
+  integrity sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==
 
 psl@^1.1.33:
   version "1.9.0"

--- a/src/services/recipientSpotlight.js
+++ b/src/services/recipientSpotlight.js
@@ -114,7 +114,7 @@ export async function getRecipientSpotlightIndicators(
     Note: LTM = Last Twelve Months
 
     Description of the seven indicators:
-    1. Child Incidents (monitoring data): Grants that have more than one child incident
+    1. Child Incidents (monitoring data): Grants that have at least one child incident
     (RAN) monitoring citation in LTM (MonitoringReviews.ReviewType).
     2. Deficiency (monitoring data): Grants that have at least one review > finding > standard
       (citation) that has a MonitoringFindingHistories.determination of Deficiency.
@@ -288,7 +288,7 @@ export async function getRecipientSpotlightIndicators(
     ---------------------------------------
     -- Spotlight indicators ---------------
     ---------------------------------------
-    -- 1. Child Incidents: Grants with more than one RAN citation in the last 12 months
+    -- 1. Child Incidents: Grants with at least one RAN citation in the last 12 months
     child_incidents AS (
       SELECT
         rid incident_rid,
@@ -298,7 +298,6 @@ export async function getRecipientSpotlightIndicators(
         AND review_status = 'Complete'
         AND rdd >= NOW() - INTERVAL '12 months'
       GROUP BY 1,2
-      HAVING COUNT(*) > 1
     ),
     
     -- 2. Deficiency: Recipients with at least one uncorrected deficiency

--- a/src/services/recipientSpotlight.test.js
+++ b/src/services/recipientSpotlight.test.js
@@ -356,23 +356,14 @@ describe('recipientSpotlight service', () => {
 
     // Create monitoring reviews, findings, and other related data
 
-    // 1. Create child incidents (RAN) reviews
+    // 1. Create child incidents (RAN) review — one is sufficient to trigger the indicator
     const childIncidentsReview1Id = faker.unique(
       () => faker.datatype.number({ min: 40000, max: 50000 }),
     ).toString();
-    const childIncidentsReview2Id = faker.unique(
-      () => faker.datatype.number({ min: 50001, max: 60000 }),
-    ).toString();
-      // Add a third incident review to ensure we have more than one (required by the logic)
-    const childIncidentsReview3Id = faker.unique(
-      () => faker.datatype.number({ min: 60001, max: 65000 }),
-    ).toString();
 
-    // Create MonitoringReviewLinks first
+    // Create MonitoringReviewLink first
     await db.MonitoringReviewLink.bulkCreate([
       { reviewId: childIncidentsReview1Id },
-      { reviewId: childIncidentsReview2Id },
-      { reviewId: childIncidentsReview3Id },
     ]);
 
     const childIncidentsReview1 = await MonitoringReview.create({
@@ -385,58 +376,16 @@ describe('recipientSpotlight service', () => {
       sourceUpdatedAt: createDate,
     });
 
-    const childIncidentsReview2 = await MonitoringReview.create({
-      reviewId: childIncidentsReview2Id,
-      contentId: faker.unique(() => faker.datatype.number({ min: 50001, max: 60000 })).toString(),
-      statusId: monitoringReviewStatus.statusId,
-      reviewType: 'RAN',
-      reportDeliveryDate: pastYear,
+    await MonitoringReviewGrantee.create({
+      reviewId: childIncidentsReview1.reviewId,
+      granteeId: childIncidentsRecipient.id.toString(),
+      grantNumber: childIncidentsGrant.number,
+      createTime: createDate,
+      updateTime: createDate,
+      updateBy: 'test-user',
       sourceCreatedAt: createDate,
       sourceUpdatedAt: createDate,
     });
-
-    const childIncidentsReview3 = await MonitoringReview.create({
-      reviewId: childIncidentsReview3Id,
-      contentId: faker.unique(() => faker.datatype.number({ min: 60001, max: 65000 })).toString(),
-      statusId: monitoringReviewStatus.statusId,
-      reviewType: 'RAN',
-      reportDeliveryDate: pastYear,
-      sourceCreatedAt: createDate,
-      sourceUpdatedAt: createDate,
-    });
-
-    await MonitoringReviewGrantee.bulkCreate([
-      {
-        reviewId: childIncidentsReview1.reviewId,
-        granteeId: childIncidentsRecipient.id.toString(),
-        grantNumber: childIncidentsGrant.number, // Use the grant number directly from the grant
-        createTime: createDate,
-        updateTime: createDate,
-        updateBy: 'test-user',
-        sourceCreatedAt: createDate,
-        sourceUpdatedAt: createDate,
-      },
-      {
-        reviewId: childIncidentsReview2.reviewId,
-        granteeId: childIncidentsRecipient.id.toString(),
-        grantNumber: childIncidentsGrant.number, // Use the grant number directly from the grant
-        createTime: createDate,
-        updateTime: createDate,
-        updateBy: 'test-user',
-        sourceCreatedAt: createDate,
-        sourceUpdatedAt: createDate,
-      },
-      {
-        reviewId: childIncidentsReview3.reviewId,
-        granteeId: childIncidentsRecipient.id.toString(),
-        grantNumber: childIncidentsGrant.number, // Use the grant number directly from the grant
-        createTime: createDate,
-        updateTime: createDate,
-        updateBy: 'test-user',
-        sourceCreatedAt: createDate,
-        sourceUpdatedAt: createDate,
-      },
-    ]);
 
     // 2. Create deficiency finding
     const deficiencyReviewId = faker.unique(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11338,9 +11338,9 @@ proto-list@~1.2.1:
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 protobufjs@^7.2.5, protobufjs@^7.3.0, protobufjs@^7.5.3:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
-  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4859,9 +4859,9 @@ baseline-browser-mapping@^2.9.0:
   integrity sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==
 
 basic-ftp@^5.0.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.2.tgz#4cb2422deddf432896bdb3c9b8f13b944ad4842c"
-  integrity sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.3.0.tgz#88f057d1ba8442643c505c4c83bbaa4442b15cfd"
+  integrity sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==
 
 bcrypt-pbkdf@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description of change

- Remove the feature flag around the monitoring dashboard
- Update the SQL query that feeds the recipient spotlight indicators so that a single RAN trips the light
- Update downstream/vendor code (protobufjs, protocol-buffers-schema, basic-ftp)

## How to test

- Confirm updated recipient spotlight display
- Confirm users without the feature flag can view the monitoring dashboard
- CI builds confirm successful vendor code builds

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5136


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [x] QA review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [x] Staging smoke test completed
- [x] PR transitioned to **Open**
- [x] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
