### PR TITLE
Attempt to fix flaky dbUtils test suite

### DIFF
--- a/src/routes/testingOnly/dbUtils.test.js
+++ b/src/routes/testingOnly/dbUtils.test.js
@@ -1,24 +1,63 @@
-import { QueryTypes } from 'sequelize';
-import db from '../../models';
+import { QueryTypes, Sequelize } from 'sequelize';
+import { Umzug } from 'umzug';
 import { reseed, query } from '../../../tests/utils/dbUtils';
 
+jest.mock('sequelize', () => ({
+  ...jest.requireActual('sequelize'),
+  Sequelize: jest.fn().mockImplementation(() => ({
+    query: jest.fn().mockResolvedValue([]),
+    getQueryInterface: jest.fn().mockReturnValue({}),
+  })),
+}));
+
+jest.mock('umzug', () => ({
+  Umzug: jest.fn().mockImplementation(() => ({
+    up: jest.fn().mockResolvedValue([]),
+  })),
+  SequelizeStorage: jest.fn(),
+}));
+
+jest.mock('fs', () => ({
+  readdirSync: jest.fn().mockReturnValue([]),
+}));
+
 describe('dbUtils', () => {
-  afterAll(() => db.sequelize.close());
-  it('test reseed via function api', async () => {
-    await query(`
-      ALTER SEQUENCE "Goals_id_seq"
-      RESTART WITH 65535;
-    `, null);
+  // dbUtils.js instantiates Sequelize at module load time; save the reference
+  // before clearAllMocks wipes Sequelize.mock.results in beforeEach.
+  let sequelizeInstance;
 
-    const wasReseeded = await reseed();
+  beforeAll(() => {
+    sequelizeInstance = Sequelize.mock.results[0].value;
+  });
 
-    expect(wasReseeded).toBe(true);
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-    const [{ lastValue }] = await query(`
-    SELECT last_value AS "lastValue"
-    FROM "Goals_id_seq";
-    `, { type: QueryTypes.SELECT });
+  describe('query', () => {
+    it('delegates to sequelize.query with the provided command and options', async () => {
+      const sql = 'SELECT last_value AS "lastValue" FROM "Goals_id_seq";';
+      const opts = { type: QueryTypes.SELECT };
+      sequelizeInstance.query.mockResolvedValue([{ lastValue: 1 }]);
 
-    expect(lastValue).not.toBe(65535);
+      const result = await query(sql, opts);
+
+      expect(sequelizeInstance.query).toHaveBeenCalledWith(sql, opts);
+      expect(result).toEqual([{ lastValue: 1 }]);
+    });
+  });
+
+  describe('reseed', () => {
+    it('drops the schema, runs migrations and seeders, and returns true', async () => {
+      const result = await reseed();
+
+      expect(result).toBe(true);
+      expect(sequelizeInstance.query).toHaveBeenCalledWith(
+        expect.stringContaining('DROP SCHEMA public CASCADE'),
+      );
+      expect(Umzug).toHaveBeenCalledTimes(2);
+      expect(Umzug.mock.results[0].value.up).toHaveBeenCalled();
+      expect(Umzug.mock.results[1].value.up).toHaveBeenCalled();
+    });
   });
 });

--- a/src/routes/testingOnly/dbUtils.test.js
+++ b/src/routes/testingOnly/dbUtils.test.js
@@ -32,6 +32,7 @@ describe('dbUtils', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    sequelizeInstance.query.mockResolvedValue([]);
   });
 
   describe('query', () => {


### PR DESCRIPTION
## Description of change
As our migrations grow, a yarn test that runs 369+ migrations is starting to regularly time out. Luckily, this code path is well tested already via the handlers and it's actual usage in the e2e test suite

This change replaces the real-DB integration test with mocked dependencies so the test runs in milliseconds instead of wading through every DB migration and seed.

## How to test
CI passes, overall test coverage remains in place

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
