### PR TITLE
[TTAHUB-5250] Added a small right margin to the review name to create space between…

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/Monitoring/components/ReviewCard.js
+++ b/frontend/src/pages/RecipientRecord/pages/Monitoring/components/ReviewCard.js
@@ -15,7 +15,7 @@ export default function ReviewCard({ review, regionId }) {
   return (
     <DataCard testId="review-card" className="ttahub-monitoring-review-card">
       <div className="display-flex flex-align-center flex-row">
-        <h3 className="font-sans-xs margin-0">Review {review.name}</h3>
+        <h3 className="font-sans-xs margin-0 margin-right-1">Review {review.name}</h3>
         <Tag>{review.reviewType}</Tag>
       </div>
       <DescriptionList>


### PR DESCRIPTION
… the review name and tag.

## Description of change
Added 8px spacing between review name and review tag on RTR/Monitoring tab/View by review name tab, because they were running into each other.


## How to test

- Go to RTR search page
- Find a recipient with monitoring reviews (search for goal text with "(Monitoring) ")
- Look at Monitoring tab, view by review name
- See if there is space between review name and review tag

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5250


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
