### PR TITLE
[Prod] Add collab reports state filter, remove feature flag from hotspot widget on monitoring regional dashboard

### DIFF
--- a/frontend/src/components/filter/collabReportFilters.js
+++ b/frontend/src/components/filter/collabReportFilters.js
@@ -15,6 +15,7 @@ import FilterCollabActivityPurpose, {
 import FilterCollabGoal from './FilterCollabGoal';
 import FilterDateRange from './FilterDateRange';
 import FilterRegionalSelect from './FilterRegionSelect';
+import FilterStateSelect from './FilterStateSelect';
 import { handleArrayQuery } from './helpers';
 
 const EMPTY_SINGLE_SELECT = {
@@ -114,6 +115,17 @@ export const goalFilter = {
   displayQuery: handleArrayQuery,
   renderInput: (id, condition, query, onApplyQuery) => (
     <FilterCollabGoal inputId={`goal-${condition}-${id}`} onApply={onApplyQuery} query={query} />
+  ),
+};
+
+export const stateCodeFilter = {
+  id: 'stateCode',
+  display: 'State or territory',
+  conditions: FILTER_CONDITIONS,
+  defaultValues: EMPTY_MULTI_SELECT,
+  displayQuery: handleArrayQuery,
+  renderInput: (id, condition, query, onApplyQuery) => (
+    <FilterStateSelect inputId={`state-${condition}-${id}`} onApply={onApplyQuery} query={query} />
   ),
 };
 

--- a/frontend/src/pages/CollaborationReports/constants.js
+++ b/frontend/src/pages/CollaborationReports/constants.js
@@ -4,6 +4,7 @@ import {
   goalFilter,
   regionFilter,
   startDateFilter,
+  stateCodeFilter,
 } from '../../components/filter/collabReportFilters';
 
 const COLLAB_REPORT_FILTER_CONFIG = [
@@ -11,6 +12,7 @@ const COLLAB_REPORT_FILTER_CONFIG = [
   activityPurposeFilter,
   goalFilter,
   regionFilter,
+  stateCodeFilter,
   startDateFilter,
 ];
 

--- a/frontend/src/pages/RegionalDashboard/components/MonitoringReportDashboard.js
+++ b/frontend/src/pages/RegionalDashboard/components/MonitoringReportDashboard.js
@@ -1,7 +1,6 @@
 import { Grid } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
 import React from 'react';
-import FeatureFlag from '../../../components/FeatureFlag';
 import ActiveDeficientCitationsWithTtaSupport from '../../../widgets/ActiveDeficientCitationsWithTtaSupport';
 import FindingCategoryHotspot from '../../../widgets/FindingCategoryHotspot';
 import MonitoringRelatedTta from '../../../widgets/MonitoringRelatedTta';
@@ -16,11 +15,9 @@ export default function MonitoringReportDashboard({ filtersToApply }) {
       <Grid row>
         <ActiveDeficientCitationsWithTtaSupport filters={filtersToApply} />
       </Grid>
-      <FeatureFlag flag="monitoring-regional-dashboard">
-        <Grid row>
-          <FindingCategoryHotspot filters={filtersToApply} />
-        </Grid>
-      </FeatureFlag>
+      <Grid row>
+        <FindingCategoryHotspot filters={filtersToApply} />
+      </Grid>
       <Grid row>
         <MonitoringRelatedTta filters={filtersToApply} />
       </Grid>

--- a/src/scopes/collabReports/index.test.js
+++ b/src/scopes/collabReports/index.test.js
@@ -104,6 +104,49 @@ describe('collabReports goal scope', () => {
   });
 });
 
+describe('collabReports stateCode scope', () => {
+  it('maps stateCode.in to an IN subquery on CollabReportActivityStates', () => {
+    const scope = topicToQuery.stateCode.in(['CA', 'TX']);
+    const sql = scope.id[Op.in].val;
+
+    expect(sql).toContain('FROM "CollabReportActivityStates"');
+    expect(sql).toContain('"activityStateCode" IN');
+    expect(sql).toContain("'CA'");
+    expect(sql).toContain("'TX'");
+  });
+
+  it('maps stateCode.nin to a NOT IN subquery on CollabReportActivityStates', () => {
+    const scope = topicToQuery.stateCode.nin(['NY']);
+    const sql = scope.id[Op.notIn].val;
+
+    expect(sql).toContain('FROM "CollabReportActivityStates"');
+    expect(sql).toContain('"activityStateCode" IN');
+    expect(sql).toContain("'NY'");
+  });
+
+  it('filters out soft-deleted activity states', () => {
+    const scope = topicToQuery.stateCode.in(['WA']);
+    const sql = scope.id[Op.in].val;
+
+    expect(sql).toContain('"deletedAt" IS NULL');
+  });
+
+  it('normalizes comma-separated state codes in a single string', () => {
+    const scope = topicToQuery.stateCode.in(['CA, TX, WA']);
+    const sql = scope.id[Op.in].val;
+
+    expect(sql).toContain("'CA'");
+    expect(sql).toContain("'TX'");
+    expect(sql).toContain("'WA'");
+  });
+
+  it('returns an empty scope when no state codes are provided', () => {
+    const scope = topicToQuery.stateCode.in([' ,  ']);
+
+    expect(scope).toEqual({});
+  });
+});
+
 describe('collabReports activityPurpose scope', () => {
   it('maps activityPurpose.in to an IN subquery on CollabReportReasons', () => {
     const scope = topicToQuery.activityPurpose.in(['participate_work_groups']);

--- a/src/scopes/collabReports/index.ts
+++ b/src/scopes/collabReports/index.ts
@@ -5,6 +5,7 @@ import { withGoal, withoutGoal } from './goal';
 import { withId, withoutId } from './id';
 import { withoutRegion, withRegion } from './region';
 import { afterStartDate, beforeStartDate, withinStartDate } from './startDate';
+import { withoutStateCode, withStateCode } from './stateCode';
 
 export const topicToQuery = {
   region: {
@@ -18,6 +19,10 @@ export const topicToQuery = {
   goal: {
     in: (query) => withGoal(query),
     nin: (query) => withoutGoal(query),
+  },
+  stateCode: {
+    in: (query) => withStateCode(query),
+    nin: (query) => withoutStateCode(query),
   },
   conductMethod: {
     in: (query) => withConductMethod(query),

--- a/src/scopes/collabReports/stateCode.ts
+++ b/src/scopes/collabReports/stateCode.ts
@@ -1,0 +1,30 @@
+import { Op } from 'sequelize';
+import { sequelize } from '../../models';
+
+const stateCodeScope = (query: string[], exclude = false) => {
+  const normalized = query
+    .flatMap((s) => s.split(',').map((item) => item.trim()))
+    .filter((s) => s.length > 0);
+
+  if (!normalized.length) {
+    return {};
+  }
+
+  const escaped = normalized.map((code) => sequelize.escape(code));
+  const operator = exclude ? Op.notIn : Op.in;
+
+  return {
+    id: {
+      [operator]: sequelize.literal(`(
+        SELECT cras."collabReportId"
+        FROM "CollabReportActivityStates" cras
+        WHERE cras."deletedAt" IS NULL
+          AND cras."activityStateCode" IN (${escaped.join(', ')})
+      )`),
+    },
+  };
+};
+
+export const withStateCode = (query: string[]) => stateCodeScope(query);
+
+export const withoutStateCode = (query: string[]) => stateCodeScope(query, true);


### PR DESCRIPTION
## Description of change

- Add state/territory filter to the collab reports dashboard
- Remove feature flag from the finding category hotspot widget on the monitoring regional dashboard

## How to test
- Impersonate a user of any access level, confirm that the finding category hotspot 
- Visit the collab reports landing page and confirm that the state territory  

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5222

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [x] QA review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [x] Staging smoke test completed
- [x] PR transitioned to **Open**
- [x] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
