### PR TITLE
[TTAHUB-5402] Add TR in person count to overview widget on TTA History tab

### DIFF
--- a/docs/openapi/paths/index.yaml
+++ b/docs/openapi/paths/index.yaml
@@ -60,6 +60,8 @@
   $ref: './goals/goal-status.yaml'
 '/widgets/overview':
   $ref: './widgets/overview.yaml'
+'/widgets/ttaHistoryOverview':
+  $ref: './widgets/ttaHistoryOverview.yaml'
 '/widgets/monitoringOverview':
   $ref: './widgets/monitoringOverview.yaml'
 '/widgets/monitoringTta':

--- a/docs/openapi/paths/widgets/ttaHistoryOverview.yaml
+++ b/docs/openapi/paths/widgets/ttaHistoryOverview.yaml
@@ -1,0 +1,39 @@
+get:
+  tags:
+    - widgets
+  operationId: ttaHistoryOverview
+  description: >
+    Gets combined overview metrics for the TTA History tab on the Recipient
+    TTA Record. All numeric fields are formatted strings (e.g. "1,234").
+    `sumDuration`, `numParticipants`, and `inPerson` combine values from
+    approved Activity Reports and approved Training Report sessions.
+    `numSessions` is the count of approved Training Report sessions only.
+  responses:
+    200:
+      description: Combined AR and TR overview metrics for the recipient
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              numReports:
+                type: string
+                description: Number of approved Activity Reports
+              numGrants:
+                type: string
+                description: Number of grants with approved Activity Reports
+              numOtherEntities:
+                type: string
+                description: Number of other entities with approved Activity Reports
+              sumDuration:
+                type: string
+                description: Total hours of TTA across approved ARs and TR sessions
+              numParticipants:
+                type: string
+                description: Total participants across approved ARs and TR sessions
+              inPerson:
+                type: string
+                description: Count of in-person activities across approved ARs and TR sessions
+              numSessions:
+                type: string
+                description: Count of approved Training Report sessions

--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -121,3 +121,20 @@ export function formatNumber(numberToFormat, decimalPlaces = 0) {
     maximumFractionDigits: decimalPlaces,
   });
 }
