### PR TITLE
[TTAHUB-5217]  Handle various date formats for session start and end date sort

### DIFF
--- a/src/services/sessionReports.test.js
+++ b/src/services/sessionReports.test.js
@@ -826,5 +826,115 @@ describe('session reports service', () => {
       expect(filteredResults.count).toBe(1);
       expect(filteredResults.rows[0].id).toBe(specificSessionId);
     });
+
+    describe('sort by startDate with mixed date formats', () => {
+      // These three formats were all found in production data.
+      // MM/DD/YYYY is the dominant format (428 rows).
+      // YYYY-MM-DD (ISO) caused error 22008 when sorted — TO_DATE read '20' as month.
+      // M/D/YY (short two-digit year) silently sorted to year 0026 before the fix.
+      const mixedEventLongId = 'R01-PD-99801';
+      let mixedEvent;
+      let mixedSessions = [];
+
+      beforeAll(async () => {
+        mixedEvent = await createEvent({
+          ownerId: 99_801,
+          regionId: 1,
+          pocIds: [18],
+          collaboratorIds: [18],
+          data: {
+            eventId: mixedEventLongId,
+            eventName: 'Mixed Date Format Event',
+            status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
+          },
+        });
+
+        mixedSessions = await Promise.all([
+          createSession({
+            eventId: mixedEvent.id,
+            data: {
+              sessionName: 'US Format Session',
+              startDate: '11/20/2024', // MM/DD/YYYY — most common format in DB
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEvent.id,
+            data: {
+              sessionName: 'ISO Format Session',
+              startDate: '2026-03-13', // YYYY-MM-DD — was causing error 22008
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEvent.id,
+            data: {
+              sessionName: 'Short Year Session',
+              startDate: '4/21/26', // M/D/YY — was silently sorting to year 0026
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEvent.id,
+            data: {
+              sessionName: 'Empty String Session',
+              startDate: '', // empty string — NULLIF guards this
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEvent.id,
+            data: {
+              sessionName: 'Null Session',
+              // startDate absent — stored as null in JSONB
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+        ]);
+      });
+
+      afterAll(async () => {
+        await Promise.all(mixedSessions.map((s) => destroySession(s.id)));
+        await destroyEvent(mixedEvent.id);
+      });
+
+      it('should not throw and should return results sorted DESC when startDate formats are mixed', async () => {
+        const result = await getSessionReports({
+          sortBy: 'Session_start_date',
+          sortDir: 'DESC',
+          limit: 100,
+          'eventId.ctn': [mixedEventLongId],
+        });
+
+        expect(result.rows.length).toBe(5);
+
+        const names = result.rows.map((r) => r.sessionName);
+        // PostgreSQL sorts NULLs first on DESC; dated sessions follow newest-to-oldest
+        // DESC order: [null, empty string (both NULL)] then 4/21/26 > 2026-03-13 > 11/20/2024
+        expect(names.slice(0, 2)).toEqual(
+          expect.arrayContaining(['Null Session', 'Empty String Session']),
+        );
+        expect(names.slice(2)).toEqual(['Short Year Session', 'ISO Format Session', 'US Format Session']);
+      });
+
+      it('should not throw and should return results sorted ASC when startDate formats are mixed', async () => {
+        const result = await getSessionReports({
+          sortBy: 'Session_start_date',
+          sortDir: 'ASC',
+          limit: 100,
+          'eventId.ctn': [mixedEventLongId],
+        });
+
+        expect(result.rows.length).toBe(5);
+
+        const names = result.rows.map((r) => r.sessionName);
+        // PostgreSQL sorts NULLs last on ASC; dated sessions come first oldest-to-newest
+        // ASC order: 11/20/2024 < 2026-03-13 < 4/21/26 then [null, empty string]
+        expect(names.slice(0, 3)).toEqual(['US Format Session', 'ISO Format Session', 'Short Year Session']);
+        expect(names.slice(3)).toEqual(
+          expect.arrayContaining(['Null Session', 'Empty String Session']),
+        );
+      });
+    });
   });
 });

--- a/src/services/sessionReports.test.js
+++ b/src/services/sessionReports.test.js
@@ -936,5 +936,119 @@ describe('session reports service', () => {
         );
       });
     });
