### PR TITLE
Remove ANC graph feature flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,2 @@
 {
-    "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/frontend/src/pages/RegionalDashboard/components/MonitoringReportDashboard.js
+++ b/frontend/src/pages/RegionalDashboard/components/MonitoringReportDashboard.js
@@ -1,7 +1,6 @@
 import { Grid } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
 import React from 'react';
-import FeatureFlag from '../../../components/FeatureFlag';
 import ActiveDeficientCitationsWithTtaSupport from '../../../widgets/ActiveDeficientCitationsWithTtaSupport';
 import ActiveNoncompliantCitationsWithTtaSupport from '../../../widgets/ActiveNoncompliantCitationsWithTtaSupport';
 import FindingCategoryHotspot from '../../../widgets/FindingCategoryHotspot';
@@ -17,11 +16,9 @@ export default function MonitoringReportDashboard({ filtersToApply }) {
       <Grid row>
         <ActiveDeficientCitationsWithTtaSupport filters={filtersToApply} />
       </Grid>
-      <FeatureFlag flag="monitoring-regional-dashboard">
-        <Grid row>
-          <ActiveNoncompliantCitationsWithTtaSupport filters={filtersToApply} />
-        </Grid>
-      </FeatureFlag>
+      <Grid row>
+        <ActiveNoncompliantCitationsWithTtaSupport filters={filtersToApply} />
+      </Grid>
       <Grid row>
         <FindingCategoryHotspot filters={filtersToApply} />
       </Grid>


### PR DESCRIPTION
## Description of change

Remove the feature flag from the Active noncompliant citations graph on the monitoring regional dashboard. A follow on PR will remove the flag entirely once I've confirmed we don't need it at all anymore.

## How to test

View the regional dashboard > monitoring tab impersonating a non-admin, non-feature flagged user
Confirm you can see the "active non-compliant citations" graph 

## Issue(s)




## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open**
- [ ] Reviewer added _(after transitioning to Open to ensure Slack notifications trigger; `elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR → Add reviewer_
  - _Confirm that Slack notification was sent after reviewer was added_

### After merge/deploy

- [ ] Update JIRA ticket status
