### PR TITLE
[NO-TICKET] send db restore failure to primary alerts channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1295,7 +1295,7 @@ commands:
         when: on_fail
         command: |
           msg="DB Restore failed to << parameters.rds_service_name >>.  ${CIRCLE_BUILD_URL}"
-          ./bin/notify-slack.sh "${msg}" acf-head-start-alerts-lower ${SLACK_BOT_TOKEN}
+          ./bin/notify-slack.sh "${msg}" acf-head-start-alerts ${SLACK_BOT_TOKEN}
 
 
   cf_retention:


### PR DESCRIPTION
## Description of change

When a db restore job fails, it sends a message to Slack.  
Send that message to `#acf-head-start-alerts` instead of `#acf-head-start-alerts-lower`

## How to test

The message works (I randomly noticed a failed db restore job today), and this just changes the channel name.

<img width="911" height="256" alt="Screenshot 2026-05-05 at 5 43 41 AM" src="https://github.com/user-attachments/assets/ac73c9c1-833b-4cc6-937e-83579d30f7f6" />


## Issue(s)

N/A

