### PR TITLE
Exclude temp/ directories from Jest module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
   },
   "jest": {
     "modulePathIgnorePatterns": [
-      "<rootDir>/build/"
+      "<rootDir>/build/",
+      "<rootDir>/temp/"
     ],
     "moduleNameMapper": {
       "^file-type$": "<rootDir>/src/__mocks__/file-type.js"


### PR DESCRIPTION
## Description of change

Add `<rootDir>/temp/` to Jest's `modulePathIgnorePatterns` in `package.json`. The `temp/` directory is used for local PR review checkouts and contains copies of the repo, causing Jest's Haste module map to find duplicate module definitions (e.g., multiple `@ttahub/common` packages and `@mesh-kit/core/client` mocks), which breaks test suite runs.

## How to test

1. Ensure `temp/pr-*/` directories exist locally.
2. Run any backend test that imports `@ttahub/common` (e.g., `src/services/dashboards/goal.integration.test.js`).
3. Confirm the `duplicate manual mock` and `cannot be resolved` Haste errors are gone.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [ ] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status