### PR TITLE
[Prod] Add work-in-progress notification preferences page, force left alignment in help drawers

### DIFF
--- a/frontend/babel.jest.config.cjs
+++ b/frontend/babel.jest.config.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }],
+    '@babel/preset-typescript',
     '@babel/preset-react',
   ],
 };

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,3 +1,0 @@
-{
-  "exclude": ["node_modules"]
-}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     "@babel/core": "^7.28.4",
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.28.4",
+    "@babel/preset-typescript": "^7.29.7",
     "@biomejs/biome": "^2.3.14",
     "@sheerun/mutationobserver-shim": "^0.3.3",
     "@testing-library/dom": "^8.11.1",

--- a/frontend/src/Routes.js
+++ b/frontend/src/Routes.js
@@ -15,6 +15,7 @@ import SomethingWentWrong from './components/SomethingWentWrong';
 import useGaPageView from './hooks/useGaPageView';
 import AccountManagement from './pages/AccountManagement';
 import Group from './pages/AccountManagement/Group';
+import ManageNotifications from './pages/AccountManagement/ManageNotifications';
 import MyGroups from './pages/AccountManagement/MyGroups';
 import ActivityReport from './pages/ActivityReport';
 import Admin from './pages/Admin';
@@ -355,6 +356,17 @@ export default function Routes({
             <AppWrapper authenticated logout={logout} hasAlerts={!!alert}>
               <RegionalCommunicationLogDashboard />
             </AppWrapper>
+          )}
+        />
+        <Route
+          exact
+          path="/account/notifications/:token?"
+          render={() => (
+            <FeatureFlag renderNotFound flag="actionable_notifications">
+              <AppWrapper authenticated logout={logout} hasAlerts={!!alert}>
+                <ManageNotifications updateUser={updateUser} />
+              </AppWrapper>
+            </FeatureFlag>
           )}
         />
         <Route

--- a/frontend/src/components/Container.d.ts
+++ b/frontend/src/components/Container.d.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export interface ContainerProps {
+  children: React.ReactNode;
+  className?: string;
+  paddingX?: number;
+  paddingY?: number;
+  skipTopPadding?: boolean;
+  skipBottomPadding?: boolean;
+  loading?: boolean;
+  loadingLabel?: string;
+  positionRelative?: boolean;
+}
+
+declare const Container: React.ForwardRefExoticComponent<
+  ContainerProps & React.RefAttributes<HTMLDivElement>
+>;
+
+export default Container;

--- a/frontend/src/components/ContentFromFeedByTag.js
+++ b/frontend/src/components/ContentFromFeedByTag.js
@@ -76,7 +76,7 @@ export default function ContentFromFeedByTag({
     };
   }, [contentSelector, tagName]);
 
