### PR TITLE
[TTAHUB-5325] correct nightly job order and rerun migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,18 +774,18 @@ jobs:
           PHASE_NAMES=(
             "download"
             "process"
+            "update_fact_tables"
             "create_monitoring_goals"
             "maintain_monitoring_data"
-            "update_fact_tables"
             "report_updates"
           )
 
           PHASE_COMMANDS=(
             "yarn cli:import-system download 1"
             "yarn cli:import-system process 1"
+            "yarn cli:updateMonitoringFactTables"
             "yarn cli:create-monitoring-goals"
             "yarn cli:maintain-monitoring-data"
-            "yarn cli:updateMonitoringFactTables"
             "yarn cli:query-monitoring-data"
           )
 

--- a/src/migrations/20260513000000-re_delete_autoreopened_monitoring.js
+++ b/src/migrations/20260513000000-re_delete_autoreopened_monitoring.js
@@ -1,0 +1,97 @@
+const { prepMigration } = require('../lib/migration');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const sessionSig = __filename;
+      await prepMigration(queryInterface, transaction, sessionSig);
+      await queryInterface.sequelize.query(
+        `
+        -- This repeats 20260106000000-delete_autoreopened_monitoring because
+        -- create_monitoring_goals ran before update_fact_tables in the pipeline,
+        -- meaning the fact tables had not yet applied the corrected logic that
+        -- avoids recreating the goals that the migration had just deleted.
+        --
+        -- So, we're re-running exactly the same logic:
+        -- Identify open goals that are neither in use nor valid according to current logic:
+        --   - created by the monitoring goal creation job
+        --   - status is not Closed or Suspended
+        --   - no non-deleted ARs associated with the Goal
+        --   - has at least one Elevated Deficiency citation where:
+        --     - its most recent review has a Compliant outcome
+        --     - has no reviews still outstanding
+        --   - has no active citations under current logic
+        DROP TABLE IF EXISTS goals_for_deletion;
+        CREATE TEMP TABLE goals_for_deletion
+        AS
+        WITH candidates AS (
+        -- monitoring goal-citation pairs with:
+        -- - no AR usage on the goal
+        -- - the citation in the error case
+        SELECT
+          g.id gid,
+          dr.outcome,
+          g.status,
+          gr.id grid,
+          gr.number grnumber,
+          r.name recipient,
+          c.id cid
+        FROM "Goals" g
+        JOIN "Grants" gr
+          ON g."grantId" = gr.id
+        JOIN "Recipients" r
+          ON gr."recipientId" = r.id
+        JOIN "GrantCitations" gc
+          ON gr.id = gc."grantId"
+        JOIN "Citations" c
+          ON gc."citationId" = c.id
+          AND c."deletedAt" IS NULL
+        JOIN "DeliveredReviews" dr
+          ON c.latest_review_uuid = dr.review_uuid
+          AND dr."deletedAt" IS NULL
+        LEFT JOIN "ActivityReportGoals" arg
+          ON arg."goalId" = g.id
+        LEFT JOIN "ActivityReports" ar
+          ON arg."activityReportId" = ar.id
+          AND ar."calculatedStatus" != 'deleted'
+        WHERE g."deletedAt" IS NULL
+          AND g.status NOT IN ('Closed','Suspended')
+          AND g."createdVia" = 'monitoring'
+          AND last_review_delivered
+          AND raw_status = 'Elevated Deficiency'
+          AND outcome = 'Compliant'
+        GROUP BY 1,2,3,4,5,6,7
+        HAVING bool_and(ar.id IS NULL)
+        )
+        -- Rejoin from the grant to Citations to check if there
+        -- are any active citations that are NOT the error case
+        SELECT
+          gid,
+          grnumber,
+          status,
+          recipient
+        FROM candidates
+        JOIN "GrantCitations" gc
+          ON grid = gc."grantId"
+        JOIN "Citations" c
+          ON gc."citationId" = c.id
+        WHERE c."deletedAt" IS NULL
+        GROUP BY 1,2,3,4
+        HAVING NOT bool_or(c.active AND c.id != cid);
+
+        -- Soft-delete the identified goals
+        UPDATE "Goals"
+        SET "deletedAt" = NOW()
+        FROM goals_for_deletion
+        WHERE id = gid;
+    `,
+        { transaction }
+      );
+    });
+  },
+
+  async down() {
+    // no rollbacks of data fixes
+  },
+};


### PR DESCRIPTION
## Description of change

in the CircleCI config.yml the previous order is                             
process->create_monitoring_goals->update_fact_tables, but this puts update_fact_tables between process and                    
  create_monitoring_goals because create_monitoring_goals relies on the fact tables being up to date.

Then, because we had this out of order, we recreated the goals that the latest migration soft-deleted, so this also adds another migration to do exactly the same thing again.

## How to test

I'm not sure there's anything to test here per se

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5325


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
