### PR TITLE
[Prod] Update MonitoringRelatedTTA widget sort options

### DIFF
--- a/docs/openapi/paths/widgets/monitoringTta.yaml
+++ b/docs/openapi/paths/widgets/monitoringTta.yaml
@@ -11,11 +11,12 @@ get:
       schema:
         type: string
         enum:
-          - recipient_finding
           - recipient_citation
           - finding
           - citation
-      description: Sort order applied to recipient+citation cards before pagination. Defaults to recipient_finding.
+          - finding_type
+          - last_tta
+      description: Sort order applied to recipient+citation cards before pagination. Defaults to finding_type.
     - in: query
       name: direction
       required: false

--- a/frontend/src/fetchers/__tests__/monitoring.js
+++ b/frontend/src/fetchers/__tests__/monitoring.js
@@ -36,7 +36,7 @@ describe('monitoring fetchers', () => {
     ]);
   });
   it('getMonitoringRelatedTtaCsv', async () => {
-    const query = 'sortBy=recipient_finding&direction=asc';
+    const query = 'sortBy=citation&direction=asc';
     fetchMock.get(`${monitoringUrl}/related-tta?${query}`, {
       body: 'col1,col2\nval1,val2',
       headers: { 'Content-Type': 'text/csv' },

--- a/frontend/src/pages/RegionalDashboard/components/PrintSelectedCitations.js
+++ b/frontend/src/pages/RegionalDashboard/components/PrintSelectedCitations.js
@@ -13,7 +13,7 @@ import './PrintSelectedCitations.css';
 
 export default function PrintSelectedCitations() {
   const location = useLocation();
-  const { selectedIds = [], sortConfig = { sortBy: 'recipient_finding', direction: 'asc' } } =
+  const { selectedIds = [], sortConfig = { sortBy: 'finding_type', direction: 'asc' } } =
     location.state || {};
 
   const [citations, setCitations] = useState([]);

--- a/frontend/src/pages/RegionalDashboard/components/__tests__/PrintSelectedCitations.js
+++ b/frontend/src/pages/RegionalDashboard/components/__tests__/PrintSelectedCitations.js
@@ -51,7 +51,7 @@ const mockCitation2 = {
 
 const defaultLocationState = {
   selectedIds: ['101:1001'],
-  sortConfig: { sortBy: 'recipient_finding', direction: 'asc' },
+  sortConfig: { sortBy: 'finding_type', direction: 'asc' },
   filters: [],
 };
 
@@ -161,7 +161,7 @@ describe('PrintSelectedCitations', () => {
     mockUseLocation.mockReturnValue({
       state: {
         selectedIds: ['999-999'],
-        sortConfig: { sortBy: 'recipient_finding', direction: 'asc' },
+        sortConfig: { sortBy: 'finding_type', direction: 'asc' },
         filters: [],
       },
     });

--- a/frontend/src/widgets/MonitoringRelatedTta.js
+++ b/frontend/src/widgets/MonitoringRelatedTta.js
@@ -19,7 +19,7 @@ const PER_PAGE_NUMBER = 10;
 export default function MonitoringRelatedTta({ filters }) {
   const history = useHistory();
   const [sortConfig, setSortConfig] = useState({
-    sortBy: 'recipient_finding',
+    sortBy: 'finding_type',
     direction: 'asc',
     offset: 0,
   });
@@ -145,14 +145,16 @@ export default function MonitoringRelatedTta({ filters }) {
           id="sortBy"
           name="sortBy"
         >
-          <option value="recipient_finding-asc">Recipient (A to Z), then Finding type</option>
-          <option value="recipient_finding-desc">Recipient (Z to A), then Finding type</option>
-          <option value="recipient_citation-asc">Recipient (A to Z), then Citation number</option>
-          <option value="recipient_citation-desc">Recipient (Z to A), then Citation number</option>
-          <option value="finding-asc">Finding category (A to Z), then Citation number</option>
-          <option value="finding-desc">Finding category (Z to A), then Citation number</option>
-          <option value="citation-asc">Citation number (low to high), then Recipient</option>
-          <option value="citation-desc">Citation number (high to low), then Recipient</option>
+          <option value="citation-asc">Citation number (low to high)</option>
+          <option value="citation-desc">Citation number (high to low)</option>
+          <option value="finding-asc">Finding category (A to Z)</option>
+          <option value="finding-desc">Finding category (Z to A)</option>
+          <option value="finding_type-asc">Finding type (AOC to DEF)</option>
+          <option value="finding_type-desc">Finding type (DEF to AOC)</option>
+          <option value="last_tta-asc">Last TTA (oldest to newest)</option>
+          <option value="last_tta-desc">Last TTA (newest to oldest)</option>
+          <option value="recipient_citation-asc">Recipient (A to Z)</option>
+          <option value="recipient_citation-desc">Recipient (Z to A)</option>
         </Dropdown>
       </div>
 

--- a/frontend/src/widgets/__tests__/MonitoringRelatedTta.js
+++ b/frontend/src/widgets/__tests__/MonitoringRelatedTta.js
@@ -90,8 +90,7 @@ const mockCitationData = [
 ];
 
 describe('MonitoringRelatedTta', () => {
-  const url =
-    '/api/widgets/monitoringTta?&sortBy=recipient_finding&direction=asc&offset=0&perPage=10';
+  const url = '/api/widgets/monitoringTta?&sortBy=finding_type&direction=asc&offset=0&perPage=10';
 
   beforeEach(() => {
     fetchMock.get('path:/api/citations/text', '');
@@ -136,31 +135,22 @@ describe('MonitoringRelatedTta', () => {
     expect(fetchMock.called(url)).toBe(true);
     const dropdown = screen.getByRole('combobox', { name: /sort by/i });
     expect(dropdown).toBeInTheDocument();
-    expect(dropdown).toHaveValue('recipient_finding-asc');
+    expect(dropdown).toHaveValue('finding_type-asc');
+    expect(screen.getByRole('option', { name: 'Recipient (A to Z)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Recipient (Z to A)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Finding category (A to Z)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Finding category (Z to A)' })).toBeInTheDocument();
     expect(
-      screen.getByRole('option', { name: 'Recipient (A to Z), then Finding type' })
+      screen.getByRole('option', { name: 'Citation number (low to high)' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('option', { name: 'Recipient (Z to A), then Finding type' })
+      screen.getByRole('option', { name: 'Citation number (high to low)' })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Recipient (A to Z), then Citation number' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Recipient (Z to A), then Citation number' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Finding category (A to Z), then Citation number' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Finding category (Z to A), then Citation number' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Citation number (low to high), then Recipient' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Citation number (high to low), then Recipient' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Finding type (AOC to DEF)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Finding type (DEF to AOC)' })).toBeInTheDocument();
+
+    expect(screen.getByRole('option', { name: 'Last TTA (oldest to newest)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Last TTA (newest to oldest)' })).toBeInTheDocument();
   });
 
   it('updates sort configuration when a new option is selected', async () => {
@@ -205,7 +195,7 @@ describe('MonitoringRelatedTta', () => {
     fetchMock.restore();
     fetchMock.get(url, { data: [], total: 25 });
     const page2Url =
-      '/api/widgets/monitoringTta?&sortBy=recipient_finding&direction=asc&offset=10&perPage=10';
+      '/api/widgets/monitoringTta?&sortBy=finding_type&direction=asc&offset=10&perPage=10';
     fetchMock.get(page2Url, { data: [], total: 25 });
 
     await act(async () => {
@@ -225,7 +215,7 @@ describe('MonitoringRelatedTta', () => {
   it('includes filter query params in the fetch URL', async () => {
     fetchMock.restore();
     const filteredUrl =
-      '/api/widgets/monitoringTta?region.in[]=5&sortBy=recipient_finding&direction=asc&offset=0&perPage=10';
+      '/api/widgets/monitoringTta?region.in[]=5&sortBy=finding_type&direction=asc&offset=0&perPage=10';
     fetchMock.get(filteredUrl, { data: [], total: 0 });
 
     await act(async () => {

--- a/src/scopes/grantCitation/index.ts
+++ b/src/scopes/grantCitation/index.ts
@@ -1,9 +1,14 @@
 import { createFiltersToScopes } from '../utils';
 import { withCitationRecipient } from './citationRecipient';
+import { withoutRegion, withRegion } from './regionId';
 
 export const topicToQuery = {
   citationRecipient: {
     in: (query: string[]) => withCitationRecipient(query),
+  },
+  regionId: {
+    in: (query: string[]) => withRegion(query),
+    notIn: (query: string[]) => withoutRegion(query),
   },
 };
 

--- a/src/scopes/grantCitation/regionId.test.ts
+++ b/src/scopes/grantCitation/regionId.test.ts
@@ -1,0 +1,44 @@
+import { Op } from 'sequelize';
+import { withoutRegion, withRegion } from './regionId';
+
+describe('grantCitation/regionId', () => {
+  describe('withRegion', () => {
+    it('returns an Op.in clause for a single region', () => {
+      expect(withRegion([1])).toEqual({
+        where: { region_id: { [Op.in]: [1] } },
+      });
+    });
+
+    it('returns an Op.in clause for multiple regions', () => {
+      expect(withRegion([1, 2, 3])).toEqual({
+        where: { region_id: { [Op.in]: [1, 2, 3] } },
+      });
+    });
+
+    it('returns an Op.in clause with an empty array', () => {
+      expect(withRegion([])).toEqual({
+        where: { region_id: { [Op.in]: [] } },
+      });
+    });
+  });
+
+  describe('withoutRegion', () => {
+    it('returns an Op.notIn clause for a single region', () => {
+      expect(withoutRegion([1])).toEqual({
+        where: { region_id: { [Op.notIn]: [1] } },
+      });
+    });
+
+    it('returns an Op.notIn clause for multiple regions', () => {
+      expect(withoutRegion([1, 2, 3])).toEqual({
+        where: { region_id: { [Op.notIn]: [1, 2, 3] } },
+      });
+    });
+
+    it('returns an Op.notIn clause with an empty array', () => {
+      expect(withoutRegion([])).toEqual({
+        where: { region_id: { [Op.notIn]: [] } },
+      });
+    });
+  });
+});

--- a/src/scopes/grantCitation/regionId.ts
+++ b/src/scopes/grantCitation/regionId.ts
@@ -3,7 +3,7 @@ import { Op } from 'sequelize';
 export function withRegion(regions) {
   return {
     where: {
-      regionId: {
+      region_id: {
         [Op.in]: regions,
       },
     },
@@ -13,7 +13,7 @@ export function withRegion(regions) {
 export function withoutRegion(regions) {
   return {
     where: {
-      regionId: {
+      region_id: {
         [Op.notIn]: regions,
       },
     },

--- a/src/scopes/grants/region.test.js
+++ b/src/scopes/grants/region.test.js
@@ -30,4 +30,21 @@ describe('grants/region', () => {
       expect.arrayContaining([recipients[2].id, recipients[5].id])
     );
   });
+
+  it('excludes grants by region', async () => {
+    const filters = { 'region.nin': [3] };
+    const scope = await filtersToScopes(filters, 'grant');
+    const found = await Grant.findAll({
+      where: { [Op.and]: [scope.grant.where, { id: possibleIds }] },
+    });
+    expect(found.length).toBe(4);
+    expect(found.map((f) => f.id)).toEqual(
+      expect.arrayContaining([
+        recipients[0].id,
+        recipients[1].id,
+        recipients[3].id,
+        recipients[4].id,
+      ])
+    );
+  });
 });

--- a/src/widgets/monitoring/monitoringTta.test.js
+++ b/src/widgets/monitoring/monitoringTta.test.js
@@ -518,7 +518,7 @@ describe('monitoringTta', () => {
     });
 
     const paginationReviews = await Promise.all(
-      paginationCitations.map((citation, index) =>
+      paginationCitations.map((_citation, index) =>
         DeliveredReview.create({
           mrid: 840000 + TEST_NUM + index,
           review_type: `Extra-${index + 1}`,
@@ -671,11 +671,11 @@ describe('monitoringTta', () => {
     const primaryRecipient = fixture.recipients[0];
     const approvedReport = fixture.reports[0];
 
-    const { data } = await monitoringTta(getScopes(), { perPage: 10 });
+    const { data } = await monitoringTta(getScopes(), { perPage: 20 });
     const noncomplianceCitation = data.find(({ citationNumber }) => citationNumber === '1302.10');
     const deficiencyCitation = data.find(({ citationNumber }) => citationNumber === '1302.12');
 
-    expect(data).toHaveLength(10);
+    expect(data).toHaveLength(12);
 
     expect(noncomplianceCitation).toEqual({
       id: `${fixture.citations[1].id}:${primaryRecipient.id}:${fixture.regions[0].id}`,
@@ -799,7 +799,7 @@ describe('monitoringTta', () => {
     ).toHaveLength(2);
   });
 
-  it('defaults to recipient then finding type sorting and supports alternate sort options', async () => {
+  it('defaults to citation sorting and supports alternate sort options', async () => {
     const { data: defaultData } = await monitoringTta(getScopes(), { perPage: 10 });
     const { data: recipientCitationData } = await monitoringTta(getScopes(), {
       sortBy: 'recipient_citation',
@@ -814,8 +814,8 @@ describe('monitoringTta', () => {
       direction: 'desc',
       perPage: 10,
     });
-    const { data: recipientFindingDescData } = await monitoringTta(getScopes(), {
-      sortBy: 'recipient_finding',
+    const { data: findingTypeDescData } = await monitoringTta(getScopes(), {
+      sortBy: 'finding_type',
       direction: 'desc',
       perPage: 10,
     });
@@ -838,8 +838,8 @@ describe('monitoringTta', () => {
     expect(
       defaultData.map(({ recipientName, citationNumber }) => `${recipientName}:${citationNumber}`)
     ).toEqual([
-      `Recipient ${TEST_KEY}:1302.12`,
       `Recipient ${TEST_KEY}:1302.10`,
+      `Recipient ${TEST_KEY}:1302.12`,
       `Recipient ${TEST_KEY}:1302.20`,
       `Recipient ${TEST_KEY}:1302.21`,
       `Recipient ${TEST_KEY}:1302.22`,
@@ -900,12 +900,12 @@ describe('monitoringTta', () => {
     ]);
 
     expect(
-      recipientFindingDescData.map(
+      findingTypeDescData.map(
         ({ recipientName, citationNumber }) => `${recipientName}:${citationNumber}`
       )
     ).toEqual([
-      `Zoo Recipient ${TEST_KEY}:1302.30`,
       `Recipient ${TEST_KEY}:1302.12`,
+      `Zoo Recipient ${TEST_KEY}:1302.30`,
       `Recipient ${TEST_KEY}:1302.10`,
       `Recipient ${TEST_KEY}:1302.20`,
       `Recipient ${TEST_KEY}:1302.21`,
@@ -1406,62 +1406,72 @@ describe('monitoringTta', () => {
       {
         recipientName: '',
         citationNumber: '1302.2',
-        findingType: 'Beta',
+        findingType: 'Noncompliance',
         category: 'Category B',
+        lastTTADate: '02/10/2025',
       },
       {
         recipientName: '',
         citationNumber: '1302.2',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category C',
+        lastTTADate: '03/20/2025',
       },
       {
         recipientName: '',
         citationNumber: '1302.2',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
+        lastTTADate: '01/15/2025',
       },
       {
         recipientName: 'Recipient 2',
         citationNumber: '1302.50',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category Z',
+        lastTTADate: null,
       },
       {
         recipientName: 'Recipient 10',
         citationNumber: '1302.50',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category Z',
+        lastTTADate: '04/01/2025',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.10',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category B',
+        lastTTADate: '01/05/2025',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.11',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
+        lastTTADate: '05/15/2025',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.10',
-        findingType: 'Beta',
+        findingType: 'Noncompliance',
         category: 'Category A',
+        lastTTADate: '01/05/2025',
       },
       {
         recipientName: 'Recipient B',
         citationNumber: '1302.2',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
+        lastTTADate: '02/28/2025',
       },
       {
         recipientName: 'Recipient A',
         citationNumber: '1302.10',
-        findingType: 'Alpha',
+        findingType: 'Area of Concern',
         category: 'Category A',
+        lastTTADate: '01/05/2025',
       },
     ];
 
@@ -1482,60 +1492,50 @@ describe('monitoringTta', () => {
     const citationRows = formatRows(
       [...rows].sort((a, b) => compareMonitoringTta(a, b, 'citation', 'asc'))
     );
-    const recipientFindingRows = formatRows(
-      [...rows].sort((a, b) => compareMonitoringTta(a, b, 'recipient_finding', 'asc'))
+    const findingTypeRows = formatRows(
+      [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'asc'))
+    );
+    const lastTtaRows = formatRows(
+      [...rows].sort((a, b) => compareMonitoringTta(a, b, 'last_tta', 'asc'))
     );
 
     expect(recipientCitationRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
     ]);
 
     expect(findingRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
     ]);
 
     expect(citationRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-    ]);
-
-    expect(recipientFindingRows).toEqual([
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
     ]);
 
     // Verify desc direction reverses the primary sort key while keeping tie-breakers ascending.
@@ -1548,60 +1548,82 @@ describe('monitoringTta', () => {
     const citationDescRows = formatRows(
       [...rows].sort((a, b) => compareMonitoringTta(a, b, 'citation', 'desc'))
     );
-    const recipientFindingDescRows = formatRows(
-      [...rows].sort((a, b) => compareMonitoringTta(a, b, 'recipient_finding', 'desc'))
+    const findingTypeDescRows = formatRows(
+      [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'desc'))
+    );
+    const lastTtaDescRows = formatRows(
+      [...rows].sort((a, b) => compareMonitoringTta(a, b, 'last_tta', 'desc'))
     );
 
     expect(recipientCitationDescRows).toEqual([
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
     ]);
 
     expect(findingDescRows).toEqual([
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
     ]);
 
     expect(citationDescRows).toEqual([
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
+      ['Recipient 2', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient 10', '1302.50', 'Area of Concern', 'Category Z'],
+      ['Recipient A', '1302.11', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category A'],
+      ['Recipient A', '1302.10', 'Area of Concern', 'Category B'],
+      ['Recipient A', '1302.10', 'Noncompliance', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category A'],
+      ['', '1302.2', 'Area of Concern', 'Category C'],
+      ['', '1302.2', 'Noncompliance', 'Category B'],
+      ['Recipient B', '1302.2', 'Area of Concern', 'Category A'],
+    ]);
+  });
+
+  it('sorts finding_type by business-logic priority, not alphabetically', () => {
+    const rows = [
+      { recipientName: 'R', citationNumber: '1302.1', findingType: 'Deficiency', category: 'Cat' },
+      {
+        recipientName: 'R',
+        citationNumber: '1302.1',
+        findingType: 'Area of Concern',
+        category: 'Cat',
+      },
+      {
+        recipientName: 'R',
+        citationNumber: '1302.1',
+        findingType: 'Noncompliance',
+        category: 'Cat',
+      },
+    ];
+
+    const ascSorted = [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'asc'));
+    expect(ascSorted.map((r) => r.findingType)).toEqual([
+      'Area of Concern',
+      'Noncompliance',
+      'Deficiency',
     ]);
 
-    expect(recipientFindingDescRows).toEqual([
-      ['Recipient B', '1302.2', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Alpha', 'Category B'],
-      ['Recipient A', '1302.11', 'Alpha', 'Category A'],
-      ['Recipient A', '1302.10', 'Beta', 'Category A'],
-      ['Recipient 10', '1302.50', 'Alpha', 'Category Z'],
-      ['Recipient 2', '1302.50', 'Alpha', 'Category Z'],
-      ['', '1302.2', 'Alpha', 'Category A'],
-      ['', '1302.2', 'Alpha', 'Category C'],
-      ['', '1302.2', 'Beta', 'Category B'],
+    const descSorted = [...rows].sort((a, b) => compareMonitoringTta(a, b, 'finding_type', 'desc'));
+    expect(descSorted.map((r) => r.findingType)).toEqual([
+      'Deficiency',
+      'Noncompliance',
+      'Area of Concern',
     ]);
   });
 

--- a/src/widgets/monitoring/monitoringTta.ts
+++ b/src/widgets/monitoring/monitoringTta.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-len */
-
 import { REPORT_STATUSES } from '@ttahub/common';
 import moment from 'moment';
 import { type FindAttributeOptions, Op, type OrderItem } from 'sequelize';
@@ -49,7 +48,12 @@ type MonitoringTtaCsvResponse = {
   lastTTADate: string | null;
 };
 
-type MonitoringTtaSortBy = 'recipient_finding' | 'recipient_citation' | 'finding' | 'citation';
+type MonitoringTtaSortBy =
+  | 'finding_type'
+  | 'last_tta'
+  | 'recipient_citation'
+  | 'finding'
+  | 'citation';
 type MonitoringTtaDirection = 'asc' | 'desc';
 
 type Specialist = {
@@ -58,7 +62,7 @@ type Specialist = {
 };
 
 const PAGE_SIZE = 10;
-const DEFAULT_SORT_BY: MonitoringTtaSortBy = 'recipient_finding';
+const DEFAULT_SORT_BY: MonitoringTtaSortBy = 'citation';
 const DEFAULT_DIRECTION: MonitoringTtaDirection = 'asc';
 
 type CitationQueryResult = {
@@ -210,8 +214,20 @@ const RECIPIENT_SORT_FALLBACK_SQL = `
   LOWER(${RECIPIENT_SORT_KEY_SQL})
 `;
 
+// Business-logic priority order for finding types.
+const FINDING_TYPE_ORDER: Record<string, number> = {
+  'Area of Concern': 1,
+  Noncompliance: 2,
+  Deficiency: 3,
+};
+
 const FINDING_SORT_SQL = `
-  LOWER(COALESCE("citation"."calculated_finding_type", ''))
+  CASE LOWER(COALESCE("citation"."calculated_finding_type", ''))
+    WHEN 'area of concern' THEN 1
+    WHEN 'noncompliance' THEN 2
+    WHEN 'deficiency' THEN 3
+    ELSE 4
+  END
 `;
 
 const CATEGORY_SORT_SQL = `
@@ -220,6 +236,22 @@ const CATEGORY_SORT_SQL = `
 
 const CITATION_SORT_FALLBACK_SQL = `
   LOWER(COALESCE("citation"."citation", ''))
+`;
+
+const LAST_TTA_SORT_SQL = `
+  (
+    SELECT MAX(ar."endDate")
+    FROM "ActivityReportObjectiveCitations" aroc
+    JOIN "ActivityReportObjectives" aro ON aro.id = aroc."activityReportObjectiveId"
+    JOIN "ActivityReports" ar ON ar.id = aro."activityReportId"
+    JOIN "GrantCitations" gc_sort
+      ON gc_sort."grantId" = aroc."grantId"
+      AND gc_sort."citationId" = aroc."citationId"
+      AND gc_sort."region_id" = "GrantCitation"."region_id"
+    WHERE ar."calculatedStatus" = 'approved'
+      AND aroc."citationId" = "citation"."id"
+      AND gc_sort."recipient_id" = "GrantCitation"."recipient_id"
+  )
 `;
 
 function compareFormattedDatesDesc(aDate: string, bDate: string): number {
@@ -397,6 +429,14 @@ function compareText(a: string | null | undefined, b: string | null | undefined)
   });
 }
 
+function findingTypeRank(value: string | null | undefined): number {
+  return FINDING_TYPE_ORDER[(value || '').trim()] ?? 5;
+}
+
+function compareFindingType(a: string | null | undefined, b: string | null | undefined): number {
+  return findingTypeRank(a) - findingTypeRank(b);
+}
+
 function sortDirection(direction: MonitoringTtaDirection): 'ASC' | 'DESC' {
   return direction === 'desc' ? 'DESC' : 'ASC';
 }
@@ -408,7 +448,7 @@ export function compareMonitoringTta(
   direction: MonitoringTtaDirection
 ): number {
   const recipientComparison = compareText(a.recipientName, b.recipientName);
-  const findingTypeComparison = compareText(a.findingType, b.findingType);
+  const findingTypeComparison = compareFindingType(a.findingType, b.findingType);
   const citationComparison = compareText(a.citationNumber, b.citationNumber);
   const categoryComparison = compareText(a.category, b.category);
 
@@ -427,6 +467,30 @@ export function compareMonitoringTta(
         recipientComparison ||
         findingTypeComparison
       );
+
+    case 'last_tta': {
+      const aLastTTADate = a.lastTTADate || '';
+      const bLastTTADate = b.lastTTADate || '';
+      const aHasValidDate =
+        !!aLastTTADate && moment(aLastTTADate, ['MM/DD/YYYY', 'M/D/YYYY'], true).isValid();
+      const bHasValidDate =
+        !!bLastTTADate && moment(bLastTTADate, ['MM/DD/YYYY', 'M/D/YYYY'], true).isValid();
+
+      let directedDate = 0;
+
+      if (aHasValidDate && !bHasValidDate) {
+        directedDate = -1;
+      } else if (!aHasValidDate && bHasValidDate) {
+        directedDate = 1;
+      } else if (aHasValidDate && bHasValidDate) {
+        // compareFormattedDatesDesc returns negative when a is more recent.
+        const dateComparison = compareFormattedDatesDesc(aLastTTADate, bLastTTADate);
+        // For 'asc' (oldest first) reverse only valid-vs-valid comparisons.
+        directedDate = direction === 'asc' ? dateComparison * -1 : dateComparison;
+      }
+
+      return directedDate || recipientComparison || citationComparison || findingTypeComparison;
+    }
     case 'citation':
       return (
         (direction === 'desc' ? citationComparison * -1 : citationComparison) ||
@@ -434,11 +498,12 @@ export function compareMonitoringTta(
         findingTypeComparison ||
         categoryComparison
       );
-    case 'recipient_finding':
+    // leaving the default cause spelled out for clarity
+    case 'finding_type':
     default:
       return (
-        (direction === 'desc' ? recipientComparison * -1 : recipientComparison) ||
-        findingTypeComparison ||
+        (direction === 'desc' ? findingTypeComparison * -1 : findingTypeComparison) ||
+        recipientComparison ||
         citationComparison ||
         categoryComparison
       );
@@ -489,20 +554,30 @@ function monitoringTtaOrder(
         literalOrder(FINDING_SORT_SQL, ascending),
         literalOrder('"citation"."id"', ascending),
       ];
-    case 'citation':
+    case 'finding_type':
       return [
-        ...citationOrder(primaryDirection),
+        literalOrder(FINDING_SORT_SQL, primaryDirection),
         ...recipientOrder(ascending),
+        ...citationOrder(ascending),
+        literalOrder(CATEGORY_SORT_SQL, ascending),
+        literalOrder('"citation"."id"', ascending),
+      ];
+    case 'last_tta':
+      return [
+        literalOrder(`CASE WHEN ${LAST_TTA_SORT_SQL} IS NULL THEN 1 ELSE 0 END`, 'ASC'),
+        literalOrder(LAST_TTA_SORT_SQL, primaryDirection),
+        ...recipientOrder(ascending),
+        ...citationOrder(ascending),
         literalOrder(FINDING_SORT_SQL, ascending),
         literalOrder(CATEGORY_SORT_SQL, ascending),
         literalOrder('"citation"."id"', ascending),
       ];
-    case 'recipient_finding':
+    // case 'citation' is the default sort
     default:
       return [
-        ...recipientOrder(primaryDirection),
+        ...citationOrder(primaryDirection),
+        ...recipientOrder(ascending),
         literalOrder(FINDING_SORT_SQL, ascending),
-        ...citationOrder(ascending),
         literalOrder(CATEGORY_SORT_SQL, ascending),
         literalOrder('"citation"."id"', ascending),
       ];
@@ -537,7 +612,6 @@ async function findPagedRecipientCitationCards(
         model: Grant.unscoped(),
         as: 'grant',
         required: true,
-        where: scopes.grant.where,
         attributes: [],
       },
       {
@@ -545,6 +619,11 @@ async function findPagedRecipientCitationCards(
         as: 'citation',
         required: true,
         attributes: [],
+        where: {
+          calculated_finding_type: {
+            [Op.in]: ['Area of Concern', 'Noncompliance', 'Deficiency'],
+          },
+        },
         include: [
           {
             model: DeliveredReviewCitation,
@@ -662,7 +741,6 @@ async function findCitationsByIds(
             model: Grant,
             required: true,
             as: 'grant',
-            where: scopes.grant.where,
             attributes: ['id', 'number', 'numberWithProgramTypes'],
             include: [
               {
@@ -707,7 +785,6 @@ async function findCitationsByIds(
                     as: 'grant',
                     required: true,
                     attributes: [],
-                    where: scopes.grant.where,
                   },
                 ],
               },


### PR DESCRIPTION
## Description of change

For the monitoring related TTA widget on the regional monitoring dashboard:

- Remove one sort option (recipient + finding type)
- Add new sort options (finding type, last TTA)
- Change default sort option (finding type)



## How to test
On the monitoring regional dashboard, confirm that the changes have been made and are correct to the [mockup](https://www.figma.com/design/vE0uwgH9c4BjzBUlwtJuXK/Monitoring-Dash-Caseload?node-id=2295-14076&m=dev). Verify that the sorting works correctly

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5229


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [x] QA review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [x] Staging smoke test completed
- [x] PR transitioned to **Open**
- [x] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
