### PR TITLE
Remove feature flag from FindingCategoryHotspot on the Monitoring Regional Dashboard

### DIFF
--- a/frontend/src/pages/RegionalDashboard/components/MonitoringReportDashboard.js
+++ b/frontend/src/pages/RegionalDashboard/components/MonitoringReportDashboard.js
@@ -1,7 +1,6 @@
 import { Grid } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
 import React from 'react';
-import FeatureFlag from '../../../components/FeatureFlag';
 import ActiveDeficientCitationsWithTtaSupport from '../../../widgets/ActiveDeficientCitationsWithTtaSupport';
 import FindingCategoryHotspot from '../../../widgets/FindingCategoryHotspot';
 import MonitoringRelatedTta from '../../../widgets/MonitoringRelatedTta';
@@ -16,11 +15,9 @@ export default function MonitoringReportDashboard({ filtersToApply }) {
       <Grid row>
         <ActiveDeficientCitationsWithTtaSupport filters={filtersToApply} />
       </Grid>
-      <FeatureFlag flag="monitoring-regional-dashboard">
-        <Grid row>
-          <FindingCategoryHotspot filters={filtersToApply} />
-        </Grid>
-      </FeatureFlag>
+      <Grid row>
+        <FindingCategoryHotspot filters={filtersToApply} />
+      </Grid>
       <Grid row>
         <MonitoringRelatedTta filters={filtersToApply} />
       </Grid>


### PR DESCRIPTION
## Description of change

What it says on the tin; any user can see the "Finding Category Hotspot" widget

## How to test


## Issue(s)

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
