### PR TITLE
Update monitoring goals check in AR creation

### DIFF
--- a/src/services/reportCache.js
+++ b/src/services/reportCache.js
@@ -15,6 +15,7 @@ import {
   Citation,
   Goal,
   GoalFieldResponse,
+  GoalTemplate,
   GoalTemplateFieldPrompt,
   Objective,
   sequelize,
@@ -181,6 +182,7 @@ const cacheTopics = async (objectiveId, activityReportObjectiveId, topics = []) 
 
 export const cacheCitations = async (objectiveId, activityReportObjectiveId, citations = []) => {
   let newCitations = [];
+
   // Delete all existing citations for this activity report objective.
   await ActivityReportObjectiveCitation.destroy({
     where: { activityReportObjectiveId },
@@ -190,16 +192,23 @@ export const cacheCitations = async (objectiveId, activityReportObjectiveId, cit
 
   // Get the goal for this objective.
   const goal = await Goal.findOne({
-    attributes: ['grantId', 'createdVia'],
-    where: {
-      createdVia: 'monitoring',
-    },
+    attributes: ['grantId'],
     include: [
+      {
+        model: GoalTemplate,
+        as: 'goalTemplate',
+        attributes: [],
+        required: true,
+        where: {
+          standard: 'Monitoring',
+        },
+      },
       {
         model: Objective,
         as: 'objectives',
         where: { id: objectiveId },
         required: true,
+        attributes: [],
       },
     ],
   });

--- a/src/services/reportCache.test.js
+++ b/src/services/reportCache.test.js
@@ -194,6 +194,9 @@ describe('activityReportObjectiveCitation', () => {
   let nonMonitoringObjective;
   let aro;
   let nonMonitoringAro;
+  let rtrObjective;
+  let rtrAro;
+  let rtrFindingId;
   let findingIdOne;
   let findingIdTwo;
   let findingIdThree;
@@ -282,6 +285,12 @@ describe('activityReportObjectiveCitation', () => {
       status: 'Not Started',
     });
 
+    rtrObjective = await Objective.create({
+      goalId: goal.id,
+      title: faker.datatype.string(200),
+      status: 'Not Started',
+    });
+
     aro = await ActivityReportObjective.create({
       objectiveId: objective.id,
       activityReportId: activityReport.id,
@@ -292,10 +301,16 @@ describe('activityReportObjectiveCitation', () => {
       activityReportId: activityReport.id,
     });
 
+    rtrAro = await ActivityReportObjective.create({
+      objectiveId: rtrObjective.id,
+      activityReportId: activityReport.id,
+    });
+
     findingIdOne = faker.datatype.uuid();
     findingIdTwo = faker.datatype.uuid();
     findingIdThree = faker.datatype.uuid();
     nonMonitoringFindingId = faker.datatype.uuid();
+    rtrFindingId = faker.datatype.uuid();
 
     const startingMfid = faker.datatype.number({ min: 100000, max: 999999 });
     await Citation.bulkCreate([
@@ -345,6 +360,12 @@ describe('activityReportObjectiveCitation', () => {
       severity: 2,
       reportDeliveryDate: '2025-02-16T05:00:00+00:00',
       monitoringFindingStatusName: 'Active',
+    });
+
+    await Citation.create({
+      mfid: startingMfid + 5,
+      finding_uuid: rtrFindingId,
+      citation: 'RTR Citation 1',
     });
   });
 
@@ -764,6 +785,45 @@ describe('activityReportObjectiveCitation', () => {
     expect(savedCitations).toHaveLength(1);
     expect(savedCitations[0].citation).toBe('Persisted citation');
     expect(savedCitations[0].findingId).toBe(findingIdOne);
+  });
+
+  it('persists citations for monitoring-template goals created via rtr', async () => {
+    await goal.update({
+      createdVia: 'rtr',
+    });
+
+    const citationsToCreate = [
+      {
+        citation: 'RTR Citation 1',
+        monitoringReferences: [buildMonitoringReference({
+          grantId: grant.id,
+          findingId: rtrFindingId,
+          reviewName: 'Review RTR',
+          standardId: 200051,
+          grantNumber: grant.number,
+          name: 'RTR Citation 1',
+          citation: 'RTR Citation 1',
+        })],
+      },
+    ];
+
+    const result = await cacheCitations(rtrObjective.id, rtrAro.id, citationsToCreate);
+
+    expect(result).toBeDefined();
+    expect(result.length).toBeGreaterThan(0);
+
+    const savedCitations = await ActivityReportObjectiveCitation.findAll({
+      where: { activityReportObjectiveId: rtrAro.id },
+    });
+
+    expect(savedCitations).toHaveLength(1);
+    expect(savedCitations[0].citation).toEqual('RTR Citation 1');
+    expect(savedCitations[0].grantId).toEqual(grant.id);
+    expect(savedCitations[0].findingId).toEqual(rtrFindingId);
+
+    await goal.update({
+      createdVia: 'monitoring',
+    });
   });
 
   it('correctly removes and prevents the saving of citations for non-monitoring goals', async () => {

--- a/src/services/reportCache.test.js
+++ b/src/services/reportCache.test.js
@@ -11,6 +11,7 @@ import {
   ActivityReportObjectiveCourse,
   ActivityReportObjectiveCitation,
   ActivityReportGoalFieldResponse,
+  GoalTemplate,
   GoalTemplateFieldPrompt,
   Topic,
   Course,
@@ -244,6 +245,12 @@ describe('activityReportObjectiveCitation', () => {
       ],
     });
 
+    const monitoringTemplate = await GoalTemplate.findOne({
+      where: {
+        standard: 'Monitoring',
+      },
+    });
+
     goal = await Goal.create({
       name: faker.lorem.sentence(20),
       status: GOAL_STATUS.NOT_STARTED,
@@ -251,6 +258,7 @@ describe('activityReportObjectiveCitation', () => {
       onApprovedAR: false,
       grantId: grant.id,
       createdVia: 'monitoring',
+      goalTemplateId: monitoringTemplate.id,
     });
 
     nonMonitoringGoal = await Goal.create({


### PR DESCRIPTION
## Description of change

Apparently some monitoring goals have a "createdVia" of "rtr"
It seems to be very old monitoring goals (prestandard) so I am following up with more work to address this. This fix simply unblocks a user in production while preserving the intent of the original check in our code

## How to test
Prod data
Impersonate user 793
On this branch, you should be able to save a citation on the goal on report 61775

## Issue(s)



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
