### PR TITLE
[TTAHUB-5418] Add infra diagram, minor doc changes

### DIFF
--- a/docs/guides/dev-setup.md
+++ b/docs/guides/dev-setup.md
@@ -1,6 +1,6 @@
 # Dev Setup
 
-## Docker Setup
+## Local Docker Setup
 
 ### Prerequisites
 
@@ -72,8 +72,9 @@ Make sure you have access to cloud.gov spaces and required credentials.
 
 On macOS:
 
-1. `cf login -a api.fr.cloud.gov --sso`
-2. `bash ./bin/latest_backup.sh -d`
+1. Install cloud foundry cli: `brew install cloudfoundry/tap/cf-cli@8`
+1. `cf login --sso`
+2. `bash ./bin/latest_backup.sh`
 3. Ensure `psql` is installed.
 4. Start the Docker stack: `yarn docker:start`
 5. Create `bounce.sql` in repo root:

--- a/docs/guides/dev-setup.md
+++ b/docs/guides/dev-setup.md
@@ -73,7 +73,7 @@ Make sure you have access to cloud.gov spaces and required credentials.
 On macOS:
 
 1. Install cloud foundry cli: `brew install cloudfoundry/tap/cf-cli@8`
-1. `cf login --sso`
+2. `cf login -a api.fr.cloud.gov --sso`
 2. `bash ./bin/latest_backup.sh`
 3. Ensure `psql` is installed.
 4. Start the Docker stack: `yarn docker:start`

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -40,6 +40,7 @@ flowchart TB
             prodredis["prod redis"]
             prodapp --> proddb
             prodapp --> prodredis
+        end
 
         subgraph stagingspace["staging space"]
             direction TB
@@ -52,6 +53,7 @@ flowchart TB
             stagingredis["staging redis"]
             stagingapp --> stagingdb
             stagingapp --> stagingredis
+        end
 
         subgraph devspace["dev space"]
             direction TB

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -23,6 +23,8 @@
 
 ## Diagram
 
+```mermaid
+
 flowchart TB
     subgraph org["cloud.gov, TTA organization"]
         direction TB
@@ -63,7 +65,7 @@ flowchart TB
             devgreenapp --> devgreendb
         end
     end
-
+```
 
 ## Continuous Integration (CI)
 

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -62,9 +62,13 @@ flowchart TB
                 g1["instance"]
             end
             devbluedb["dev-blue db"]
+            devblueredis["dev-blue redis"]
             devgreendb["dev-green db"]
+            devgreenredis["dev-green redis"]
             devblueapp --> devbluedb
+            devblueapp --> devblueredis
             devgreenapp --> devgreendb
+            devgreenapp --> devgreenredis
         end
     end
 ```

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -49,8 +49,9 @@ flowchart TB
                 s2["instance"]
             end
             stagingdb["staging db"]
+            stagingredis["staging redis"]
             stagingapp --> stagingdb
-        end
+            stagingapp --> stagingredis
 
         subgraph devspace["dev space"]
             direction TB

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -37,8 +37,9 @@ flowchart TB
                 p2["instance"]
             end
             proddb["prod db"]
+            prodredis["prod redis"]
             prodapp --> proddb
-        end
+            prodapp --> prodredis
 
         subgraph stagingspace["staging space"]
             direction TB

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -21,6 +21,50 @@
 - There are multiple deployments within dev (blue, green, red, etc).  Each dev deployment consists of a single instance with dedicated database and redis, and has its own DNS entry.
 - Dev and staging databases are restored to an anonymized version of production data every night, via a schedule job that runs via CircleCI
 
+## Diagram
+
+flowchart TB
+    subgraph org["cloud.gov, TTA organization"]
+        direction TB
+
+        subgraph prodspace["prod space"]
+            direction TB
+            subgraph prodapp["prod app"]
+                direction LR
+                p1["instance"]
+                p2["instance"]
+            end
+            proddb["prod db"]
+            prodapp --> proddb
+        end
+
+        subgraph stagingspace["staging space"]
+            direction TB
+            subgraph stagingapp["staging app"]
+                direction LR
+                s1["instance"]
+                s2["instance"]
+            end
+            stagingdb["staging db"]
+            stagingapp --> stagingdb
+        end
+
+        subgraph devspace["dev space"]
+            direction TB
+            subgraph devblueapp["dev-blue app"]
+                b1["instance"]
+            end
+            subgraph devgreenapp["dev-green app"]
+                g1["instance"]
+            end
+            devbluedb["dev-blue db"]
+            devgreendb["dev-green db"]
+            devblueapp --> devbluedb
+            devgreenapp --> devgreendb
+        end
+    end
+
+
 ## Continuous Integration (CI)
 
 The bulk of CI configurations can be found in this repo's [.circleci/config.yml](../../.circleci/config.yml) file, the [application manifest](../../manifest.yml) and the environment specific [deployment_config](../../deployment_config/) variable files. Linting, unit tests, test coverage analysis, and an accessibility scan are all run automatically on each push to the HHS/Head-Start-TTADP repo. Merges to the main branch are blocked if the CI tests do not pass. For more information on the security audit and scan tools used in the continuous integration pipeline see [ADR 0009](../adr/0009-security-scans.md).


### PR DESCRIPTION
## Description of change

Add an inline mermaid infrastructure diagram to the existing infra doc.

Can be seen here:
https://github.com/HHS/Head-Start-TTADP/blob/tm/infra-docs/docs/guides/infrastructure.md#diagram

<img width="1116" height="371" alt="Screenshot 2026-06-10 at 2 39 39 PM" src="https://github.com/user-attachments/assets/8eea7376-01f6-4970-a0b8-51a433830f82" />


## How to test

N/A

## Jira Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5418

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- N/A Code is meaningfully tested
- N/A Meets accessibility standards (WCAG 2.1 Levels A, AA)
- N/A API Documentation updated
- N/A Boundary diagram updated
- N/A Logical Data Model updated
- N/A [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- N/A UI review complete
- N/A QA review complete
