### PR TITLE
Properly apply region filters to the monitoring dash

### DIFF
--- a/src/scopes/grantCitation/index.ts
+++ b/src/scopes/grantCitation/index.ts
@@ -6,9 +6,9 @@ export const topicToQuery = {
   citationRecipient: {
     in: (query: string[]) => withCitationRecipient(query),
   },
-  regionId: {
+  region: {
     in: (query: string[]) => withRegion(query),
-    notIn: (query: string[]) => withoutRegion(query),
+    nin: (query: string[]) => withoutRegion(query),
   },
 };
 

--- a/src/scopes/grantCitation/regionId.test.ts
+++ b/src/scopes/grantCitation/regionId.test.ts
@@ -5,19 +5,19 @@ describe('grantCitation/regionId', () => {
   describe('withRegion', () => {
     it('returns an Op.in clause for a single region', () => {
       expect(withRegion([1])).toEqual({
-        where: { region_id: { [Op.in]: [1] } },
+        region_id: { [Op.in]: [1] },
       });
     });
 
     it('returns an Op.in clause for multiple regions', () => {
       expect(withRegion([1, 2, 3])).toEqual({
-        where: { region_id: { [Op.in]: [1, 2, 3] } },
+        region_id: { [Op.in]: [1, 2, 3] },
       });
     });
 
     it('returns an Op.in clause with an empty array', () => {
       expect(withRegion([])).toEqual({
-        where: { region_id: { [Op.in]: [] } },
+        region_id: { [Op.in]: [] },
       });
     });
   });
@@ -25,19 +25,19 @@ describe('grantCitation/regionId', () => {
   describe('withoutRegion', () => {
     it('returns an Op.notIn clause for a single region', () => {
       expect(withoutRegion([1])).toEqual({
-        where: { region_id: { [Op.notIn]: [1] } },
+        region_id: { [Op.notIn]: [1] },
       });
     });
 
     it('returns an Op.notIn clause for multiple regions', () => {
       expect(withoutRegion([1, 2, 3])).toEqual({
-        where: { region_id: { [Op.notIn]: [1, 2, 3] } },
+        region_id: { [Op.notIn]: [1, 2, 3] },
       });
     });
 
     it('returns an Op.notIn clause with an empty array', () => {
       expect(withoutRegion([])).toEqual({
-        where: { region_id: { [Op.notIn]: [] } },
+        region_id: { [Op.notIn]: [] },
       });
     });
   });

--- a/src/scopes/grantCitation/regionId.ts
+++ b/src/scopes/grantCitation/regionId.ts
@@ -2,20 +2,16 @@ import { Op } from 'sequelize';
 
 export function withRegion(regions) {
   return {
-    where: {
-      region_id: {
-        [Op.in]: regions,
-      },
+    region_id: {
+      [Op.in]: regions,
     },
   };
 }
 
 export function withoutRegion(regions) {
   return {
-    where: {
-      region_id: {
-        [Op.notIn]: regions,
-      },
+    region_id: {
+      [Op.notIn]: regions,
     },
   };
 }


### PR DESCRIPTION
## Description of change

A typo in the region filters for the monitoring dash meant that "region" filter wasn't applied to the monitoring related TTA widget

## How to test
Impersonate a user with access to one region and confirm that on the monitoring regional dashboard > monitoring related TTA widget, the user can only see the appropriate citations

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
