### PR TITLE
Fix syntax error in PR review metrics

### DIFF
--- a/.github/workflows/review-metrics-report.yml
+++ b/.github/workflows/review-metrics-report.yml
@@ -128,7 +128,7 @@ jobs:
             const reportLines = [
               `# Review Metrics Report`,
               ``,
-              `**Generated:** ${now} | **Repo:** ${owner}/${repo} | **Lookback:** ${lookbackDays}d (since ${since.slice(0, 10)}) | **PRs:** ${allPrs.length}/${maxPrs}`,
+              `**Generated:** ${now} | **Repo:** ${owner}/${repo} | **Lookback:** ${lookbackDays}d (since ${since.toISOString().slice(0, 10)}) | **PRs:** ${allPrs.length}/${maxPrs}`,
               ``,
               `## Summary`,
               ``,


### PR DESCRIPTION

## Description of change

`since` is a Date object; .slice() is a String method. Calling since.toISOString().slice(0, 10) produces the YYYY-MM-DD string.

## How to test
Error:
https://github.com/HHS/Head-Start-TTADP/actions/runs/26958691212
Fix: 
https://github.com/HHS/Head-Start-TTADP/actions/runs/26960688149/job/79549899775

## Issue(s)
- https://jira.acf.gov/browse/TTAHUB-5411


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] JIRA ticket status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
