### PR TITLE
[NO-TICKET} run seed/migration before starting e2e app containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -952,6 +952,12 @@ commands:
     - attach_workspace:
         at: .
     - run:
+        name: Run migrations ci
+        command: yarn db:migrate:ci
+    - run:
+        name: Seed database
+        command: yarn db:seed:ci
+    - run:
         name: Start backend (8080) & watch logs
         command: |
           export BYPASS_AUTH=true
@@ -978,12 +984,6 @@ commands:
           export POSTGRES_DB="ttasmarthub"
           yarn start:testingonly
         background: true
-    - run:
-        name: Run migrations ci
-        command: yarn db:migrate:ci
-    - run:
-        name: Seed database
-        command: yarn db:seed:ci
     - run:
         name: Wait for server to start
         command: |


### PR DESCRIPTION
## Description of change

When running e2e tests in CI, we hit intermittent issues with certain migrations.  I tracked this down to the ordering in the setup of the e2e test environment in CI.  The migrations could be running against the db while the backend was coming up, and potentially interfering with each other.  Moving the db setup to before the app containers start appears to solve the problem.

## How to test

Ran the CI pipeline multiple times, did not observe the previous error.

## Issue(s)

N/A

