### PR TITLE
[TTAHUB-5281] Handle hybrid participant totals in overview widget

### DIFF
--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -10,6 +10,38 @@ import {
 } from '../models';
 import { formatNumber, getAllRecipientsFiltered } from './helpers';
 
+function parseParticipantCount(value) {
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function hasParticipantCount(value) {
+  return value !== null && value !== undefined;
+}
+
+function getParticipantCount(report) {
+  const method = (report.deliveryMethod || '').toLowerCase();
+
+  if (method !== 'hybrid') {
+    return parseParticipantCount(report.numberOfParticipants);
+  }
+
+  const inPerson = parseParticipantCount(report.numberOfParticipantsInPerson);
+  const virtual = parseParticipantCount(report.numberOfParticipantsVirtually);
+  const hasInPerson = hasParticipantCount(report.numberOfParticipantsInPerson);
+  const hasVirtual = hasParticipantCount(report.numberOfParticipantsVirtually);
+
+  if (hasInPerson && hasVirtual) {
+    return inPerson + virtual;
+  }
+
+  if (hasParticipantCount(report.numberOfParticipants)) {
+    return parseParticipantCount(report.numberOfParticipants);
+  }
+
+  return inPerson + virtual;
+}
+
 export default async function overview(scopes) {
   // get all distinct recipient ids from recipients with the proper scopes applied
 
@@ -84,7 +116,13 @@ export default async function overview(scopes) {
    * above, since that one is excluding some of these reports by recipients
    */
   const duration = await ActivityReport.findAll({
-    attributes: ['duration', 'deliveryMethod', 'numberOfParticipants'],
+    attributes: [
+      'duration',
+      'deliveryMethod',
+      'numberOfParticipants',
+      'numberOfParticipantsInPerson',
+      'numberOfParticipantsVirtually',
+    ],
     where: {
       [Op.and]: [scopes.activityReport],
       calculatedStatus: REPORT_STATUSES.APPROVED,
@@ -99,16 +137,13 @@ export default async function overview(scopes) {
   );
 
   const inPerson = formatNumber(
-    duration.filter((report) => report.deliveryMethod.toLowerCase() === 'in-person').length,
+    duration.filter((report) => (report.deliveryMethod || '').toLowerCase() === 'in-person').length,
     1
   ).toString();
 
   // eslint-disable-next-line max-len
   const numParticipants = duration
-    .reduce(
-      (prev, ar) => prev + (ar.numberOfParticipants ? parseInt(ar.numberOfParticipants, 10) : 0),
-      0
-    )
+    .reduce((prev, report) => prev + getParticipantCount(report), 0)
     .toString();
 
   // our final query, it stands on its own as explained in the comment for the last one

--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -39,6 +39,8 @@ function getParticipantCount(report) {
     return parseParticipantCount(report.numberOfParticipants);
   }
 
+  // Preserve any defined split counts for partially migrated hybrid rows
+  // instead of dropping the dashboard total to zero.
   return inPerson + virtual;
 }
 

--- a/src/widgets/overview.test.js
+++ b/src/widgets/overview.test.js
@@ -30,7 +30,8 @@ describe('Dashboard overview widget', () => {
   let reportWithNewDate;
   let hybridRegionTwoReport;
   let legacyHybridRegionTwoReport;
-  let partialHybridRegionTwoReport;
+  let partialHybridWithLegacyRegionTwoReport;
+  let partialHybridWithoutLegacyRegionTwoReport;
 
   let weirdRegionOne;
   let weirdRegionTwo;
@@ -119,13 +120,23 @@ describe('Dashboard overview widget', () => {
       numberOfParticipantsInPerson: null,
       numberOfParticipantsVirtually: null,
     });
-    partialHybridRegionTwoReport = await createReport({
+    partialHybridWithLegacyRegionTwoReport = await createReport({
       ...regionTwoReportConfig,
       startDate: '2021-08-02T12:00:00Z',
       endDate: '2021-08-02T12:00:00Z',
       deliveryMethod: 'hybrid',
       duration: 1,
       numberOfParticipants: 10,
+      numberOfParticipantsInPerson: 4,
+      numberOfParticipantsVirtually: null,
+    });
+    partialHybridWithoutLegacyRegionTwoReport = await createReport({
+      ...regionTwoReportConfig,
+      startDate: '2021-08-03T12:00:00Z',
+      endDate: '2021-08-03T12:00:00Z',
+      deliveryMethod: 'hybrid',
+      duration: 1.5,
+      numberOfParticipants: null,
       numberOfParticipantsInPerson: 4,
       numberOfParticipantsVirtually: null,
     });
@@ -140,7 +151,8 @@ describe('Dashboard overview widget', () => {
     await destroyReport(reportWithNewDate);
     await destroyReport(hybridRegionTwoReport);
     await destroyReport(legacyHybridRegionTwoReport);
-    await destroyReport(partialHybridRegionTwoReport);
+    await destroyReport(partialHybridWithLegacyRegionTwoReport);
+    await destroyReport(partialHybridWithoutLegacyRegionTwoReport);
 
     await Grant.destroy({
       where: {
@@ -227,7 +239,7 @@ describe('Dashboard overview widget', () => {
     expect(data.recipientPercentage).toBe('100.00%');
   });
 
-  it('falls back to the legacy participant field when a hybrid breakdown is partial', async () => {
+  it('falls back to the legacy participant field when hybrid breakdown data is partial', async () => {
     const query = { 'region.in': [weirdRegionTwo.id], 'startDate.win': '2021/08/02-2021/08/02' };
     const scopes = await filtersToScopes(query);
     const data = await overview(scopes, formatQuery(query));
@@ -236,6 +248,20 @@ describe('Dashboard overview widget', () => {
     expect(data.numGrants).toBe('1');
     expect(data.sumDuration).toBe('1.0');
     expect(data.numParticipants).toBe('10');
+    expect(data.numRecipients).toBe('1');
+    expect(data.totalRecipients).toBe('1');
+    expect(data.recipientPercentage).toBe('100.00%');
+  });
+
+  it('uses the available hybrid participant counts when the legacy total is missing', async () => {
+    const query = { 'region.in': [weirdRegionTwo.id], 'startDate.win': '2021/08/03-2021/08/03' };
+    const scopes = await filtersToScopes(query);
+    const data = await overview(scopes, formatQuery(query));
+
+    expect(data.numReports).toBe('1');
+    expect(data.numGrants).toBe('1');
+    expect(data.sumDuration).toBe('1.5');
+    expect(data.numParticipants).toBe('4');
     expect(data.numRecipients).toBe('1');
     expect(data.totalRecipients).toBe('1');
     expect(data.recipientPercentage).toBe('100.00%');

--- a/src/widgets/overview.test.js
+++ b/src/widgets/overview.test.js
@@ -28,6 +28,9 @@ describe('Dashboard overview widget', () => {
   let regionOneReportFour;
   let regionTwoReport;
   let reportWithNewDate;
+  let hybridRegionTwoReport;
+  let legacyHybridRegionTwoReport;
+  let partialHybridRegionTwoReport;
 
   let weirdRegionOne;
   let weirdRegionTwo;
@@ -71,7 +74,7 @@ describe('Dashboard overview widget', () => {
       regionId: weirdRegionOne.id,
     };
 
-    regionTwoReport = {
+    const regionTwoReportConfig = {
       ...reportObject,
       numberOfParticipants: 8,
       regionId: weirdRegionTwo.id,
@@ -94,8 +97,38 @@ describe('Dashboard overview widget', () => {
     });
     regionOneReportThree = await createReport({ ...regionOneReport, duration: 4 });
     regionOneReportFour = await createReport({ ...regionOneReport, duration: 5 });
-    regionTwoReport = await createReport({ ...regionTwoReport, duration: 1.5 });
+    regionTwoReport = await createReport({ ...regionTwoReportConfig, duration: 1.5 });
     reportWithNewDate = await createReport({ ...reportWithNewDate, duration: 6 });
+    hybridRegionTwoReport = await createReport({
+      ...regionTwoReportConfig,
+      startDate: '2021-07-01T12:00:00Z',
+      endDate: '2021-07-01T12:00:00Z',
+      deliveryMethod: 'hybrid',
+      duration: 2.5,
+      numberOfParticipants: null,
+      numberOfParticipantsInPerson: 5,
+      numberOfParticipantsVirtually: 7,
+    });
+    legacyHybridRegionTwoReport = await createReport({
+      ...regionTwoReportConfig,
+      startDate: '2021-08-01T12:00:00Z',
+      endDate: '2021-08-01T12:00:00Z',
+      deliveryMethod: 'hybrid',
+      duration: 3,
+      numberOfParticipants: 9,
+      numberOfParticipantsInPerson: null,
+      numberOfParticipantsVirtually: null,
+    });
+    partialHybridRegionTwoReport = await createReport({
+      ...regionTwoReportConfig,
+      startDate: '2021-08-02T12:00:00Z',
+      endDate: '2021-08-02T12:00:00Z',
+      deliveryMethod: 'hybrid',
+      duration: 1,
+      numberOfParticipants: 10,
+      numberOfParticipantsInPerson: 4,
+      numberOfParticipantsVirtually: null,
+    });
   });
 
   afterAll(async () => {
@@ -105,6 +138,9 @@ describe('Dashboard overview widget', () => {
     await destroyReport(regionOneReportFour);
     await destroyReport(regionTwoReport);
     await destroyReport(reportWithNewDate);
+    await destroyReport(hybridRegionTwoReport);
+    await destroyReport(legacyHybridRegionTwoReport);
+    await destroyReport(partialHybridRegionTwoReport);
 
     await Grant.destroy({
       where: {
@@ -149,7 +185,7 @@ describe('Dashboard overview widget', () => {
   });
 
   it('accounts for different regions', async () => {
-    const query = { 'region.in': [weirdRegionTwo.id] };
+    const query = { 'region.in': [weirdRegionTwo.id], 'startDate.win': '2021/01/01-2021/01/01' };
     const scopes = await filtersToScopes(query);
     const data = await overview(scopes, formatQuery(query));
 
@@ -160,6 +196,48 @@ describe('Dashboard overview widget', () => {
     expect(data.sumDuration).toBe('1.5');
     expect(data.totalRecipients).toBe('1');
     expect(data.numRecipients).toBe('1');
+    expect(data.recipientPercentage).toBe('100.00%');
+  });
+
+  it('counts hybrid participants from in-person and virtual fields', async () => {
+    const query = { 'region.in': [weirdRegionTwo.id], 'startDate.win': '2021/07/01-2021/07/01' };
+    const scopes = await filtersToScopes(query);
+    const data = await overview(scopes, formatQuery(query));
+
+    expect(data.numReports).toBe('1');
+    expect(data.numGrants).toBe('1');
+    expect(data.sumDuration).toBe('2.5');
+    expect(data.numParticipants).toBe('12');
+    expect(data.numRecipients).toBe('1');
+    expect(data.totalRecipients).toBe('1');
+    expect(data.recipientPercentage).toBe('100.00%');
+  });
+
+  it('falls back to the legacy participant field for older hybrid reports', async () => {
+    const query = { 'region.in': [weirdRegionTwo.id], 'startDate.win': '2021/08/01-2021/08/01' };
+    const scopes = await filtersToScopes(query);
+    const data = await overview(scopes, formatQuery(query));
+
+    expect(data.numReports).toBe('1');
+    expect(data.numGrants).toBe('1');
+    expect(data.sumDuration).toBe('3.0');
+    expect(data.numParticipants).toBe('9');
+    expect(data.numRecipients).toBe('1');
+    expect(data.totalRecipients).toBe('1');
+    expect(data.recipientPercentage).toBe('100.00%');
+  });
+
+  it('falls back to the legacy participant field when a hybrid breakdown is partial', async () => {
+    const query = { 'region.in': [weirdRegionTwo.id], 'startDate.win': '2021/08/02-2021/08/02' };
+    const scopes = await filtersToScopes(query);
+    const data = await overview(scopes, formatQuery(query));
+
+    expect(data.numReports).toBe('1');
+    expect(data.numGrants).toBe('1');
+    expect(data.sumDuration).toBe('1.0');
+    expect(data.numParticipants).toBe('10');
+    expect(data.numRecipients).toBe('1');
+    expect(data.totalRecipients).toBe('1');
     expect(data.recipientPercentage).toBe('100.00%');
   });
 });


### PR DESCRIPTION
## Description of change

Updates the dashboard overview widget to count hybrid participant totals from
`numberOfParticipantsInPerson + numberOfParticipantsVirtually` when both split
fields are present, while preserving backward compatibility for older hybrid
activity reports that still only have `numberOfParticipants`.

## How to test
Navigate to Regional Dashboard
Select the following filter:

- data started between 2.1.26 and 4.30.26
- Select Hybrid for delivery method
- select region 5
- confirm the participant count is 12, not 0 

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5281


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
