### PR TITLE
[TTAHUB-5135] Update child incidents indicator language

### DIFF
--- a/frontend/src/pages/RecipientRecord/components/RecipientSpotlight.js
+++ b/frontend/src/pages/RecipientRecord/components/RecipientSpotlight.js
@@ -22,7 +22,7 @@ const mappedData = (data) => ([
     'childIncidents',
     'Child incidents',
     data.childIncidents,
-    'Recipient grant has experienced more than one child incident cited in a RAN in the last 12 months',
+    'Recipient grant has experienced at least one child incident cited in a RAN in the last 12 months',
   ),
   createRowForEachIndicator(
     'deficiency',

--- a/frontend/src/pages/RecipientRecord/components/__tests__/RecipientSpotlight.js
+++ b/frontend/src/pages/RecipientRecord/components/__tests__/RecipientSpotlight.js
@@ -197,7 +197,7 @@ describe('RecipientSpotlight', () => {
     expect(fetchMock.called(spotlightUrl)).toBe(true);
 
     await waitFor(() => {
-      expect(screen.getByText(/Recipient grant has experienced more than one child incident/i)).toBeInTheDocument();
+      expect(screen.getByText(/Recipient grant has experienced at least one child incident/i)).toBeInTheDocument();
       expect(screen.getByText(/Recipient is in the first 4 years as a Head Start program/i)).toBeInTheDocument();
       expect(screen.getByText(/Recipient grant does not have any TTA reports in last 12 months/i)).toBeInTheDocument();
     });
@@ -210,7 +210,7 @@ describe('RecipientSpotlight', () => {
     renderRecipientSpotlight();
 
     await waitFor(() => {
-      expect(screen.getByText(/Recipient grant has experienced more than one child incident/i)).toBeInTheDocument();
+      expect(screen.getByText(/Recipient grant has experienced at least one child incident/i)).toBeInTheDocument();
       expect(screen.getByText(/Recipient grant has at least one active monitoring deficiency/i)).toBeInTheDocument();
       expect(screen.getByText(/Recipient grant has changed the name of the director or fiscal officer/i)).toBeInTheDocument();
       expect(screen.getByText(/Recipient grant does not have any TTA reports in last 12 months/i)).toBeInTheDocument();

--- a/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
+++ b/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
@@ -13,7 +13,7 @@ const DISPLAYED_INDICATOR_COUNT = 5;
 const INDICATOR_DETAILS = {
   childIncidents: {
     label: 'Child incidents',
-    description: 'Recipient has experienced more than one child incident cited in a RAN in the last 12 months',
+    description: 'Recipient has experienced at least one child incident cited in a RAN in the last 12 months',
   },
   deficiency: {
     label: 'Deficiency',

--- a/frontend/src/pages/RegionalDashboard/components/__tests__/RecipientSpotlightCard.js
+++ b/frontend/src/pages/RegionalDashboard/components/__tests__/RecipientSpotlightCard.js
@@ -89,7 +89,7 @@ describe('RecipientSpotlightCard', () => {
 
     expect(screen.getByText('Child incidents')).toBeInTheDocument();
     expect(screen.getByText('New recipient')).toBeInTheDocument();
-    expect(screen.getByText(/more than one child incident cited in a RAN/)).toBeInTheDocument();
+    expect(screen.getByText(/at least one child incident cited in a RAN/)).toBeInTheDocument();
   });
 
   it('changes button text to "Hide" when expanded', () => {
@@ -179,7 +179,7 @@ describe('RecipientSpotlightCard', () => {
     const expandButton = screen.getByRole('button', { name: /indicators for recipient/i });
     fireEvent.click(expandButton);
 
-    expect(screen.getByText(/Recipient has experienced more than one child incident/)).toBeInTheDocument();
+    expect(screen.getByText(/Recipient has experienced at least one child incident/)).toBeInTheDocument();
     expect(screen.getByText(/Recipient is in the first 4 years as a Head Start program/)).toBeInTheDocument();
   });
 
@@ -250,7 +250,7 @@ describe('RecipientSpotlightCard', () => {
     fireEvent.click(expandButton);
 
     // Descriptions should say "Recipient has", not "Recipient grant has"
-    expect(screen.getByText(/Recipient has experienced more than one child incident/)).toBeInTheDocument();
+    expect(screen.getByText(/Recipient has experienced at least one child incident/)).toBeInTheDocument();
     expect(screen.queryByText(/Recipient grant has/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description of change

Update Child Incidents indicator in both the regional and grant level spotlight 

Regional new text: "Recipient has experienced at least one child incident cited in a RAN in the last 12 months"
Grant level new text: "Recipient grant has experienced at least one child incident cited in a RAN in the last 12 months"

## How to test

- Review the code.
- Make sure RTR and Recipient Spotlight show the correct language for child incidents.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5135


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [x] Update JIRA ticket status
