### PR TITLE
[TTAHUB-5399] New overview widget for TR count on TTA History

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -10,7 +10,7 @@ import useSessionFiltersAndReflectInUrl from '../../../hooks/useSessionFiltersAn
 import { getUserRegions } from '../../../permissions';
 import UserContext from '../../../UserContext';
 import { expandFilters, formatDateRange } from '../../../utils';
-import Overview from '../../../widgets/DashboardOverview';
+import { TTAHistoryOverview } from '../../../widgets/DashboardOverview';
 import FrequencyGraph from '../../../widgets/FrequencyGraph';
 import TargetPopulationsTable from '../../../widgets/TargetPopulationsTable';
 import { TTAHISTORY_FILTER_CONFIG } from './constants';
@@ -90,8 +90,8 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
             allUserRegions={regions}
           />
         </div>
-        <Overview
-          fields={['Activity reports', 'Hours of TTA', 'Participants', 'In person activities']}
+        <TTAHistoryOverview
+          fields={['Activity reports', 'Training report sessions', 'Hours of TTA', 'Participants', 'In person activities']}
           showTooltips
           filters={filtersToApply}
         />

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -21,6 +21,7 @@ describe('Recipient Record - TTA History', () => {
     inPerson: '0',
     sumDuration: '1.0',
     numParticipants: '1',
+    numSessions: '3',
   };
 
   const tableResponse = {
@@ -53,10 +54,10 @@ describe('Recipient Record - TTA History', () => {
   };
 
   beforeEach(async () => {
-    const overviewUrl = `/api/widgets/overview?startDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`;
+    const ttaHistoryOverviewUrl = `/api/widgets/ttaHistoryOverview?startDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`;
     const tableUrl = `/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&startDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`;
 
-    fetchMock.get(overviewUrl, overviewResponse);
+    fetchMock.get(ttaHistoryOverviewUrl, overviewResponse);
     fetchMock.get(tableUrl, tableResponse);
 
     fetchMock.get(
@@ -77,6 +78,12 @@ describe('Recipient Record - TTA History', () => {
     act(() => renderTTAHistory());
     const overview = document.querySelector('.smart-hub--dashboard-overview-container');
     expect(overview).toBeTruthy();
+  });
+
+  it('renders the TR sessions widget', async () => {
+    act(() => renderTTAHistory());
+    const trSessionsLabel = await screen.findByText('Training report sessions');
+    expect(trSessionsLabel).toBeTruthy();
   });
 
   it('renders the activity reports table', async () => {
@@ -106,7 +113,7 @@ describe('Recipient Record - TTA History', () => {
       200
     );
     fetchMock.get(
-      '/api/widgets/overview?role.in[]=Family%20Engagement%20Specialist&role.in[]=Grantee%20Specialist&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/ttaHistoryOverview?role.in[]=Family%20Engagement%20Specialist&role.in[]=Grantee%20Specialist&region.in[]=1&recipientId.ctn[]=401',
       overviewResponse
     );
 

--- a/frontend/src/widgets/DashboardOverview.js
+++ b/frontend/src/widgets/DashboardOverview.js
@@ -81,6 +81,16 @@ const getDashboardFields = (data, showTooltip) => ({
     label1: 'Activity reports',
     data: data.numReports,
   },
+  'Training report sessions': {
+    key: 'training-report-sessions',
+    showTooltip,
+    tooltipText: 'The number of approved Training Report sessions.',
+    icon: faChartColumn,
+    iconColor: colors.success,
+    backgroundColor: colors.successLighter,
+    label1: 'Training report sessions',
+    data: data.numSessions,
+  },
   'Training reports': {
     key: 'training-reports',
     showTooltip,
@@ -230,6 +240,7 @@ DashboardOverviewWidget.propTypes = {
     recipientPercentage: PropTypes.string,
     totalRecipients: PropTypes.string,
     numRecipients: PropTypes.string,
+    numSessions: PropTypes.string,
     percentCompliantFollowUpReviewsWithTtaSupport: PropTypes.string,
     totalCompliantFollowUpReviewsWithTtaSupport: PropTypes.string,
     totalCompliantFollowUpReviews: PropTypes.string,
@@ -256,6 +267,7 @@ DashboardOverviewWidget.defaultProps = {
     totalRecipients: '0',
     recipientPercentage: '0%',
     numRecipients: '0',
+    numSessions: '0',
     percentCompliantFollowUpReviewsWithTtaSupport: '0%',
     totalCompliantFollowUpReviewsWithTtaSupport: '0',
     totalCompliantFollowUpReviews: '0',
@@ -277,5 +289,7 @@ DashboardOverviewWidget.defaultProps = {
   ],
   maxToolTipWidth: null,
 };
+
+export const TTAHistoryOverview = withWidgetData(DashboardOverviewWidget, 'ttaHistoryOverview');
 
 export default withWidgetData(DashboardOverviewWidget, 'overview');

--- a/src/scopes/grants/index.js
+++ b/src/scopes/grants/index.js
@@ -26,7 +26,6 @@ export const topicToQuery = {
     ctn: (query) => withRecipientId(query),
     in: (query) => withRecipientId(query),
     nin: (query) => withoutRecipientId(query),
-    ctn: (query) => withRecipientId(query),
   },
   programSpecialist: {
     ctn: (query) => withProgramSpecialist(query),

--- a/src/scopes/grants/index.js
+++ b/src/scopes/grants/index.js
@@ -23,6 +23,7 @@ export const topicToQuery = {
     nctn: (query) => withoutRecipientName(query),
   },
   recipientId: {
+    ctn: (query) => withRecipientId(query),
     in: (query) => withRecipientId(query),
     nin: (query) => withoutRecipientId(query),
   },

--- a/src/scopes/grants/recipientId.test.js
+++ b/src/scopes/grants/recipientId.test.js
@@ -32,6 +32,19 @@ describe('grants/recipientId', () => {
     });
   });
 
+  it('filters by recipientId.ctn (mapped to withRecipientId)', async () => {
+    const filters = { 'recipientId.ctn': [recipients[0].id] };
+    const scope = await filtersToScopes(filters, 'grant');
+    const found = await Grant.findAll({
+      where: { [Op.and]: [scope.grant.where, { id: possibleIds }] },
+    });
+
+    expect(found.length).toBeGreaterThan(0);
+    found.forEach((grant) => {
+      expect(grant.recipientId).toBe(recipients[0].id);
+    });
+  });
+
   it('filters by multiple recipientIds', async () => {
     const recipientIds = [recipients[0].id, recipients[1].id];
     const filters = { 'recipientId.in': recipientIds };

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -29,14 +29,14 @@ const logContext = {
  */
 export async function currentUserId(req, res) {
   function idFromSessionOrLocals() {
-    if (req.session && req.session.userId) {
+   /* if (req.session && req.session.userId) {
       httpContext.set('impersonationUserId', Number(req.session.userId));
       return Number(req.session.userId);
     }
     if (res.locals && res.locals.userId) {
       httpContext.set('impersonationUserId', Number(res.locals.userId));
       return Number(res.locals.userId);
-    }
+    }*/
 
     // bypass authorization, used for cucumber UAT and axe accessibility testing
     if (process.env.NODE_ENV !== 'production' && process.env.BYPASS_AUTH === 'true') {

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -34,7 +34,7 @@ export async function currentUserId(req, res) {
       return Number(req.session.userId);
     }
     if (res.locals && res.locals.userId) {
-      httpContext.set('impersonationUserId', Number(reßs.locals.userId));
+      httpContext.set('impersonationUserId', Number(res.locals.userId));
       return Number(res.locals.userId);
     }
 

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -29,14 +29,14 @@ const logContext = {
  */
 export async function currentUserId(req, res) {
   function idFromSessionOrLocals() {
-   /* if (req.session && req.session.userId) {
+   if (req.session && req.session.userId) {
       httpContext.set('impersonationUserId', Number(req.session.userId));
       return Number(req.session.userId);
     }
     if (res.locals && res.locals.userId) {
-      httpContext.set('impersonationUserId', Number(res.locals.userId));
+      httpContext.set('impersonationUserId', Number(reßs.locals.userId));
       return Number(res.locals.userId);
-    }*/
+    }
 
     // bypass authorization, used for cucumber UAT and axe accessibility testing
     if (process.env.NODE_ENV !== 'production' && process.env.BYPASS_AUTH === 'true') {

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -19,7 +19,9 @@ import totalHrsAndRecipientGraph from './totalHrsAndRecipientGraph';
 import trHoursOfTrainingByNationalCenter from './trHoursOfTrainingByNationalCenter';
 import trOverview from './trOverview';
 import trSessionsByTopic from './trSessionsByTopic';
+import trSessionsForRecipient from './trSessionsForRecipient';
 import trStandardGoalList from './trStandardGoalList';
+import ttaHistoryOverview from './ttaHistoryOverview';
 
 /*
   All widgets need to be added to this object
@@ -38,6 +40,8 @@ export default {
   trOverview,
   trStandardGoalList,
   trSessionsByTopic,
+  trSessionsForRecipient,
+  ttaHistoryOverview,
   trHoursOfTrainingByNationalCenter,
   approvalRateByDeadline,
 

--- a/src/widgets/trSessionsForRecipient.test.ts
+++ b/src/widgets/trSessionsForRecipient.test.ts
@@ -1,0 +1,225 @@
+import { TRAINING_REPORT_STATUSES } from '@ttahub/common';
+import db from '../models';
+import {
+  createGrant,
+  createRecipient,
+  createSessionReport,
+  createTrainingReport,
+  createUser,
+} from '../testUtils';
+import trSessionsForRecipient from './trSessionsForRecipient';
+
+const { EventReportPilot, Grant, Recipient, SessionReportPilot, User } = db;
+
+// We need to mock this so that we don't try to send emails or otherwise engage the queue
+jest.mock('bull');
+
+describe('TR sessions for recipient widget', () => {
+  let userCreator;
+
+  let recipient1;
+  let recipient2;
+
+  let grant1;
+  let grant2;
+
+  let trainingReport1;
+  let trainingReport2;
+
+  beforeAll(async () => {
+    userCreator = await createUser();
+
+    // recipient 1 - the target recipient for counting
+    recipient1 = await createRecipient();
+    // recipient 2 - other recipient; sessions on their grants should not count for recipient 1
+    recipient2 = await createRecipient();
+
+    // grant 1 belongs to recipient 1
+    grant1 = await createGrant({ recipientId: recipient1.id, regionId: userCreator.homeRegionId });
+    // grant 2 belongs to recipient 2
+    grant2 = await createGrant({ recipientId: recipient2.id, regionId: userCreator.homeRegionId });
+
+    // --- Training report 1: sessions for recipient1 ---
+    trainingReport1 = await createTrainingReport({
+      collaboratorIds: [],
+      pocIds: [],
+      ownerId: userCreator.id,
+    });
+
+    // Session 1: has recipient1's grant, COMPLETE -> counts for recipient1
+    await createSessionReport({
+      eventId: trainingReport1.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 10,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // Session 2: has recipient1's grant, COMPLETE -> counts for recipient1
+    await createSessionReport({
+      eventId: trainingReport1.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 10,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // Session 3: has recipient1's grant, IN_PROGRESS -> excluded by baseTRScopes (not COMPLETE)
+    await createSessionReport({
+      eventId: trainingReport1.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 10,
+        status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
+      },
+    });
+
+    await trainingReport1.update({
+      data: {
+        ...trainingReport1.data,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // --- Training report 2: session only for recipient2 ---
+    trainingReport2 = await createTrainingReport({
+      collaboratorIds: [],
+      pocIds: [],
+      ownerId: userCreator.id,
+    });
+
+    // Session 4: only has recipient2's grant, COMPLETE -> counts for recipient2, NOT recipient1
+    await createSessionReport({
+      eventId: trainingReport2.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant2.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 10,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    await trainingReport2.update({
+      data: {
+        ...trainingReport2.data,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await SessionReportPilot.destroy({
+      where: {
+        eventId: [trainingReport1.id, trainingReport2.id],
+      },
+    });
+
+    await EventReportPilot.destroy({
+      where: {
+        id: [trainingReport1.id, trainingReport2.id],
+      },
+    });
+
+    await db.GrantNumberLink.destroy({
+      where: {
+        grantId: [grant1.id, grant2.id],
+      },
+      force: true,
+    });
+
+    await Grant.destroy({
+      where: {
+        id: [grant1.id, grant2.id],
+      },
+      individualHooks: true,
+    });
+
+    await Recipient.destroy({
+      where: {
+        id: [recipient1.id, recipient2.id],
+      },
+    });
+
+    await User.destroy({
+      where: {
+        id: [userCreator.id],
+      },
+    });
+
+    await db.sequelize.close();
+  });
+
+  it('counts only COMPLETE sessions where the recipient has a matching grant', async () => {
+    // Scope restricted to our test data only
+    const scopes = {
+      grant: {
+        where: [{ id: [grant1.id, grant2.id] }],
+      },
+      trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
+    } as any;
+
+    const data = await trSessionsForRecipient(scopes, {
+      'recipientId.ctn': [String(recipient1.id)],
+    });
+
+    // session1 + session2 = 2 (session3 is IN_PROGRESS so excluded; session4 is for recipient2)
+    expect(data.numSessions).toBe('2');
+  });
+
+  it('does not count sessions belonging only to other recipients', async () => {
+    const scopes = {
+      grant: {
+        where: [{ id: [grant1.id, grant2.id] }],
+      },
+      trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
+    } as any;
+
+    const data = await trSessionsForRecipient(scopes, {
+      'recipientId.ctn': [String(recipient2.id)],
+    });
+
+    // Only session4 has grant2 (recipient2) and is COMPLETE
+    expect(data.numSessions).toBe('1');
+  });
+
+  it('returns 0 when no recipientId is provided', async () => {
+    const scopes = {
+      grant: {
+        where: [{ id: [grant1.id, grant2.id] }],
+      },
+      trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
+    } as any;
+
+    const data = await trSessionsForRecipient(scopes, {});
+    expect(data.numSessions).toBe('0');
+  });
+
+  it('returns 0 when an empty recipientId array is provided', async () => {
+    const scopes = {
+      grant: {
+        where: [{ id: [grant1.id, grant2.id] }],
+      },
+      trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
+    } as any;
+
+    const data = await trSessionsForRecipient(scopes, { 'recipientId.ctn': [] });
+    expect(data.numSessions).toBe('0');
+  });
+});

--- a/src/widgets/trSessionsForRecipient.test.ts
+++ b/src/widgets/trSessionsForRecipient.test.ts
@@ -167,59 +167,44 @@ describe('TR sessions for recipient widget', () => {
   });
 
   it('counts only COMPLETE sessions where the recipient has a matching grant', async () => {
-    // Scope restricted to our test data only
+    // Scope grant.where to only grant1 (recipient1) — mirrors what grantsFiltersToScopes produces
     const scopes = {
       grant: {
-        where: [{ id: [grant1.id, grant2.id] }],
+        where: [{ id: [grant1.id] }],
       },
       trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
     } as any;
 
-    const data = await trSessionsForRecipient(scopes, {
-      'recipientId.ctn': [String(recipient1.id)],
-    });
+    const data = await trSessionsForRecipient(scopes);
 
     // session1 + session2 = 2 (session3 is IN_PROGRESS so excluded; session4 is for recipient2)
     expect(data.numSessions).toBe('2');
   });
 
   it('does not count sessions belonging only to other recipients', async () => {
+    // Scope grant.where to only grant2 (recipient2)
     const scopes = {
       grant: {
-        where: [{ id: [grant1.id, grant2.id] }],
+        where: [{ id: [grant2.id] }],
       },
       trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
     } as any;
 
-    const data = await trSessionsForRecipient(scopes, {
-      'recipientId.ctn': [String(recipient2.id)],
-    });
+    const data = await trSessionsForRecipient(scopes);
 
     // Only session4 has grant2 (recipient2) and is COMPLETE
     expect(data.numSessions).toBe('1');
   });
 
-  it('returns 0 when no recipientId is provided', async () => {
+  it('returns 0 when no grants are in scope', async () => {
     const scopes = {
       grant: {
-        where: [{ id: [grant1.id, grant2.id] }],
+        where: [{ id: [] }],
       },
       trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
     } as any;
 
-    const data = await trSessionsForRecipient(scopes, {});
-    expect(data.numSessions).toBe('0');
-  });
-
-  it('returns 0 when an empty recipientId array is provided', async () => {
-    const scopes = {
-      grant: {
-        where: [{ id: [grant1.id, grant2.id] }],
-      },
-      trainingReport: [{ id: [trainingReport1.id, trainingReport2.id] }],
-    } as any;
-
-    const data = await trSessionsForRecipient(scopes, { 'recipientId.ctn': [] });
+    const data = await trSessionsForRecipient(scopes);
     expect(data.numSessions).toBe('0');
   });
 });

--- a/src/widgets/trSessionsForRecipient.ts
+++ b/src/widgets/trSessionsForRecipient.ts
@@ -4,18 +4,10 @@ import { validatedIdArray } from '../scopes/utils';
 import { baseTRScopes, formatNumber } from './helpers';
 import type { IScopes } from './types';
 
-const { EventReportPilot: TrainingReport, Grant } = db;
-
-interface ISessionReport {
-  data: {
-    recipients: {
-      value: number;
-    }[];
-  };
-}
+const { EventReportPilot: TrainingReport, Grant, sequelize } = db;
 
 interface ITrainingReportForSessionCount {
-  sessionReports: ISessionReport[];
+  sessionReports: { id: number }[];
 }
 
 /**
@@ -58,22 +50,32 @@ export default async function trSessionsForRecipient(
     return { numSessions: '0' };
   }
 
-  // Get completed training reports with their complete sessions via shared scope helper
+  // Build a SQL literal that restricts sessions to only those containing at least
+  // one of the recipient's grant IDs in the JSONB data.recipients array, pushing
+  // the filter into SQL rather than scanning all sessions in JS.
+  const grantIdList = [...recipientGrantIds].join(', ');
+  const recipientGrantFilter = sequelize.literal(`EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements("sessionReports"."data"->'recipients') elem
+    WHERE (elem->>'value')::integer IN (${grantIdList})
+  )`);
+
+  const baseScopes = baseTRScopes(scopes);
   const reports = (await TrainingReport.findAll({
     attributes: ['id'],
-    ...baseTRScopes(scopes),
+    ...baseScopes,
+    include: {
+      ...baseScopes.include,
+      attributes: ['id'],
+      where: {
+        ...baseScopes.include.where,
+        [Op.and]: [recipientGrantFilter],
+      },
+    },
   })) as ITrainingReportForSessionCount[];
 
-  // Count sessions where the recipient has at least one matching grant in data.recipients
-  let numSessions = 0;
-  reports.forEach((report) => {
-    report.sessionReports.forEach((session) => {
-      const sessionGrantIds = (session.data.recipients || []).map((r) => r.value);
-      if (sessionGrantIds.some((id) => recipientGrantIds.has(id))) {
-        numSessions += 1;
-      }
-    });
-  });
+  // Each session in the result already matches a recipient grant, so count them all.
+  const numSessions = reports.reduce((sum, r) => sum + r.sessionReports.length, 0);
 
   return { numSessions: formatNumber(numSessions) };
 }

--- a/src/widgets/trSessionsForRecipient.ts
+++ b/src/widgets/trSessionsForRecipient.ts
@@ -1,0 +1,79 @@
+import { Op } from 'sequelize';
+import db from '../models';
+import { validatedIdArray } from '../scopes/utils';
+import { baseTRScopes, formatNumber } from './helpers';
+import type { IScopes } from './types';
+
+const { EventReportPilot: TrainingReport, Grant } = db;
+
+interface ISessionReport {
+  data: {
+    recipients: {
+      value: number;
+    }[];
+  };
+}
+
+interface ITrainingReportForSessionCount {
+  sessionReports: ISessionReport[];
+}
+
+/**
+ * Widget: count of approved (COMPLETE) Training Report sessions for a given recipient.
+ * Used on the RTR TTA History tab.
+ *
+ * NOTE: The `numSessions` key returned here is per-recipient and is distinct from the
+ * `numSessions` returned by `trOverview`, which is a global count across visible TRs.
+ */
+export default async function trSessionsForRecipient(
+  scopes: IScopes,
+  query: Record<string, unknown>
+): Promise<{ numSessions: string }> {
+  const recipientIdsRaw = query['recipientId.ctn'];
+  const rawList = Array.isArray(recipientIdsRaw)
+    ? recipientIdsRaw
+    : recipientIdsRaw != null ? [recipientIdsRaw] : [];
+  const recipientIds = validatedIdArray(rawList.map((v) => String(v)));
+
+  if (!recipientIds.length) {
+    return { numSessions: '0' };
+  }
+
+  // Find all grants belonging to this recipient, respecting any active grant scopes
+  // (e.g. region) so we don't include grants the user isn't entitled to see.
+  const grants = (await Grant.findAll({
+    attributes: ['id'],
+    where: {
+      [Op.and]: [
+        { recipientId: { [Op.in]: recipientIds } },
+        scopes.grant.where,
+      ],
+    },
+    raw: true,
+  })) as { id: number }[];
+
+  const recipientGrantIds = new Set(grants.map((g) => g.id));
+
+  if (!recipientGrantIds.size) {
+    return { numSessions: '0' };
+  }
+
+  // Get completed training reports with their complete sessions via shared scope helper
+  const reports = (await TrainingReport.findAll({
+    attributes: ['id'],
+    ...baseTRScopes(scopes),
+  })) as ITrainingReportForSessionCount[];
+
+  // Count sessions where the recipient has at least one matching grant in data.recipients
+  let numSessions = 0;
+  reports.forEach((report) => {
+    report.sessionReports.forEach((session) => {
+      const sessionGrantIds = (session.data.recipients || []).map((r) => r.value);
+      if (sessionGrantIds.some((id) => recipientGrantIds.has(id))) {
+        numSessions += 1;
+      }
+    });
+  });
+
+  return { numSessions: formatNumber(numSessions) };
+}

--- a/src/widgets/trSessionsForRecipient.ts
+++ b/src/widgets/trSessionsForRecipient.ts
@@ -30,20 +30,36 @@ export default async function trSessionsForRecipient(
     raw: true,
   })) as { id: number }[];
 
-  const recipientGrantIds = new Set(grants.map((g) => g.id));
+  // Independently validate that every grant id is a positive integer before
+  // interpolating into the SQL literal below. Per AGENTS.md ("Traps to Avoid →
+  // SQL injection in filters"), `sequelize.escape` is insufficient — types
+  // must be re-checked at the SQL boundary even when the upstream source
+  // (here, Grant.findAll) is expected to return integers.
+  const grantIdList = [...new Set(grants.map((g) => g.id))]
+    .map((id) => Number(id))
+    .filter((id) => Number.isInteger(id) && id > 0);
 
-  if (!recipientGrantIds.size) {
+  if (grantIdList.length === 0) {
     return { numSessions: '0' };
   }
 
   // Build a SQL literal that restricts sessions to only those containing at least
   // one of the recipient's grant IDs in the JSONB data.recipients array, pushing
   // the filter into SQL rather than scanning all sessions in JS.
-  const grantIdList = [...recipientGrantIds].join(', ');
+  //
+  // Guard the ::integer cast against malformed session data: a single recipient
+  // entry whose `value` is null, an object, or a non-numeric string would
+  // otherwise raise "invalid input syntax for type integer" and fail the
+  // entire widget for everyone in scope. We accept either a JSONB number or
+  // a JSONB string of digits, and skip everything else.
   const recipientGrantFilter = sequelize.literal(`EXISTS (
     SELECT 1
     FROM jsonb_array_elements("sessionReports"."data"->'recipients') elem
-    WHERE (elem->>'value')::integer IN (${grantIdList})
+    WHERE (
+      jsonb_typeof(elem->'value') = 'number'
+      OR (jsonb_typeof(elem->'value') = 'string' AND elem->>'value' ~ '^[0-9]+$')
+    )
+    AND (elem->>'value')::integer IN (${grantIdList.join(', ')})
   )`);
 
   const baseScopes = baseTRScopes(scopes);

--- a/src/widgets/trSessionsForRecipient.ts
+++ b/src/widgets/trSessionsForRecipient.ts
@@ -1,6 +1,5 @@
 import { Op } from 'sequelize';
 import db from '../models';
-import { validatedIdArray } from '../scopes/utils';
 import { baseTRScopes, formatNumber } from './helpers';
 import type { IScopes } from './types';
 
@@ -14,33 +13,20 @@ interface ITrainingReportForSessionCount {
  * Widget: count of approved (COMPLETE) Training Report sessions for a given recipient.
  * Used on the RTR TTA History tab.
  *
+ * The recipient filter flows in via scopes.grant.where (from the recipientId.ctn
+ * URL param processed by grantsFiltersToScopes), matching how all other overview
+ * widgets are scoped.
+ *
  * NOTE: The `numSessions` key returned here is per-recipient and is distinct from the
  * `numSessions` returned by `trOverview`, which is a global count across visible TRs.
  */
 export default async function trSessionsForRecipient(
-  scopes: IScopes,
-  query: Record<string, unknown>
+  scopes: IScopes
 ): Promise<{ numSessions: string }> {
-  const recipientIdsRaw = query['recipientId.ctn'];
-  const rawList = Array.isArray(recipientIdsRaw)
-    ? recipientIdsRaw
-    : recipientIdsRaw != null ? [recipientIdsRaw] : [];
-  const recipientIds = validatedIdArray(rawList.map((v) => String(v)));
-
-  if (!recipientIds.length) {
-    return { numSessions: '0' };
-  }
-
-  // Find all grants belonging to this recipient, respecting any active grant scopes
-  // (e.g. region) so we don't include grants the user isn't entitled to see.
+  // Find all grants visible to this user/recipient via the standard grant scopes.
   const grants = (await Grant.findAll({
     attributes: ['id'],
-    where: {
-      [Op.and]: [
-        { recipientId: { [Op.in]: recipientIds } },
-        scopes.grant.where,
-      ],
-    },
+    where: scopes.grant.where,
     raw: true,
   })) as { id: number }[];
 

--- a/src/widgets/ttaHistoryOverview.test.ts
+++ b/src/widgets/ttaHistoryOverview.test.ts
@@ -37,16 +37,6 @@ describe('ttaHistoryOverview widget', () => {
     expect(result).toEqual({ ...AR_DATA, numSessions: '7' });
   });
 
-  it('passes the query object through to trSessionsForRecipient', async () => {
-    mockOverview.mockResolvedValue(AR_DATA);
-    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '3' });
-
-    const query = { 'recipientId.ctn': ['42'], 'region.in': ['7'] };
-    await ttaHistoryOverview(SCOPES, query);
-
-    expect(mockTrSessionsForRecipient).toHaveBeenCalledWith(SCOPES, query);
-  });
-
   it('numSessions from trSessionsForRecipient overwrites any numSessions from overview', async () => {
     mockOverview.mockResolvedValue({ ...AR_DATA, numSessions: 'should-be-overwritten' } as any);
     mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '4' });
@@ -63,6 +53,6 @@ describe('ttaHistoryOverview widget', () => {
     await ttaHistoryOverview(SCOPES, {});
 
     expect(mockOverview).toHaveBeenCalledWith(SCOPES);
-    expect(mockTrSessionsForRecipient).toHaveBeenCalledWith(SCOPES, {});
+    expect(mockTrSessionsForRecipient).toHaveBeenCalledWith(SCOPES);
   });
 });

--- a/src/widgets/ttaHistoryOverview.test.ts
+++ b/src/widgets/ttaHistoryOverview.test.ts
@@ -1,0 +1,68 @@
+import ttaHistoryOverview from './ttaHistoryOverview';
+
+jest.mock('./overview');
+jest.mock('./trSessionsForRecipient');
+
+import overview from './overview';
+import trSessionsForRecipient from './trSessionsForRecipient';
+
+const mockOverview = overview as jest.MockedFunction<typeof overview>;
+const mockTrSessionsForRecipient = trSessionsForRecipient as jest.MockedFunction<typeof trSessionsForRecipient>;
+
+const AR_DATA = {
+  numReports: '5',
+  numGrants: '3',
+  numRecipients: '2',
+  totalRecipients: '10',
+  sumDuration: '12',
+  inPerson: '2',
+  numParticipants: '40',
+  recipientPercentage: '20.00%',
+  numOtherEntities: '0',
+};
+
+const SCOPES = {} as any;
+
+describe('ttaHistoryOverview widget', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('merges AR overview data with numSessions from trSessionsForRecipient', async () => {
+    mockOverview.mockResolvedValue(AR_DATA);
+    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '7' });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    expect(result).toEqual({ ...AR_DATA, numSessions: '7' });
+  });
+
+  it('passes the query object through to trSessionsForRecipient', async () => {
+    mockOverview.mockResolvedValue(AR_DATA);
+    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '3' });
+
+    const query = { 'recipientId.ctn': ['42'], 'region.in': ['7'] };
+    await ttaHistoryOverview(SCOPES, query);
+
+    expect(mockTrSessionsForRecipient).toHaveBeenCalledWith(SCOPES, query);
+  });
+
+  it('numSessions from trSessionsForRecipient overwrites any numSessions from overview', async () => {
+    mockOverview.mockResolvedValue({ ...AR_DATA, numSessions: 'should-be-overwritten' } as any);
+    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '4' });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    expect(result.numSessions).toBe('4');
+  });
+
+  it('calls both overview and trSessionsForRecipient with the same scopes', async () => {
+    mockOverview.mockResolvedValue(AR_DATA);
+    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '0' });
+
+    await ttaHistoryOverview(SCOPES, {});
+
+    expect(mockOverview).toHaveBeenCalledWith(SCOPES);
+    expect(mockTrSessionsForRecipient).toHaveBeenCalledWith(SCOPES, {});
+  });
+});

--- a/src/widgets/ttaHistoryOverview.ts
+++ b/src/widgets/ttaHistoryOverview.ts
@@ -1,0 +1,21 @@
+import overview from './overview';
+import trSessionsForRecipient from './trSessionsForRecipient';
+import type { IScopes } from './types';
+
+/**
+ * Combined widget for the TTA History tab overview row.
+ * Returns all standard Activity Report overview metrics plus the count of
+ * approved Training Report sessions for the recipient, so both can be rendered
+ * in a single in-order field row.
+ */
+export default async function ttaHistoryOverview(
+  scopes: IScopes,
+  query: Record<string, unknown>
+) {
+  const [arData, trData] = await Promise.all([
+    overview(scopes),
+    trSessionsForRecipient(scopes, query),
+  ]);
+
+  return { ...arData, numSessions: trData.numSessions };
+}

--- a/src/widgets/ttaHistoryOverview.ts
+++ b/src/widgets/ttaHistoryOverview.ts
@@ -10,8 +10,10 @@ import type { IScopes } from './types';
  */
 export default async function ttaHistoryOverview(
   scopes: IScopes,
-  query: Record<string, unknown>
-) {
+  // Accepted to match the widget runner signature in
+  // src/routes/widgets/handlers.js; not currently used by this widget.
+  _query: Record<string, unknown>
+): Promise<Record<string, string> & { numSessions: string }> {
   const [arData, trData] = await Promise.all([
     overview(scopes),
     trSessionsForRecipient(scopes),

--- a/src/widgets/ttaHistoryOverview.ts
+++ b/src/widgets/ttaHistoryOverview.ts
@@ -14,7 +14,7 @@ export default async function ttaHistoryOverview(
 ) {
   const [arData, trData] = await Promise.all([
     overview(scopes),
-    trSessionsForRecipient(scopes, query),
+    trSessionsForRecipient(scopes),
   ]);
 
   return { ...arData, numSessions: trData.numSessions };


### PR DESCRIPTION
## Description of change

This PR adds a new TR overview widget to the TTA History page. It introduces a `ttaHistoryOverview` backend widget that combines existing Activity Report overview metrics with a per-recipient Training Report session count (`numSessions`), and wires it into the frontend TTA History page via a new `TTAHistoryOverview` named export from `DashboardOverview`.

Also merged latest `main` branch changes (TTAHUB-5340 AR vs TR graph) which added `ApprovedARAndTRByGoalCategory` to the TTA History page.

## How to test

- Review the code
- Ensure we show the correct formatting and data per recipient being viewed.


## Jira Issue(s)



* https://jira.acf.gov/browse/TTAHUB-5399


## Checklists

### Every PR


- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status