### PR TITLE
[PROD] TTAHUB-5400 Add TR hours to TTA History overview

### DIFF
--- a/src/widgets/trSessionsForRecipient.test.ts
+++ b/src/widgets/trSessionsForRecipient.test.ts
@@ -65,7 +65,7 @@ describe('TR sessions for recipient widget', () => {
       eventId: trainingReport1.id,
       data: {
         deliveryMethod: 'in-person',
-        duration: 1,
+        duration: 1.5,
         recipients: [{ value: grant1.id }],
         numberOfParticipantsVirtually: 0,
         numberOfParticipantsInPerson: 0,
@@ -107,7 +107,7 @@ describe('TR sessions for recipient widget', () => {
       eventId: trainingReport2.id,
       data: {
         deliveryMethod: 'in-person',
-        duration: 1,
+        duration: 2,
         recipients: [{ value: grant2.id }],
         numberOfParticipantsVirtually: 0,
         numberOfParticipantsInPerson: 0,
@@ -179,6 +179,8 @@ describe('TR sessions for recipient widget', () => {
 
     // session1 + session2 = 2 (session3 is IN_PROGRESS so excluded; session4 is for recipient2)
     expect(data.numSessions).toBe('2');
+    // session1 duration (1) + session2 duration (1.5) = 2.5
+    expect(data.sumDuration).toBe(2.5);
     // session1 (10) + session2 (10) = 20 participants
     expect(data.numParticipants).toBe(20);
   });
@@ -196,6 +198,8 @@ describe('TR sessions for recipient widget', () => {
 
     // Only session4 has grant2 (recipient2) and is COMPLETE
     expect(data.numSessions).toBe('1');
+    // session4 duration (2)
+    expect(data.sumDuration).toBe(2);
     // session4 numberOfParticipants = 10
     expect(data.numParticipants).toBe(10);
   });
@@ -210,6 +214,7 @@ describe('TR sessions for recipient widget', () => {
 
     const data = await trSessionsForRecipient(scopes);
     expect(data.numSessions).toBe('0');
+    expect(data.sumDuration).toBe(0);
     expect(data.numParticipants).toBe(0);
   });
 
@@ -254,6 +259,8 @@ describe('TR sessions for recipient widget', () => {
       expect(data.numSessions).toBe('1');
       // hybrid: 4 + 3 = 7 (numberOfParticipants is ignored on hybrid path)
       expect(data.numParticipants).toBe(7);
+      // hybrid session duration (1)
+      expect(data.sumDuration).toBe(1);
     } finally {
       await SessionReportPilot.destroy({ where: { eventId: hybridTr.id } });
       await EventReportPilot.destroy({ where: { id: hybridTr.id } });

--- a/src/widgets/trSessionsForRecipient.ts
+++ b/src/widgets/trSessionsForRecipient.ts
@@ -7,6 +7,7 @@ const { EventReportPilot: TrainingReport, Grant, sequelize } = db;
 
 interface ISessionDataForRecipient {
   deliveryMethod?: string;
+  duration?: number | string;
   numberOfParticipants?: number | string;
   numberOfParticipantsInPerson?: number | string;
   numberOfParticipantsVirtually?: number | string;
@@ -39,7 +40,8 @@ function getSessionParticipantCount(data: ISessionDataForRecipient): number {
 
 /**
  * Widget: count of approved (COMPLETE) Training Report sessions for a given recipient,
- * plus the total number of participants across those sessions.
+ * plus the total hours of TTA delivered and the total number of participants
+ * across those sessions.
  * Used on the RTR TTA History tab.
  *
  * The recipient filter flows in via scopes.grant.where (from the recipientId.ctn
@@ -48,12 +50,12 @@ function getSessionParticipantCount(data: ISessionDataForRecipient): number {
  *
  * NOTE: The `numSessions` key returned here is per-recipient and is distinct from the
  * `numSessions` returned by `trOverview`, which is a global count across visible TRs.
- * `numParticipants` is returned as a raw number so it can be summed with the AR
- * participant count in `ttaHistoryOverview`; formatting happens in the caller.
+ * `sumDuration` and `numParticipants` are returned as raw numbers so they can be
+ * summed with the AR values in `ttaHistoryOverview`; formatting happens in the caller.
  */
 export default async function trSessionsForRecipient(
   scopes: IScopes
-): Promise<{ numSessions: string; numParticipants: number }> {
+): Promise<{ numSessions: string; sumDuration: number; numParticipants: number }> {
   // Find all grants visible to this user/recipient via the standard grant scopes.
   const grants = (await Grant.findAll({
     attributes: ['id'],
@@ -71,7 +73,7 @@ export default async function trSessionsForRecipient(
     .filter((id) => Number.isInteger(id) && id > 0);
 
   if (grantIdList.length === 0) {
-    return { numSessions: '0', numParticipants: 0 };
+    return { numSessions: '0', sumDuration: 0, numParticipants: 0 };
   }
 
   // Build a SQL literal that restricts sessions to only those containing at least
@@ -110,6 +112,17 @@ export default async function trSessionsForRecipient(
   // Each session in the result already matches a recipient grant, so count them all.
   const numSessions = reports.reduce((sum, r) => sum + r.sessionReports.length, 0);
 
+  // Sum the duration across every matching session. Sessions store duration as a
+  // number in JSONB, but we parseFloat defensively to match the activity report
+  // overview's handling of legacy/string-typed durations.
+  const sumDuration = reports.reduce(
+    (sum, r) => sum + r.sessionReports.reduce(
+      (sessionSum, s) => sessionSum + (parseFloat(s.data?.duration as string) || 0),
+      0,
+    ),
+    0,
+  );
+
   // Sum participants across every matching session using the same per-delivery-method
   // logic as `trOverview`, so the combined widget value stays consistent with the
   // global TR overview.
@@ -121,5 +134,5 @@ export default async function trSessionsForRecipient(
     0,
   );
 
-  return { numSessions: formatNumber(numSessions), numParticipants };
+  return { numSessions: formatNumber(numSessions), sumDuration, numParticipants };
 }

--- a/src/widgets/ttaHistoryOverview.test.ts
+++ b/src/widgets/ttaHistoryOverview.test.ts
@@ -28,28 +28,73 @@ describe('ttaHistoryOverview widget', () => {
     jest.clearAllMocks();
   });
 
-  it('merges AR overview data with numSessions and combined numParticipants', async () => {
+  it('merges AR overview data with numSessions, combined sumDuration, and combined numParticipants', async () => {
     mockOverview.mockResolvedValue(AR_DATA);
-    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '7', numParticipants: 13 });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '7',
+      sumDuration: 3.5,
+      numParticipants: 13,
+    });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
+    // AR sumDuration "12" + TR sumDuration 3.5 = 15.5 (formatted with 1 decimal)
     // AR numParticipants 40 + TR numParticipants 13 = 53
-    expect(result).toEqual({ ...AR_DATA, numParticipants: '53', numSessions: '7' });
+    expect(result).toEqual({
+      ...AR_DATA,
+      sumDuration: '15.5',
+      numParticipants: '53',
+      numSessions: '7',
+    });
   });
 
   it('numSessions from trSessionsForRecipient overwrites any numSessions from overview', async () => {
     mockOverview.mockResolvedValue({ ...AR_DATA, numSessions: 'should-be-overwritten' } as any);
-    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '4', numParticipants: 0 });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '4',
+      sumDuration: 0,
+      numParticipants: 0,
+    });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
     expect(result.numSessions).toBe('4');
   });
 
+  it('parses AR sumDuration with thousands separators before summing', async () => {
+    mockOverview.mockResolvedValue({ ...AR_DATA, sumDuration: '1,234.5' });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 10,
+      numParticipants: 0,
+    });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    // 1234.5 + 10 = 1244.5
+    expect(result.sumDuration).toBe('1,244.5');
+  });
+
+  it('falls back to 0 hours when AR sumDuration is missing', async () => {
+    mockOverview.mockResolvedValue({ ...AR_DATA, sumDuration: undefined } as any);
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 2.5,
+      numParticipants: 0,
+    });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    expect(result.sumDuration).toBe('2.5');
+  });
+
   it('strips thousands separators from numParticipants before summing', async () => {
     mockOverview.mockResolvedValue({ ...AR_DATA, numParticipants: '1,234' });
-    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '0', numParticipants: 10 });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 0,
+      numParticipants: 10,
+    });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
@@ -61,7 +106,11 @@ describe('ttaHistoryOverview widget', () => {
 
   it('falls back to 0 participants when AR numParticipants is missing', async () => {
     mockOverview.mockResolvedValue({ ...AR_DATA, numParticipants: undefined } as any);
-    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '0', numParticipants: 5 });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 0,
+      numParticipants: 5,
+    });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
@@ -70,7 +119,11 @@ describe('ttaHistoryOverview widget', () => {
 
   it('calls both overview and trSessionsForRecipient with the same scopes', async () => {
     mockOverview.mockResolvedValue(AR_DATA);
-    mockTrSessionsForRecipient.mockResolvedValue({ numSessions: '0', numParticipants: 0 });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 0,
+      numParticipants: 0,
+    });
 
     await ttaHistoryOverview(SCOPES, {});
 

--- a/src/widgets/ttaHistoryOverview.ts
+++ b/src/widgets/ttaHistoryOverview.ts
@@ -9,6 +9,10 @@ import type { IScopes } from './types';
  * approved Training Report sessions for the recipient, so both can be rendered
  * in a single in-order field row.
  *
+ * `sumDuration` represents the total hours of TTA delivered to the recipient
+ * across approved Activity Reports AND approved Training Report sessions
+ * combined, so the "Hours of TTA" widget reflects both delivery channels.
+ *
  * `numParticipants` represents the total participants on approved Activity
  * Reports AND approved Training Report sessions combined for the recipient,
  * so the "Participants" widget reflects both delivery channels.
@@ -24,6 +28,12 @@ export default async function ttaHistoryOverview(
     trSessionsForRecipient(scopes),
   ]);
 
+  // `overview` returns sumDuration formatted with toLocaleString (e.g. "1,234.5"),
+  // so strip the thousands separators before parsing to combine with the raw
+  // numeric TR duration.
+  const arDuration = parseFloat((arData.sumDuration || '0').replace(/,/g, '')) || 0;
+  const combinedSumDuration = formatNumber(arDuration + trData.sumDuration, 1);
+
   // overview() returns numParticipants as a locale-formatted string (e.g.
   // "1,234"). Strip the thousands separators before parsing so we can sum
   // it with the TR participant count and re-format the total.
@@ -34,6 +44,7 @@ export default async function ttaHistoryOverview(
 
   return {
     ...arData,
+    sumDuration: combinedSumDuration,
     numParticipants: combinedNumParticipants,
     numSessions: trData.numSessions,
   };


### PR DESCRIPTION
## Description of change

_Note: This ticket was missed in the last PROD PR due to a merge conflict. The other PR has been updated to reflect that it doesn't contain this update._

**TTAHUB-5400:** It adds TR hours to the TTA History hours overview widget.

## How to test

**TTAHUB-5400:**  This adds TR hours to the TTA History hours overview widget.

## Jira Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5400

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [x] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
