### PR TITLE
Bypass grant/region middleware for admins to allow for reopening monitoring goals

### DIFF
--- a/src/middleware/canWriteReportsInGrantRegionMiddleware.js
+++ b/src/middleware/canWriteReportsInGrantRegionMiddleware.js
@@ -1,7 +1,7 @@
 import { auditLogger } from '../logger';
 import { Grant } from '../models';
 import ActivityReportPolicy from '../policies/activityReport';
-// import { validateUserAuthForAccess } from '../services/accessValidation';
+import { validateUserAuthForAdmin } from '../services/accessValidation';
 import { currentUserId } from '../services/currentUser';
 import { userById } from '../services/users';
 
@@ -29,6 +29,12 @@ export default async function canWriteReportsInGrantRegionMiddleware(req, res, n
     auditLogger.warn(`User ${userId} denied access due to invalid grant param`);
     res.sendStatus(403);
     return;
+  }
+
+  // admin users should have access to all grants, so we can skip the rest of the checks if the user is an admin
+  const isAdmin = await validateUserAuthForAdmin(userId);
+  if (isAdmin) {
+    return next();
   }
 
   const policy = new ActivityReportPolicy(user, { regionId: grant.regionId });

--- a/src/middleware/canWriteReportsInGrantRegionMiddleware.js
+++ b/src/middleware/canWriteReportsInGrantRegionMiddleware.js
@@ -1,7 +1,6 @@
 import { auditLogger } from '../logger';
 import { Grant } from '../models';
 import ActivityReportPolicy from '../policies/activityReport';
-import { validateUserAuthForAdmin } from '../services/accessValidation';
 import { currentUserId } from '../services/currentUser';
 import { userById } from '../services/users';
 
@@ -31,13 +30,12 @@ export default async function canWriteReportsInGrantRegionMiddleware(req, res, n
     return;
   }
 
+  const policy = new ActivityReportPolicy(user, { regionId: grant.regionId });
+
   // admin users should have access to all grants, so we can skip the rest of the checks if the user is an admin