-  const classNames = `${className} ttahub-single-feed-item--by-tag ${contentSelector ? 'ttahub-single-feed-item--by-tag--with-selector' : ''}`;
+  const classNames = `${className} ttahub-single-feed-item--by-tag text-left ${contentSelector ? 'ttahub-single-feed-item--by-tag--with-selector' : ''}`;
   return (
     <div className={classNames}>
       <FeedArticle

--- a/frontend/src/pages/AccountManagement/ManageNotifications.test.tsx
+++ b/frontend/src/pages/AccountManagement/ManageNotifications.test.tsx
@@ -1,0 +1,493 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import AppLoadingContext from '../../AppLoadingContext';
+import UserContext from '../../UserContext';
+import ManageNotifications from './ManageNotifications';
+
+const mockClearAlertsCaptures: Record<string, Array<unknown>> = {
+  activityReport: [],
+  collabReport: [],
+  communicationLog: [],
+  trainingReport: [],
+  systemRelated: [],
+  other: [],
+};
+
+jest.mock('./EmailVerifier', () => () => <div data-testid="email-verifier" />);
+
+jest.mock('./components/notifications/ActivityReportNotifications', () => {
+  const { useFormContext } = require('react-hook-form');
+
+  return function MockActivityReportNotifications(props: { clearAlerts?: boolean }) {
+    const { register } = useFormContext();
+    mockClearAlertsCaptures.activityReport.push(props.clearAlerts);
+
+    return (
+      <div data-testid="activity-report-notifications">
+        <span data-testid="activity-report-clear-alerts">{String(props.clearAlerts)}</span>
+        <label htmlFor="emailWhenReportSubmittedForReview">Submitted for review</label>
+        <select
+          id="emailWhenReportSubmittedForReview"
+          name="emailWhenReportSubmittedForReview"
+          ref={register}
+        >
+          <option value="never">Never</option>
+          <option value="immediately">Immediately</option>
+          <option value="today">Daily digest</option>
+          <option value="this week">Weekly digest</option>
+          <option value="this month">Monthly digest</option>
+        </select>
+      </div>
+    );
+  };
+});
+
+jest.mock('./components/notifications/CollabReportNotifications', () => {
+  const { useFormContext } = require('react-hook-form');
+
+  return function MockCollabReportNotifications(props: { clearAlerts?: boolean }) {
+    const { register } = useFormContext();
+    mockClearAlertsCaptures.collabReport.push(props.clearAlerts);
+
+    return (
+      <div data-testid="collab-report-notifications">
+        <span data-testid="collab-report-clear-alerts">{String(props.clearAlerts)}</span>
+        {[
+          'emailWhenChangeRequested',
+          'emailWhenReportApproval',
+          'emailWhenAppointedCollaborator',
+        ].map((name) => (
+          <div key={name}>
+            <label htmlFor={name}>{name}</label>
+            <select id={name} name={name} ref={register}>
+              <option value="never">Never</option>
+              <option value="immediately">Immediately</option>
+              <option value="today">Daily digest</option>
+              <option value="this week">Weekly digest</option>
+              <option value="this month">Monthly digest</option>
+            </select>
+          </div>
+        ))}
+      </div>
+    );
+  };
+});
+
+jest.mock(
+  './components/notifications/CommunicationLogNotification',
+  () =>
+    function MockCommunicationLogNotifications(props: { clearAlerts?: boolean }) {
+      mockClearAlertsCaptures.communicationLog.push(props.clearAlerts);
+      return (
+        <div data-testid="communication-log-notifications">
+          <span data-testid="communication-log-clear-alerts">{String(props.clearAlerts)}</span>
+        </div>
+      );
+    }
+);
+
+jest.mock('./components/notifications/TrainingReportNotifications', () => {
+  const { useFormContext } = require('react-hook-form');
+
+  return function MockTrainingReportNotifications(props: { clearAlerts?: boolean }) {
+    const { register } = useFormContext();
+    mockClearAlertsCaptures.trainingReport.push(props.clearAlerts);
+
+    return (
+      <div data-testid="training-report-notifications">
+        <span data-testid="training-report-clear-alerts">{String(props.clearAlerts)}</span>
+        <label htmlFor="emailWhenRecipientReportApprovedProgramSpecialist">
+          Recipient report approved
+        </label>
+        <select
+          id="emailWhenRecipientReportApprovedProgramSpecialist"
+          name="emailWhenRecipientReportApprovedProgramSpecialist"
+          ref={register}
+        >
+          <option value="never">Never</option>
+          <option value="immediately">Immediately</option>
+          <option value="today">Daily digest</option>
+          <option value="this week">Weekly digest</option>
+          <option value="this month">Monthly digest</option>
+        </select>
+      </div>
+    );
+  };
+});
+
+jest.mock(
+  './components/notifications/SystemRelatedNotifications',
+  () =>
+    function MockSystemRelatedNotifications(props: { clearAlerts?: boolean }) {
+      mockClearAlertsCaptures.systemRelated.push(props.clearAlerts);
+      return (
+        <div data-testid="system-related-notifications">
+          <span data-testid="system-related-clear-alerts">{String(props.clearAlerts)}</span>
+        </div>
+      );
+    }
+);
+
+jest.mock(
+  './components/notifications/OtherNotifications',
+  () =>
+    function MockOtherNotifications(props: { clearAlerts?: boolean }) {
+      mockClearAlertsCaptures.other.push(props.clearAlerts);
+      return (
+        <div data-testid="other-notifications">
+          <span data-testid="other-clear-alerts">{String(props.clearAlerts)}</span>
+        </div>
+      );
+    }
+);
+
+describe('ManageNotifications', () => {
+  const validatedUser = {
+    id: 1,
+    validationStatus: [{ type: 'email', validatedAt: '2024-01-01T00:00:00.000Z' }],
+  };
+
+  const unvalidatedUser = {
+    id: 1,
+    validationStatus: [],
+  };
+
+  const emailSettings = [
+    { key: 'emailWhenReportSubmittedForReview', value: 'this week' },
+    { key: 'emailWhenChangeRequested', value: 'today' },
+    { key: 'emailWhenReportApproval', value: 'immediately' },
+    { key: 'emailWhenAppointedCollaborator', value: 'this week' },
+    { key: 'emailWhenRecipientReportApprovedProgramSpecialist', value: 'today' },
+  ];
+
+  const renderManageNotifications = ({
+    user = validatedUser,
+    setIsAppLoading = jest.fn(),
+    updateUser = jest.fn(),
+  }: {
+    user?: { id: number; validationStatus: Array<{ type: string; validatedAt?: string }> };
+    setIsAppLoading?: jest.Mock;
+    updateUser?: jest.Mock;
+  } = {}) =>
+    render(
+      <MemoryRouter>
+        <AppLoadingContext.Provider value={{ isAppLoading: false, setIsAppLoading }}>
+          <UserContext.Provider value={{ user }}>
+            <ManageNotifications updateUser={updateUser} />
+          </UserContext.Provider>
+        </AppLoadingContext.Provider>
+      </MemoryRouter>
+    );
+
+  beforeEach(() => {
+    Object.keys(mockClearAlertsCaptures).forEach((key) => {
+      mockClearAlertsCaptures[key] = [];
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.restoreAllMocks();
+  });
+
+  it('renders the heading, back link, and all accordion sections', async () => {
+    fetchMock.get('/api/settings/email', emailSettings);
+
+    renderManageNotifications();
+
+    expect(screen.getByRole('heading', { name: 'Notification Preferences' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to Notifications' })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Activity Reports')).toBeInTheDocument();
+    });
+
+    [
+      'Collaboration Reports',
+      'Communication Logs',
+      'Training Reports',
+      'System Related',
+      'Other',
+    ].forEach((section) => {
+      expect(screen.getByText(section)).toBeInTheDocument();
+    });
+  });
+
+  it('loads email settings on mount and seeds form values from the response', async () => {
+    fetchMock.get('/api/settings/email', emailSettings);
+
+    renderManageNotifications();
+
+    await waitFor(() => expect(fetchMock.called('/api/settings/email')).toBe(true));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Submitted for review')).toHaveValue('this week');
+      expect(screen.getByLabelText('emailWhenChangeRequested')).toHaveValue('today');
+      expect(screen.getByLabelText('emailWhenReportApproval')).toHaveValue('immediately');
+      expect(screen.getByLabelText('emailWhenAppointedCollaborator')).toHaveValue('this week');
+      expect(screen.getByLabelText('Recipient report approved')).toHaveValue('today');
+    });
+  });
+
+  it('keeps defaults when loading email settings fails', async () => {
+    fetchMock.get('/api/settings/email', { throws: new Error('unable to load') });
+
+    renderManageNotifications();
+
+    expect(screen.getByRole('heading', { name: 'Notification Preferences' })).toBeInTheDocument();
+
+    await waitFor(() => expect(fetchMock.called('/api/settings/email')).toBe(true));
+
+    expect(screen.getByLabelText('Submitted for review')).toHaveValue('never');
+    expect(screen.getByLabelText('emailWhenChangeRequested')).toHaveValue('never');
+    expect(screen.getByLabelText('Recipient report approved')).toHaveValue('never');
+  });
+
+  it('toggles app loading around the initial fetch', async () => {
+    fetchMock.get('/api/settings/email', emailSettings);
+    const setIsAppLoading = jest.fn();
+
+    renderManageNotifications({ setIsAppLoading });
+
+    await waitFor(() => {
+      expect(setIsAppLoading).toHaveBeenNthCalledWith(1, true);
+      expect(setIsAppLoading).toHaveBeenNthCalledWith(2, false);
+    });
+  });
+
+  it('submits settings for verified users and shows a success alert', async () => {
+    fetchMock.get('/api/settings/email', emailSettings);
+    fetchMock.put('/api/settings', 204);
+
+    renderManageNotifications();
+
+    fireEvent.change(screen.getByLabelText('Submitted for review'), {
+      target: { value: 'today' },
+    });
+    fireEvent.change(screen.getByLabelText('emailWhenChangeRequested'), {
+      target: { value: 'this week' },
+    });
+    fireEvent.change(screen.getByLabelText('emailWhenReportApproval'), {
+      target: { value: 'immediately' },
+    });
+    fireEvent.change(screen.getByLabelText('emailWhenAppointedCollaborator'), {
+      target: { value: 'today' },
+    });
+    fireEvent.change(screen.getByLabelText('Recipient report approved'), {
+      target: { value: 'this week' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save preferences' }));
+
+    await waitFor(() => expect(fetchMock.called('/api/settings')).toBe(true));
+    await waitFor(() => {
+      expect(screen.getByText('Your preferences have been saved.')).toBeInTheDocument();
+    });
+
+    const lastCall = fetchMock.lastCall('/api/settings');
+    const payload = JSON.parse(String(lastCall?.[1]?.body));
+
+    expect(payload).toEqual([
+      { key: 'emailWhenReportSubmittedForReview', value: 'today' },
+      { key: 'emailWhenChangeRequested', value: 'this week' },
+      { key: 'emailWhenReportApproval', value: 'immediately' },
+      { key: 'emailWhenAppointedCollaborator', value: 'today' },
+      { key: 'emailWhenRecipientReportApprovedProgramSpecialist', value: 'this week' },
+    ]);
+  });
+
+  it('shows an error alert when updating settings fails', async () => {
+    fetchMock.get('/api/settings/email', emailSettings);
+    fetchMock.put('/api/settings', { throws: new Error('Unable to save preferences') });
+
+    renderManageNotifications();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save preferences' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/there was an error saving your preferences: unable to save preferences/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('requests a verification email and updates the button label on success', async () => {
+    fetchMock.get('/api/settings/email', emailSettings);
+    fetchMock.post('/api/users/send-verification-email', 200);
+
+    renderManageNotifications({ user: unvalidatedUser });
+
+    fireEvent.click(screen.getByTestId('send-verification-email-button'));
+
+    await waitFor(() => {
+      expect(fetchMock.called('/api/users/send-verification-email')).toBe(true);
+      expect(screen.getByTestId('send-verification-email-button')).toHaveTextContent(
+        'Resend verification email'
+      );
+    });
+  });
+
+  it('surfaces verification email errors through EmailValidationPreferenceBox', async () => {
+    fetchMock.get('/api/settings/email', emailSettings);
+    fetchMock.post('/api/users/send-verification-email', {
+      throws: new Error('Unable to send verification email'),
+    });
+
+    renderManageNotifications({ user: unvalidatedUser });
+
+    fireEvent.click(screen.getByTestId('send-verification-email-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to send verification email')).toBeInTheDocument();
+    });
+  });
+
+  describe('clearAlerts propagation', () => {
+    const recipientSections = [
+      'activityReport',
+      'collabReport',
+      'communicationLog',
+      'trainingReport',
+    ] as const;
+
+    const nonRecipientSections = ['systemRelated', 'other'] as const;
+
+    it('starts with clearAlerts === false on every section that accepts the prop', async () => {
+      fetchMock.get('/api/settings/email', emailSettings);
+
+      renderManageNotifications();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-report-notifications')).toBeInTheDocument();
+      });
+
+      recipientSections.forEach((section) => {
+        expect(mockClearAlertsCaptures[section]).not.toHaveLength(0);
+        expect(mockClearAlertsCaptures[section].every((value) => value === false)).toBe(true);
+      });
+    });
+
+    it('never forwards clearAlerts to SystemRelated or Other notifications', async () => {
+      fetchMock.get('/api/settings/email', emailSettings);
+      fetchMock.post('/api/users/send-verification-email', 200);
+
+      renderManageNotifications({ user: unvalidatedUser });
+
+      fireEvent.click(screen.getByTestId('send-verification-email-button'));
+
+      await waitFor(() => {
+        expect(fetchMock.called('/api/users/send-verification-email')).toBe(true);
+      });
+
+      nonRecipientSections.forEach((section) => {
+        expect(mockClearAlertsCaptures[section]).not.toHaveLength(0);
+        expect(mockClearAlertsCaptures[section].every((value) => value === undefined)).toBe(true);
+      });
+    });
+
+    it('toggles clearAlerts true and resets it back to false (one-shot) on each verification request', async () => {
+      fetchMock.get('/api/settings/email', emailSettings);
+      fetchMock.post('/api/users/send-verification-email', 200);
+
+      renderManageNotifications({ user: unvalidatedUser });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-report-notifications')).toBeInTheDocument();
+      });
+
+      recipientSections.forEach((section) => {
+        mockClearAlertsCaptures[section] = [];
+      });
+
+      fireEvent.click(screen.getByTestId('send-verification-email-button'));
+
+      await waitFor(() => {
+        recipientSections.forEach((section) => {
+          expect(mockClearAlertsCaptures[section]).toContain(true);
+        });
+      });
+
+      await waitFor(() => {
+        recipientSections.forEach((section) => {
+          const history = mockClearAlertsCaptures[section];
+          expect(history[history.length - 1]).toBe(false);
+        });
+      });
+
+      recipientSections.forEach((section) => {
+        const history = mockClearAlertsCaptures[section];
+        const lastTrueIdx = history.lastIndexOf(true);
+        expect(lastTrueIdx).toBeGreaterThanOrEqual(0);
+        expect(history.slice(lastTrueIdx + 1).every((value) => value === false)).toBe(true);
+      });
+    });
+
+    it('re-fires the clearAlerts cycle when the verification button is clicked again', async () => {
+      fetchMock.get('/api/settings/email', emailSettings);
+      fetchMock.post('/api/users/send-verification-email', 200);
+
+      renderManageNotifications({ user: unvalidatedUser });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-report-notifications')).toBeInTheDocument();
+      });
+
+      recipientSections.forEach((section) => {
+        mockClearAlertsCaptures[section] = [];
+      });
+
+      fireEvent.click(screen.getByTestId('send-verification-email-button'));
+
+      await waitFor(() => {
+        const history = mockClearAlertsCaptures.activityReport;
+        expect(history.lastIndexOf(true)).toBeGreaterThanOrEqual(0);
+        expect(history[history.length - 1]).toBe(false);
+      });
+
+      const trueCountsAfterFirst = recipientSections.map(
+        (section) => mockClearAlertsCaptures[section].filter((value) => value === true).length
+      );
+
+      fireEvent.click(screen.getByTestId('send-verification-email-button'));
+
+      await waitFor(() => {
+        recipientSections.forEach((section, idx) => {
+          const totalTrueCount = mockClearAlertsCaptures[section].filter(
+            (value) => value === true
+          ).length;
+          expect(totalTrueCount).toBeGreaterThan(trueCountsAfterFirst[idx]);
+        });
+      });
+
+      await waitFor(() => {
+        recipientSections.forEach((section) => {
+          const history = mockClearAlertsCaptures[section];
+          expect(history[history.length - 1]).toBe(false);
+        });
+      });
+    });
+
+    it('reflects the current clearAlerts value through the child data-testid after the reset settles', async () => {
+      fetchMock.get('/api/settings/email', emailSettings);
+      fetchMock.post('/api/users/send-verification-email', 200);
+
+      renderManageNotifications({ user: unvalidatedUser });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-report-clear-alerts')).toHaveTextContent('false');
+      });
+
+      fireEvent.click(screen.getByTestId('send-verification-email-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activity-report-clear-alerts')).toHaveTextContent('false');
+        expect(screen.getByTestId('collab-report-clear-alerts')).toHaveTextContent('false');
+        expect(screen.getByTestId('communication-log-clear-alerts')).toHaveTextContent('false');
+        expect(screen.getByTestId('training-report-clear-alerts')).toHaveTextContent('false');
+      });
+    });
+  });
+});

