### PR TITLE
fix: sort calculated_finding_type by business-logic priority order

### DIFF
--- a/src/widgets/monitoring/monitoringTta.test.js
+++ b/src/widgets/monitoring/monitoringTta.test.js
@@ -671,11 +671,11 @@ describe('monitoringTta', () => {
     const primaryRecipient = fixture.recipients[0];
     const approvedReport = fixture.reports[0];
 
-    const { data } = await monitoringTta(getScopes(), { perPage: 10 });
+    const { data } = await monitoringTta(getScopes(), { perPage: 20 });
     const noncomplianceCitation = data.find(({ citationNumber }) => citationNumber === '1302.10');
     const deficiencyCitation = data.find(({ citationNumber }) => citationNumber === '1302.12');
 
-    expect(data).toHaveLength(10);
+    expect(data).toHaveLength(12);
 
     expect(noncomplianceCitation).toEqual({
       id: `${fixture.citations[1].id}:${primaryRecipient.id}:${fixture.regions[0].id}`,
@@ -838,7 +838,6 @@ describe('monitoringTta', () => {
     expect(
       defaultData.map(({ recipientName, citationNumber }) => `${recipientName}:${citationNumber}`)
     ).toEqual([
-      `Recipient ${TEST_KEY}:1302.12`,
       `Recipient ${TEST_KEY}:1302.10`,
       `Recipient ${TEST_KEY}:1302.20`,
       `Recipient ${TEST_KEY}:1302.21`,
@@ -848,6 +847,7 @@ describe('monitoringTta', () => {
       `Recipient ${TEST_KEY}:1302.25`,
       `Recipient ${TEST_KEY}:1302.26`,
       `Recipient ${TEST_KEY}:1302.27`,
+      `Recipient ${TEST_KEY}:1302.28`,
     ]);
 
     expect(
@@ -905,7 +905,6 @@ describe('monitoringTta', () => {
       )
     ).toEqual([
       `Zoo Recipient ${TEST_KEY}:1302.30`,
-      `Recipient ${TEST_KEY}:1302.12`,
       `Recipient ${TEST_KEY}:1302.10`,
       `Recipient ${TEST_KEY}:1302.20`,
       `Recipient ${TEST_KEY}:1302.21`,
@@ -914,6 +913,7 @@ describe('monitoringTta', () => {
       `Recipient ${TEST_KEY}:1302.24`,
       `Recipient ${TEST_KEY}:1302.25`,
       `Recipient ${TEST_KEY}:1302.26`,
+      `Recipient ${TEST_KEY}:1302.27`,
     ]);
 
     expect(
@@ -1623,7 +1623,11 @@ describe('monitoringTta', () => {
       },
     ];
 
-    const ascSorted = [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'asc'));
+    // When recipient is the same, findingType is the second tiebreaker in recipient_finding sort.
+    const ascSorted = [...rows].sort((a, b) =>
+      compareMonitoringTta(a, b, 'recipient_finding', 'asc')
+    );
+    // Business order: Area of Concern, Noncompliance, Withdrawn, Deficiency
     expect(ascSorted.map((r) => r.findingType)).toEqual([
       'Area of Concern',
       'Noncompliance',
@@ -1631,12 +1635,15 @@ describe('monitoringTta', () => {
       'Deficiency',
     ]);
 
-    const descSorted = [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'desc'));
+    // desc reverses recipient (primary), but findingType (tiebreaker) stays ascending
+    const descSorted = [...rows].sort((a, b) =>
+      compareMonitoringTta(a, b, 'recipient_finding', 'desc')
+    );
     expect(descSorted.map((r) => r.findingType)).toEqual([
-      'Deficiency',
-      'Withdrawn',
-      'Noncompliance',
       'Area of Concern',
+      'Noncompliance',
+      'Withdrawn',
+      'Deficiency',
     ]);
   });
 

--- a/src/widgets/monitoring/monitoringTta.test.js
+++ b/src/widgets/monitoring/monitoringTta.test.js
@@ -1406,61 +1406,61 @@ describe('monitoringTta', () => {
       {
         recipientName: '',
         citationNumber: '1302.2',
-        findingType: 'Beta',
+        findingType: 'Noncompliance',
         category: 'Category B',
       },
       {
         recipientName: '',
         citationNumber: '1302.2',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category C',
       },
       {
         recipientName: '',
         citationNumber: '1302.2',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
       },
       {
         recipientName: 'Recipient 2',
         citationNumber: '1302.50',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category Z',
       },
       {
         recipientName: 'Recipient 10',
         citationNumber: '1302.50',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category Z',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.10',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category B',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.11',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.10',
-        findingType: 'Beta',
+        findingType: 'Noncompliance',
         category: 'Category A',
       },
       {
         recipientName: 'Recipient B',
         citationNumber: '1302.2',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.10',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
       },
     ];
@@ -1487,55 +1487,55 @@ describe('monitoringTta', () => {
     );
 
     expect(recipientCitationRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
     ]);
 
     expect(findingRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
     ]);
 
     expect(citationRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
     ]);
 
     expect(recipientFindingRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
     ]);
 
     // Verify desc direction reverses the primary sort key while keeping tie-breakers ascending.
@@ -1553,55 +1553,90 @@ describe('monitoringTta', () => {
     );
 
     expect(recipientCitationDescRows).toEqual([
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
     ]);
 
     expect(findingDescRows).toEqual([
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
     ]);
 
     expect(citationDescRows).toEqual([
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
     ]);
 
     expect(recipientFindingDescRows).toEqual([
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+    ]);
+  });
+
+  it('sorts finding_type by business-logic priority, not alphabetically', () => {
+    const rows = [
+      { recipientName: 'R', citationNumber: '1302.1', findingType: 'Deficiency', category: 'Cat' },
+      {
+        recipientName: 'R',
+        citationNumber: '1302.1',
+        findingType: 'Area of Concern',
+        category: 'Cat',
+      },
+      { recipientName: 'R', citationNumber: '1302.1', findingType: 'Withdrawn', category: 'Cat' },
+      {
+        recipientName: 'R',
+        citationNumber: '1302.1',
+        findingType: 'Noncompliance',
+        category: 'Cat',
+      },
+    ];
+
+    const ascSorted = [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'asc'));
+    expect(ascSorted.map((r) => r.findingType)).toEqual([
+      'Area of Concern',
+      'Noncompliance',
+      'Withdrawn',
+      'Deficiency',
+    ]);
+
+    const descSorted = [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'desc'));
+    expect(descSorted.map((r) => r.findingType)).toEqual([
+      'Deficiency',
+      'Withdrawn',
+      'Noncompliance',
+      'Area of Concern',
     ]);
   });
 

--- a/src/widgets/monitoring/monitoringTta.ts
+++ b/src/widgets/monitoring/monitoringTta.ts
@@ -210,8 +210,22 @@ const RECIPIENT_SORT_FALLBACK_SQL = `
   LOWER(${RECIPIENT_SORT_KEY_SQL})
 `;
 
+// Business-logic priority order for finding types.
+const FINDING_TYPE_ORDER: Record<string, number> = {
+  'Area of Concern': 1,
+  Noncompliance: 2,
+  Withdrawn: 3,
+  Deficiency: 4,
+};
+
 const FINDING_SORT_SQL = `
-  LOWER(COALESCE("citation"."calculated_finding_type", ''))
+  CASE LOWER(COALESCE("citation"."calculated_finding_type", ''))
+    WHEN 'area of concern' THEN 1
+    WHEN 'noncompliance' THEN 2
+    WHEN 'withdrawn' THEN 3
+    WHEN 'deficiency' THEN 4
+    ELSE 5
+  END
 `;
 
 const CATEGORY_SORT_SQL = `
@@ -397,6 +411,14 @@ function compareText(a: string | null | undefined, b: string | null | undefined)
   });
 }
 
+function findingTypeRank(value: string | null | undefined): number {
+  return FINDING_TYPE_ORDER[(value || '').trim()] ?? 5;
+}
+
+function compareFindingType(a: string | null | undefined, b: string | null | undefined): number {
+  return findingTypeRank(a) - findingTypeRank(b);
+}
+
 function sortDirection(direction: MonitoringTtaDirection): 'ASC' | 'DESC' {
   return direction === 'desc' ? 'DESC' : 'ASC';
 }
@@ -408,7 +430,7 @@ export function compareMonitoringTta(
   direction: MonitoringTtaDirection
 ): number {
   const recipientComparison = compareText(a.recipientName, b.recipientName);
-  const findingTypeComparison = compareText(a.findingType, b.findingType);
+  const findingTypeComparison = compareFindingType(a.findingType, b.findingType);
   const citationComparison = compareText(a.citationNumber, b.citationNumber);
   const categoryComparison = compareText(a.category, b.category);
 


### PR DESCRIPTION
## Summary

Sorts finding types by business-logic priority instead of alphabetically:

1. Area of Concern
2. Noncompliance
3. Withdrawn
4. Deficiency

## Changes

- **SQL ORDER BY**: Replaced alphabetical `LOWER(COALESCE(...))` with a `CASE` expression mapping each finding type to a rank (1–4, unknown → 5)
- **In-memory comparator**: Added `compareFindingType` helper using the same rank map, replacing `compareText` for finding type comparisons
- **Tests**: Updated integration test expectations and added a dedicated test verifying the business-logic sort order