### PR TITLE
[NO-TICKET] Logging improvements for monitoring import

### DIFF
--- a/bin/run-task.js
+++ b/bin/run-task.js
@@ -426,7 +426,7 @@ async function main(argv = process.argv.slice(2)) {
   }
 
   const result = await runTask(config);
-  await sleep(60000); // Ensure all logs are flushed before exiting
+  await sleep(30000); // Ensure all logs are flushed before exiting
   logRecentTaskOutput(config.appName, config.taskName);
 
   if (config.statusFile) {

--- a/bin/run-task.js
+++ b/bin/run-task.js
@@ -16,6 +16,7 @@ const {
 
 const DEFAULT_TIMEOUT_SECONDS = 1800;
 const POLL_INTERVAL_MS = 10000;
+const LOG_FLUSH_WAIT_MS = 30000;
 
 function sleep(ms) {
   return new Promise((resolve) => {
@@ -341,7 +342,9 @@ function buildTaskRunRecord(config, result) {
 
 async function runTask(config, dependencies = {}) {
   const {
+    logFlushWaitMs = LOG_FLUSH_WAIT_MS,
     runCfCommandImpl = runCfCommand,
+    sleepImpl = sleep,
     startLogStreamImpl = startLogStream,
     waitForTaskImpl = waitForTask,
   } = dependencies;
@@ -383,6 +386,10 @@ async function runTask(config, dependencies = {}) {
           })
         : new Promise(() => {}),
     ]);
+
+    if (logFlushWaitMs > 0) {
+      await sleepImpl(logFlushWaitMs);
+    }
 
     if (status === 'SUCCEEDED') {
       console.log(`Task ${taskName} completed successfully`);
@@ -426,8 +433,9 @@ async function main(argv = process.argv.slice(2)) {
   }
 
   const result = await runTask(config);
-  await sleep(30000); // Ensure all logs are flushed before exiting
-  logRecentTaskOutput(config.appName, config.taskName);
+  if (result.exitCode !== 0) {
+    logRecentTaskOutput(config.appName, config.taskName);
+  }
 
   if (config.statusFile) {
     try {
@@ -447,6 +455,7 @@ if (require.main === module) {
 
 module.exports = {
   DEFAULT_TIMEOUT_SECONDS,
+  LOG_FLUSH_WAIT_MS,
   POLL_INTERVAL_MS,
   appendTaskRunStatus,
   buildTaskRunRecord,

--- a/bin/run-task.js
+++ b/bin/run-task.js
@@ -426,9 +426,8 @@ async function main(argv = process.argv.slice(2)) {
   }
 
   const result = await runTask(config);
-  if (result.exitCode !== 0) {
-    logRecentTaskOutput(config.appName, config.taskName);
-  }
+  await sleep(60000); // Ensure all logs are flushed before exiting
+  logRecentTaskOutput(config.appName, config.taskName);
 
   if (config.statusFile) {
     try {

--- a/bin/run-task.test.js
+++ b/bin/run-task.test.js
@@ -11,6 +11,7 @@ jest.mock('node:child_process', () => ({
 const childProcess = require('node:child_process');
 const {
   DEFAULT_TIMEOUT_SECONDS,
+  LOG_FLUSH_WAIT_MS,
   appendTaskRunStatus,
   buildTaskRunRecord,
   filterLogChunk,
@@ -168,6 +169,7 @@ id   name          state
         timeoutSeconds: 30,
       },
       {
+        logFlushWaitMs: 0,
         runCfCommandImpl: jest.fn(),
         startLogStreamImpl: jest.fn(() => ({ stop })),
         waitForTaskImpl: jest.fn().mockResolvedValue('SUCCEEDED'),
@@ -176,6 +178,31 @@ id   name          state
 
     expect(result.exitCode).toBe(0);
     expect(result.status).toBe('SUCCEEDED');
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it('waits for task logs to flush before returning success', async () => {
+    const stop = jest.fn().mockResolvedValue();
+    const sleepImpl = jest.fn().mockResolvedValue();
+
+    const result = await runTask(
+      {
+        appName: 'tta-smarthub-prod',
+        cfArgs: ['--command', 'yarn db:migrate:prod', '--name', 'migrate-prod'],
+        command: 'yarn db:migrate:prod',
+        taskName: 'migrate-prod',
+        timeoutSeconds: 30,
+      },
+      {
+        runCfCommandImpl: jest.fn(),
+        sleepImpl,
+        startLogStreamImpl: jest.fn(() => ({ stop })),
+        waitForTaskImpl: jest.fn().mockResolvedValue('SUCCEEDED'),
+      }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(sleepImpl).toHaveBeenCalledWith(LOG_FLUSH_WAIT_MS);
     expect(stop).toHaveBeenCalled();
   });
 
@@ -190,6 +217,7 @@ id   name          state
         timeoutSeconds: 30,
       },
       {
+        logFlushWaitMs: 0,
         runCfCommandImpl: jest.fn(),
         startLogStreamImpl: jest.fn(() => ({ stop })),
         waitForTaskImpl: jest.fn().mockResolvedValue('FAILED'),
@@ -213,6 +241,7 @@ id   name          state
         timeoutSeconds: 30,
       },
       {
+        logFlushWaitMs: 0,
         runCfCommandImpl: jest.fn(() => {
           throw error;
         }),
@@ -274,6 +303,7 @@ id   name          state
         timeoutSeconds: 30,
       },
       {
+        logFlushWaitMs: 0,
         runCfCommandImpl: jest.fn(),
         startLogStreamImpl: jest.fn(() => ({ stop, completion })),
         waitForTaskImpl: jest.fn(() => new Promise(() => {})),


### PR DESCRIPTION
## Description of change

* Wait 30s for task logs to flush to cloud.gov after task completes
  * This also makes Slack reporting more reliable, as new goals are parsed from task output
* Always log script output to stdout so it appears for debugging in CircleCI 

## How to test

Run job, validate output
https://app.circleci.com/pipelines/github/HHS/Head-Start-TTADP/36800/workflows/5853b279-f66b-4e31-95fc-d91694ecdb0d/jobs/261848

## Issue(s)

N/A

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete
