### PR TITLE
[TTAHUB-5388] rev postgresql client

### DIFF
--- a/automation/common/scripts/postgrescli_install.sh
+++ b/automation/common/scripts/postgrescli_install.sh
@@ -223,7 +223,7 @@ function cleanup() {
 function main() {
     local deb_url="https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.18-0+deb12u1_amd64.deb"
     local deb_file="/tmp/postgresql.deb"
-    local deb_sha256="7bd128ea802231ec6f601c56744deac916c8abbb066c3db148777e4ccc45dc16"
+    local deb_sha256="6974c43ddec4f383d099e7d642cd59d0af83c2c90c0fb153a4179aa1bb4d73c1"
     local bin_dir="/tmp/local/bin"
     local tools=("pg_dump" "pg_isready" "pg_restore" "psql" "reindexdb" "vacuumdb")
 

--- a/automation/common/scripts/postgrescli_install.sh
+++ b/automation/common/scripts/postgrescli_install.sh
@@ -221,7 +221,7 @@ function cleanup() {
 
 # Main function to control workflow
 function main() {
-    local deb_url="https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.16-0+deb12u1_amd64.deb"
+    local deb_url="https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.18-0+deb12u1_amd64.deb"
     local deb_file="/tmp/postgresql.deb"
     local deb_sha256="7bd128ea802231ec6f601c56744deac916c8abbb066c3db148777e4ccc45dc16"
     local bin_dir="/tmp/local/bin"

--- a/automation/common/scripts/postgrescli_install.sh
+++ b/automation/common/scripts/postgrescli_install.sh
@@ -223,7 +223,7 @@ function cleanup() {
 function main() {
     local deb_url="https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.18-0+deb12u1_amd64.deb"
     local deb_file="/tmp/postgresql.deb"
-    local deb_sha256="6974c43ddec4f383d099e7d642cd59d0af83c2c90c0fb153a4179aa1bb4d73c1"
+    local deb_sha256="fc98076d378231baac95d6eae09a3e01730cd706f4d00bbcda6ba580d38355a1"
     local bin_dir="/tmp/local/bin"
     local tools=("pg_dump" "pg_isready" "pg_restore" "psql" "reindexdb" "vacuumdb")
 


### PR DESCRIPTION
## Description of change

Due to the fact we still use a pinned deb for postgres tools, it periodically becomes unavailable as new versions are released.  Update the new pinned version and sha256 to match.  

Current versions can be seen here:
https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/

## How to test


## Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5388


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