+
+    describe('sort by endDate with mixed date formats', () => {
+      // endDate shares the same CASE casting logic as startDate and had the same
+      // production-error surface.  These tests verify it is equally robust.
+      const mixedEndEventLongId = 'R01-PD-99802';
+      let mixedEndEvent;
+      let mixedEndSessions = [];
+
+      beforeAll(async () => {
+        mixedEndEvent = await createEvent({
+          ownerId: 99_802,
+          regionId: 1,
+          pocIds: [18],
+          collaboratorIds: [18],
+          data: {
+            eventId: mixedEndEventLongId,
+            eventName: 'Mixed End Date Format Event',
+            status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
+          },
+        });
+
+        mixedEndSessions = await Promise.all([
+          createSession({
+            eventId: mixedEndEvent.id,
+            data: {
+              sessionName: 'US Format End Session',
+              endDate: '11/20/2024', // MM/DD/YYYY
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEndEvent.id,
+            data: {
+              sessionName: 'ISO Format End Session',
+              endDate: '2026-03-13', // YYYY-MM-DD
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEndEvent.id,
+            data: {
+              sessionName: 'Short Year End Session',
+              endDate: '4/21/26', // M/D/YY
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEndEvent.id,
+            data: {
+              sessionName: 'Malformed End Session',
+              endDate: 'not-a-date', // unrecognized — should sort as NULL
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+          createSession({
+            eventId: mixedEndEvent.id,
+            data: {
+              sessionName: 'Empty End Session',
+              endDate: '', // empty string — NULLIF guards this
+              status: TRAINING_REPORT_STATUSES.COMPLETE,
+            },
+          }),
+        ]);
+      });
+
+      afterAll(async () => {
+        await Promise.all(mixedEndSessions.map((s) => destroySession(s.id)));
+        await destroyEvent(mixedEndEvent.id);
+      });
+
+      it('should not throw and should return results sorted DESC when endDate formats are mixed', async () => {
+        const result = await getSessionReports({
+          sortBy: 'Session_end_date',
+          sortDir: 'DESC',
+          limit: 100,
+          'eventId.ctn': [mixedEndEventLongId],
+        });
+
+        expect(result.rows.length).toBe(5);
+
+        const names = result.rows.map((r) => r.sessionName);
+        // NULLs (empty, malformed) first on DESC; then newest-to-oldest
+        expect(names.slice(0, 2)).toEqual(
+          expect.arrayContaining(['Malformed End Session', 'Empty End Session']),
+        );
+        expect(names.slice(2)).toEqual([
+          'Short Year End Session',
+          'ISO Format End Session',
+          'US Format End Session',
+        ]);
+      });
+
+      it('should not throw and should return results sorted ASC when endDate formats are mixed', async () => {
+        const result = await getSessionReports({
+          sortBy: 'Session_end_date',
+          sortDir: 'ASC',
+          limit: 100,
+          'eventId.ctn': [mixedEndEventLongId],
+        });
+
+        expect(result.rows.length).toBe(5);
+
+        const names = result.rows.map((r) => r.sessionName);
+        // Dated sessions come first oldest-to-newest; NULLs (empty, malformed) last on ASC
+        expect(names.slice(0, 3)).toEqual([
+          'US Format End Session',
+          'ISO Format End Session',
+          'Short Year End Session',
+        ]);
+        expect(names.slice(3)).toEqual(
+          expect.arrayContaining(['Malformed End Session', 'Empty End Session']),
+        );
+      });
+    });
   });
 });

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -360,28 +360,30 @@ export async function getPossibleSessionParticipants(
 }
 
 /**
- * Get training reports (sessions) with pagination, sorting, and filtering
- * @param params Query parameters including pagination, sorting, filtering, and format
- * @returns JSON object with count and rows
- */
-/**
  * Builds a SQL CASE expression that casts a JSONB date string field to a proper date,
  * handling the inconsistent formats found in production data:
- *   YYYY-MM-DD  (ISO — direct cast)
- *   M/D/YY      (short year — TO_DATE MM/DD/YY)
- *   MM/DD/YYYY  (US standard — TO_DATE MM/DD/YYYY, the dominant format and ELSE default)
+ *   YYYY-MM-DD  (ISO — direct cast, strict match)
+ *   M/D/YY or MM/DD/YY  (short year — TO_DATE MM/DD/YY)
+ *   M/D/YYYY or MM/DD/YYYY  (US standard — TO_DATE MM/DD/YYYY)
  *   null / ''   (guarded by NULLIF → NULL)
+ *   any other value (unrecognized format → NULL to prevent sort errors)
  */
 function sessionReportDateSort(field: string): string {
   const col = `"SessionReportPilot".data->>'${field}'`;
   return `CASE
     WHEN NULLIF(${col}, '') IS NULL THEN NULL
-    WHEN ${col} ~ '^\\d{4}-' THEN (${col})::date
-    WHEN ${col} ~ '/\\d{2}$' THEN TO_DATE(${col}, 'MM/DD/YY')
-    ELSE TO_DATE(${col}, 'MM/DD/YYYY')
+    WHEN ${col} ~ '^\\d{4}-\\d{2}-\\d{2}$' THEN (${col})::date
+    WHEN ${col} ~ '^\\d{1,2}/\\d{1,2}/\\d{2}$' THEN TO_DATE(${col}, 'MM/DD/YY')
+    WHEN ${col} ~ '^\\d{1,2}/\\d{1,2}/\\d{4}$' THEN TO_DATE(${col}, 'MM/DD/YYYY')
+    ELSE NULL
   END`;
 }
 
+/**
+ * Get training reports (sessions) with pagination, sorting, and filtering
+ * @param params Query parameters including pagination, sorting, filtering, and format
+ * @returns JSON object with count and rows
+ */
 export async function getSessionReports(
   params: GetSessionReportsParams,
 ): Promise<GetSessionReportsResponse> {

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -364,6 +364,24 @@ export async function getPossibleSessionParticipants(
  * @param params Query parameters including pagination, sorting, filtering, and format
  * @returns JSON object with count and rows
  */
+/**
+ * Builds a SQL CASE expression that casts a JSONB date string field to a proper date,
+ * handling the inconsistent formats found in production data:
+ *   YYYY-MM-DD  (ISO — direct cast)
+ *   M/D/YY      (short year — TO_DATE MM/DD/YY)
+ *   MM/DD/YYYY  (US standard — TO_DATE MM/DD/YYYY, the dominant format and ELSE default)
+ *   null / ''   (guarded by NULLIF → NULL)
+ */
+function sessionReportDateSort(field: string): string {
+  const col = `"SessionReportPilot".data->>'${field}'`;
+  return `CASE
+    WHEN NULLIF(${col}, '') IS NULL THEN NULL
+    WHEN ${col} ~ '^\\d{4}-' THEN (${col})::date
+    WHEN ${col} ~ '/\\d{2}$' THEN TO_DATE(${col}, 'MM/DD/YY')
+    ELSE TO_DATE(${col}, 'MM/DD/YYYY')
+  END`;
+}
+
 export async function getSessionReports(
   params: GetSessionReportsParams,
 ): Promise<GetSessionReportsResponse> {
@@ -394,26 +412,8 @@ export async function getSessionReports(
   const sortMap: SessionReportSortSortMap = {
     id: ['id'],
     sessionName: [sequelize.literal('("SessionReportPilot".data->>\'sessionName\')::text')],
-    startDate: [sequelize.literal(`CASE
-      WHEN NULLIF("SessionReportPilot".data->>'startDate', '') IS NULL THEN NULL
-      WHEN "SessionReportPilot".data->>'startDate' ~ '^\\d{4}-\\d{2}-\\d{2}$'
-        THEN ("SessionReportPilot".data->>'startDate')::date
-      WHEN "SessionReportPilot".data->>'startDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{2}$'
-        THEN TO_DATE("SessionReportPilot".data->>'startDate', 'MM/DD/YY')
-      WHEN "SessionReportPilot".data->>'startDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{4}$'
-        THEN TO_DATE("SessionReportPilot".data->>'startDate', 'MM/DD/YYYY')
-      ELSE NULL
-    END`)],
-    endDate: [sequelize.literal(`CASE
-      WHEN NULLIF("SessionReportPilot".data->>'endDate', '') IS NULL THEN NULL
-      WHEN "SessionReportPilot".data->>'endDate' ~ '^\\d{4}-\\d{2}-\\d{2}$'
-        THEN ("SessionReportPilot".data->>'endDate')::date
-      WHEN "SessionReportPilot".data->>'endDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{2}$'
-        THEN TO_DATE("SessionReportPilot".data->>'endDate', 'MM/DD/YY')
-      WHEN "SessionReportPilot".data->>'endDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{4}$'
-        THEN TO_DATE("SessionReportPilot".data->>'endDate', 'MM/DD/YYYY')
-      ELSE NULL
-    END`)],
+    startDate: [sequelize.literal(sessionReportDateSort('startDate'))],
+    endDate: [sequelize.literal(sessionReportDateSort('endDate'))],
     eventId: ['event', sequelize.literal('data->>\'eventId\'::text')],
     eventName: ['event', sequelize.literal('data->>\'eventName\'::text')],
     supportingGoals: [sequelize.literal('(SELECT MIN(gt.standard) FROM "SessionReportPilotGoalTemplates" srpgt JOIN "GoalTemplates" gt ON srpgt."goalTemplateId" = gt.id WHERE srpgt."sessionReportPilotId" = "SessionReportPilot".id)')],

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -394,8 +394,26 @@ export async function getSessionReports(
   const sortMap: SessionReportSortSortMap = {
     id: ['id'],
     sessionName: [sequelize.literal('("SessionReportPilot".data->>\'sessionName\')::text')],
-    startDate: [sequelize.literal('TO_DATE(NULLIF("SessionReportPilot".data->>\'startDate\', \'\'), \'MM/DD/YYYY\')')],
-    endDate: [sequelize.literal('TO_DATE(NULLIF("SessionReportPilot".data->>\'endDate\', \'\'), \'MM/DD/YYYY\')')],
+    startDate: [sequelize.literal(`CASE
+      WHEN NULLIF("SessionReportPilot".data->>'startDate', '') IS NULL THEN NULL
+      WHEN "SessionReportPilot".data->>'startDate' ~ '^\\d{4}-\\d{2}-\\d{2}$'
+        THEN ("SessionReportPilot".data->>'startDate')::date
+      WHEN "SessionReportPilot".data->>'startDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{2}$'
+        THEN TO_DATE("SessionReportPilot".data->>'startDate', 'MM/DD/YY')
+      WHEN "SessionReportPilot".data->>'startDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{4}$'
+        THEN TO_DATE("SessionReportPilot".data->>'startDate', 'MM/DD/YYYY')
+      ELSE NULL
+    END`)],
+    endDate: [sequelize.literal(`CASE
+      WHEN NULLIF("SessionReportPilot".data->>'endDate', '') IS NULL THEN NULL
+      WHEN "SessionReportPilot".data->>'endDate' ~ '^\\d{4}-\\d{2}-\\d{2}$'
+        THEN ("SessionReportPilot".data->>'endDate')::date
+      WHEN "SessionReportPilot".data->>'endDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{2}$'
+        THEN TO_DATE("SessionReportPilot".data->>'endDate', 'MM/DD/YY')
+      WHEN "SessionReportPilot".data->>'endDate' ~ '^\\d{1,2}/\\d{1,2}/\\d{4}$'
+        THEN TO_DATE("SessionReportPilot".data->>'endDate', 'MM/DD/YYYY')
+      ELSE NULL
+    END`)],
     eventId: ['event', sequelize.literal('data->>\'eventId\'::text')],
     eventName: ['event', sequelize.literal('data->>\'eventName\'::text')],
     supportingGoals: [sequelize.literal('(SELECT MIN(gt.standard) FROM "SessionReportPilotGoalTemplates" srpgt JOIN "GoalTemplates" gt ON srpgt."goalTemplateId" = gt.id WHERE srpgt."sessionReportPilotId" = "SessionReportPilot".id)')],


### PR DESCRIPTION
## Description of change

The issue here is there are some different date formats in the db. When we attempt to sort by start or end date we get the error. I will create a new ticket to investigate why we have different date formats but for now this fixes their issue.

https://jira.acf.gov/browse/TTAHUB-5220 - addresses the larger issue of how these dates are getting through.

## How to test

- Review the code
- Make sure you can sort start and end date on the TR dashboard.


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5217


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [x] Update JIRA ticket status
