### PR TITLE
[TTAHUB-5218] Prevent session storage values from being overwritten when switching dashboard contexts

### DIFF
--- a/frontend/src/pages/RegionalDashboard/__tests__/index.js
+++ b/frontend/src/pages/RegionalDashboard/__tests__/index.js
@@ -381,6 +381,71 @@ describe('Regional Dashboard page', () => {
     expect(await screen.findByText('Specialist name')).toBeVisible();
   });
 
+  it('clears filters when switching tabs and restores them when returning', () => {
+    // Reset shared state that bleeds from prior tests
+    window.sessionStorage.clear();
+    history.replace({ search: '' });
+
+    const activityKey = 'regional-dashboard-filters-activity-reports';
+    const trainingKey = 'regional-dashboard-filters-training-reports';
+
+    // Seed distinct, identifiable filters for each tab
+    const activityFilters = [{
+      id: 'ar-filter', topic: 'startDate', condition: 'is within', query: 'last-thirty-days',
+    }];
+    const trainingFilters = [{
+      id: 'tr-filter', topic: 'startDate', condition: 'is within', query: 'custom',
+    }];
+    window.sessionStorage.setItem(activityKey, JSON.stringify(activityFilters));
+    window.sessionStorage.setItem(trainingKey, JSON.stringify(trainingFilters));
+
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+    const user = {
+      homeRegionId: 1,
+      permissions: [{ regionId: 1, scopeId: SCOPE_IDS.READ_ACTIVITY_REPORTS }],
+    };
+
+    const renderContent = (reportType) => (
+      <AppLoadingContext.Provider value={{ setIsAppLoading: jest.fn() }}>
+        <AriaLiveContext.Provider value={{ announce: jest.fn() }}>
+          <UserContext.Provider value={{ user }}>
+            <Router history={history}>
+              <RegionalDashboard match={{ params: { reportType }, path: '', url: '' }} />
+            </Router>
+          </UserContext.Provider>
+        </AriaLiveContext.Provider>
+      </AppLoadingContext.Provider>
+    );
+
+    const { rerender, unmount } = render(renderContent('activity-reports'));
+
+    // Clear spy counts so we only observe the tab-switch writes
+    setItemSpy.mockClear();
+
+    // Switch to training tab — key={reportType} forces full remount of inner component
+    rerender(renderContent('training-reports'));
+
+    // The training key must never have been written with activity-reports filter data
+    const trainingKeyWrites = setItemSpy.mock.calls.filter(([key]) => key === trainingKey);
+    trainingKeyWrites.forEach(([, val]) => {
+      expect(JSON.parse(val)).not.toContainEqual(expect.objectContaining({ id: 'ar-filter' }));
+    });
+
+    // Clear spy and return to activity tab
+    setItemSpy.mockClear();
+    rerender(renderContent('activity-reports'));
+
+    // The activity key must never have been written with training-reports filter data
+    const activityKeyWrites = setItemSpy.mock.calls.filter(([key]) => key === activityKey);
+    activityKeyWrites.forEach(([, val]) => {
+      expect(JSON.parse(val)).not.toContainEqual(expect.objectContaining({ id: 'tr-filter' }));
+    });
+
+    setItemSpy.mockRestore();
+    unmount();
+  });
+
   it('shows region filter if user has more than one region', async () => {
     fetchMock.get('/api/widgets/overview?region.in[]=1&region.in[]=2', overViewResponse, { overwriteRoutes: true });
     fetchMock.get('/api/widgets/totalHrsAndRecipientGraph?region.in[]=1&region.in[]=2', totalHoursResponse, { overwriteRoutes: true });

--- a/frontend/src/pages/RegionalDashboard/__tests__/index.js
+++ b/frontend/src/pages/RegionalDashboard/__tests__/index.js
@@ -389,12 +389,18 @@ describe('Regional Dashboard page', () => {
     const activityKey = 'regional-dashboard-filters-activity-reports';
     const trainingKey = 'regional-dashboard-filters-training-reports';
 
-    // Seed distinct, identifiable filters for each tab
+    // Seed distinct, identifiable filters for each tab using valid persisted date ranges
     const activityFilters = [{
-      id: 'ar-filter', topic: 'startDate', condition: 'is within', query: 'last-thirty-days',
+      id: 'ar-filter',
+      topic: 'startDate',
+      condition: 'is within',
+      query: formatDateRange({ lastThirtyDays: true, forDateTime: true }),
     }];
     const trainingFilters = [{
-      id: 'tr-filter', topic: 'startDate', condition: 'is within', query: 'custom',
+      id: 'tr-filter',
+      topic: 'startDate',
+      condition: 'is within',
+      query: '2024/01/01-2024/01/31',
     }];
     window.sessionStorage.setItem(activityKey, JSON.stringify(activityFilters));
     window.sessionStorage.setItem(trainingKey, JSON.stringify(trainingFilters));

--- a/frontend/src/pages/RegionalDashboard/index.js
+++ b/frontend/src/pages/RegionalDashboard/index.js
@@ -69,7 +69,7 @@ export const links = [
   },
 ];
 
-export default function RegionalDashboard({ match }) {
+function RegionalDashboardContent({ match }) {
   const { user } = useContext(UserContext);
   const [resetPagination, setResetPagination] = useState(false);
 
@@ -153,6 +153,15 @@ export default function RegionalDashboard({ match }) {
       />
     </div>
   );
+}
+
+RegionalDashboardContent.propTypes = {
+  match: ReactRouterPropTypes.match.isRequired,
+};
+
+export default function RegionalDashboard({ match }) {
+  const { reportType } = match.params;
+  return <RegionalDashboardContent key={reportType || 'default'} match={match} />;
 }
 
 RegionalDashboard.propTypes = {


### PR DESCRIPTION
## Description of change

Due to the architecture of the session storage hook, dashboard navigation would cause the previous pages filters to overwrite the destination pages, so that invalid filters would be present on the monitoring dashboard, for example

This change causes the "Dashboard" component to fully and properly unmount before writing to sessionStorage, applying filters, etc. 

## How to test

Add some filters to the activity report dashboard: goal text = "monitoring", etc
Click on the monitoring dashboard and confirm the filters are not applied. (Check the URL and the network request)

## Issue(s)

https://jira.acf.gov/browse/TTAHUB-5218

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
