### PR TITLE
Goal lifecycle/objective bug

### DIFF
--- a/src/goalServices/goals.test.js
+++ b/src/goalServices/goals.test.js
@@ -787,14 +787,19 @@ describe('Goals DB service', () => {
         id: 1,
         name: 'name',
         objectives: [{
-          title: 'title', id: mockObjectiveId, status: 'Closed', goalId: mockGoalId,
+          title: 'title', id: mockObjectiveId, ids: [mockObjectiveId], status: 'Closed', goalId: mockGoalId,
         }],
         update: jest.fn(),
         grantIds: [mockGrantId],
         goalIds: [mockGoalId],
       };
 
-      Objective.findOne.mockResolvedValue({ id: mockObjectiveId });
+      Objective.findOne.mockResolvedValue({
+        id: mockObjectiveId,
+        update: existingObjectiveUpdate,
+        save: jest.fn(),
+        toJSON: jest.fn().mockReturnValue({ id: mockObjectiveId }),
+      });
       await saveStandardGoalsForReport([existingGoal], { id: mockActivityReportId });
       expect(existingObjectiveUpdate).toHaveBeenCalledWith({ title: 'title' }, { individualHooks: true });
     });

--- a/src/services/standardGoal.test.js
+++ b/src/services/standardGoal.test.js
@@ -1486,6 +1486,7 @@ describe('standardGoal service', () => {
     const objectives = [
       {
         id: 1,
+        ids: [1],
         isNew: false,
         ttaProvided: 'TTA provided details',
         title: 'Objective title 1',
@@ -1530,7 +1531,6 @@ describe('standardGoal service', () => {
     });
 
     it('should create new objectives for new items', async () => {
-      Objective.findByPk = jest.fn().mockResolvedValue(null);
       Objective.findOne = jest.fn().mockResolvedValue(null);
       Objective.create = jest.fn().mockResolvedValue({
         toJSON: () => ({
@@ -1543,7 +1543,6 @@ describe('standardGoal service', () => {
 
       const result = await createObjectivesForGoal(goal, objectives);
 
-      expect(Objective.findByPk).toHaveBeenCalledTimes(1);
       expect(Objective.create).toHaveBeenCalledWith(expect.objectContaining({
         title: 'Objective title 2',
         goalId: goal.id,
@@ -1556,7 +1555,7 @@ describe('standardGoal service', () => {
     });
 
     it('should update existing objectives', async () => {
-      Objective.findByPk = jest.fn().mockResolvedValue({
+      const existingObj = {
         id: 1,
         title: 'Objective title 1',
         onApprovedAR: false,
@@ -1568,9 +1567,18 @@ describe('standardGoal service', () => {
           status: OBJECTIVE_STATUS.IN_PROGRESS,
           goalId: goal.id,
         }),
-      });
+      };
 
-      Objective.findOne = jest.fn().mockResolvedValue(null);
+      Objective.findOne = jest.fn()
+        .mockImplementation(({ where }) => {
+          // First call: lookup by ids + goalId for existing objective
+          if (where.id) {
+            return Promise.resolve(existingObj);
+          }
+          // Fallback: title-based lookup for new objectives
+          return Promise.resolve(null);
+        });
+
       Objective.create = jest.fn().mockResolvedValue({
         toJSON: () => ({
           id: 2,
@@ -1582,8 +1590,12 @@ describe('standardGoal service', () => {
 
       const result = await createObjectivesForGoal(goal, objectives);
 
-      expect(Objective.findByPk).toHaveBeenCalledTimes(1);
-      expect(Objective.findByPk).toHaveBeenCalledWith(1);
+      expect(Objective.findOne).toHaveBeenCalledWith({
+        where: {
+          id: [1, 1],
+          goalId: goal.id,
+        },
+      });
 
       expect(result).toHaveLength(2);
       expect(result[0].title).toBe('Objective title 1');
@@ -1591,8 +1603,6 @@ describe('standardGoal service', () => {
     });
 
     it('should reuse an existing objective if conditions match', async () => {
-      Objective.findByPk = jest.fn().mockResolvedValue(null);
-
       // Mock finding the objective by title and goal ID
       Objective.findOne = jest.fn()
         .mockImplementation(({ where }) => {
@@ -1648,7 +1658,6 @@ describe('standardGoal service', () => {
         },
       ];
 
-      Objective.findByPk = jest.fn().mockResolvedValue(null);
       Objective.findOne = jest.fn().mockResolvedValue(null);
       Objective.create = jest.fn().mockResolvedValue({
         toJSON: () => ({
@@ -1663,6 +1672,76 @@ describe('standardGoal service', () => {
 
       expect(result).toHaveLength(0);
       expect(Objective.create).not.toHaveBeenCalled();
+    });
+
+    it('should create a new objective when continuing from a closed goal lifecycle', async () => {
+      // Scenario: Goal template has been through a lifecycle.
+      // - Old goal (id: 50) was closed, had Objective 10 on it.
+      // - New goal (id: 100) is a fresh lifecycle of the same template.
+      // - User selects Objective 10 for continuation on the new goal.
+      //
+      // The old code had two bugs:
+      // 1. findByPk(id) found the old objective without checking goalId,
+      //    attaching it to the wrong goal.
+      // 2. The `ids` search excluded the primary `id`, so the objective
+      //    was missed and a duplicate was created.
+      //
+      // The fix ensures findOne always filters by goalId and includes
+      // both `id` and `ids` in the search.
+
+      const newGoal = { id: 100 };
+      const continuedObjectives = [
+        {
+          id: 10,
+          ids: [10],
+          isNew: false,
+          ttaProvided: 'Continued TTA',
+          title: 'Continued Objective',
+          status: OBJECTIVE_STATUS.NOT_STARTED,
+          topics: ['topic1'],
+          resources: [],
+          files: [],
+          courses: [],
+          closeSuspendReason: null,
+          closeSuspendContext: null,
+          ActivityReportObjective: {},
+          supportType: 'supportType1',
+          goalId: 50, // old closed goal
+          createdHere: false,
+        },
+      ];
+
+      // findOne with goalId: 100 returns null because no objective exists on the new goal yet
+      Objective.findOne = jest.fn().mockResolvedValue(null);
+      Objective.create = jest.fn().mockResolvedValue({
+        toJSON: () => ({
+          id: 99,
+          title: 'Continued Objective',
+          status: OBJECTIVE_STATUS.NOT_STARTED,
+          goalId: newGoal.id,
+        }),
+      });
+
+      const result = await createObjectivesForGoal(newGoal, continuedObjectives, 1);
+
+      // The lookup must search by ids+id AND constrain by the new goal's id
+      expect(Objective.findOne).toHaveBeenCalledWith({
+        where: {
+          id: [10, 10],
+          goalId: newGoal.id,
+        },
+      });
+
+      // No objective found on the new goal, so a new one is created
+      expect(Objective.create).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Continued Objective',
+        goalId: newGoal.id,
+        status: OBJECTIVE_STATUS.NOT_STARTED,
+        createdVia: 'activityReport',
+      }));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].goalId).toBe(newGoal.id);
     });
   });
 });

--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -176,26 +176,20 @@ export async function createObjectivesForGoal(goal, objectives, reportId) {
 
     // If the goal set on the objective does not match
     // the goals passed we need to save the objectives.
-    const objectiveMatchesGoal = objective.goalId === goal.id;
     const updatedObjective = {
       ...updatedFields, title, goalId: goal.id,
     };
     // Check if objective exists.
     let savedObjective;
-    if (!isNew && id) {
-      // If the goal on this objective matches look it up by ID.
-      if (objectiveMatchesGoal) {
-        savedObjective = await Objective.findByPk(id);
-      } else if (ids && ids.length) {
-        // If the goal on this objective doesn't match, look it up by IDs and Goal ID.
-        savedObjective = await Objective.findOne({
-          where: {
-            id: Array.isArray(ids) ? ids : [ids],
-            goalId: goal.id,
-          },
-        });
-      }
+    if (!isNew && id && ids && ids.length) {
+      savedObjective = await Objective.findOne({
+        where: {
+          id: Array.isArray(ids) ? [...ids, id] : [ids, id],
+          goalId: goal.id,
+        },
+      });
     }
+
     if (savedObjective) {
       // We should only allow the title to change if we are not on a approved AR.
       if (!savedObjective.onApprovedAR) {
@@ -233,6 +227,7 @@ export async function createObjectivesForGoal(goal, objectives, reportId) {
         savedObjective = existingObjective;
       }
     }
+
     return {
       ...savedObjective.toJSON(),
       status,

--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -181,10 +181,13 @@ export async function createObjectivesForGoal(goal, objectives, reportId) {
     };
     // Check if objective exists.
     let savedObjective;
-    if (!isNew && id && ids && ids.length) {
+    if (!isNew && id) {
+      const idsToCheck = [id, ...(Array.isArray(ids) ? ids : (ids ? [ids] : []))]
+        .filter(Boolean);
+
       savedObjective = await Objective.findOne({
         where: {
-          id: Array.isArray(ids) ? [...ids, id] : [ids, id],
+          id: idsToCheck,
           goalId: goal.id,
         },
       });

--- a/src/services/standardGoals.ts
+++ b/src/services/standardGoals.ts
@@ -182,6 +182,8 @@ export async function createObjectivesForGoal(goal, objectives, reportId) {
     // Check if objective exists.
     let savedObjective;
     if (!isNew && id) {
+      // I think this is readable as is, so ignoring no-nested-ternary for now
+      // eslint-disable-next-line no-nested-ternary
       const idsToCheck = [id, ...(Array.isArray(ids) ? ids : (ids ? [ids] : []))]
         .filter(Boolean);
 

--- a/src/services/standardGoalsSaveReportMock.test.js
+++ b/src/services/standardGoalsSaveReportMock.test.js
@@ -429,7 +429,7 @@ describe('Goals DB service', () => {
         id: 1,
         name: 'name',
         objectives: [{
-          title: 'title', id: mockObjectiveId, status: 'Closed', goalId: mockGoalId,
+          title: 'title', id: mockObjectiveId, ids: [mockObjectiveId], status: 'Closed', goalId: mockGoalId,
         }],
         update: jest.fn(),
         grantIds: [mockGrantId],
@@ -442,7 +442,12 @@ describe('Goals DB service', () => {
         standard: 'Standard',
       });
 
-      Objective.findOne.mockResolvedValue({ id: mockObjectiveId });
+      Objective.findOne.mockResolvedValue({
+        id: mockObjectiveId,
+        update: existingObjectiveUpdate,
+        save: jest.fn(),
+        toJSON: jest.fn().mockReturnValue({ id: mockObjectiveId }),
+      });
       await saveStandardGoalsForReport([existingGoal], { id: mockActivityReportId });
       expect(existingObjectiveUpdate).toHaveBeenCalledWith({ title: 'title' }, { individualHooks: true });
     });


### PR DESCRIPTION
## Description of change

A mistake in logic meant that reusing existing objectives from previous goal lifecycles found the old objective without checking goalId, causing the objective to be subsequently cleaned up and never displayed in the UI

## How to test
Prod data: Impersonate user 273. Edit report 62361. Add an objective and "save goal." Confirm no data is lost  

## Issue(s)



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
