### PR TITLE
[NO-TICKET] Replace stale CI/CD doc PR reference

### DIFF
--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -552,7 +552,6 @@ terraform apply
 
 **Bind the infrastructure to the application**
 
-CloudFoundry/cloud.gov requires that some "services" (e.g. AWS infrastructure) be "bound" to the application instance. S3, and Redis are all services that require this "binding" step. See the [cloud.gov documentation][cloudgov-bind] for more direction on this. Also, check out [PR#71][PR#71] for an example of how this was done for the RDS instances.
+Cloud Foundry/cloud.gov requires managed services to be bound to the application instance. In this repo, those bindings are declared in the [`services:` block of `manifest.yml`](../../manifest.yml); the current deploy binds `ttahub-((env))`, `ttahub-redis-((env))`, and `ttahub-document-upload-((env))` to the app. The `((env))` value comes from the environment-specific files under [deployment_config/](../../deployment_config/). If you add another managed service, add it to the manifest `services:` list so it is bound during deployment. See the [cloud.gov documentation][cloudgov-bind] for more direction on this.
 
 [cloudgov-bind]: https://cloud.gov/docs/getting-started/your-first-deploy/#bind-a-service
-[PR#71]: https://github.com/HHS/Head-Start-TTADP/pull/71

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -552,6 +552,6 @@ terraform apply
 
 **Bind the infrastructure to the application**
 
-Cloud Foundry/cloud.gov requires managed services to be bound to the application instance. In this repo, those bindings are declared in the [`services:` block of `manifest.yml`](../../manifest.yml); the current deploy binds `ttahub-((env))`, `ttahub-redis-((env))`, and `ttahub-document-upload-((env))` to the app. The `((env))` value comes from the environment-specific files under [deployment_config/](../../deployment_config/). If you add another managed service, add it to the manifest `services:` list so it is bound during deployment. See the [cloud.gov documentation][cloudgov-bind] for more direction on this.
+Cloud Foundry/cloud.gov requires managed services to be bound to the application instance. In this repo, those bindings are declared in the [`services:` block of `manifest.yml`](../../manifest.yml), which is the source of truth for the current set of services bound during deployment. The `((env))` value comes from the environment-specific files under [deployment_config/](../../deployment_config/). If you add another managed service, add it to the manifest `services:` list so it is bound during deployment. See the [cloud.gov documentation][cloudgov-bind] for more direction on this.
 
 [cloudgov-bind]: https://cloud.gov/docs/getting-started/your-first-deploy/#bind-a-service


### PR DESCRIPTION
## Description of change

This updates the CI/CD infrastructure documentation to remove a stale historical GitHub PR reference from the service binding section.

Instead of sending readers to an old PR example, the guide now points them to the current source of truth in `manifest.yml` and `deployment_config/`, and explains which managed services are bound during deployment.

## How to test

- Review `docs/guides/infrastructure.md` in the "Bind the infrastructure to the application" section.
- Confirm the section points to `manifest.yml` and `deployment_config/` instead of a legacy PR.
- Confirm the stale `PR#71` reference has been removed.

## Issue(s)

- NO-TICKET

## Checklists

### Every PR

- [x] Meets issue criteria
- [n/a] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [n/a] QA review complete

### Before merge to main

- [n/a] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [n/a] Staging smoke test completed
- [n/a] PR transitioned to **Open**
- [n/a] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR -> Smoke test -> Open PR -> Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [n/a] Update JIRA ticket status
