### PR TITLE
[TTAHUB-5309] Refactor recipientSpotlight for fact tables

### DIFF
--- a/src/services/recipientSpotlight.js
+++ b/src/services/recipientSpotlight.js
@@ -197,8 +197,6 @@ export async function getRecipientSpotlightIndicators(
   const spotLightSql = `
     WITH
     -- Creating some useful CTEs
-    -- make it easy to limit to only monitoring data in the valid timeframe
-    monitoring_dates AS ( SELECT '2025-01-21'::date monitoring_start_date),
     -- Join grants and recipients so we don't have to do it repeatedly
     grant_recipients AS (
       SELECT
@@ -219,7 +217,7 @@ export async function getRecipientSpotlightIndicators(
       rname,
       region,
       ARRAY_AGG(DISTINCT grid)::text[] grant_ids,
-      MAX(ar."startDate") last_tta,
+      MAX(ar."endDate") last_tta,
       -- toggle whether we're calculating for just a specific grant
       -- or if we're calculating indicators for an entire recipient
       -- blank is recipient mode, nonblank is grantmode
@@ -264,27 +262,19 @@ export async function getRecipientSpotlightIndicators(
       rid,
       region,
       grid,
-      mr."reviewId" ruuid,
-      mr."reviewType" review_type,
-      mrs.name review_status,
-      mr."reportDeliveryDate" rdd,
-      mr."startDate" rsd,
-      mr."sourceCreatedAt" rsc
+      review_uuid,
+      review_type,
+      review_status,
+      report_delivery_date rdd,
+      report_start_date rsd,
+      dr."createdAt" rsc
     FROM all_grants
-    JOIN "MonitoringReviewGrantees" mrg
-      ON grnumber = mrg."grantNumber"
-    JOIN "MonitoringReviews" mr
-      ON mrg."reviewId" = mr."reviewId"
-    JOIN "MonitoringReviewStatuses" mrs
-      ON mr."statusId" = mrs."statusId"
-    CROSS JOIN monitoring_dates
-    WHERE mr."deletedAt" IS NULL 
+    JOIN "GrantDeliveredReviews" gdr
+      ON grid = gdr."grantId"
+    JOIN "DeliveredReviews" dr
+      ON gdr."deliveredReviewId" = dr.id
+    WHERE dr."deletedAt" IS NULL 
       AND grstatus = 'Active'
-      AND (
-        mr."reportDeliveryDate" > monitoring_start_date
-        OR
-        mr."sourceCreatedAt" > monitoring_start_date
-      )
     ),
     ---------------------------------------
     -- Spotlight indicators ---------------
@@ -301,43 +291,18 @@ export async function getRecipientSpotlightIndicators(
       GROUP BY 1,2
     ),
     
-    -- 2. Deficiency: Recipients with at least one uncorrected deficiency
-    --    in monitoring findings. The logic for "uncorrected" is complex
-    --    because we cannot simply rely on the finding's statusId value.
-
-    -- associate each citation with its most recent review to see 
-    ordered_citation_reviews AS (
-    SELECT DISTINCT ON (mf."findingId")
-      rid,
-      region,
-      grid,
-      mf."findingId" fid,
-      -- this is only safe with deficiencies because AOCs and ANCs are not
-      -- consistent between findingType and determination
-      COALESCE(mfh.determination, mf."findingType") finding_type,
-      mfs.name finding_status,
-      ruuid,
-      review_status,
-      rdd
-    FROM "MonitoringFindings" mf
-    JOIN "MonitoringFindingHistories" mfh
-      ON mf."findingId" = mfh."findingId"
-      AND mf."sourceDeletedAt" IS NULL
-    JOIN all_reviews
-      ON mfh."reviewId" = ruuid
-    JOIN "MonitoringFindingStatuses" mfs
-      ON mf."statusId" = mfs."statusId"
-    WHERE mf."findingType" = 'Deficiency'
-      OR mfs.name = 'Elevated Deficiency'
-    ORDER BY mf."findingId",rsd DESC, rsc DESC
-    ),
+    -- 2. Deficiency: Recipients with at least one active Deficiency citation
     deficiencies AS (
       SELECT DISTINCT
-        rid deficiency_rid,
-        region deficiency_region
-      FROM ordered_citation_reviews
-      WHERE finding_status IN ('Active','Elevated Deficiency')
-        OR rdd IS NULL
+        ag.rid deficiency_rid,
+        ag.region deficiency_region
+      FROM "Citations" c
+      JOIN "GrantCitations" gc ON c.id = gc."citationId"
+      JOIN all_grants ag ON gc."grantId" = ag.grid
+      WHERE c.calculated_finding_type = 'Deficiency'
+        AND c.active = TRUE
+        AND c."deletedAt" IS NULL
+        AND ag.grstatus = 'Active'
     ),
 
     -- 3. New Recipients: Recipients with oldest grant less than 4 years old

--- a/src/services/recipientSpotlight.js
+++ b/src/services/recipientSpotlight.js
@@ -255,40 +255,24 @@ export async function getRecipientSpotlightIndicators(
       )
     WHERE (gr.deleted IS NULL OR NOT gr.deleted)
     ),
-    -- Select all the potentially-relevant reviews
-    -- for early filtering of monitoring datasets
-    all_reviews AS (
-    SELECT DISTINCT
-      rid,
-      region,
-      grid,
-      review_uuid,
-      review_type,
-      review_status,
-      report_delivery_date rdd,
-      report_start_date rsd,
-      dr."createdAt" rsc
-    FROM all_grants
-    JOIN "GrantDeliveredReviews" gdr
-      ON grid = gdr."grantId"
-    JOIN "DeliveredReviews" dr
-      ON gdr."deliveredReviewId" = dr.id
-    WHERE dr."deletedAt" IS NULL 
-      AND grstatus = 'Active'
-    ),
     ---------------------------------------
     -- Spotlight indicators ---------------
     ---------------------------------------
     -- 1. Child Incidents: Grants with at least one RAN citation in the last 12 months
     child_incidents AS (
-      SELECT
+      SELECT DISTINCT
         rid incident_rid,
         region incident_region
-      FROM all_reviews
-      WHERE review_type = 'RAN'
-        AND review_status = 'Complete'
-        AND rdd >= NOW() - INTERVAL '12 months'
-      GROUP BY 1,2
+      FROM all_grants
+      JOIN "GrantDeliveredReviews" gdr
+        ON grid = gdr."grantId"
+      JOIN "DeliveredReviews" dr
+        ON gdr."deliveredReviewId" = dr.id
+      WHERE dr."deletedAt" IS NULL
+        AND grstatus = 'Active'
+        AND dr.review_type = 'RAN'
+        AND dr.review_status = 'Complete'
+        AND dr.report_delivery_date >= NOW() - INTERVAL '12 months'
     ),
     
     -- 2. Deficiency: Recipients with at least one active Deficiency citation

--- a/src/services/recipientSpotlight.test.js
+++ b/src/services/recipientSpotlight.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 import faker from '@faker-js/faker';
 import db from '../models';
+import updateMonitoringFactTables from '../tools/updateMonitoringFactTables';
 import { getRecipientSpotlightIndicators } from './recipientSpotlight';
 
 // Helper function to create scopes with region filter
@@ -59,6 +60,17 @@ const {
   ActivityReportGoal,
 } = db;
 
+// Fact-table models used to verify the new monitoring data pipeline
+const {
+  Citation,
+  DeliveredReview,
+  DeliveredReviewCitation,
+  GrantCitation,
+  GrantDeliveredReview,
+  MonitoringFindingStandard,
+  MonitoringStandard,
+} = db;
+
 describe('recipientSpotlight service', () => {
   // Test data constants
   const REGION_ID = 1; // Region ID can remain hardcoded as it's often a reference to real regions
@@ -84,6 +96,10 @@ describe('recipientSpotlight service', () => {
   let monitoringReviewStatus;
   let monitoringFindingStatus;
   let deficiencyFinding;
+
+  // Fact-table records created by updateMonitoringFactTables; used in tests and afterAll cleanup
+  let deficiencyCitation;
+  let deficiencyStandardId;
 
   const createDate = new Date();
   // Make pastYear clearly within the last 12 months (9 months ago) to avoid edge cases
@@ -464,6 +480,40 @@ describe('recipientSpotlight service', () => {
       sourceCreatedAt: createDate,
       sourceUpdatedAt: createDate,
     });
+
+    // MonitoringFindingStandard + MonitoringStandard are required by updateMonitoringFactTables
+    // to produce a Citation row for this finding.
+    deficiencyStandardId = faker.datatype.number({ min: 200000, max: 299999 });
+    await MonitoringStandard.findOrCreate({
+      where: { standardId: deficiencyStandardId },
+      defaults: {
+        standardId: deficiencyStandardId,
+        contentId: faker.datatype.uuid(),
+        citation: '1302.47(b)',
+        text: 'Test deficiency standard',
+        guidance: 'Fiscal',
+        citable: 1,
+        hash: faker.datatype.uuid(),
+        sourceCreatedAt: createDate,
+        sourceUpdatedAt: createDate,
+      },
+    });
+    await MonitoringFindingStandard.create({
+      findingId: deficiencyFinding.findingId,
+      standardId: deficiencyStandardId,
+      sourceCreatedAt: createDate,
+      sourceUpdatedAt: createDate,
+    });
+
+    // Populate DeliveredReviews, Citations, GrantDeliveredReviews, and GrantCitations
+    // from the raw monitoring data we created above.
+    await updateMonitoringFactTables();
+
+    // Look up the Citation the update produced so the deficiency test can
+    // soft-delete it and verify the indicator drops to false.
+    deficiencyCitation = await Citation.findOne({
+      where: { finding_uuid: deficiencyFinding.findingId },
+    });
   });
 
   afterAll(async () => {
@@ -503,6 +553,14 @@ describe('recipientSpotlight service', () => {
       });
 
       await MonitoringFinding.destroy({
+        where: {},
+        force: true,
+        transaction,
+      });
+
+      // MonitoringFindingStandard references MonitoringFindingLink; must be deleted first.
+      // Broad cleanup consistent with the where:{} pattern used for all other monitoring tables.
+      await MonitoringFindingStandard.destroy({
         where: {},
         force: true,
         transaction,
@@ -579,6 +637,46 @@ describe('recipientSpotlight service', () => {
         force: true,
         transaction,
       });
+
+      // Clean up fact table records created by updateMonitoringFactTables.
+      // Junction tables must be deleted before their referenced entities.
+      if (grantIds.length > 0) {
+        const testGDRs = await GrantDeliveredReview.findAll({
+          where: { grantId: grantIds },
+          attributes: ['deliveredReviewId'],
+          raw: true,
+          transaction,
+        });
+        const drIds = testGDRs.map((r) => r.deliveredReviewId);
+        if (drIds.length > 0) {
+          await DeliveredReviewCitation.destroy({
+            where: { deliveredReviewId: drIds },
+            force: true,
+            transaction,
+          });
+          await GrantDeliveredReview.destroy({
+            where: { deliveredReviewId: drIds },
+            force: true,
+            transaction,
+          });
+          await DeliveredReview.destroy({
+            where: { id: drIds },
+            force: true,
+            transaction,
+          });
+        }
+        await GrantCitation.destroy({ where: { grantId: grantIds }, force: true, transaction });
+      }
+      if (deficiencyCitation?.id) {
+        await Citation.destroy({ where: { id: deficiencyCitation.id }, force: true, transaction });
+      }
+      if (deficiencyStandardId) {
+        await MonitoringStandard.destroy({
+          where: { standardId: deficiencyStandardId },
+          force: true,
+          transaction,
+        });
+      }
 
       // Clean up grants
       if (grantIds.length > 0) {
@@ -696,8 +794,11 @@ describe('recipientSpotlight service', () => {
       expect(Array.isArray(result.recipients)).toBe(true);
       expect(result.recipients[0].deficiency).toBe(true);
 
-      // Source-deleted findings must be excluded — soft-delete the finding and verify
+      // Simulate a source deletion: mark the MonitoringFinding as deleted, then re-run
+      // updateMonitoringFactTables. The update script should set Citations.deletedAt on the
+      // now-invalid Citation, which is the real mechanism the new deficiency query relies on.
       await deficiencyFinding.update({ sourceDeletedAt: new Date() });
+      await updateMonitoringFactTables();
       const resultAfterDelete = await getRecipientSpotlightIndicators(
         scopes,
         'recipientName',
@@ -707,7 +808,24 @@ describe('recipientSpotlight service', () => {
         [REGION_ID]
       );
       expect(resultAfterDelete.recipients[0].deficiency).toBe(false);
+
+      // Restore the finding and re-run; the ON CONFLICT DO UPDATE path in the update script
+      // sets deletedAt = NULL, bringing the indicator back.
       await deficiencyFinding.update({ sourceDeletedAt: null });
+      await updateMonitoringFactTables();
+      // Refresh the outer reference so afterAll cleanup has a valid Citation instance.
+      deficiencyCitation = await Citation.findOne({
+        where: { finding_uuid: deficiencyFinding.findingId },
+      });
+      const resultAfterRestore = await getRecipientSpotlightIndicators(
+        scopes,
+        'recipientName',
+        'ASC',
+        0,
+        10,
+        [REGION_ID]
+      );
+      expect(resultAfterRestore.recipients[0].deficiency).toBe(true);
     });
 
     it('identifies new recipients correctly', async () => {
@@ -839,6 +957,87 @@ describe('recipientSpotlight service', () => {
       expect(result.recipients).toBeDefined();
       expect(Array.isArray(result.recipients)).toBe(true);
       expect(result.recipients[0].noTTA).toBe(true);
+    });
+
+    it('sets lastTTA from the activity report endDate, not startDate', async () => {
+      // Uses a report where startDate is 3 years ago but endDate is 9 months ago.
+      // Verifies MAX(ar."endDate") is used — not MAX(ar."startDate").
+      const grantNumber = `G-LASTTA-${faker.datatype.number({ min: 100000, max: 999999 })}`;
+      await db.GrantNumberLink.create({ grantNumber });
+
+      const ttaRecipient = await Recipient.create({
+        id: faker.unique(() => faker.datatype.number({ min: 10000, max: 30000 })),
+        name: 'Last TTA Date Recipient',
+        regionId: REGION_ID,
+      });
+
+      const ttaGrant = await Grant.create({
+        id: faker.unique(() => faker.datatype.number({ min: 10000, max: 30000 })),
+        number: grantNumber,
+        recipientId: ttaRecipient.id,
+        regionId: REGION_ID,
+        status: 'Active',
+        startDate: pastFiveYears,
+        endDate: createDate,
+        cdi: false,
+      });
+
+      const ttaGoal = await Goal.create({
+        name: 'Last TTA Test Goal',
+        status: 'Not Started',
+        grantId: ttaGrant.id,
+      });
+
+      // startDate is 3 years ago; endDate is 9 months ago — intentionally different.
+      const ttaReport = await ActivityReport.create({
+        activityRecipientType: 'recipient',
+        submissionStatus: 'submitted',
+        calculatedStatus: 'approved',
+        userId: testUser.id,
+        regionId: REGION_ID,
+        startDate: pastThreeYears,
+        endDate: pastYear,
+        approvedAt: pastYear,
+        duration: 1,
+      });
+
+      await ActivityReportGoal.create({
+        activityReportId: ttaReport.id,
+        grantId: ttaGrant.id,
+        goalId: ttaGoal.id,
+      });
+
+      try {
+        const scopes = createScopesWithRecipientAndRegion(ttaRecipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID]
+        );
+        expect(result.recipients.length).toBe(1);
+        const row = result.recipients[0];
+
+        // lastTTA must reflect endDate (pastYear ≈ 9 months ago),
+        // not startDate (pastThreeYears ≈ 3 years ago).
+        expect(row.lastTTA).not.toBeNull();
+        const lastTTA = new Date(row.lastTTA);
+        expect(lastTTA.getFullYear()).toBe(pastYear.getFullYear());
+        expect(lastTTA.getMonth()).toBe(pastYear.getMonth());
+        expect(lastTTA.getFullYear()).not.toBe(pastThreeYears.getFullYear());
+      } finally {
+        await ActivityReportGoal.destroy({
+          where: { activityReportId: ttaReport.id },
+          force: true,
+        });
+        await ActivityReport.destroy({ where: { id: ttaReport.id }, force: true });
+        await Goal.destroy({ where: { id: ttaGoal.id }, force: true });
+        await Grant.destroy({ where: { id: ttaGrant.id }, force: true, individualHooks: true });
+        await Recipient.destroy({ where: { id: ttaRecipient.id }, force: true });
+        await db.GrantNumberLink.destroy({ where: { grantNumber }, force: true });
+      }
     });
 
     it('includes recipients with zero indicators in results when no indicator filters are applied', async () => {
@@ -1177,6 +1376,10 @@ describe('recipientSpotlight service', () => {
       ]);
       // End setup for childIncidents
 
+      // Push the new monitoring reviews into the fact tables so that
+      // all_reviews (which now reads DeliveredReviews/GrantDeliveredReviews) can see them.
+      await updateMonitoringFactTables();
+
       try {
         // Test with the grant that has an indicator
         const scopesWithIndicator = createScopesWithRecipientAndRegion(
@@ -1260,6 +1463,31 @@ describe('recipientSpotlight service', () => {
           where: { id: singleGrantGoal.id },
           force: true,
         });
+
+        // Clean up fact table records created by the updateMonitoringFactTables call above
+        const sgGrantIds = [
+          singleGrantWithIndicator.id,
+          singleGrantWithoutIndicator.id,
+          singleGrantOther.id,
+        ];
+        const sgGDRs = await GrantDeliveredReview.findAll({
+          where: { grantId: sgGrantIds },
+          attributes: ['deliveredReviewId'],
+          raw: true,
+        });
+        const sgDrIds = sgGDRs.map((r) => r.deliveredReviewId);
+        if (sgDrIds.length > 0) {
+          await DeliveredReviewCitation.destroy({
+            where: { deliveredReviewId: sgDrIds },
+            force: true,
+          });
+          await GrantDeliveredReview.destroy({
+            where: { deliveredReviewId: sgDrIds },
+            force: true,
+          });
+          await DeliveredReview.destroy({ where: { id: sgDrIds }, force: true });
+        }
+        await GrantCitation.destroy({ where: { grantId: sgGrantIds }, force: true });
 
         await MonitoringReviewGrantee.destroy({
           where: { reviewId: [singleGrantReview.reviewId, singleGrantReview2.reviewId] },
@@ -1721,11 +1949,20 @@ describe('recipientSpotlight service', () => {
         if (existingGrants.length > 0) {
           const existingGrantIds = existingGrants.map((g) => g.id);
           const existingRecipientIds = [...new Set(existingGrants.map((g) => g.recipientId))];
-          await ActivityReportGoal.destroy({
+          const existingGoals = await Goal.findAll({
             where: { grantId: existingGrantIds },
-            force: true,
+            attributes: ['id'],
+            raw: true,
             transaction: t,
           });
+          const existingGoalIds = existingGoals.map((g) => g.id);
+          if (existingGoalIds.length > 0) {
+            await ActivityReportGoal.destroy({
+              where: { goalId: existingGoalIds },
+              force: true,
+              transaction: t,
+            });
+          }
           await Goal.destroy({ where: { grantId: existingGrantIds }, force: true, transaction: t });
           await Grant.destroy({
             where: { id: existingGrantIds },

--- a/src/services/recipientSpotlight.test.js
+++ b/src/services/recipientSpotlight.test.js
@@ -1022,11 +1022,14 @@ describe('recipientSpotlight service', () => {
 
         // lastTTA must reflect endDate (pastYear ≈ 9 months ago),
         // not startDate (pastThreeYears ≈ 3 years ago).
+        // Compare YYYY-MM-DD strings directly — DATE columns have no timezone component
+        // in Postgres, so no shifting occurs on read. Use local date parts to match
+        // how Sequelize serialized pastYear on write.
+        const pad = (n) => String(n).padStart(2, '0');
+        const toLocalYMD = (d) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
         expect(row.lastTTA).not.toBeNull();
-        const lastTTA = new Date(row.lastTTA);
-        expect(lastTTA.getFullYear()).toBe(pastYear.getFullYear());
-        expect(lastTTA.getMonth()).toBe(pastYear.getMonth());
-        expect(lastTTA.getFullYear()).not.toBe(pastThreeYears.getFullYear());
+        expect(row.lastTTA.slice(0, 10)).toBe(toLocalYMD(pastYear));
+        expect(row.lastTTA.slice(0, 10)).not.toBe(toLocalYMD(pastThreeYears));
       } finally {
         await ActivityReportGoal.destroy({
           where: { activityReportId: ttaReport.id },


### PR DESCRIPTION
## Description of change

Updating recipientSpotlight to use the fact tables instead of rolling its own logic out of the monitoring tables.

Also corrects last_tta to use `ActivityReports.endDate` rather than `startDate`.

## How to test

There really shouldn't be any differences except in last TTA values.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5309


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