--- a/frontend/src/pages/AccountManagement/ManageNotifications.tsx
+++ b/frontend/src/pages/AccountManagement/ManageNotifications.tsx
@@ -1,0 +1,277 @@
+import { Accordion, Alert, Button } from '@trussworks/react-uswds';
+import type { AccordionItemProps } from '@trussworks/react-uswds/lib/components/Accordion/Accordion';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Link } from 'react-router-dom';
+import AppLoadingContext from '../../AppLoadingContext';
+import BackLink from '../../components/BackLink';
+import Container from '../../components/Container';
+import { getEmailSettings, updateSettings } from '../../fetchers/settings';
+import { requestVerificationEmail } from '../../fetchers/users';
+import UserContext from '../../UserContext';
+import { emailTypesMap } from '.';
+import ActivityReportNotifications from './components/notifications/ActivityReportNotifications';
+import CollabReportNotifications from './components/notifications/CollabReportNotifications';
+import CommunicationLogNotifications from './components/notifications/CommunicationLogNotification';
+import EmailValidationPreferenceBox from './components/notifications/EmailValidationPreferenceBox';
+import OtherNotifications from './components/notifications/OtherNotifications';
+import SystemRelatedNotifications from './components/notifications/SystemRelatedNotifications';
+import TrainingReportNotifications from './components/notifications/TrainingReportNotifications';
+
+type EmailFrequency = 'never' | 'immediately' | 'today' | 'this week' | 'this month';
+
+interface SettingFormData {
+  emailWhenAppointedCollaborator: EmailFrequency;
+  emailWhenChangeRequested: EmailFrequency;
+  emailWhenRecipientReportApprovedProgramSpecialist: EmailFrequency;
+  emailWhenReportApproval: EmailFrequency;
+  emailWhenReportSubmittedForReview: EmailFrequency;
+  inAppWhenAppointedCollaborator: boolean;
+  inAppWhenChangeRequested: boolean;
+  inAppWhenRecipientReportApprovedProgramSpecialist: boolean;
+  inAppWhenReportApproval: boolean;
+  inAppWhenReportSubmittedForReview: boolean;
+}
+
+export default function ManageNotifications({
+  updateUser,
+}: {
+  updateUser: (user: { id: number }) => void;
+}): JSX.Element {
+  const { user } = useContext(UserContext);
+  const { setIsAppLoading } = useContext(AppLoadingContext) as {
+    setIsAppLoading: (isLoading: boolean) => void;
+  };
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [clearAlerts, setClearAlerts] = useState(false);
+  const [saveError, setSaveError] = useState<string | false>(false);
+  const [emailValidated, setEmailValidated] = useState(false);
+  const [emailVerificationSent, setEmailVerificationSent] = useState(false);
+  const [verificationEmailSendError, setVerificationEmailSendError] = useState<string | false>(
+    false
+  );
+
+  useEffect(() => {
+    // reset the clear alerts watcher
+    // after it triggers a change in the child components to clear their alerts
+    // after sending a verification email
+    if (clearAlerts) {
+      setClearAlerts(false);
+    }
+  }, [clearAlerts]);
+
+  const sendVerificationEmail = useCallback(() => {
+    setClearAlerts(true);
+    requestVerificationEmail()
+      .then(() => {
+        setEmailVerificationSent(true);
+      })
+      .catch((error) => {
+        setVerificationEmailSendError(String(error.message || error));
+      });
+  }, []);
+
+  const accordionItems = useMemo(
+    () =>
+      [
+        {
+          title: 'Activity Reports',
+          content: (
+            <ActivityReportNotifications
+              clearAlerts={clearAlerts}
+              emailVerified={emailValidated}
+              sendVerificationEmail={sendVerificationEmail}
+              emailVerificationSent={emailVerificationSent}
+            />
+          ),
+          id: 'activity-report-notifications',
+          expanded: true,
+          headingLevel: 'h2',
+        },
+        {
+          title: 'Collaboration Reports',
+          content: (
+            <CollabReportNotifications
+              clearAlerts={clearAlerts}
+              emailVerified={emailValidated}
+              sendVerificationEmail={sendVerificationEmail}
+              emailVerificationSent={emailVerificationSent}
+            />
+          ),
+          id: 'collab-report-notifications',
+          expanded: true,
+          headingLevel: 'h2',
+        },
+        {
+          title: 'Communication Logs',
+          content: (
+            <CommunicationLogNotifications
+              clearAlerts={clearAlerts}
+              emailVerified={emailValidated}
+              sendVerificationEmail={sendVerificationEmail}
+              emailVerificationSent={emailVerificationSent}
+            />
+          ),
+          id: 'communication-log-notifications',
+          expanded: true,
+          headingLevel: 'h2',
+        },
+        {
+          title: 'Training Reports',
+          content: (
+            <TrainingReportNotifications
+              emailVerified={emailValidated}
+              clearAlerts={clearAlerts}
+              sendVerificationEmail={sendVerificationEmail}
+              emailVerificationSent={emailVerificationSent}
+            />
+          ),
+          id: 'training-report-notifications',
+          expanded: true,
+          headingLevel: 'h2',
+        },
+        {
+          title: 'System Related',
+          content: (
+            <SystemRelatedNotifications
+              emailVerified={emailValidated}
+              sendVerificationEmail={sendVerificationEmail}
+              emailVerificationSent={emailVerificationSent}
+            />
+          ),
+          id: 'system-related-notifications',
+          expanded: true,
+          headingLevel: 'h2',
+        },
+        {
+          title: 'Other',
+          content: (
+            <OtherNotifications
+              emailVerified={emailValidated}
+              sendVerificationEmail={sendVerificationEmail}
+              emailVerificationSent={emailVerificationSent}
+            />
+          ),
+          id: 'other-notifications',
+          expanded: true,
+          headingLevel: 'h2',
+        },
+      ] as AccordionItemProps[],
+    [emailValidated, sendVerificationEmail, emailVerificationSent, clearAlerts]
+  );
+
+  const methods = useForm({
+    defaultValues: {
+      emailWhenAppointedCollaborator: 'never',
+      emailWhenChangeRequested: 'never',
+      emailWhenRecipientReportApprovedProgramSpecialist: 'never',
+      emailWhenReportApproval: 'never',
+      emailWhenReportSubmittedForReview: 'never',
+      inAppWhenAppointedCollaborator: true,
+      inAppWhenChangeRequested: true,
+      inAppWhenRecipientReportApprovedProgramSpecialist: true,
+      inAppWhenReportApproval: true,
+      inAppWhenReportSubmittedForReview: true,
+    },
+  });
+
+  const { setValue } = methods;
+
+  useEffect(() => {
+    const emailValidationStatus = (user.validationStatus ?? []).find(
+      ({ type }) => type === 'email'
+    );
+    if (emailValidationStatus?.validatedAt) {
+      setEmailValidated(true);
+      return;
+    }
+
+    setEmailValidated(false);
+  }, [user.validationStatus]);
+
+  useEffect(() => {
+    async function fetchSettings() {
+      setIsAppLoading(true);
+      try {
+        const res = await getEmailSettings();
+        res.forEach(({ key, value }) => {
+          setValue(key, value);
+        });
+      } catch (_error) {
+        // fail silently, form defaults will be used
+      } finally {
+        setIsAppLoading(false);
+      }
+    }
+
+    fetchSettings();
+  }, [setValue, setIsAppLoading]);
+
+  const onSubmit = async (formData: SettingFormData) => {
+    // TODO: For now, simply return early if no email validation
+    if (!emailValidated) {
+      return;
+    }
+
+    // TODO: this will eventually need to handle in-app settings as well, but for now the only options are email settings
+    const newSettings = Object.entries(emailTypesMap).reduce((acc, entry) => {
+      const options = entry[1];
+      options.forEach((option) => {
+        acc.push({ key: option.keyName, value: formData[option.keyName] });
+      });
+      return acc;
+    }, []);
+
+    try {
+      setIsAppLoading(true);
+      await updateSettings(newSettings);
+      setSaveError(false);
+      setSaveSuccess(true);
+    } catch (error) {
+      setSaveSuccess(false);
+      setSaveError(String(error.message || error));
+    } finally {
+      setIsAppLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <BackLink to="/notifications">Back to Notifications</BackLink>
+      <h1 className="landing margin-top-0">Notification Preferences</h1>
+      <EmailValidationPreferenceBox
+        emailVerificationSent={emailVerificationSent}
+        emailValidated={emailValidated}
+        updateUser={updateUser}
+        sendVerificationEmail={sendVerificationEmail}
+        verificationEmailSendError={verificationEmailSendError}
+      />
+      <Container>
+        <FormProvider {...methods}>
+          <form onSubmit={methods.handleSubmit(onSubmit)}>
+            {saveSuccess && (
+              <Alert headingLevel="h2" type="success" className="margin-bottom-2">
+                Your preferences have been saved.
+              </Alert>
+            )}
+            {saveError && (
+              <Alert headingLevel="h2" type="error" className="margin-bottom-2">
+                There was an error saving your preferences: {saveError}
+              </Alert>
+            )}
+            <Accordion items={accordionItems} multiselectable />
+            <Button type="submit" className="margin-top-2">
+              Save preferences
+            </Button>
+            <Link
+              to="/notifications"
+              className="usa-button usa-button--outline margin-top-2 margin-left-1"
+            >
+              Cancel
+            </Link>
+          </form>
+        </FormProvider>
+      </Container>
+    </>
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/ActivityReportNotifications.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/ActivityReportNotifications.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import NotificationsSection from './NotificationsSection';
+
+export default function ActivityReportNotifications({
+  emailVerified,
+  sendVerificationEmail,
+  emailVerificationSent,
+  clearAlerts,
+}: {
+  emailVerified: boolean;
+  sendVerificationEmail: () => void;
+  emailVerificationSent: boolean;
+  clearAlerts?: boolean;
+}) {
+  return (
+    <NotificationsSection
+      emailVerified={emailVerified}
+      sendVerificationEmail={sendVerificationEmail}
+      emailVerificationSent={emailVerificationSent}
+      clearAlerts={clearAlerts}
+      groupController={{
+        name: 'ActivityReports',
+        label: 'Set preferences for all Activity Report notifications',
+        ids: [
+          'WhenReportSubmittedForReview',
+          'WhenChangeRequested',
+          'WhenAppointedCollaborator',
+          'WhenRecipientReportApprovedProgramSpecialist',
+          'WhenReportApproval',
+        ],
+      }}
+      items={[
+        {
+          id: 'WhenReportSubmittedForReview',
+          label: 'Someone submits an Activity Report for my approval.',
+        },
+        {
+          id: 'WhenCollaboratorReportSubmittedForReview',
+          label: 'Someone submits an Activity Report for approval that I am a collaborator on.',
+        },
+        {
+          id: 'WhenCreatorReportSubmittedForReview',
+          label: 'Someone submits an Activity Report for approval that I created.',
+        },
+        {
+          id: 'WhenChangeRequested',
+          label:
+            'A manager requests changes to an activity report that I created or collaborated on.',
+        },
+        {
+          id: 'WhenReportApproval',
+          label: 'A manager approves an Activity Report that I created or collaborated on.',
+        },
+        {
+          id: 'WhenAppointedCollaborator',
+          label: "I'm added as a collaborator on an activity report.",
+        },
+        {
+          id: 'WhenRecipientReportApprovedProgramSpecialist',
+          label: (
+            <>
+              <em>Program specialists only:</em>
+              <br /> One of my recipients&apos; activity reports is available.
+            </>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/CollabReportNotifications.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/CollabReportNotifications.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import NotificationsSection from './NotificationsSection';
+/**
+ * Note that none of these are implemented yet here and mocked out only for UI verification
+ * @returns
+ */
+export default function CollabReportNotifications({
+  emailVerified,
+  sendVerificationEmail,
+  emailVerificationSent,
+  clearAlerts = false,
+}: {
+  emailVerified: boolean;
+  sendVerificationEmail: () => void;
+  emailVerificationSent: boolean;
+  clearAlerts?: boolean;
+}) {
+  return (
+    <NotificationsSection
+      emailVerified={emailVerified}
+      sendVerificationEmail={sendVerificationEmail}
+      emailVerificationSent={emailVerificationSent}
+      clearAlerts={clearAlerts}
+      groupController={{
+        name: 'CollabReports',
+        label: 'Set preferences for all Collaboration Report notifications',
+        ids: [
+          'WhenCollabReportSubmittedForReview',
+          'WhenCollaborationReportSubmittedForReview',
+          'WhenCreatorCollaborationReportCollaboratorSubmittedForReview',
+          'WhenCollaborationChangeRequested',
+          'WhenCollaborationReportApproved',
+          'WhenAddedAsCollaborationCollaborator',
+        ],
+      }}
+      items={[
+        {
+          id: 'WhenCollabReportSubmittedForReview',
+          label: 'Someone submits a Collaboration Report for my approval.',
+        },
+        {
+          id: 'WhenCollaborationReportSubmittedForReview',
+          label:
+            'A Creator submits a Collaboration Report for approval that I am a Collaborator on.',
+        },
+        {
+          id: 'WhenCreatorCollaborationReportCollaboratorSubmittedForReview',
+          label: 'A Collaborator submits an Collaboration Report for approval that I created.',
+        },
+        {
+          id: 'WhenCollaborationChangeRequested',
+          label:
+            'A manager requests changes to a Collaboration report that I created or collaborated on.',
+        },
+        {
+          id: 'WhenCollaborationReportApproved',
+          label: 'A manager approves a Collaboration report that I created or collaborated on.',
+        },
+        {
+          id: 'WhenAddedAsCollaborationCollaborator',
+          label: "I'm added as a collaborator on a Collaboration report.",
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/CommunicationLogNotification.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/CommunicationLogNotification.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import NotificationsSection from './NotificationsSection';
+/**
+ * Note that none of these are implemented yet here and mocked out only for UI verification
+ * @returns
+ */
+export default function CommunicationLogNotifications({
+  emailVerified,
+  sendVerificationEmail,
+  emailVerificationSent,
+  clearAlerts = false,
+}: {
+  emailVerified: boolean;
+  sendVerificationEmail: () => void;
+  emailVerificationSent: boolean;
+  clearAlerts?: boolean;
+}) {
+  return (
+    <NotificationsSection
+      emailVerified={emailVerified}
+      sendVerificationEmail={sendVerificationEmail}
+      emailVerificationSent={emailVerificationSent}
+      clearAlerts={clearAlerts}
+      groupController={{
+        name: 'CommunicationLogs',
+        label: 'Set preferences for all Communication Log notifications',
+        ids: ['WhenAddedAsTTAStaffCommLog', 'WhenAddedAsRecipientCommLog'],
+      }}
+      items={[
+        {
+          id: 'WhenAddedAsTTAStaffCommLog',
+          label: "I'm added as TTA staff on a Communication Log.",
+        },
+        {
+          id: 'WhenAddedAsRecipientCommLog',
+          label: 'A Communication Log was entered for a recipient in one of “My groups”.',
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/EmailValidationPreferenceBox.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/EmailValidationPreferenceBox.tsx
@@ -1,0 +1,76 @@
+import { Alert, Button } from '@trussworks/react-uswds';
+import React from 'react';
+import { useParams } from 'react-router';
+import Container from '../../../../components/Container';
+
+import EmailVerifier from '../../EmailVerifier';
+
+export default function EmailValidationPreferenceBox({
+  emailVerificationSent,
+  emailValidated,
+  updateUser,
+  sendVerificationEmail,
+  verificationEmailSendError,
+}: {
+  emailVerificationSent: boolean;
+  emailValidated: boolean;
+  updateUser: (user: { id: number }) => void;
+  sendVerificationEmail: () => void;
+  verificationEmailSendError: boolean | string;
+}): JSX.Element {
+  const { token } = useParams();
+
+  if (emailValidated) {
+    return null;
+  }
+
+  return (
+    <Container>
+      <EmailVerifier token={token} updateUser={updateUser} />
+
+      {!emailValidated && !emailVerificationSent && (
+        <Alert headingLevel="h3" type="warning">
+          Your email address isn&apos;t verified. Select &apos;Send verification email&apos; below.
+        </Alert>
+      )}
+
+      {!emailValidated && emailVerificationSent && (
+        <Alert headingLevel="h3" type="info">
+          Verification email sent. Check your inbox.
+          <br />
+          If you don&apos;t receive an email within thirty minutes, check your spam folder,
+          then&nbsp;
+          <a
+            href="https://app.smartsheetgov.com/b/form/f0b4725683f04f349a939bd2e3f5425a"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            request support
+          </a>
+          .
+        </Alert>
+      )}
+
+      {!emailValidated && (
+        <>
+          <h2 className="font-serif-xl">Verify email address</h2>
+          <p>To receive TTA Hub email notifications, you must verify your email address.</p>
+          <Button
+            data-testid="send-verification-email-button"
+            className="display-block margin-top-3"
+            onClick={sendVerificationEmail}
+            type="button"
+          >
+            {emailVerificationSent ? 'Resend verification email' : 'Send verification email'}
+          </Button>
+        </>
+      )}
+
+      {verificationEmailSendError && (
+        <Alert headingLevel="h3" type="error">
+          {verificationEmailSendError}
+        </Alert>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/NotificationsGroupController.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/NotificationsGroupController.tsx
@@ -1,0 +1,90 @@
+import { Checkbox, Dropdown } from '@trussworks/react-uswds';
+import React, { useEffect, useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { frequencyValues } from '../..';
+
+export default function NotificationsGroupController({
+  groupName,
+  ids,
+  label,
+  emailVerified,
+  setDisplayAlert,
+}: {
+  groupName: string;
+  ids: string[];
+  label: string;
+  emailVerified: boolean;
+  setDisplayAlert: (display: boolean) => void;
+}): JSX.Element {
+  const { setValue, control } = useFormContext();
+
+  const [groupInAppSelected, setGroupInAppSelected] = useState(false);
+  const [groupEmailSelected, setGroupEmailSelected] = useState('');
+
+  // Watch all email and inApp fields for this group so the group controls stay
+  // in sync after async form population (e.g. getEmailSettings()).
+  const inAppFieldNames = ids.map((id) => `inApp${id}`);
+  const watchedInAppValues: boolean[] | undefined = useWatch({
+    control,
+    name: inAppFieldNames,
+  });
+
+  useEffect(() => {
+    const values = watchedInAppValues ? Object.values(watchedInAppValues) : [];
+    setGroupInAppSelected(values.length > 0 && values.every((value) => value === true));
+  }, [watchedInAppValues]);
+
+  const handleGroupInAppChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { checked } = e.target;
+    setGroupInAppSelected(checked);
+    ids.forEach((id) => {
+      setValue(`inApp${id}`, checked);
+    });
+  };
+
+  const handleGroupEmailChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (!emailVerified) {
+      setDisplayAlert(true);
+      return;
+    }
+    const { value } = e.target;
+    setGroupEmailSelected(value);
+    ids.forEach((id) => {
+      setValue(`email${id}`, value);
+    });
+  };
+
+  return (
+    <div className="display-flex flex-align-center">
+      <div className="flex-1">{label}</div>
+
+      <Checkbox
+        id={`inApp${groupName}`}
+        name={`inApp${groupName}`}
+        label={<span className="usa-sr-only">In App</span>}
+        checked={groupInAppSelected}
+        className="ttahub-in-app-checkbox width-10"
+        onChange={handleGroupInAppChange}
+      />
+      <label htmlFor={`email${groupName}`} className="usa-sr-only">
+        Email
+      </label>
+      <Dropdown
+        id={`email${groupName}`}
+        name={`email${groupName}`}
+        className="width-card"
+        value={groupEmailSelected}
+        onChange={handleGroupEmailChange}
+      >
+        <option value="" disabled hidden>
+          - Select -
+        </option>
+        {frequencyValues.map(({ key, label }) => (
+          <option key={key} value={key}>
+            {label}
+          </option>
+        ))}
+      </Dropdown>
+    </div>
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/NotificationsRow.css
+++ b/frontend/src/pages/AccountManagement/components/notifications/NotificationsRow.css
@@ -1,0 +1,3 @@
+.ttahub-in-app-checkbox .usa-checkbox__label {
+  margin-top: -0.5em;
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/NotificationsRow.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/NotificationsRow.tsx
@@ -1,0 +1,79 @@
+import { Checkbox, Dropdown } from '@trussworks/react-uswds';
+import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { frequencyValues } from '../..';
+import './NotificationsRow.css';
+
+export default function NotificationsRow({
+  id,
+  label,
+  emailVerified,
+  setDisplayAlert,
+  hideInApp = false,
+}: {
+  id: string;
+  label: React.ReactNode;
+  emailVerified: boolean;
+  setDisplayAlert: (display: boolean) => void;
+  hideInApp?: boolean;
+}): JSX.Element {
+  const { control, getValues } = useFormContext();
+
+  return (
+    <div className="display-flex flex-align-center">
+      <div className="flex-1">{label}</div>
+
+      {hideInApp ? (
+        <div className="width-10" />
+      ) : (
+        <Controller
+          control={control}
+          name={`inApp${id}`}
+          defaultValue={getValues(`inApp${id}`) ?? true}
+          render={({ onChange, value }) => (
+            <Checkbox
+              id={`inApp${id}`}
+              name={`inApp${id}`}
+              label={<span className="usa-sr-only">In App</span>}
+              checked={Boolean(value)}
+              className="ttahub-in-app-checkbox width-10"
+              onChange={(e) => onChange(e.target.checked)}
+            />
+          )}
+        />
+      )}
+      <label htmlFor={`email${id}`} className="usa-sr-only">
+        Email
+      </label>
+      <Controller
+        control={control}
+        name={`email${id}`}
+        defaultValue={getValues(`email${id}`) || ''}
+        render={({ onChange, value }) => (
+          <Dropdown
+            id={`email${id}`}
+            name={`email${id}`}
+            className="width-card"
+            value={value || ''}
+            onChange={(e) => {
+              if (!emailVerified) {
+                setDisplayAlert(true);
+                return;
+              }
+              onChange(e.target.value);
+            }}
+          >
+            <option value="" disabled hidden>
+              - Select -
+            </option>
+            {frequencyValues.map(({ key, label: optionLabel }) => (
+              <option key={key} value={key}>
+                {optionLabel}
+              </option>
+            ))}
+          </Dropdown>
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/NotificationsSection.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/NotificationsSection.tsx
@@ -1,0 +1,77 @@
+import { Alert, Button } from '@trussworks/react-uswds';
+import React, { useEffect, useState } from 'react';
+import NotificationsGroupController from './NotificationsGroupController';
+import NotificationsRow from './NotificationsRow';
+
+export default function NotificationsSection({
+  emailVerified,
+  sendVerificationEmail,
+  emailVerificationSent,
+  items,
+  groupController = undefined,
+  clearAlerts = false,
+}: {
+  clearAlerts?: boolean;
+  emailVerified: boolean;
+  sendVerificationEmail: () => void;
+  emailVerificationSent: boolean;
+  groupController?: {
+    label: string;
+    ids: string[];
+    name: string;
+  };
+  items: Array<{
+    id: string;
+    label: React.ReactNode;
+    hideInApp?: boolean;
+  }>;
+}) {
+  const [displayAlert, setDisplayAlert] = useState(false);
+
+  useEffect(() => {
+    if (clearAlerts) {
+      setDisplayAlert(false);
+    }
+  }, [clearAlerts]);
+
+  return (
+    <div>
+      {displayAlert && (
+        <Alert headingLevel="h3" type="error" className="margin-bottom-2">
+          You must verify your email before setting email preferences or receiving email
+          notifications.{' '}
+          <Button onClick={sendVerificationEmail} type="button" unstyled>
+            {emailVerificationSent ? 'Resend verification email' : 'Send verification email'}
+          </Button>
+        </Alert>
+      )}
+
+      <div className="display-flex flex-align-center">
+        <div className="flex-1 text-bold">Event</div>
+        <div className="text-bold width-10">In-app</div>
+        <div className="text-bold width-card">Email</div>
+      </div>
+      {groupController && (
+        <NotificationsGroupController
+          groupName={groupController.name}
+          ids={groupController.ids}
+          label={groupController.label}
+          emailVerified={emailVerified}
+          setDisplayAlert={setDisplayAlert}
+        />
+      )}
+
+      <hr />
+      {items.map(({ id, label, hideInApp }) => (
+        <NotificationsRow
+          key={id}
+          id={id}
+          label={label}
+          emailVerified={emailVerified}
+          setDisplayAlert={setDisplayAlert}
+          hideInApp={hideInApp}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/OtherNotifications.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/OtherNotifications.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import NotificationsSection from './NotificationsSection';
+/**
+ * Note that none of these are implemented yet here and mocked out only for UI verification
+ * @returns
+ */
+export default function OtherNotifications({
+  emailVerified,
+  sendVerificationEmail,
+  emailVerificationSent,
+}: {
+  emailVerified: boolean;
+  sendVerificationEmail: () => void;
+  emailVerificationSent: boolean;
+}) {
+  return (
+    <NotificationsSection
+      emailVerified={emailVerified}
+      sendVerificationEmail={sendVerificationEmail}
+      emailVerificationSent={emailVerificationSent}
+      items={[
+        {
+          id: 'WhenMonitoringDetailsAdded',
+          label:
+            "New monitoring details are added for recipients in my region where I'm the TTAC or Manager.",
+        },
+        {
+          id: 'WhenAddedAsCoOwner',
+          label: "I'm added as a Co-owner of a “My group”.",
+          hideInApp: true,
+        },
+        {
+          id: 'WhenSharedMyGroup',
+          label: 'Someone shares their “My group” with me.',
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/SystemRelatedNotifications.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/SystemRelatedNotifications.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import NotificationsSection from './NotificationsSection';
+/**
+ * Note that none of these are implemented yet here and mocked out only for UI verification
+ * @returns
+ */
+export default function SystemRelatedNotifications({
+  emailVerified,
+  sendVerificationEmail,
+  emailVerificationSent,
+}: {
+  emailVerified: boolean;
+  sendVerificationEmail: () => void;
+  emailVerificationSent: boolean;
+}) {
+  return (
+    <NotificationsSection
+      emailVerified={emailVerified}
+      sendVerificationEmail={sendVerificationEmail}
+      emailVerificationSent={emailVerificationSent}
+      items={[
+        {
+          id: 'WhenPlannedOutage',
+          label: 'Planned system outage alerts.',
+        },
+        {
+          id: 'WhenUnplannedOutage',
+          label: 'Unplanned system outage alerts.',
+          hideInApp: true,
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/TrainingReportNotifications.tsx
+++ b/frontend/src/pages/AccountManagement/components/notifications/TrainingReportNotifications.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import NotificationsSection from './NotificationsSection';
+/**
+ * Note that none of these are implemented yet here and mocked out only for UI verification
+ * @returns
+ */
+export default function TrainingReportNotifications({
+  emailVerified,
+  sendVerificationEmail,
+  emailVerificationSent,
+  clearAlerts = false,
+}: {
+  emailVerified: boolean;
+  sendVerificationEmail: () => void;
+  emailVerificationSent: boolean;
+  clearAlerts?: boolean;
+}) {
+  return (
+    <NotificationsSection
+      emailVerified={emailVerified}
+      sendVerificationEmail={sendVerificationEmail}
+      emailVerificationSent={emailVerificationSent}
+      clearAlerts={clearAlerts}
+      groupController={{
+        name: 'TrainingReports',
+        label: 'Set preferences for all Training Report notifications',
+        ids: [
+          'WhenAddedAsPocTrainingReport',
+          'WhenAddedAsCollaboratorTrainingReport',
+          'WhenSessionReviewRequestedTrainingReport',
+          'WhenSessionChangesRequestedTrainingReport',
+          'WhenSessionDetails20DaysCreatorCollaborator',
+          'WhenSessionDetails20DaysPoc',
+          'WhenNoSessionsCreatorCollaborator',
+          'WhenEventDetails20DaysCreatorCollaborator',
+          'WhenEventNotCompleted',
+        ],
+      }}
+      items={[
+        {
+          id: 'WhenAddedAsPocTrainingReport',
+          label: "I'm added as a Regional point of contact on a Training Report.",
+        },
+        {
+          id: 'WhenAddedAsCollaboratorTrainingReport',
+          label: "I'm added as a collaborator on a Training Report.",
+        },
+        {
+          id: 'WhenSessionReviewRequestedTrainingReport',
+          label: 'Someone submits an event session for my review.',
+        },
+        {
+          id: 'WhenSessionChangesRequestedTrainingReport',
+          label:
+            'A manager requests changes to an event session that I created or collaborated on.',
+        },
+        {
+          id: 'WhenEventDetails20DaysCreatorCollaborator',
+          label:
+            "Event details are not completed within 20 days of the event start date where I'm the Creator or Collaborator.",
+        },
+        {
+          id: 'WhenSessionDetails20DaysCreatorCollaborator',
+          label:
+            "Session details are not completed within 20 days of the session start date where I'm the Creator or Collaborator.",
+        },
+        {
+          id: 'WhenSessionDetails20DaysPoc',
+          label:
+            "Session details are not completed within 20 days of the session start date where I'm the Regional point of contact.",
+        },
+        {
+          id: 'WhenNoSessionsCreatorCollaborator',
+          label:
+            "No sessions have been created within 20 days of the event end date where I'm the Event Creator or Collaborator.",
+        },
+        {
+          id: 'WhenEventNotCompleted',
+          label: 'Event creator has not completed event within 20 days of event end date.',
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/ActivityReportNotifications.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/ActivityReportNotifications.js
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import ActivityReportNotifications from '../ActivityReportNotifications';
+
+function renderComponent() {
+  function Wrapper() {
+    const methods = useForm();
+    return (
+      <FormProvider {...methods}>
+        <ActivityReportNotifications />
+      </FormProvider>
+    );
+  }
+
+  render(<Wrapper />);
+}
+
+describe('ActivityReportNotifications', () => {
+  it('renders column headers', () => {
+    renderComponent();
+
+    expect(screen.getByText('Event')).toBeInTheDocument();
+    expect(screen.getByText('In-app')).toBeInTheDocument();
+    expect(screen.getAllByText('Email').length).toBeGreaterThan(0);
+  });
+
+  it('renders group controller label', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText('Set preferences for all Activity Report notifications')
+    ).toBeInTheDocument();
+  });
+
+  it('renders expected row labels', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText('Someone submits an Activity Report for my approval.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'A manager requests changes to an activity report that I created or collaborated on.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("I'm added as a collaborator on an activity report.")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/CollabReportNotifications.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/CollabReportNotifications.js
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import CollabReportNotifications from '../CollabReportNotifications';
+
+function renderComponent() {
+  function Wrapper() {
+    const methods = useForm();
+    return (
+      <FormProvider {...methods}>
+        <CollabReportNotifications />
+      </FormProvider>
+    );
+  }
+
+  render(<Wrapper />);
+}
+
+describe('CollabReportNotifications', () => {
+  it('renders column headers', () => {
+    renderComponent();
+
+    expect(screen.getByText('Event')).toBeInTheDocument();
+    expect(screen.getByText('In-app')).toBeInTheDocument();
+    expect(screen.getAllByText('Email').length).toBeGreaterThan(0);
+  });
+
+  it('renders group controller label', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText('Set preferences for all Collaboration Report notifications')
+    ).toBeInTheDocument();
+  });
+
+  it('renders expected row labels', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText('Someone submits a Collaboration Report for my approval.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("I'm added as a collaborator on a Collaboration report.")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/CommunicationLogNotification.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/CommunicationLogNotification.js
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import CommunicationLogNotification from '../CommunicationLogNotification';
+
+function renderComponent() {
+  function Wrapper() {
+    const methods = useForm();
+    return (
+      <FormProvider {...methods}>
+        <CommunicationLogNotification />
+      </FormProvider>
+    );
+  }
+
+  render(<Wrapper />);
+}
+
+describe('CommunicationLogNotification', () => {
+  it('renders column headers', () => {
+    renderComponent();
+
+    expect(screen.getByText('Event')).toBeInTheDocument();
+    expect(screen.getByText('In-app')).toBeInTheDocument();
+    expect(screen.getAllByText('Email').length).toBeGreaterThan(0);
+  });
+
+  it('renders group controller label', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText('Set preferences for all Communication Log notifications')
+    ).toBeInTheDocument();
+  });
+
+  it('renders expected row labels', () => {
+    renderComponent();
+
+    expect(screen.getByText("I'm added as TTA staff on a Communication Log.")).toBeInTheDocument();
+    expect(
+      screen.getByText(/A Communication Log was entered for a recipient in one of .*My groups.*\./)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/EmailValidationPreferenceBox.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/EmailValidationPreferenceBox.js
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import EmailValidationPreferenceBox from '../EmailValidationPreferenceBox';
+
+jest.mock('../../../EmailVerifier', () => () => <div data-testid="email-verifier" />);
+
+describe('EmailValidationPreferenceBox', () => {
+  const defaultProps = {
+    emailVerificationSent: false,
+    emailValidated: false,
+    updateUser: jest.fn(),
+    sendVerificationEmail: jest.fn(),
+    verificationEmailSendError: false,
+  };
+
+  const renderBox = (props = {}, initialEntry = '/account/notifications') =>
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Route path="/account/notifications/:token?">
+          <EmailValidationPreferenceBox {...defaultProps} {...props} />
+        </Route>
+      </MemoryRouter>
+    );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when email is already validated', () => {
+    const { container } = renderBox({ emailValidated: true });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows a warning alert when email is unverified and no verification email has been sent', () => {
+    renderBox();
+
+    expect(screen.getByText(/your email address isn't verified/i)).toBeInTheDocument();
+  });
+
+  it('shows an info alert when a verification email has been sent', () => {
+    renderBox({ emailVerificationSent: true });
+
+    expect(screen.getByText(/verification email sent\. check your inbox\./i)).toBeInTheDocument();
+  });
+
+  it('shows a send verification email button before an email has been sent', () => {
+    renderBox();
+
+    expect(screen.getByRole('button', { name: /send verification email/i })).toBeInTheDocument();
+  });
+
+  it('shows a resend verification email button after an email has been sent', () => {
+    renderBox({ emailVerificationSent: true });
+
+    expect(screen.getByRole('button', { name: /resend verification email/i })).toBeInTheDocument();
+  });
+
+  it('invokes sendVerificationEmail when the button is clicked', () => {
+    const sendVerificationEmail = jest.fn();
+    renderBox({ sendVerificationEmail });
+
+    fireEvent.click(screen.getByRole('button', { name: /send verification email/i }));
+
+    expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an error alert when verificationEmailSendError contains a message', () => {
+    renderBox({ verificationEmailSendError: 'Unable to send verification email.' });
+
+    expect(screen.getByText('Unable to send verification email.')).toBeInTheDocument();
+  });
+
+  it('does not render an error alert when verificationEmailSendError is false', () => {
+    renderBox({ verificationEmailSendError: false });
+
+    expect(
+      screen.queryByRole('alert', { name: /unable to send verification email/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Unable to send verification email.')).not.toBeInTheDocument();
+  });
+
+  it('renders EmailVerifier when a token route param is present', () => {
+    renderBox({}, '/account/notifications/token123');
+
+    expect(screen.getByTestId('email-verifier')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/NotificationsGroupController.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/NotificationsGroupController.js
@@ -1,0 +1,282 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import NotificationsGroupController from '../NotificationsGroupController';
+import NotificationsRow from '../NotificationsRow';
+
+function FieldRegistrar({ ids }) {
+  const { register } = useFormContext();
+  return (
+    <>
+      {ids.map((id) => (
+        <input
+          key={id}
+          type="checkbox"
+          name={`inApp${id}`}
+          ref={register}
+          style={{ display: 'none' }}
+        />
+      ))}
+    </>
+  );
+}
+
+describe('NotificationsGroupController', () => {
+  const defaultProps = {
+    groupName: 'ReportUpdates',
+    ids: ['ReportSubmitted', 'ReportApproved', 'ReportChanged'],
+    label: 'Report updates',
+  };
+
+  const renderNotificationsGroupController = (props = {}, formProps = {}) => {
+    let setValueSpy;
+    const setDisplayAlert = jest.fn();
+    const formRef = {};
+    const mergedProps = { ...defaultProps, ...props };
+
+    function Wrapper({ children }) {
+      const methods = useForm(formProps);
+      setValueSpy = jest.spyOn(methods, 'setValue');
+      formRef.methods = methods;
+
+      return (
+        <FormProvider {...methods}>
+          <FieldRegistrar ids={mergedProps.ids} />
+          {children}
+        </FormProvider>
+      );
+    }
+
+    const utils = render(
+      <Wrapper>
+        <NotificationsGroupController
+          emailVerified={true}
+          setDisplayAlert={setDisplayAlert}
+          {...mergedProps}
+        />
+      </Wrapper>
+    );
+
+    return { ...utils, setValueSpy, setDisplayAlert, formRef };
+  };
+
+  const renderWithRows = (props = {}, formProps = {}) => {
+    const setDisplayAlert = jest.fn();
+    const formRef = {};
+    const mergedProps = { ...defaultProps, ...props };
+
+    function Wrapper() {
+      const methods = useForm(formProps);
+      formRef.methods = methods;
+
+      return (
+        <FormProvider {...methods}>
+          <NotificationsGroupController
+            emailVerified={true}
+            setDisplayAlert={setDisplayAlert}
+            {...mergedProps}
+          />
+          {mergedProps.ids.map((id) => (
+            <NotificationsRow
+              key={id}
+              id={id}
+              label={`Row ${id}`}
+              emailVerified={true}
+              setDisplayAlert={setDisplayAlert}
+            />
+          ))}
+        </FormProvider>
+      );
+    }
+
+    const utils = render(<Wrapper />);
+    return { ...utils, setDisplayAlert, formRef, ids: mergedProps.ids };
+  };
+
+  it('renders the label text', () => {
+    renderNotificationsGroupController();
+
+    expect(screen.getByText(defaultProps.label)).toBeInTheDocument();
+  });
+
+  it('renders the checkbox with the group id', () => {
+    renderNotificationsGroupController();
+
+    expect(screen.getByRole('checkbox')).toHaveAttribute('id', `inApp${defaultProps.groupName}`);
+  });
+
+  it('renders the dropdown with the group id', () => {
+    renderNotificationsGroupController();
+
+    expect(screen.getByRole('combobox')).toHaveAttribute('id', `email${defaultProps.groupName}`);
+  });
+
+  it('initializes the email dropdown to the empty placeholder option', () => {
+    renderNotificationsGroupController();
+
+    const dropdown = screen.getByRole('combobox');
+    expect(dropdown).toHaveValue('');
+
+    const firstOption = dropdown.querySelector('option');
+    expect(firstOption).toHaveValue('');
+    expect(firstOption).toHaveTextContent('- Select -');
+  });
+
+  it('renders all frequency options in the dropdown plus the placeholder', () => {
+    renderNotificationsGroupController();
+
+    expect(screen.getAllByRole('option', { hidden: true })).toHaveLength(6);
+    expect(screen.getByRole('option', { name: 'Do not notify me' })).toHaveValue('never');
+    expect(screen.getByRole('option', { name: 'Immediately' })).toHaveValue('immediately');
+    expect(screen.getByRole('option', { name: 'Daily digest' })).toHaveValue('today');
+    expect(screen.getByRole('option', { name: 'Weekly digest' })).toHaveValue('this week');
+    expect(screen.getByRole('option', { name: 'Monthly digest' })).toHaveValue('this month');
+  });
+
+  it('toggles the checkbox and calls setValue for each id with the correct boolean value', () => {
+    const initialValues = defaultProps.ids.reduce((acc, id) => {
+      acc[`inApp${id}`] = false;
+      return acc;
+    }, {});
+    const { setValueSpy } = renderNotificationsGroupController(
+      {},
+      { defaultValues: initialValues }
+    );
+    const checkbox = screen.getByRole('checkbox');
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+    expect(setValueSpy).toHaveBeenCalledTimes(defaultProps.ids.length);
+    defaultProps.ids.forEach((id, index) => {
+      expect(setValueSpy).toHaveBeenNthCalledWith(index + 1, `inApp${id}`, true);
+    });
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).not.toBeChecked();
+    expect(setValueSpy).toHaveBeenCalledTimes(defaultProps.ids.length * 2);
+    defaultProps.ids.forEach((id, index) => {
+      expect(setValueSpy).toHaveBeenNthCalledWith(
+        defaultProps.ids.length + index + 1,
+        `inApp${id}`,
+        false
+      );
+    });
+  });
+
+  it('changes the dropdown and calls setValue for each id with the selected value', () => {
+    const { setValueSpy } = renderNotificationsGroupController();
+    const dropdown = screen.getByRole('combobox');
+
+    fireEvent.change(dropdown, { target: { value: 'this week' } });
+
+    expect(dropdown).toHaveValue('this week');
+    expect(setValueSpy).toHaveBeenCalledTimes(defaultProps.ids.length);
+    defaultProps.ids.forEach((id, index) => {
+      expect(setValueSpy).toHaveBeenNthCalledWith(index + 1, `email${id}`, 'this week');
+    });
+  });
+
+  describe('email verification gating', () => {
+    it('does not update form state and shows the alert when email is unverified', () => {
+      const { setValueSpy, setDisplayAlert } = renderNotificationsGroupController({
+        emailVerified: false,
+      });
+      const dropdown = screen.getByRole('combobox');
+
+      fireEvent.change(dropdown, { target: { value: 'this week' } });
+
+      expect(setDisplayAlert).toHaveBeenCalledWith(true);
+      const emailSetValueCalls = setValueSpy.mock.calls.filter(([key]) => key.startsWith('email'));
+      expect(emailSetValueCalls).toHaveLength(0);
+    });
+  });
+
+  describe('checkbox sync with child rows', () => {
+    const allCheckedDefaults = (ids) =>
+      ids.reduce((acc, id) => {
+        acc[`inApp${id}`] = true;
+        return acc;
+      }, {});
+
+    it('reflects the checked state of every child row on mount', () => {
+      const { container } = renderWithRows(
+        {},
+        { defaultValues: allCheckedDefaults(defaultProps.ids) }
+      );
+
+      const groupCheckbox = container.querySelector(`#inApp${defaultProps.groupName}`);
+      expect(groupCheckbox).toBeChecked();
+
+      defaultProps.ids.forEach((id) => {
+        expect(container.querySelector(`#inApp${id}`)).toBeChecked();
+      });
+    });
+
+    it('unchecks the group when a single child checkbox is unchecked', () => {
+      const { container } = renderWithRows(
+        {},
+        { defaultValues: allCheckedDefaults(defaultProps.ids) }
+      );
+
+      const groupCheckbox = container.querySelector(`#inApp${defaultProps.groupName}`);
+      const firstChild = container.querySelector(`#inApp${defaultProps.ids[0]}`);
+
+      expect(groupCheckbox).toBeChecked();
+
+      fireEvent.click(firstChild);
+
+      expect(firstChild).not.toBeChecked();
+      expect(groupCheckbox).not.toBeChecked();
+    });
+
+    it('re-checks the group when the last unchecked child is checked', () => {
+      const initialValues = allCheckedDefaults(defaultProps.ids);
+      initialValues[`inApp${defaultProps.ids[0]}`] = false;
+
+      const { container } = renderWithRows({}, { defaultValues: initialValues });
+
+      const groupCheckbox = container.querySelector(`#inApp${defaultProps.groupName}`);
+      const firstChild = container.querySelector(`#inApp${defaultProps.ids[0]}`);
+
+      expect(groupCheckbox).not.toBeChecked();
+      expect(firstChild).not.toBeChecked();
+
+      fireEvent.click(firstChild);
+
+      expect(firstChild).toBeChecked();
+      expect(groupCheckbox).toBeChecked();
+    });
+
+    it('toggles every child row when the group checkbox is clicked', () => {
+      const { container } = renderWithRows(
+        {},
+        { defaultValues: allCheckedDefaults(defaultProps.ids) }
+      );
+
+      const groupCheckbox = container.querySelector(`#inApp${defaultProps.groupName}`);
+
+      act(() => {
+        fireEvent.click(groupCheckbox);
+      });
+
+      expect(groupCheckbox).not.toBeChecked();
+      defaultProps.ids.forEach((id) => {
+        expect(container.querySelector(`#inApp${id}`)).not.toBeChecked();
+      });
+
+      act(() => {
+        fireEvent.click(groupCheckbox);
+      });
+
+      expect(groupCheckbox).toBeChecked();
+      defaultProps.ids.forEach((id) => {
+        expect(container.querySelector(`#inApp${id}`)).toBeChecked();
+      });
+    });
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/NotificationsRow.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/NotificationsRow.js
@@ -1,0 +1,151 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import NotificationsRow from '../NotificationsRow';
+
+const frequencyOptions = [
+  { key: 'never', label: 'Do not notify me' },
+  { key: 'immediately', label: 'Immediately' },
+  { key: 'today', label: 'Daily digest' },
+  { key: 'this week', label: 'Weekly digest' },
+  { key: 'this month', label: 'Monthly digest' },
+];
+
+function renderRow(props = {}, formProps = {}) {
+  const formRef = {};
+  const setDisplayAlert = jest.fn();
+
+  function Wrapper() {
+    const methods = useForm(formProps);
+    formRef.methods = methods;
+
+    return (
+      <FormProvider {...methods}>
+        <NotificationsRow
+          id="Approved"
+          label="Approved reports"
+          emailVerified={true}
+          setDisplayAlert={setDisplayAlert}
+          {...props}
+        />
+      </FormProvider>
+    );
+  }
+
+  const utils = render(<Wrapper />);
+  return { ...utils, formRef, setDisplayAlert };
+}
+
+describe('NotificationsRow', () => {
+  it('renders the label text', () => {
+    renderRow();
+
+    expect(screen.getByText('Approved reports')).toBeInTheDocument();
+  });
+
+  it('renders an in-app checkbox by default', () => {
+    const { container } = renderRow();
+
+    const checkbox = container.querySelector('#inAppApproved');
+
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveAttribute('type', 'checkbox');
+  });
+
+  it('does not render the in-app checkbox when hideInApp is true', () => {
+    const { container } = renderRow({ hideInApp: true });
+
+    expect(container.querySelector('#inAppApproved')).not.toBeInTheDocument();
+  });
+
+  it('renders the email dropdown with all frequency options', () => {
+    renderRow();
+
+    const dropdown = screen.getByLabelText('Email');
+
+    expect(dropdown).toHaveAttribute('id', 'emailApproved');
+
+    frequencyOptions.forEach(({ label, key }) => {
+      expect(screen.getByRole('option', { name: label })).toHaveValue(key);
+    });
+  });
+
+  it('renders a width-10 spacer when hideInApp is true', () => {
+    const { container } = renderRow({ hideInApp: true });
+
+    const spacer = container.querySelector('div.width-10');
+
+    expect(spacer).toBeInTheDocument();
+    expect(spacer.querySelector('input')).toBeNull();
+  });
+
+  describe('email verification gating', () => {
+    it('does not update the displayed value or form state when email is unverified', () => {
+      const { formRef, setDisplayAlert } = renderRow(
+        { emailVerified: false },
+        { defaultValues: { emailApproved: 'never' } }
+      );
+
+      const dropdown = screen.getByLabelText('Email');
+      expect(dropdown).toHaveValue('never');
+
+      fireEvent.change(dropdown, { target: { value: 'this week' } });
+
+      expect(setDisplayAlert).toHaveBeenCalledWith(true);
+      expect(dropdown).toHaveValue('never');
+      expect(formRef.methods.getValues('emailApproved')).toBe('never');
+    });
+
+    it('updates the displayed value and form state when email is verified', () => {
+      const { formRef, setDisplayAlert } = renderRow(
+        { emailVerified: true },
+        { defaultValues: { emailApproved: 'never' } }
+      );
+
+      const dropdown = screen.getByLabelText('Email');
+
+      fireEvent.change(dropdown, { target: { value: 'this week' } });
+
+      expect(dropdown).toHaveValue('this week');
+      expect(formRef.methods.getValues('emailApproved')).toBe('this week');
+      expect(setDisplayAlert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('controlled in-app checkbox', () => {
+    it('reflects programmatic setValue updates on its form field', () => {
+      const { formRef, container } = renderRow({}, { defaultValues: { inAppApproved: true } });
+
+      const checkbox = container.querySelector('#inAppApproved');
+      expect(checkbox).toBeChecked();
+
+      act(() => {
+        formRef.methods.setValue('inAppApproved', false);
+      });
+
+      expect(checkbox).not.toBeChecked();
+
+      act(() => {
+        formRef.methods.setValue('inAppApproved', true);
+      });
+
+      expect(checkbox).toBeChecked();
+    });
+
+    it('updates form state when the user toggles the checkbox', () => {
+      const { formRef, container } = renderRow({}, { defaultValues: { inAppApproved: true } });
+
+      const checkbox = container.querySelector('#inAppApproved');
+
+      fireEvent.click(checkbox);
+
+      expect(checkbox).not.toBeChecked();
+      expect(formRef.methods.getValues('inAppApproved')).toBe(false);
+
+      fireEvent.click(checkbox);
+
+      expect(checkbox).toBeChecked();
+      expect(formRef.methods.getValues('inAppApproved')).toBe(true);
+    });
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/NotificationsSection.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/NotificationsSection.js
@@ -1,0 +1,190 @@
+/* eslint-disable react/prop-types */
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import NotificationsSection from '../NotificationsSection';
+
+jest.mock(
+  '../NotificationsGroupController',
+  () =>
+    function MockNotificationsGroupController({ setDisplayAlert }) {
+      return (
+        <button
+          type="button"
+          data-testid="trigger-alert-group"
+          onClick={() => setDisplayAlert(true)}
+        >
+          trigger group alert
+        </button>
+      );
+    }
+);
+
+jest.mock(
+  '../NotificationsRow',
+  () =>
+    function MockNotificationsRow({ id, setDisplayAlert }) {
+      return (
+        <button
+          type="button"
+          data-testid={`trigger-alert-row-${id}`}
+          onClick={() => setDisplayAlert(true)}
+        >
+          {`trigger row alert ${id}`}
+        </button>
+      );
+    }
+);
+
+const ALERT_TEXT = /you must verify your email before setting email preferences/i;
+
+function renderSection(props = {}) {
+  const {
+    clearAlerts,
+    emailVerified = false,
+    emailVerificationSent = false,
+    sendVerificationEmail = jest.fn(),
+    items = [{ id: 'Approved', label: 'Approved reports' }],
+    groupController,
+    omitClearAlerts = false,
+  } = props;
+
+  function Wrapper({ clearAlertsProp }) {
+    const methods = useForm();
+    const sectionProps = {
+      emailVerified,
+      emailVerificationSent,
+      sendVerificationEmail,
+      items,
+      groupController,
+    };
+
+    if (!omitClearAlerts) {
+      sectionProps.clearAlerts = clearAlertsProp;
+    }
+
+    return (
+      <FormProvider {...methods}>
+        <NotificationsSection {...sectionProps} />
+      </FormProvider>
+    );
+  }
+
+  const utils = render(<Wrapper clearAlertsProp={clearAlerts} />);
+  return {
+    ...utils,
+    rerenderWith: (clearAlertsProp) =>
+      utils.rerender(<Wrapper clearAlertsProp={clearAlertsProp} />),
+  };
+}
+
+describe('NotificationsSection alert clearing', () => {
+  it('renders the verification alert after a row sets displayAlert to true', () => {
+    renderSection({ clearAlerts: false });
+
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+  });
+
+  it('renders the verification alert after the group controller sets displayAlert to true', () => {
+    renderSection({
+      clearAlerts: false,
+      groupController: { name: 'ReportUpdates', ids: ['Approved'], label: 'All' },
+    });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-group'));
+
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+  });
+
+  it('hides a visible alert when clearAlerts transitions from false to true', () => {
+    const { rerenderWith } = renderSection({ clearAlerts: false });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+
+    rerenderWith(true);
+
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('does not affect alert visibility while clearAlerts remains false', () => {
+    const { rerenderWith } = renderSection({ clearAlerts: false });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+
+    rerenderWith(false);
+
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+  });
+
+  it('keeps the alert hidden across repeated truthy clearAlerts transitions', () => {
+    const { rerenderWith } = renderSection({ clearAlerts: false });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+
+    rerenderWith(true);
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+
+    rerenderWith(false);
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+
+    rerenderWith(true);
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('re-hides the alert if displayAlert is re-triggered and clearAlerts cycles again', () => {
+    const { rerenderWith } = renderSection({ clearAlerts: false });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+    rerenderWith(true);
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+
+    rerenderWith(false);
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+
+    rerenderWith(true);
+    expect(screen.queryByText(ALERT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('treats an omitted clearAlerts prop the same as false', () => {
+    renderSection({ omitClearAlerts: true });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+
+    expect(screen.getByText(ALERT_TEXT)).toBeInTheDocument();
+  });
+
+  it('shows the "Send verification email" button label when no verification email has been sent', () => {
+    renderSection({ clearAlerts: false, emailVerificationSent: false });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+
+    expect(screen.getByRole('button', { name: 'Send verification email' })).toBeInTheDocument();
+  });
+
+  it('shows the "Resend verification email" button label after a verification email was sent', () => {
+    renderSection({ clearAlerts: false, emailVerificationSent: true });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+
+    expect(screen.getByRole('button', { name: 'Resend verification email' })).toBeInTheDocument();
+  });
+
+  it('invokes sendVerificationEmail when the alert button is clicked', () => {
+    const sendVerificationEmail = jest.fn();
+    renderSection({ clearAlerts: false, sendVerificationEmail });
+
+    fireEvent.click(screen.getByTestId('trigger-alert-row-Approved'));
+    fireEvent.click(screen.getByRole('button', { name: 'Send verification email' }));
+
+    expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/OtherNotifications.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/OtherNotifications.js
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import OtherNotifications from '../OtherNotifications';
+
+function renderComponent() {
+  function Wrapper() {
+    const methods = useForm();
+    return (
+      <FormProvider {...methods}>
+        <OtherNotifications />
+      </FormProvider>
+    );
+  }
+
+  render(<Wrapper />);
+}
+
+describe('OtherNotifications', () => {
+  it('renders column headers', () => {
+    renderComponent();
+
+    expect(screen.getByText('Event')).toBeInTheDocument();
+    expect(screen.getByText('In-app')).toBeInTheDocument();
+    expect(screen.getAllByText('Email').length).toBeGreaterThan(0);
+  });
+
+  it('renders expected row labels', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText(
+        "New monitoring details are added for recipients in my region where I'm the TTAC or Manager."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/I'm added as a Co-owner of a .*My group.*\./)).toBeInTheDocument();
+    expect(screen.getByText(/Someone shares their .*My group.* with me\./)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/SystemRelatedNotifications.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/SystemRelatedNotifications.js
@@ -1,0 +1,41 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import SystemRelatedNotifications from '../SystemRelatedNotifications';
+
+function renderComponent() {
+  function Wrapper() {
+    const methods = useForm();
+    return (
+      <FormProvider {...methods}>
+        <SystemRelatedNotifications />
+      </FormProvider>
+    );
+  }
+
+  render(<Wrapper />);
+}
+
+describe('SystemRelatedNotifications', () => {
+  it('renders column headers', () => {
+    renderComponent();
+
+    expect(screen.getByText('Event')).toBeInTheDocument();
+    expect(screen.getByText('In-app')).toBeInTheDocument();
+    expect(screen.getAllByText('Email').length).toBeGreaterThan(0);
+  });
+
+  it('renders expected row labels', () => {
+    renderComponent();
+
+    expect(screen.getByText('Planned system outage alerts.')).toBeInTheDocument();
+    expect(screen.getByText('Unplanned system outage alerts.')).toBeInTheDocument();
+  });
+
+  it('does not render an in-app checkbox for unplanned outage alerts', () => {
+    renderComponent();
+
+    expect(document.getElementById('inAppWhenUnplannedOutage')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AccountManagement/components/notifications/__tests__/TrainingReportNotifications.js
+++ b/frontend/src/pages/AccountManagement/components/notifications/__tests__/TrainingReportNotifications.js
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import TrainingReportNotifications from '../TrainingReportNotifications';
+
+function renderComponent() {
+  function Wrapper() {
+    const methods = useForm();
+    return (
+      <FormProvider {...methods}>
+        <TrainingReportNotifications />
+      </FormProvider>
+    );
+  }
+
+  render(<Wrapper />);
+}
+
+describe('TrainingReportNotifications', () => {
+  it('renders column headers', () => {
+    renderComponent();
+
+    expect(screen.getByText('Event')).toBeInTheDocument();
+    expect(screen.getByText('In-app')).toBeInTheDocument();
+    expect(screen.getAllByText('Email').length).toBeGreaterThan(0);
+  });
+
+  it('renders group controller label', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText('Set preferences for all Training Report notifications')
+    ).toBeInTheDocument();
+  });
+
+  it('renders expected row labels', () => {
+    renderComponent();
+
+    expect(
+      screen.getByText("I'm added as a Regional point of contact on a Training Report.")
+    ).toBeInTheDocument();
+    expect(screen.getByText('Someone submits an event session for my review.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AccountManagement/index.js
+++ b/frontend/src/pages/AccountManagement/index.js
@@ -26,8 +26,9 @@ import EmailVerifier from './EmailVerifier';
 
 const emailPreferenceErrorMessage = 'Please select a frequency preference';
 
+// TODO: Use TS/shared packages
 // these keys should match the keys in /src/constants.js:USER_SETTINGS.EMAIL.VALUES
-const frequencyValues = [
+export const frequencyValues = [
   { key: 'never', label: 'Do not notify me' },
   { key: 'immediately', label: 'Immediately' },
   { key: 'today', label: 'Daily digest' },
@@ -41,7 +42,7 @@ const managerAndCollaboratorRoles = ['ECM', 'ECS', 'FES', 'GS', 'GSM', 'HS', 'SS
 
 const recipientsAvailable = ['PS', 'SPS', 'GMS'];
 
-const emailTypesMap = {
+export const emailTypesMap = {
   submitsForApprovalRoles: [
     {
       name: '',

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node", "jest"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "build", "coverage"]
+}

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -1,11 +1,12 @@
 import { createRequire } from 'node:module';
-import { defineConfig, loadEnv, transformWithEsbuild } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig, loadEnv, transformWithEsbuild } from 'vite';
 
 const require = createRequire(import.meta.url);
 
 const loadJsFilesAsJsx = {
   name: 'load-js-files-as-jsx',
+  // Transforms .js files in src/ as JSX. .ts/.tsx files are handled natively by @vitejs/plugin-react.
   async transform(code, id) {
     if (!/\/src\/.*\.js$/.test(id)) {
       return null;
@@ -21,21 +22,23 @@ const loadJsFilesAsJsx = {
 const htmlTemplateBehavior = (env) => ({
   name: 'html-template-behavior',
   transformIndexHtml(html) {
-    const accessibilityCssLink = env.REACT_APP_INCLUDE_ACCESSIBILITY_CSS === 'true'
-      ? '<link rel="stylesheet" href="/accessibility-errors.css" />'
-      : '';
+    const accessibilityCssLink =
+      env.REACT_APP_INCLUDE_ACCESSIBILITY_CSS === 'true'
+        ? '<link rel="stylesheet" href="/accessibility-errors.css" />'
+        : '';
 
     const gtmAuth = JSON.stringify(env.REACT_APP_GTM_AUTH || '');
     const gtmPreview = JSON.stringify(env.REACT_APP_GTM_PREVIEW || '');
     const gtmId = JSON.stringify(env.REACT_APP_GTM_ID || '');
 
-    const gtmScript = env.REACT_APP_GTM_ENABLED === 'true'
-      ? `<script nonce="__NONCE__">(function(w,d,s,l,i,auth,preview){w[l]=w[l]||[];w[l].push({'gtm.start':
+    const gtmScript =
+      env.REACT_APP_GTM_ENABLED === 'true'
+        ? `<script nonce="__NONCE__">(function(w,d,s,l,i,auth,preview){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth='+auth+'&gtm_preview='+preview+'&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer', ${gtmId}, ${gtmAuth}, ${gtmPreview});</script>`
-      : '';
+        : '';
 
     return html
       .replace('<!-- __ACCESSIBILITY_CSS__ -->', accessibilityCssLink)
@@ -47,7 +50,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const backendProxy = env.BACKEND_PROXY || process.env.BACKEND_PROXY;
   const reactAppEnv = Object.fromEntries(
-    Object.entries(env).filter(([key]) => key.startsWith('REACT_APP_')),
+    Object.entries(env).filter(([key]) => key.startsWith('REACT_APP_'))
   );
 
   return {
@@ -60,6 +63,7 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [loadJsFilesAsJsx, react(), htmlTemplateBehavior(env)],
     resolve: {
+      extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
       alias: {
         '@mesh-kit/core/client': require.resolve('@mesh-kit/core/client'),
         '@use-it/interval': require.resolve('@use-it/interval/dist/index.js'),
@@ -81,11 +85,11 @@ export default defineConfig(({ mode }) => {
       strictPort: true,
       proxy: backendProxy
         ? {
-          '/api': {
-            target: backendProxy,
-            changeOrigin: true,
-          },
-        }
+            '/api': {
+              target: backendProxy,
+              changeOrigin: true,
+            },
+          }
         : undefined,
     },
     build: {
@@ -97,9 +101,9 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         onwarn(warning, warn) {
           if (
-            warning.code === 'SOURCEMAP_ERROR'
-            || (typeof warning.message === 'string'
-              && warning.message.includes('Failed to parse source map'))
+            warning.code === 'SOURCEMAP_ERROR' ||
+            (typeof warning.message === 'string' &&
+              warning.message.includes('Failed to parse source map'))
           ) {
             return;
           }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16,6 +16,15 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.3":
   version "7.29.3"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.3.tgz#e3f5347f0589596c91d227ccb6a541d37fb1307b"
@@ -53,12 +62,30 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
+"@babel/generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
+  integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
 "@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz#f31fd86b915fc4daf1f3ac6976c59be7084ed9c5"
   integrity sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==
   dependencies:
     "@babel/types" "^7.27.3"
+
+"@babel/helper-annotate-as-pure@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz#c70fe3c6ecbdc3fd2dd1b0f498428b88b82ce47f"
+  integrity sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==
+  dependencies:
+    "@babel/types" "^7.29.7"
 
 "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.28.6":
   version "7.28.6"
@@ -82,6 +109,19 @@
     "@babel/helper-replace-supers" "^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
     "@babel/traverse" "^7.29.0"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz#6eddf286f2ec418f740c91d60a83347c55838ddd"
+  integrity sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
     semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1", "@babel/helper-create-regexp-features-plugin@^7.28.5":
@@ -109,6 +149,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
   integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
 
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
+
 "@babel/helper-member-expression-to-functions@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz#f3e07a10be37ed7a63461c63e6929575945a6150"
@@ -117,6 +162,14 @@
     "@babel/traverse" "^7.28.5"
     "@babel/types" "^7.28.5"
 
+"@babel/helper-member-expression-to-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz#8dbdb3ce0b5c487e1aec10e13c9a43a500814df8"
+  integrity sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
@@ -124,6 +177,14 @@
   dependencies:
     "@babel/traverse" "^7.28.6"
     "@babel/types" "^7.28.6"
+
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.28.6":
   version "7.28.6"
@@ -134,6 +195,15 @@
     "@babel/helper-validator-identifier" "^7.28.5"
     "@babel/traverse" "^7.28.6"
 
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
 "@babel/helper-optimise-call-expression@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz#c65221b61a643f3e62705e5dd2b5f115e35f9200"
@@ -141,10 +211,22 @@
   dependencies:
     "@babel/types" "^7.27.1"
 
+"@babel/helper-optimise-call-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz#77b0b5b94f1997fa9d6e3125f445227b1faf9d85"
+  integrity sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.8.0":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz#6f13ea251b68c8532e985fd532f28741a8af9ac8"
   integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
+
+"@babel/helper-plugin-utils@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
 
 "@babel/helper-remap-async-to-generator@^7.27.1":
   version "7.27.1"
@@ -164,6 +246,15 @@
     "@babel/helper-optimise-call-expression" "^7.27.1"
     "@babel/traverse" "^7.28.6"
 
+"@babel/helper-replace-supers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz#bc3c3964329043c79112e513c1b198f16589ac21"
+  integrity sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz#62bb91b3abba8c7f1fec0252d9dbea11b3ee7a56"
@@ -172,20 +263,43 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
+"@babel/helper-skip-transparent-expression-wrappers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz#50c95c7e4c4f54936cfa0116428edc559862d551"
+  integrity sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
 
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
+
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
 
 "@babel/helper-wrap-function@^7.27.1":
   version "7.28.6"
@@ -210,6 +324,13 @@
   integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
   dependencies:
     "@babel/types" "^7.29.0"
+
+"@babel/parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
+  dependencies:
+    "@babel/types" "^7.29.7"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.28.5":
   version "7.28.5"
@@ -326,6 +447,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
+"@babel/plugin-syntax-jsx@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -381,6 +509,13 @@
   integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.28.6"
@@ -592,6 +727,14 @@
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
+
+"@babel/plugin-transform-modules-commonjs@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz#70e6835abf2663dafbe94b8ef1f51de7351ef135"
+  integrity sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-transform-modules-systemjs@^7.29.4":
   version "7.29.4"
@@ -810,6 +953,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz#f0449c3df7037bbe232043476851c38f5e4a7615"
+  integrity sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/plugin-syntax-typescript" "^7.29.7"
+
 "@babel/plugin-transform-unicode-escapes@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz#3e3143f8438aef842de28816ece58780190cf806"
@@ -939,6 +1093,17 @@
     "@babel/plugin-transform-react-jsx-development" "^7.27.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
 
+"@babel/preset-typescript@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz#de9be1f47b785c979ec7b3a71f4cd8bae5267b62"
+  integrity sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-syntax-jsx" "^7.29.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.29.7"
+    "@babel/plugin-transform-typescript" "^7.29.7"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.4", "@babel/runtime@^7.26.10", "@babel/runtime@^7.28.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
@@ -953,6 +1118,15 @@
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
 
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
@@ -966,6 +1140,19 @@
     "@babel/types" "^7.29.0"
     debug "^4.3.1"
 
+"@babel/traverse@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.7.tgz#c47b07a41b95da0907d026b5dd894d98de7d2f2d"
+  integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.29.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
@@ -973,6 +1160,14 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"


### PR DESCRIPTION
## Description of change
- Add "Manage Notifications"/"Notifications Preference" page (non-functional) complete with email flow
- Add Typescript to the frontend as an opt-in (developer convenience)
- Fixes: Confluence content is inheriting text-alignment from centered containers when showing the "empty widget" message. We want the confluence content to always be left-aligned



## How to test

New page is at ```/account/notifications```

To test bug: 
1. Filter monitoring dash to just today to force empty states
2. Click "get help using filters"
3. Confirm content is left aligned


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5310
* https://jira.acf.gov/browse/TTAHUB-5416

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [x] QA review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [x] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
