### PR TITLE
[TTAHUB-5219] Unblock flag maint. job from reporting results to MaintenanceLogs

### DIFF
--- a/src/migrations/20260514000000-add_missing_maintenance_type_enum_values.js
+++ b/src/migrations/20260514000000-add_missing_maintenance_type_enum_values.js
@@ -1,0 +1,20 @@
+const { prepMigration, addValuesToEnumIfTheyDontExist } = require('../lib/migration');
+const { MAINTENANCE_TYPE } = require('../constants');
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await prepMigration(queryInterface, transaction, __filename);
+      await addValuesToEnumIfTheyDontExist(
+        queryInterface,
+        transaction,
+        'enum_MaintenanceLogs_type',
+        Object.values(MAINTENANCE_TYPE)
+      );
+    });
+  },
+  async down() {
+    // Postgres does not support removing enum values so a down would be more
+    // complex than it's worth.
+  },
+};


### PR DESCRIPTION
## Description of change

In the test environments Sequelize builds enums from definitions, so when I added it via SQL it caused collisions, but in production it needs to be added with the migration. This migration adds it the Sequelize way and should work for everybody.

## How to test

It's not obvious that there's a way to test this apart from watching to see that it works after deploy.

## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5219


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
