### PR TITLE
add the tr table to to the TTA History tab

### DIFF
--- a/docs/openapi/paths/index.yaml
+++ b/docs/openapi/paths/index.yaml
@@ -60,6 +60,8 @@
   $ref: './goals/goal-status.yaml'
 '/widgets/overview':
   $ref: './widgets/overview.yaml'
+'/widgets/ttaHistoryOverview':
+  $ref: './widgets/ttaHistoryOverview.yaml'
 '/widgets/monitoringOverview':
   $ref: './widgets/monitoringOverview.yaml'
 '/widgets/monitoringTta':

--- a/docs/openapi/paths/widgets/ttaHistoryOverview.yaml
+++ b/docs/openapi/paths/widgets/ttaHistoryOverview.yaml
@@ -1,0 +1,39 @@
+get:
+  tags:
+    - widgets
+  operationId: ttaHistoryOverview
+  description: >
+    Gets combined overview metrics for the TTA History tab on the Recipient
+    TTA Record. All numeric fields are formatted strings (e.g. "1,234").
+    `sumDuration`, `numParticipants`, and `inPerson` combine values from
+    approved Activity Reports and approved Training Report sessions.
+    `numSessions` is the count of approved Training Report sessions only.
+  responses:
+    200:
+      description: Combined AR and TR overview metrics for the recipient
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              numReports:
+                type: string
+                description: Number of approved Activity Reports
+              numGrants:
+                type: string
+                description: Number of grants with approved Activity Reports
+              numOtherEntities:
+                type: string
+                description: Number of other entities with approved Activity Reports
+              sumDuration:
+                type: string
+                description: Total hours of TTA across approved ARs and TR sessions
+              numParticipants:
+                type: string
+                description: Total participants across approved ARs and TR sessions
+              inPerson:
+                type: string
+                description: Count of in-person activities across approved ARs and TR sessions
+              numSessions:
+                type: string
+                description: Count of approved Training Report sessions

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -15,6 +15,7 @@ import ApprovedARAndTRByGoalCategory from '../../../widgets/ApprovedARAndTRByGoa
 import FrequencyGraph from '../../../widgets/FrequencyGraph';
 import TargetPopulationsTable from '../../../widgets/TargetPopulationsTable';
 import { TTAHISTORY_FILTER_CONFIG } from './constants';
