### PR TITLE
Fix session report table user permissions

### DIFF
--- a/src/routes/sessionReports/handlers.test.js
+++ b/src/routes/sessionReports/handlers.test.js
@@ -21,7 +21,7 @@ import { findEventBySmartsheetId, findEventByDbId } from '../../services/event';
 import { userById } from '../../services/users';
 import SCOPES from '../../middleware/scopeConstants';
 import { groupsByRegion } from '../../services/groups';
-import { getUserReadRegions } from '../../services/accessValidation';
+import { setTrainingReportReadRegions } from '../../services/accessValidation';
 
 jest.mock('../../services/event');
 jest.mock('../../policies/event');
@@ -35,6 +35,7 @@ jest.mock('../../services/groups', () => ({
 }));
 jest.mock('../../services/accessValidation', () => ({
   getUserReadRegions: jest.fn(),
+  setTrainingReportReadRegions: jest.fn(),
 }));
 
 describe('session report handlers', () => {
@@ -365,7 +366,7 @@ describe('session report handlers', () => {
     });
 
     it('returns training reports in JSON format', async () => {
-      getUserReadRegions.mockResolvedValue([1, 2, 3]);
+      setTrainingReportReadRegions.mockResolvedValue({});
       getSessionReports.mockResolvedValue(mockTrainingReportResponse);
 
       await getSessionReportsHandler(mockRequest, mockResponse);
@@ -374,7 +375,7 @@ describe('session report handlers', () => {
     });
 
     it('returns training reports with default pagination', async () => {
-      getUserReadRegions.mockResolvedValue([1, 2, 3]);
+      setTrainingReportReadRegions.mockResolvedValue({});
       getSessionReports.mockResolvedValue(mockTrainingReportResponse);
 
       await getSessionReportsHandler(mockRequest, mockResponse);
@@ -391,7 +392,7 @@ describe('session report handlers', () => {
     });
 
     it('returns training reports with custom pagination', async () => {
-      getUserReadRegions.mockResolvedValue([1, 2, 3]);
+      setTrainingReportReadRegions.mockResolvedValue({});
       getSessionReports.mockResolvedValue(mockTrainingReportResponse);
 
       const requestWithPagination = {
@@ -417,7 +418,7 @@ describe('session report handlers', () => {
     });
 
     it('returns training reports in CSV format', async () => {
-      getUserReadRegions.mockResolvedValue([1, 2, 3]);
+      setTrainingReportReadRegions.mockResolvedValue({});
       getSessionReports.mockResolvedValue({
         count: 2,
         rows: mockTrainingReportResponse.rows,
@@ -456,7 +457,7 @@ describe('session report handlers', () => {
     });
 
     it('supports sorting by event fields (eventId, eventName)', async () => {
-      getUserReadRegions.mockResolvedValue([1, 2, 3]);
+      setTrainingReportReadRegions.mockResolvedValue({});
       getSessionReports.mockResolvedValue(mockTrainingReportResponse);
 
       const requestWithEventSorting = {
@@ -474,17 +475,11 @@ describe('session report handlers', () => {
       );
     });
 
-    it('returns 403 when user has no readable regions', async () => {
-      getUserReadRegions.mockResolvedValue([]); // Empty array
-
-      await getSessionReportsHandler(mockRequest, mockResponse);
-
-      expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
-      expect(getSessionReports).not.toHaveBeenCalled();
-    });
-
     it('passes additional filter parameters to service', async () => {
-      getUserReadRegions.mockResolvedValue([1, 2, 3]);
+      setTrainingReportReadRegions.mockResolvedValue({
+        'startDate.bef': '2024-06-01',
+        'eventId.ctn': '1037',
+      });
       getSessionReports.mockResolvedValue(mockTrainingReportResponse);
 
       const requestWithFilters = {
@@ -506,7 +501,7 @@ describe('session report handlers', () => {
     });
 
     it('handles errors gracefully', async () => {
-      getUserReadRegions.mockResolvedValue([1, 2, 3]);
+      setTrainingReportReadRegions.mockResolvedValue({});
       getSessionReports.mockRejectedValue(new Error('Database error'));
 
       await getSessionReportsHandler(mockRequest, mockResponse);

--- a/src/routes/sessionReports/handlers.ts
+++ b/src/routes/sessionReports/handlers.ts
@@ -292,17 +292,27 @@ export const getSessionReportsHandler = async (req: Request, res: Response) => {
       limit,
       format,
       ...filterParams
-    } = req.query as Record<string, string | undefined>;
+    } = req.query as Record<string, string | string[] | undefined>;
 
-    // Previously, we returned an UNAUTHORIZED error after checking to see if
+    const normalizedFilterParams = { ...filterParams };
+
+    if (typeof normalizedFilterParams['region.in'] === 'string') {
+      normalizedFilterParams['region.in'] = [normalizedFilterParams['region.in']];
+    }
+
+    if (typeof normalizedFilterParams['region.in[]'] === 'string') {
+      normalizedFilterParams['region.in[]'] = [normalizedFilterParams['region.in[]']];
+    }
+
+    // Previously, we returned a FORBIDDEN (403) error after checking to see if
     // a user had regions, however, missing region URL params would cause
     // overly permissive access to session reports.
     // Using setTrainingReportReadRegions switches to the pattern used throughout the rest
     // of our application/handlers (the user experience will be the same: an empty sessions table)
-    const filteredFilterParams = await setTrainingReportReadRegions(filterParams, userId);
+    const filteredFilterParams = await setTrainingReportReadRegions(normalizedFilterParams, userId);
 
     // Build params object for service
-    // Service layer filters will handle region filtering based on userReadRegions
+    // Region filtering has already been applied via setTrainingReportReadRegions
     // For CSV export, don't apply limit/offset to get all rows
 
     let offsetValue = offset ? Number(offset) : 0;

--- a/src/routes/sessionReports/handlers.ts
+++ b/src/routes/sessionReports/handlers.ts
@@ -19,7 +19,7 @@ import { userById } from '../../services/users';
 import { getEventAuthorization } from '../events/handlers';
 import { currentUserId } from '../../services/currentUser';
 import { groupsByRegion } from '../../services/groups';
-import { getUserReadRegions, setTrainingReportReadRegions } from '../../services/accessValidation';
+import { setTrainingReportReadRegions } from '../../services/accessValidation';
 
 const namespace = 'SERVICE:SESSIONREPORTS';
 

--- a/src/routes/sessionReports/handlers.ts
+++ b/src/routes/sessionReports/handlers.ts
@@ -19,7 +19,7 @@ import { userById } from '../../services/users';
 import { getEventAuthorization } from '../events/handlers';
 import { currentUserId } from '../../services/currentUser';
 import { groupsByRegion } from '../../services/groups';
-import { getUserReadRegions } from '../../services/accessValidation';
+import { getUserReadRegions, setTrainingReportReadRegions } from '../../services/accessValidation';
 
 const namespace = 'SERVICE:SESSIONREPORTS';
 
@@ -284,14 +284,6 @@ export const getSessionReportsHandler = async (req: Request, res: Response) => {
   try {
     const userId = await currentUserId(req, res);
 
-    // Get user's readable regions for authorization
-    const userReadRegions = await getUserReadRegions(userId);
-
-    // Return FORBIDDEN if user has no readable regions
-    if (!userReadRegions.length) {
-      return res.sendStatus(httpCodes.FORBIDDEN);
-    }
-
     // Extract query parameters
     const {
       sortBy,
@@ -301,6 +293,13 @@ export const getSessionReportsHandler = async (req: Request, res: Response) => {
       format,
       ...filterParams
     } = req.query as Record<string, string | undefined>;
+
+    // Previously, we returned an UNAUTHORIZED error after checking to see if
+    // a user had regions, however, missing region URL params would cause
+    // overly permissive access to session reports.
+    // Using setTrainingReportReadRegions switches to the pattern used throughout the rest
+    // of our application/handlers (the user experience will be the same: an empty sessions table)
+    const filteredFilterParams = await setTrainingReportReadRegions(filterParams, userId);
 
     // Build params object for service
     // Service layer filters will handle region filtering based on userReadRegions
@@ -323,7 +322,7 @@ export const getSessionReportsHandler = async (req: Request, res: Response) => {
       offset: offsetValue,
       limit: limitValue,
       format: formatValue as 'json' | 'csv',
-      ...filterParams,
+      ...filteredFilterParams,
     };
 
     const result: GetSessionReportsResponse = await getSessionReports(serviceParams);

--- a/src/routes/sessionReports/handlers.ts
+++ b/src/routes/sessionReports/handlers.ts
@@ -318,7 +318,7 @@ export const getSessionReportsHandler = async (req: Request, res: Response) => {
     let offsetValue = offset ? Number(offset) : 0;
     let limitValue: number | 'all' = limit ? Number(limit) : 10;
 
-    const formatValue = format ? format.toLowerCase() : 'json';
+    const formatValue = format ? ([format].flat()[0]).toLowerCase() : 'json';
     const isCSV = format === 'csv';
 
     if (isCSV) {


### PR DESCRIPTION
## Description of change
Fix the logic on the backend of the session report table, was previously too permissive


## How to test
Impersonate a user with single region access. Clear all filters via the URL, view the session reports table. You should see only sessions your user has permission to.

## Issue(s)



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