+
+/**
+ * Parse a value that may be a locale-formatted numeric string (e.g. "1,234.5"
+ * produced by `formatNumber`) back into a plain JavaScript number.
+ *
+ * Strips thousands separators (",") before parsing so values previously
+ * formatted with `toLocaleString('en-US', ...)` round-trip cleanly. Returns 0
+ * for null, undefined, empty, or non-numeric input so callers can safely sum
+ * the result without additional guards.
+ */
+export function parseFormattedNumber(value) {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  const parsed = parseFloat(String(value).replace(/,/g, ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/src/widgets/helpers.test.js
+++ b/src/widgets/helpers.test.js
@@ -1,4 +1,4 @@
-import { baseTRScopes, countBySingleKey, formatNumber } from './helpers';
+import { baseTRScopes, countBySingleKey, formatNumber, parseFormattedNumber } from './helpers';
 
 describe('Format Number', () => {
   it('renders with correct decimal places and separator', async () => {
@@ -22,6 +22,48 @@ describe('Format Number', () => {
     expect(formatNumber('sdfgdfg', 3)).toBe('0');
 
     expect(formatNumber()).toBe('0');
+  });
+});
+
+describe('parseFormattedNumber', () => {
+  it('parses a plain integer string', () => {
+    expect(parseFormattedNumber('1234')).toBe(1234);
+  });
+
+  it('strips thousands separators before parsing', () => {
+    expect(parseFormattedNumber('1,234')).toBe(1234);
+    expect(parseFormattedNumber('1,234,567')).toBe(1234567);
+  });
+
+  it('parses a locale-formatted decimal string', () => {
+    expect(parseFormattedNumber('1,234.5')).toBe(1234.5);
+  });
+
+  it('round-trips a value produced by formatNumber', () => {
+    expect(parseFormattedNumber(formatNumber(12345.678, 2))).toBe(12345.68);
+  });
+
+  it('accepts a numeric value and returns it unchanged', () => {
+    expect(parseFormattedNumber(42)).toBe(42);
+    expect(parseFormattedNumber(3.14)).toBe(3.14);
+    expect(parseFormattedNumber(0)).toBe(0);
+  });
+
+  it('returns 0 for null, undefined, or empty input', () => {
+    expect(parseFormattedNumber(null)).toBe(0);
+    expect(parseFormattedNumber(undefined)).toBe(0);
+    expect(parseFormattedNumber('')).toBe(0);
+  });
+
+  it('returns 0 for non-numeric strings', () => {
+    expect(parseFormattedNumber('abc')).toBe(0);
+    expect(parseFormattedNumber(',,,')).toBe(0);
+  });
+
+  it('returns 0 for NaN/Infinity to keep sums finite', () => {
+    expect(parseFormattedNumber(NaN)).toBe(0);
+    expect(parseFormattedNumber(Infinity)).toBe(0);
+    expect(parseFormattedNumber(-Infinity)).toBe(0);
   });
 });
 

--- a/src/widgets/trSessionsForRecipient.test.ts
+++ b/src/widgets/trSessionsForRecipient.test.ts
@@ -183,6 +183,8 @@ describe('TR sessions for recipient widget', () => {
     expect(data.sumDuration).toBe(2.5);
     // session1 (10) + session2 (10) = 20 participants
     expect(data.numParticipants).toBe(20);
+    // session1 + session2 are both in-person and COMPLETE
+    expect(data.numInPerson).toBe(2);
   });
 
   it('does not count sessions belonging only to other recipients', async () => {
@@ -202,6 +204,8 @@ describe('TR sessions for recipient widget', () => {
     expect(data.sumDuration).toBe(2);
     // session4 numberOfParticipants = 10
     expect(data.numParticipants).toBe(10);
+    // session4 is in-person
+    expect(data.numInPerson).toBe(1);
   });
 
   it('returns 0 when no grants are in scope', async () => {
@@ -216,6 +220,7 @@ describe('TR sessions for recipient widget', () => {
     expect(data.numSessions).toBe('0');
     expect(data.sumDuration).toBe(0);
     expect(data.numParticipants).toBe(0);
+    expect(data.numInPerson).toBe(0);
   });
 
   it('sums hybrid session participants from in-person + virtual counts', async () => {
@@ -261,9 +266,102 @@ describe('TR sessions for recipient widget', () => {
       expect(data.numParticipants).toBe(7);
       // hybrid session duration (1)
       expect(data.sumDuration).toBe(1);
+      // hybrid is NOT counted as in-person — matches the AR overview's strict
+      // equality check on the 'in-person' delivery method
+      expect(data.numInPerson).toBe(0);
     } finally {
       await SessionReportPilot.destroy({ where: { eventId: hybridTr.id } });
       await EventReportPilot.destroy({ where: { id: hybridTr.id } });
+    }
+  });
+
+  it('counts only sessions with deliveryMethod === "in-person" in numInPerson', async () => {
+    const mixedTr = await createTrainingReport({
+      collaboratorIds: [],
+      pocIds: [],
+      ownerId: userCreator.id,
+    });
+
+    // in-person -> counted
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 5,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // virtual -> not counted
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'virtual',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 5,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // hybrid -> not counted as in-person
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'hybrid',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 1,
+        numberOfParticipantsInPerson: 2,
+        numberOfParticipants: 0,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // in-person but IN_PROGRESS -> excluded by baseTRScopes
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 5,
+        status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
+      },
+    });
+
+    await mixedTr.update({
+      data: {
+        ...mixedTr.data,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    try {
+      const scopes = {
+        grant: {
+          where: [{ id: [grant1.id] }],
+        },
+        trainingReport: [{ id: [mixedTr.id] }],
+      } as any;
+
+      const data = await trSessionsForRecipient(scopes);
+
+      // 3 COMPLETE sessions (in-person, virtual, hybrid) — the IN_PROGRESS one is excluded
+      expect(data.numSessions).toBe('3');
+      // Only the single COMPLETE in-person session counts
+      expect(data.numInPerson).toBe(1);
+    } finally {
+      await SessionReportPilot.destroy({ where: { eventId: mixedTr.id } });
+      await EventReportPilot.destroy({ where: { id: mixedTr.id } });
     }
   });
 });

--- a/src/widgets/trSessionsForRecipient.ts
+++ b/src/widgets/trSessionsForRecipient.ts
@@ -40,8 +40,8 @@ function getSessionParticipantCount(data: ISessionDataForRecipient): number {
 
 /**
  * Widget: count of approved (COMPLETE) Training Report sessions for a given recipient,
- * plus the total hours of TTA delivered and the total number of participants
- * across those sessions.
+ * plus the total hours of TTA delivered, the total number of participants,
+ * and the count of in-person sessions across those sessions.
  * Used on the RTR TTA History tab.
  *
  * The recipient filter flows in via scopes.grant.where (from the recipientId.ctn
@@ -50,12 +50,23 @@ function getSessionParticipantCount(data: ISessionDataForRecipient): number {
  *
  * NOTE: The `numSessions` key returned here is per-recipient and is distinct from the
  * `numSessions` returned by `trOverview`, which is a global count across visible TRs.
- * `sumDuration` and `numParticipants` are returned as raw numbers so they can be
- * summed with the AR values in `ttaHistoryOverview`; formatting happens in the caller.
+ * `sumDuration`, `numParticipants`, and `numInPerson` are returned as raw numbers so
+ * they can be summed with the AR values in `ttaHistoryOverview`; formatting happens
+ * in the caller.
+ *
+ * `numInPerson` matches the activity report overview's strict equality check on the
+ * 'in-person' delivery method (see `src/widgets/overview.js`); hybrid sessions are
+ * intentionally excluded so the combined "In person activities" widget stays
+ * consistent with the AR-only behavior.
  */
 export default async function trSessionsForRecipient(
   scopes: IScopes
-): Promise<{ numSessions: string; sumDuration: number; numParticipants: number }> {
+): Promise<{
+  numSessions: string;
+  sumDuration: number;
+  numParticipants: number;
+  numInPerson: number;
+}> {
   // Find all grants visible to this user/recipient via the standard grant scopes.
   const grants = (await Grant.findAll({
     attributes: ['id'],
@@ -73,7 +84,9 @@ export default async function trSessionsForRecipient(
     .filter((id) => Number.isInteger(id) && id > 0);
 
   if (grantIdList.length === 0) {
-    return { numSessions: '0', sumDuration: 0, numParticipants: 0 };
+    return {
+      numSessions: '0', sumDuration: 0, numParticipants: 0, numInPerson: 0,
+    };
   }
 
   // Build a SQL literal that restricts sessions to only those containing at least
@@ -134,5 +147,17 @@ export default async function trSessionsForRecipient(
     0,
   );
 
-  return { numSessions: formatNumber(numSessions), sumDuration, numParticipants };
+  // Count sessions whose delivery method is strictly 'in-person', mirroring the
+  // AR overview's equality check so the combined "In person activities" widget
+  // counts AR and TR sessions the same way.
+  const numInPerson = reports.reduce(
+    (sum, r) => sum + r.sessionReports.filter(
+      (s) => (s.data?.deliveryMethod || '').toLowerCase() === 'in-person',
+    ).length,
+    0,
+  );
+
+  return {
+    numSessions: formatNumber(numSessions), sumDuration, numParticipants, numInPerson,
+  };
 }

--- a/src/widgets/ttaHistoryOverview.test.ts
+++ b/src/widgets/ttaHistoryOverview.test.ts
@@ -137,7 +137,7 @@ describe('ttaHistoryOverview widget', () => {
     const result = await ttaHistoryOverview(SCOPES, {});
 
     // 1,234 + 6 = 1,240, formatted with thousands separator. Confirms commas
-    // are stripped before parseInt — otherwise parseInt('1,234') => 1.
+    // are stripped before parseFloat — otherwise parseFloat('1,234') => 1.
     expect(result.inPerson).toBe('1,240');
   });
 

--- a/src/widgets/ttaHistoryOverview.test.ts
+++ b/src/widgets/ttaHistoryOverview.test.ts
@@ -28,22 +28,25 @@ describe('ttaHistoryOverview widget', () => {
     jest.clearAllMocks();
   });
 
-  it('merges AR overview data with numSessions, combined sumDuration, and combined numParticipants', async () => {
+  it('merges AR overview data with numSessions, combined sumDuration, combined numParticipants, and combined inPerson', async () => {
     mockOverview.mockResolvedValue(AR_DATA);
     mockTrSessionsForRecipient.mockResolvedValue({
       numSessions: '7',
       sumDuration: 3.5,
       numParticipants: 13,
+      numInPerson: 4,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
     // AR sumDuration "12" + TR sumDuration 3.5 = 15.5 (formatted with 1 decimal)
     // AR numParticipants 40 + TR numParticipants 13 = 53
+    // AR inPerson 2 + TR numInPerson 4 = 6
     expect(result).toEqual({
       ...AR_DATA,
       sumDuration: '15.5',
       numParticipants: '53',
+      inPerson: '6',
       numSessions: '7',
     });
   });
@@ -54,6 +57,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '4',
       sumDuration: 0,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -67,6 +71,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 10,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -81,6 +86,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 2.5,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -94,6 +100,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 0,
       numParticipants: 10,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -110,11 +117,42 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 0,
       numParticipants: 5,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
     expect(result.numParticipants).toBe('5');
+  });
+
+  it('strips thousands separators from inPerson before summing', async () => {
+    mockOverview.mockResolvedValue({ ...AR_DATA, inPerson: '1,234' });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 0,
+      numParticipants: 0,
+      numInPerson: 6,
+    });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    // 1,234 + 6 = 1,240, formatted with thousands separator. Confirms commas
+    // are stripped before parseInt — otherwise parseInt('1,234') => 1.
+    expect(result.inPerson).toBe('1,240');
+  });
+
+  it('falls back to 0 in-person when AR inPerson is missing', async () => {
+    mockOverview.mockResolvedValue({ ...AR_DATA, inPerson: undefined } as any);
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 0,
+      numParticipants: 0,
+      numInPerson: 3,
+    });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    expect(result.inPerson).toBe('3');
   });
 
   it('calls both overview and trSessionsForRecipient with the same scopes', async () => {
@@ -123,6 +161,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 0,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     await ttaHistoryOverview(SCOPES, {});

--- a/src/widgets/ttaHistoryOverview.ts
+++ b/src/widgets/ttaHistoryOverview.ts
@@ -1,6 +1,6 @@
 import overview from './overview';
 import trSessionsForRecipient from './trSessionsForRecipient';
-import { formatNumber } from './helpers';
+import { formatNumber, parseFormattedNumber } from './helpers';
 import type { IScopes } from './types';
 
 /**
@@ -16,6 +16,11 @@ import type { IScopes } from './types';
  * `numParticipants` represents the total participants on approved Activity
  * Reports AND approved Training Report sessions combined for the recipient,
  * so the "Participants" widget reflects both delivery channels.
+ *
+ * `inPerson` represents the count of in-person activities across approved
+ * Activity Reports AND approved Training Report sessions combined for the
+ * recipient, so the "In person activities" widget reflects both delivery
+ * channels.
  */
 export default async function ttaHistoryOverview(
   scopes: IScopes,
@@ -28,24 +33,25 @@ export default async function ttaHistoryOverview(
     trSessionsForRecipient(scopes),
   ]);
 
-  // `overview` returns sumDuration formatted with toLocaleString (e.g. "1,234.5"),
-  // so strip the thousands separators before parsing to combine with the raw
-  // numeric TR duration.
-  const arDuration = parseFloat((arData.sumDuration || '0').replace(/,/g, '')) || 0;
-  const combinedSumDuration = formatNumber(arDuration + trData.sumDuration, 1);
-
-  // overview() returns numParticipants as a locale-formatted string (e.g.
-  // "1,234"). Strip the thousands separators before parsing so we can sum
-  // it with the TR participant count and re-format the total.
-  const arParticipants = parseInt((arData.numParticipants || '0').replace(/,/g, ''), 10) || 0;
+  // `overview` returns AR aggregates as locale-formatted strings (e.g.
+  // "1,234.5"), so use `parseFormattedNumber` to strip thousands separators
+  // and coerce to a number before summing with the raw numeric TR values.
+  const combinedSumDuration = formatNumber(
+    parseFormattedNumber(arData.sumDuration) + trData.sumDuration,
+    1,
+  );
   const combinedNumParticipants = formatNumber(
-    arParticipants + trData.numParticipants
+    parseFormattedNumber(arData.numParticipants) + trData.numParticipants,
+  );
+  const combinedInPerson = formatNumber(
+    parseFormattedNumber(arData.inPerson) + trData.numInPerson,
   );
 
   return {
     ...arData,
     sumDuration: combinedSumDuration,
     numParticipants: combinedNumParticipants,
+    inPerson: combinedInPerson,
     numSessions: trData.numSessions,
   };
 }


### PR DESCRIPTION
## Description of change

This adds the TR approved reports to the in-person overview count widget on the TTA History tab of the RTR.

## How to test

- Review the code changes.
- Ensure the count now reflects both AR and TR counts.


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5402


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