+import RecipientTrainingReportsTable from './components/RecipientTrainingReportsTable';
 
 const defaultDate = formatDateRange({
   yearToDate: true,
@@ -115,6 +116,7 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
             setResetPagination={setResetPagination}
           />
         </FilterContext.Provider>
+        <RecipientTrainingReportsTable filters={filtersToApply} />
       </div>
     </>
   );

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -72,6 +72,7 @@ describe('Recipient Record - TTA History', () => {
       `/api/widgets/approvedARAndTRByGoalCategory?startDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`,
       []
     );
+    fetchMock.get(/\/api\/session-reports.*/, { count: 0, rows: [] });
   });
 
   afterEach(() => {

--- a/frontend/src/pages/RecipientRecord/pages/components/RecipientTrainingReportsTable.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/RecipientTrainingReportsTable.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { getSessionReportsTable } from '../../../../fetchers/session';
+import useFetch from '../../../../hooks/useFetch';
+import useRequestSort from '../../../../hooks/useRequestSort';
+import useSessionSort from '../../../../hooks/useSessionSort';
+import TrainingReportsTable from '../../../RegionalDashboard/components/TrainingReportsTable';
+
+export default function RecipientTrainingReportsTable({ filters }) {
+  const [sortConfig, setSortConfig] = useSessionSort(
+    {
+      sortBy: 'Event_ID',
+      direction: 'desc',
+      activePage: 1,
+      offset: 0,
+    },
+    'recipientTrainingReportsTable'
+  );
+
+  const requestSort = useRequestSort(setSortConfig);
+
+  const { data, error } = useFetch(
+    { rows: [], count: 0 },
+    () => getSessionReportsTable(sortConfig, filters),
+    [sortConfig, filters],
+    'Unable to fetch training reports'
+  );
+
+  return (
+    <TrainingReportsTable
+      data={data}
+      error={error}
+      title="Approved training reports"
+      emptyMsg="No training reports found"
+      requestSort={requestSort}
+      sortConfig={sortConfig}
+      setSortConfig={setSortConfig}
+      filters={filters}
+    />
+  );
+}
+
+RecipientTrainingReportsTable.defaultProps = {
+  filters: [],
+};
+
+RecipientTrainingReportsTable.propTypes = {
+  filters: PropTypes.arrayOf(PropTypes.shape({})),
+};

--- a/frontend/src/pages/RecipientRecord/pages/components/__tests__/RecipientTrainingReportsTable.js
+++ b/frontend/src/pages/RecipientRecord/pages/components/__tests__/RecipientTrainingReportsTable.js
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import RecipientTrainingReportsTable from '../RecipientTrainingReportsTable';
+
+const renderTable = (filters = []) =>
+  render(
+    <MemoryRouter>
+      <RecipientTrainingReportsTable filters={filters} />
+    </MemoryRouter>
+  );
+
+describe('RecipientTrainingReportsTable', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('renders the table title', async () => {
+    fetchMock.get(/\/api\/session-reports.*/, { count: 0, rows: [] });
+    renderTable();
+    expect(await screen.findByText('Approved training reports')).toBeInTheDocument();
+  });
+
+  it('shows the empty message when no sessions are returned', async () => {
+    fetchMock.get(/\/api\/session-reports.*/, { count: 0, rows: [] });
+    renderTable();
+    expect(await screen.findByText('No training reports found')).toBeInTheDocument();
+  });
+
+  it('makes an API request that includes the recipientId filter', async () => {
+    fetchMock.get(/\/api\/session-reports.*/, { count: 0, rows: [] });
+
+    const filters = [
+      { topic: 'recipientId', condition: 'contains', query: '401' },
+      { topic: 'region', condition: 'is', query: '1' },
+    ];
+
+    renderTable(filters);
+
+    await waitFor(() => {
+      const calls = fetchMock.calls().map(([url]) => url);
+      expect(calls.some((url) => url.includes('recipientId.ctn%5B%5D=401') || url.includes('recipientId.ctn[]=401'))).toBe(true);
+    });
+  });
+
+  it('renders a row for each returned session', async () => {
+    fetchMock.get(/\/api\/session-reports.*/, {
+      count: 1,
+      rows: [
+        {
+          id: 1,
+          eventId: 'R01-PD-25-1234',
+          eventName: 'Test Event',
+          sessionName: 'Session One',
+          startDate: '2025-01-15',
+          endDate: '2025-01-16',
+          objectiveTopics: ['Topic A'],
+          goalTemplates: [],
+          recipients: [{ label: 'Test Recipient' }],
+          participants: [],
+          duration: 1,
+        },
+      ],
+    });
+
+    renderTable();
+
+    expect(await screen.findByText('R01-PD-25-1234')).toBeInTheDocument();
+    expect(screen.getAllByText('Test Event').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Session One').length).toBeGreaterThan(0);
+  });
+});

--- a/src/scopes/sessionReports/index.ts
+++ b/src/scopes/sessionReports/index.ts
@@ -1,7 +1,11 @@
 import { createFiltersToScopes } from '../utils';
+import { withRecipientId } from './recipientId';
 import { withSessionId } from './sessionId';
 
 export const topicToQuery = {
+  recipientId: {
+    ctn: (query: string[]) => withRecipientId(query),
+  },
   sessionId: {
     in: (query: string[]) => withSessionId(query),
   },

--- a/src/scopes/sessionReports/recipientId.test.ts
+++ b/src/scopes/sessionReports/recipientId.test.ts
@@ -1,0 +1,84 @@
+import { Op } from 'sequelize';
+import db from '../../models';
+import filtersToScopes from '..';
+import { createGrant, createRecipient } from '../../testUtils';
+import { mockUser } from './testHelpers';
+
+const { sequelize } = db;
+
+describe('sessionReports/recipientId', () => {
+  let recipient;
+  let grant;
+  let eventReportPilot;
+  let sessionWithRecipient;
+  let sessionWithoutRecipient;
+  let possibleIds;
+
+  beforeAll(async () => {
+    await db.User.create(mockUser);
+
+    recipient = await createRecipient();
+    grant = await createGrant({ recipientId: recipient.id });
+
+    eventReportPilot = await db.EventReportPilot.create(
+      {
+        ownerId: mockUser.id,
+        pocIds: [mockUser.id],
+        collaboratorIds: [],
+        regionId: mockUser.homeRegionId,
+        data: {},
+      },
+      { individualHooks: false }
+    );
+
+    // Session linked to the recipient via grantId in JSONB recipients array.
+    sessionWithRecipient = await db.SessionReportPilot.create(
+      {
+        eventId: eventReportPilot.id,
+        data: {
+          recipients: [{ value: grant.id, label: recipient.name }],
+        },
+      },
+      { individualHooks: false }
+    );
+
+    // Session with no recipients.
+    sessionWithoutRecipient = await db.SessionReportPilot.create(
+      {
+        eventId: eventReportPilot.id,
+        data: { recipients: [] },
+      },
+      { individualHooks: false }
+    );
+
+    possibleIds = [sessionWithRecipient.id, sessionWithoutRecipient.id];
+  });
+
+  afterAll(async () => {
+    await db.SessionReportPilot.destroy({ where: { id: possibleIds } });
+    await db.EventReportPilot.destroy({ where: { id: eventReportPilot.id } });
+    await db.Grant.destroy({ where: { id: grant.id }, individualHooks: true });
+    await db.Recipient.destroy({ where: { id: recipient.id }, individualHooks: true });
+    await db.User.destroy({ where: { id: mockUser.id } });
+    await sequelize.close();
+  });
+
+  it('returns sessions that include a grant belonging to the recipient', async () => {
+    const filters = { 'recipientId.ctn': [recipient.id.toString()] };
+    const { sessionReport: scope } = await filtersToScopes(filters);
+    const found = await db.SessionReportPilot.findAll({
+      where: { [Op.and]: [scope, { id: possibleIds }] },
+    });
+    expect(found.length).toBe(1);
+    expect(found[0].id).toBe(sessionWithRecipient.id);
+  });
+
+  it('returns no sessions when the recipient has no matching grants', async () => {
+    const filters = { 'recipientId.ctn': ['999999'] };
+    const { sessionReport: scope } = await filtersToScopes(filters);
+    const found = await db.SessionReportPilot.findAll({
+      where: { [Op.and]: [scope, { id: possibleIds }] },
+    });
+    expect(found.length).toBe(0);
+  });
+});

--- a/src/scopes/sessionReports/recipientId.ts
+++ b/src/scopes/sessionReports/recipientId.ts
@@ -1,0 +1,37 @@
+import { Op } from 'sequelize';
+import { sequelize } from '../../models';
+
+/**
+ * Filters SessionReportPilot rows to only those that include at least one
+ * grant belonging to the specified recipient. Grant IDs are stored in the
+ * JSONB field data->'recipients'[].value (either as a JSON number or a
+ * numeric string), so we join via jsonb_array_elements to the Grants table
+ * and filter by recipientId.
+ *
+ * Per AGENTS.md ("Traps to Avoid → SQL injection in filters"), the input is
+ * independently validated as a positive integer before interpolation.
+ */
+export function withRecipientId(recipientIds: string[]) {
+  const recipientId = Number(recipientIds[0]);
+  if (!Number.isInteger(recipientId) || recipientId <= 0) {
+    return {};
+  }
+
+  return {
+    [Op.and]: [
+      sequelize.literal(`EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements("SessionReportPilot"."data"->'recipients') AS elem
+        INNER JOIN "Grants" g ON (
+          CASE
+            WHEN jsonb_typeof(elem->'value') = 'number'
+                 OR (jsonb_typeof(elem->'value') = 'string' AND elem->>'value' ~ '^[0-9]+$')
+            THEN (elem->>'value')::integer
+            ELSE NULL
+          END
+        ) = g."id"
+        WHERE g."recipientId" = ${sequelize.escape(recipientId)}
+      )`),
+    ],
+  };
+}

--- a/src/widgets/helpers.js
+++ b/src/widgets/helpers.js
@@ -121,3 +121,20 @@ export function formatNumber(numberToFormat, decimalPlaces = 0) {
     maximumFractionDigits: decimalPlaces,
   });
 }
+
+/**
+ * Parse a value that may be a locale-formatted numeric string (e.g. "1,234.5"
+ * produced by `formatNumber`) back into a plain JavaScript number.
+ *
+ * Strips thousands separators (",") before parsing so values previously
+ * formatted with `toLocaleString('en-US', ...)` round-trip cleanly. Returns 0
+ * for null, undefined, empty, or non-numeric input so callers can safely sum
+ * the result without additional guards.
+ */
+export function parseFormattedNumber(value) {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  const parsed = parseFloat(String(value).replace(/,/g, ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/src/widgets/helpers.test.js
+++ b/src/widgets/helpers.test.js
@@ -1,4 +1,4 @@
-import { baseTRScopes, countBySingleKey, formatNumber } from './helpers';
+import { baseTRScopes, countBySingleKey, formatNumber, parseFormattedNumber } from './helpers';
 
 describe('Format Number', () => {
   it('renders with correct decimal places and separator', async () => {
@@ -22,6 +22,48 @@ describe('Format Number', () => {
     expect(formatNumber('sdfgdfg', 3)).toBe('0');
 
     expect(formatNumber()).toBe('0');
+  });
+});
+
+describe('parseFormattedNumber', () => {
+  it('parses a plain integer string', () => {
+    expect(parseFormattedNumber('1234')).toBe(1234);
+  });
+
+  it('strips thousands separators before parsing', () => {
+    expect(parseFormattedNumber('1,234')).toBe(1234);
+    expect(parseFormattedNumber('1,234,567')).toBe(1234567);
+  });
+
+  it('parses a locale-formatted decimal string', () => {
+    expect(parseFormattedNumber('1,234.5')).toBe(1234.5);
+  });
+
+  it('round-trips a value produced by formatNumber', () => {
+    expect(parseFormattedNumber(formatNumber(12345.678, 2))).toBe(12345.68);
+  });
+
+  it('accepts a numeric value and returns it unchanged', () => {
+    expect(parseFormattedNumber(42)).toBe(42);
+    expect(parseFormattedNumber(3.14)).toBe(3.14);
+    expect(parseFormattedNumber(0)).toBe(0);
+  });
+
+  it('returns 0 for null, undefined, or empty input', () => {
+    expect(parseFormattedNumber(null)).toBe(0);
+    expect(parseFormattedNumber(undefined)).toBe(0);
+    expect(parseFormattedNumber('')).toBe(0);
+  });
+
+  it('returns 0 for non-numeric strings', () => {
+    expect(parseFormattedNumber('abc')).toBe(0);
+    expect(parseFormattedNumber(',,,')).toBe(0);
+  });
+
+  it('returns 0 for NaN/Infinity to keep sums finite', () => {
+    expect(parseFormattedNumber(NaN)).toBe(0);
+    expect(parseFormattedNumber(Infinity)).toBe(0);
+    expect(parseFormattedNumber(-Infinity)).toBe(0);
   });
 });
 

--- a/src/widgets/trSessionsForRecipient.test.ts
+++ b/src/widgets/trSessionsForRecipient.test.ts
@@ -183,6 +183,8 @@ describe('TR sessions for recipient widget', () => {
     expect(data.sumDuration).toBe(2.5);
     // session1 (10) + session2 (10) = 20 participants
     expect(data.numParticipants).toBe(20);
+    // session1 + session2 are both in-person and COMPLETE
+    expect(data.numInPerson).toBe(2);
   });
 
   it('does not count sessions belonging only to other recipients', async () => {
@@ -202,6 +204,8 @@ describe('TR sessions for recipient widget', () => {
     expect(data.sumDuration).toBe(2);
     // session4 numberOfParticipants = 10
     expect(data.numParticipants).toBe(10);
+    // session4 is in-person
+    expect(data.numInPerson).toBe(1);
   });
 
   it('returns 0 when no grants are in scope', async () => {
@@ -216,6 +220,7 @@ describe('TR sessions for recipient widget', () => {
     expect(data.numSessions).toBe('0');
     expect(data.sumDuration).toBe(0);
     expect(data.numParticipants).toBe(0);
+    expect(data.numInPerson).toBe(0);
   });
 
   it('sums hybrid session participants from in-person + virtual counts', async () => {
@@ -261,9 +266,102 @@ describe('TR sessions for recipient widget', () => {
       expect(data.numParticipants).toBe(7);
       // hybrid session duration (1)
       expect(data.sumDuration).toBe(1);
+      // hybrid is NOT counted as in-person — matches the AR overview's strict
+      // equality check on the 'in-person' delivery method
+      expect(data.numInPerson).toBe(0);
     } finally {
       await SessionReportPilot.destroy({ where: { eventId: hybridTr.id } });
       await EventReportPilot.destroy({ where: { id: hybridTr.id } });
+    }
+  });
+
+  it('counts only sessions with deliveryMethod === "in-person" in numInPerson', async () => {
+    const mixedTr = await createTrainingReport({
+      collaboratorIds: [],
+      pocIds: [],
+      ownerId: userCreator.id,
+    });
+
+    // in-person -> counted
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 5,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // virtual -> not counted
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'virtual',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 5,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // hybrid -> not counted as in-person
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'hybrid',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 1,
+        numberOfParticipantsInPerson: 2,
+        numberOfParticipants: 0,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    // in-person but IN_PROGRESS -> excluded by baseTRScopes
+    await createSessionReport({
+      eventId: mixedTr.id,
+      data: {
+        deliveryMethod: 'in-person',
+        duration: 1,
+        recipients: [{ value: grant1.id }],
+        numberOfParticipantsVirtually: 0,
+        numberOfParticipantsInPerson: 0,
+        numberOfParticipants: 5,
+        status: TRAINING_REPORT_STATUSES.IN_PROGRESS,
+      },
+    });
+
+    await mixedTr.update({
+      data: {
+        ...mixedTr.data,
+        status: TRAINING_REPORT_STATUSES.COMPLETE,
+      },
+    });
+
+    try {
+      const scopes = {
+        grant: {
+          where: [{ id: [grant1.id] }],
+        },
+        trainingReport: [{ id: [mixedTr.id] }],
+      } as any;
+
+      const data = await trSessionsForRecipient(scopes);
+
+      // 3 COMPLETE sessions (in-person, virtual, hybrid) — the IN_PROGRESS one is excluded
+      expect(data.numSessions).toBe('3');
+      // Only the single COMPLETE in-person session counts
+      expect(data.numInPerson).toBe(1);
+    } finally {
+      await SessionReportPilot.destroy({ where: { eventId: mixedTr.id } });
+      await EventReportPilot.destroy({ where: { id: mixedTr.id } });
     }
   });
 });

--- a/src/widgets/trSessionsForRecipient.ts
+++ b/src/widgets/trSessionsForRecipient.ts
@@ -40,8 +40,8 @@ function getSessionParticipantCount(data: ISessionDataForRecipient): number {
 
 /**
  * Widget: count of approved (COMPLETE) Training Report sessions for a given recipient,
- * plus the total hours of TTA delivered and the total number of participants
- * across those sessions.
+ * plus the total hours of TTA delivered, the total number of participants,
+ * and the count of in-person sessions across those sessions.
  * Used on the RTR TTA History tab.
  *
  * The recipient filter flows in via scopes.grant.where (from the recipientId.ctn
@@ -50,12 +50,23 @@ function getSessionParticipantCount(data: ISessionDataForRecipient): number {
  *
  * NOTE: The `numSessions` key returned here is per-recipient and is distinct from the
  * `numSessions` returned by `trOverview`, which is a global count across visible TRs.
- * `sumDuration` and `numParticipants` are returned as raw numbers so they can be
- * summed with the AR values in `ttaHistoryOverview`; formatting happens in the caller.
+ * `sumDuration`, `numParticipants`, and `numInPerson` are returned as raw numbers so
+ * they can be summed with the AR values in `ttaHistoryOverview`; formatting happens
+ * in the caller.
+ *
+ * `numInPerson` matches the activity report overview's strict equality check on the
+ * 'in-person' delivery method (see `src/widgets/overview.js`); hybrid sessions are
+ * intentionally excluded so the combined "In person activities" widget stays
+ * consistent with the AR-only behavior.
  */
 export default async function trSessionsForRecipient(
   scopes: IScopes
-): Promise<{ numSessions: string; sumDuration: number; numParticipants: number }> {
+): Promise<{
+  numSessions: string;
+  sumDuration: number;
+  numParticipants: number;
+  numInPerson: number;
+}> {
   // Find all grants visible to this user/recipient via the standard grant scopes.
   const grants = (await Grant.findAll({
     attributes: ['id'],
@@ -73,7 +84,9 @@ export default async function trSessionsForRecipient(
     .filter((id) => Number.isInteger(id) && id > 0);
 
   if (grantIdList.length === 0) {
-    return { numSessions: '0', sumDuration: 0, numParticipants: 0 };
+    return {
+      numSessions: '0', sumDuration: 0, numParticipants: 0, numInPerson: 0,
+    };
   }
 
   // Build a SQL literal that restricts sessions to only those containing at least
@@ -134,5 +147,17 @@ export default async function trSessionsForRecipient(
     0,
   );
 
-  return { numSessions: formatNumber(numSessions), sumDuration, numParticipants };
+  // Count sessions whose delivery method is strictly 'in-person', mirroring the
+  // AR overview's equality check so the combined "In person activities" widget
+  // counts AR and TR sessions the same way.
+  const numInPerson = reports.reduce(
+    (sum, r) => sum + r.sessionReports.filter(
+      (s) => (s.data?.deliveryMethod || '').toLowerCase() === 'in-person',
+    ).length,
+    0,
+  );
+
+  return {
+    numSessions: formatNumber(numSessions), sumDuration, numParticipants, numInPerson,
+  };
 }

--- a/src/widgets/ttaHistoryOverview.test.ts
+++ b/src/widgets/ttaHistoryOverview.test.ts
@@ -137,7 +137,7 @@ describe('ttaHistoryOverview widget', () => {
     const result = await ttaHistoryOverview(SCOPES, {});
 
     // 1,234 + 6 = 1,240, formatted with thousands separator. Confirms commas
-    // are stripped before parseInt — otherwise parseInt('1,234') => 1.
+    // are stripped before parseFloat — otherwise parseFloat('1,234') => 1.
     expect(result.inPerson).toBe('1,240');
   });
 

--- a/src/widgets/ttaHistoryOverview.test.ts
+++ b/src/widgets/ttaHistoryOverview.test.ts
@@ -28,22 +28,25 @@ describe('ttaHistoryOverview widget', () => {
     jest.clearAllMocks();
   });
 
-  it('merges AR overview data with numSessions, combined sumDuration, and combined numParticipants', async () => {
+  it('merges AR overview data with numSessions, combined sumDuration, combined numParticipants, and combined inPerson', async () => {
     mockOverview.mockResolvedValue(AR_DATA);
     mockTrSessionsForRecipient.mockResolvedValue({
       numSessions: '7',
       sumDuration: 3.5,
       numParticipants: 13,
+      numInPerson: 4,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
     // AR sumDuration "12" + TR sumDuration 3.5 = 15.5 (formatted with 1 decimal)
     // AR numParticipants 40 + TR numParticipants 13 = 53
+    // AR inPerson 2 + TR numInPerson 4 = 6
     expect(result).toEqual({
       ...AR_DATA,
       sumDuration: '15.5',
       numParticipants: '53',
+      inPerson: '6',
       numSessions: '7',
     });
   });
@@ -54,6 +57,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '4',
       sumDuration: 0,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -67,6 +71,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 10,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -81,6 +86,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 2.5,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -94,6 +100,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 0,
       numParticipants: 10,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
@@ -110,11 +117,42 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 0,
       numParticipants: 5,
+      numInPerson: 0,
     });
 
     const result = await ttaHistoryOverview(SCOPES, {});
 
     expect(result.numParticipants).toBe('5');
+  });
+
+  it('strips thousands separators from inPerson before summing', async () => {
+    mockOverview.mockResolvedValue({ ...AR_DATA, inPerson: '1,234' });
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 0,
+      numParticipants: 0,
+      numInPerson: 6,
+    });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    // 1,234 + 6 = 1,240, formatted with thousands separator. Confirms commas
+    // are stripped before parseInt — otherwise parseInt('1,234') => 1.
+    expect(result.inPerson).toBe('1,240');
+  });
+
+  it('falls back to 0 in-person when AR inPerson is missing', async () => {
+    mockOverview.mockResolvedValue({ ...AR_DATA, inPerson: undefined } as any);
+    mockTrSessionsForRecipient.mockResolvedValue({
+      numSessions: '0',
+      sumDuration: 0,
+      numParticipants: 0,
+      numInPerson: 3,
+    });
+
+    const result = await ttaHistoryOverview(SCOPES, {});
+
+    expect(result.inPerson).toBe('3');
   });
 
   it('calls both overview and trSessionsForRecipient with the same scopes', async () => {
@@ -123,6 +161,7 @@ describe('ttaHistoryOverview widget', () => {
       numSessions: '0',
       sumDuration: 0,
       numParticipants: 0,
+      numInPerson: 0,
     });
 
     await ttaHistoryOverview(SCOPES, {});

--- a/src/widgets/ttaHistoryOverview.ts
+++ b/src/widgets/ttaHistoryOverview.ts
@@ -1,6 +1,6 @@
 import overview from './overview';
 import trSessionsForRecipient from './trSessionsForRecipient';
-import { formatNumber } from './helpers';
+import { formatNumber, parseFormattedNumber } from './helpers';
 import type { IScopes } from './types';
 
 /**
@@ -16,6 +16,11 @@ import type { IScopes } from './types';
  * `numParticipants` represents the total participants on approved Activity
  * Reports AND approved Training Report sessions combined for the recipient,
  * so the "Participants" widget reflects both delivery channels.
+ *
+ * `inPerson` represents the count of in-person activities across approved
+ * Activity Reports AND approved Training Report sessions combined for the
+ * recipient, so the "In person activities" widget reflects both delivery
+ * channels.
  */
 export default async function ttaHistoryOverview(
   scopes: IScopes,
@@ -28,24 +33,25 @@ export default async function ttaHistoryOverview(
     trSessionsForRecipient(scopes),
   ]);
 
-  // `overview` returns sumDuration formatted with toLocaleString (e.g. "1,234.5"),
-  // so strip the thousands separators before parsing to combine with the raw
-  // numeric TR duration.
-  const arDuration = parseFloat((arData.sumDuration || '0').replace(/,/g, '')) || 0;
-  const combinedSumDuration = formatNumber(arDuration + trData.sumDuration, 1);
-
-  // overview() returns numParticipants as a locale-formatted string (e.g.
-  // "1,234"). Strip the thousands separators before parsing so we can sum
-  // it with the TR participant count and re-format the total.
-  const arParticipants = parseInt((arData.numParticipants || '0').replace(/,/g, ''), 10) || 0;
+  // `overview` returns AR aggregates as locale-formatted strings (e.g.
+  // "1,234.5"), so use `parseFormattedNumber` to strip thousands separators
+  // and coerce to a number before summing with the raw numeric TR values.
+  const combinedSumDuration = formatNumber(
+    parseFormattedNumber(arData.sumDuration) + trData.sumDuration,
+    1,
+  );
   const combinedNumParticipants = formatNumber(
-    arParticipants + trData.numParticipants
+    parseFormattedNumber(arData.numParticipants) + trData.numParticipants,
+  );
+  const combinedInPerson = formatNumber(
+    parseFormattedNumber(arData.inPerson) + trData.numInPerson,
   );
 
   return {
     ...arData,
     sumDuration: combinedSumDuration,
     numParticipants: combinedNumParticipants,
+    inPerson: combinedInPerson,
     numSessions: trData.numSessions,
   };
 }


### PR DESCRIPTION
## Description of change

We are adding TR's to the overview widgets on the TTA History. We need a way to tie out the numbers we are showing that now combine AR and TR values. This adds the already created TR table to the bottom of the page below the AR table.

## How to test

- Review the code.
- Make sure the table respects the valid fitlers and works the same as the TR table on the TR regional dash.


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-0


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
