### PR TITLE
[NO JIRA] Restore reviewType guard on creating Monitoring Goals

### DIFF
--- a/src/tools/createMonitoringGoals.js
+++ b/src/tools/createMonitoringGoals.js
@@ -54,6 +54,11 @@ const createMonitoringGoals = async () => {
         ON gc."citationId" = c.id
       JOIN "Grants" gr
         ON gr.id = gc."grantId"
+      JOIN "DeliveredReviewCitations" drc
+        ON drc."citationId" = c.id
+      JOIN "DeliveredReviews" dr
+        ON dr.id = drc."deliveredReviewId"
+        AND dr."deletedAt" IS NULL
       LEFT JOIN "Goals" g
         ON g."grantId" = gr.id
         AND g."goalTemplateId" = (SELECT monitoring_gtid FROM monitoring_template)
@@ -63,6 +68,14 @@ const createMonitoringGoals = async () => {
         AND c.active
         AND NOT gr.cdi
         AND g.id IS NULL
+        AND dr.review_type IN (
+          'AIAN-DEF',
+          'RAN',
+          'Follow-up',
+          'FA-1', 'FA1-FR', 'FA1-PSR',
+          'FA-2', 'FA2-CR', 'FA2-CSR',
+          'Special'
+        )
         AND (clv.last_closed_goal IS NULL
           OR clv.last_closed_goal <= c.latest_report_delivery_date)
       GROUP BY 1

--- a/src/tools/createMonitoringGoals.test.js
+++ b/src/tools/createMonitoringGoals.test.js
@@ -5,6 +5,8 @@ import { captureSnapshot, rollbackToSnapshot } from '../lib/programmaticTransact
 import { auditLogger } from '../logger';
 import {
   Citation,
+  DeliveredReview,
+  DeliveredReviewCitation,
   Goal,
   GoalStatusChange,
   GoalTemplate,
@@ -41,9 +43,16 @@ describe('createMonitoringGoals', () => {
       ...overrides,
     });
 
-  // Creates a Citation that is active by default.
-  const createCitation = (overrides = {}) =>
-    Citation.create({
+  // Creates a Citation that is active by default, linked to a DeliveredReview.
+  const createCitation = async (overrides = {}, reviewType = 'FA-1') => {
+    const dr = await DeliveredReview.create({
+      mrid: faker.datatype.number({ min: 99999 }),
+      review_uuid: uuidv4(),
+      review_type: reviewType,
+      review_status: 'Complete',
+      report_delivery_date: new Date('2025-06-01'),
+    });
+    const citation = await Citation.create({
       mfid: faker.datatype.number({ min: 9999 }),
       finding_uuid: uuidv4(),
       active: true,
@@ -51,8 +60,12 @@ describe('createMonitoringGoals', () => {
       calculated_status: 'Active',
       raw_status: 'Active',
       latest_report_delivery_date: new Date('2025-06-01'),
+      latest_review_uuid: dr.review_uuid,
       ...overrides,
     });
+    await DeliveredReviewCitation.create({ deliveredReviewId: dr.id, citationId: citation.id });
+    return citation;
+  };
 
   const createGrantCitation = (grantId, citationId) =>
     GrantCitation.create({
@@ -227,6 +240,17 @@ describe('createMonitoringGoals', () => {
   it('does not create a goal for a grant with only inactive Citations', async () => {
     const grant = await createGrant();
     const citation = await createCitation({ active: false, calculated_status: 'Corrected' });
+    await createGrantCitation(grant.id, citation.id);
+
+    await createMonitoringGoals();
+
+    const goals = await Goal.findAll({ where: { grantId: grant.id } });
+    expect(goals.length).toBe(0);
+  });
+
+  it('does not create a goal for a citation whose review type is not in the allowed list (e.g. CLASS)', async () => {
+    const grant = await createGrant();
+    const citation = await createCitation({}, 'CLASS');
     await createGrantCitation(grant.id, citation.id);
 
     await createMonitoringGoals();


### PR DESCRIPTION
## Description of change

The recent refactor loses the reviewType guard to make sure we only create goals on eligible Monitoring reviews, and this restores it.

## How to test

It actually turns out that this isn't as pressing as I thought, as eligible reviews don't have Findings. Still keeping the PR, though, to protect against invalid data.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