-  const isAdmin = await validateUserAuthForAdmin(userId);
-  if (isAdmin) {
+  if (policy.isAdmin()) {
     return next();
   }
-
-  const policy = new ActivityReportPolicy(user, { regionId: grant.regionId });
 
   if (!policy.canWriteInRegion()) {
     auditLogger.warn(`User ${userId} denied access to grant ${grantId}`);

--- a/src/middleware/canWriteReportsInGrantRegionMiddleware.test.js
+++ b/src/middleware/canWriteReportsInGrantRegionMiddleware.test.js
@@ -1,6 +1,7 @@
 import { auditLogger } from '../logger';
 import { Grant } from '../models';
 import ActivityReportPolicy from '../policies/activityReport';
+import { validateUserAuthForAdmin } from '../services/accessValidation';
 import { currentUserId } from '../services/currentUser';
 import { userById } from '../services/users';
 import canWriteReportsInGrantRegionMiddleware from './canWriteReportsInGrantRegionMiddleware';
@@ -10,6 +11,7 @@ jest.mock('../services/currentUser');
 jest.mock('../models');
 jest.mock('../policies/activityReport');
 jest.mock('../services/users');
+jest.mock('../services/accessValidation');
 
 describe('canWriteReportsInGrantRegionMiddleware', () => {
   let req;
@@ -39,6 +41,7 @@ describe('canWriteReportsInGrantRegionMiddleware', () => {
     ActivityReportPolicy.mockImplementation(() => ({
       canWriteInRegion: () => true,
     }));
+    validateUserAuthForAdmin.mockResolvedValue(false);
 
     await canWriteReportsInGrantRegionMiddleware(req, res, next);
 
@@ -50,6 +53,7 @@ describe('canWriteReportsInGrantRegionMiddleware', () => {
     currentUserId.mockResolvedValue(1);
     userById.mockResolvedValue({ id: 1 });
     Grant.findOne.mockResolvedValue(null);
+    validateUserAuthForAdmin.mockResolvedValue(false);
 
     await canWriteReportsInGrantRegionMiddleware(req, res, next);
 
@@ -67,11 +71,28 @@ describe('canWriteReportsInGrantRegionMiddleware', () => {
     ActivityReportPolicy.mockImplementation(() => ({
       canWriteInRegion: () => false,
     }));
+    validateUserAuthForAdmin.mockResolvedValue(false);
 
     await canWriteReportsInGrantRegionMiddleware(req, res, next);
 
     expect(res.sendStatus).toHaveBeenCalledWith(403);
     expect(next).not.toHaveBeenCalled();
     expect(auditLogger.warn).toHaveBeenCalledWith('User 1 denied access to grant 1');
+  });
+
+  it('should call next if user is an admin', async () => {
+    currentUserId.mockResolvedValue(1);
+    userById.mockResolvedValue({ id: 1 });
+    Grant.findOne.mockResolvedValue({ id: 1, regionId: 1 });
+    ActivityReportPolicy.mockImplementation(() => ({
+      canWriteInRegion: () => false,
+    }));
+    validateUserAuthForAdmin.mockResolvedValue(true);
+
+    await canWriteReportsInGrantRegionMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.sendStatus).not.toHaveBeenCalled();
+    expect(auditLogger.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/middleware/canWriteReportsInGrantRegionMiddleware.test.js
+++ b/src/middleware/canWriteReportsInGrantRegionMiddleware.test.js
@@ -1,7 +1,6 @@
 import { auditLogger } from '../logger';
 import { Grant } from '../models';
 import ActivityReportPolicy from '../policies/activityReport';
-import { validateUserAuthForAdmin } from '../services/accessValidation';
 import { currentUserId } from '../services/currentUser';
 import { userById } from '../services/users';
 import canWriteReportsInGrantRegionMiddleware from './canWriteReportsInGrantRegionMiddleware';
@@ -11,7 +10,6 @@ jest.mock('../services/currentUser');
 jest.mock('../models');
 jest.mock('../policies/activityReport');
 jest.mock('../services/users');
-jest.mock('../services/accessValidation');
 
 describe('canWriteReportsInGrantRegionMiddleware', () => {
   let req;
@@ -39,9 +37,9 @@ describe('canWriteReportsInGrantRegionMiddleware', () => {
     userById.mockResolvedValue({ id: 1 });
     Grant.findOne.mockResolvedValue({ id: 1, regionId: 1 });
     ActivityReportPolicy.mockImplementation(() => ({
+      isAdmin: () => false,
       canWriteInRegion: () => true,
     }));
-    validateUserAuthForAdmin.mockResolvedValue(false);
 
     await canWriteReportsInGrantRegionMiddleware(req, res, next);
 
@@ -53,7 +51,6 @@ describe('canWriteReportsInGrantRegionMiddleware', () => {
     currentUserId.mockResolvedValue(1);
     userById.mockResolvedValue({ id: 1 });
     Grant.findOne.mockResolvedValue(null);
-    validateUserAuthForAdmin.mockResolvedValue(false);
 
     await canWriteReportsInGrantRegionMiddleware(req, res, next);
 
@@ -69,9 +66,9 @@ describe('canWriteReportsInGrantRegionMiddleware', () => {
     userById.mockResolvedValue({ id: 1 });
     Grant.findOne.mockResolvedValue({ id: 1, regionId: 1 });
     ActivityReportPolicy.mockImplementation(() => ({
+      isAdmin: () => false,
       canWriteInRegion: () => false,
     }));
-    validateUserAuthForAdmin.mockResolvedValue(false);
 
     await canWriteReportsInGrantRegionMiddleware(req, res, next);
 
@@ -85,9 +82,9 @@ describe('canWriteReportsInGrantRegionMiddleware', () => {
     userById.mockResolvedValue({ id: 1 });
     Grant.findOne.mockResolvedValue({ id: 1, regionId: 1 });
     ActivityReportPolicy.mockImplementation(() => ({
-      canWriteInRegion: () => false,
+      isAdmin: () => true,
+      canWriteInRegion: jest.fn(),
     }));
-    validateUserAuthForAdmin.mockResolvedValue(true);
 
     await canWriteReportsInGrantRegionMiddleware(req, res, next);
 


### PR DESCRIPTION
## Description of change

Code comments within the reopen goals flow indicated that admins should be able to change monitoring goal status and indeed, the permissions on the backend validate this, but admin permissions were not checked for this one view on the frontend, meaning admins aren't able to access the UI for reopening a goal without giving themselves permissions to view the goal first.

## How to test

Reopen a closed goal in a region your admin user does not have read/write access to.

## Issue(s)



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
