### PR TITLE
Update pre-commit for bash 3.2 compatibility

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,10 +2,8 @@
 set -euo pipefail
 
 collect_staged_files() {
-  local -n files_ref=$1
-
   while IFS= read -r -d '' file; do
-    files_ref+=("$file")
+    staged_files+=("$file")
   done < <(git diff --cached --name-only --diff-filter=ACMR -z)
 }
 
@@ -67,7 +65,7 @@ validate_common_versioning() {
 
 main() {
   staged_files=()
-  collect_staged_files staged_files
+  collect_staged_files
 
   if [ ${#staged_files[@]} -eq 0 ]; then
     exit 0
@@ -116,8 +114,12 @@ main() {
     esac
   done
 
-  run_biome_fix "." "${root_biome_files[@]}"
-  run_biome_fix "frontend" "${frontend_biome_files[@]}"
+  if [ ${#root_biome_files[@]} -gt 0 ]; then
+    run_biome_fix "." "${root_biome_files[@]}"
+  fi
+  if [ ${#frontend_biome_files[@]} -gt 0 ]; then
+    run_biome_fix "frontend" "${frontend_biome_files[@]}"
+  fi
 
   git add -- "${staged_files[@]}"
 


### PR DESCRIPTION
## Description of change

Bash 3.2 (macOS default) raises "unbound variable" when expanding an empty array under set -u. Wrap the run_biome_fix calls with length checks to avoid this.

local -n (nameref variables) requires Bash 4.3+.  Bash 3.2 doesn't support namerefs at all — it would fail with a syntax error. By removing the nameref and writing directly to staged_files, the function works on any Bash version.

## How to test

pre-commit runs

## Issue(s)

No ticket

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
