### PR TITLE
[TTAHUB-5299] Fix missing comma in old ZAL migration

### DIFF
--- a/src/migrations/20220115000000-audit-system.js
+++ b/src/migrations/20220115000000-audit-system.js
@@ -269,7 +269,7 @@ module.exports = {
                       session_sig,
                       descriptor_id)
                   VALUES (
-                      'ARCHIVE DATA'
+                      'ARCHIVE DATA',
                       'AUDIT LOG TABLE',
                       'ttasmarthub',
                       %L,

--- a/src/migrations/20260511180000-fix-zal-no-delete-archive-log.js
+++ b/src/migrations/20260511180000-fix-zal-no-delete-archive-log.js
@@ -1,0 +1,117 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+
+      await queryInterface.sequelize.query(
+        `
+        CREATE OR REPLACE FUNCTION "ZAFCreateALNoDelete"(t_name varchar(63))
+          RETURNS VOID
+          LANGUAGE plpgsql AS
+        $func$
+        BEGIN
+          EXECUTE format($sql$
+            CREATE OR REPLACE FUNCTION %I()
+              RETURNS trigger
+              LANGUAGE plpgsql AS
+            $body$
+            DECLARE
+              CREATED_BY bigint;
+              TRANSACTION_ID uuid;
+              SESSION_SIG TEXT;
+              DESCRIPTOR_ID int;
+            BEGIN
+              CREATED_BY := COALESCE(NULLIF(current_setting('audit.loggedUser', true), '')::BIGINT, -1);
+
+              TRANSACTION_ID := COALESCE(
+                NULLIF(current_setting('audit.transactionId', true), '')::uuid,
+                lpad(txid_current()::text,32, '0')::uuid);
+
+              SESSION_SIG := NULLIF(current_setting('audit.sessionSig', true), '')::TEXT;
+
+              DESCRIPTOR_ID := "ZAFDescriptorToID"(
+                NULLIF(current_setting('audit.auditDescriptor', true)::TEXT, ''));
+
+              IF ( DESCRIPTOR_ID = "ZAFDescriptorToID"('ARCHIVE AUDIT LOG') ) THEN
+                RAISE NOTICE 'Archive Data: %% by %%', %L, CREATED_BY;
+
+                INSERT INTO "ZALDDL" (
+                  command_tag,
+                  object_type,
+                  schema_name,
+                  object_identity,
+                  ddl_timestamp,
+                  ddl_by,
+                  ddl_txid,
+                  session_sig,
+                  descriptor_id)
+                VALUES (
+                  'ARCHIVE DATA',
+                  'AUDIT LOG TABLE',
+                  'ttasmarthub',
+                  %L,
+                  CURRENT_TIMESTAMP,
+                  CREATED_BY,
+                  TRANSACTION_ID,
+                  SESSION_SIG,
+                  DESCRIPTOR_ID);
+
+                RETURN OLD;
+              ELSE
+                RAISE EXCEPTION 'Delete from %s is not supported to maintain audit log integrity.';
+              END IF;
+            END;
+            $body$;$sql$,
+            'ZALNoDeleteF' || t_name,
+            'ZAL' || t_name,
+            'ZAL' || t_name,
+            'ZAL' || t_name);
+
+          EXECUTE format($sql$
+            DROP TRIGGER IF EXISTS %I ON %I$sql$,
+            'ZALNoDeleteT' || t_name,
+            'ZAL' || t_name);
+
+          EXECUTE format($sql$
+            CREATE TRIGGER %I
+              BEFORE DELETE ON %I
+              FOR EACH ROW EXECUTE FUNCTION %I()$sql$,
+            'ZALNoDeleteT' || t_name,
+            'ZAL' || t_name,
+            'ZALNoDeleteF' || t_name);
+        END
+        $func$;
+
+        DO
+        $$
+        DECLARE
+          audit_table record;
+        BEGIN
+          FOR audit_table IN
+            SELECT
+              table_name,
+              substring(table_name from 4) AS base_table_name
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_type = 'BASE TABLE'
+              AND table_name LIKE 'ZAL%'
+            ORDER BY table_name
+          LOOP
+            PERFORM "ZAFCreateALNoDelete"(audit_table.base_table_name::varchar(63));
+          END LOOP;
+        END
+        $$;
+        `,
+        { transaction }
+      );
+    });
+  },
+
+  async down() {
+    // no rollback: this fixes broken generated audit-log trigger functions.
+  },
+};


### PR DESCRIPTION
## Description of change

The migration to create ZAL audit tables has an invalid SQL bug.  Fix the missing comma so records can be deleted with the expected `ARCHIVE AUDIT LOG` context instead of failing inside the generated delete-prevention trigger.

  - Line 272 in `20220115000000-audit-system.js` had a missing comma.  Fix the original migration by adding the comma
  - Create a new migration to repair the audit no-delete generator so archive deletes write valid ZALDDL metadata and return the deleted row from the trigger path.
  - Refresh existing generated ZAL no-delete trigger functions so current databases pick up the
    corrected archive behavior.
  - Keep the migration forward-only because it repairs broken audit infrastructure rather than
    introducing reversible product data changes.

## How to test

Ran migration locally and on dev environment, validated it ran successfully and fixed the issue by querying the db

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5299


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
