### PR TITLE
[TTAHUB-5513] Other trainers in session summary

### DIFF
--- a/frontend/src/hooks/__tests__/useEventAndSessionStaff.js
+++ b/frontend/src/hooks/__tests__/useEventAndSessionStaff.js
@@ -306,7 +306,12 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event, true), { wrapper });
 
       expect(result.current.optionsForValue).toEqual(mockNationalCenterTrainers);
-      expect(result.current.trainerOptions).toEqual(mockNationalCenterTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'National Center trainers',
+          options: mockNationalCenterTrainers,
+        },
+      ]);
     });
 
     it('returns national center trainers when isEvent=true with facilitation=regional_tta_staff', () => {
@@ -324,7 +329,12 @@ describe('useEventAndSessionStaff', () => {
 
       // facilitation=regional_tta_staff does not match the isEvent condition, so returns empty
       expect(result.current.optionsForValue).toEqual(mockNationalCenterTrainers);
-      expect(result.current.trainerOptions).toEqual(mockNationalCenterTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'National Center trainers',
+          options: mockNationalCenterTrainers,
+        },
+      ]);
     });
 
     it('returns both trainers when isEvent=true with facilitation=both', () => {
@@ -371,10 +381,15 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event, false), { wrapper });
 
       expect(result.current.optionsForValue).toEqual(mockNationalCenterTrainers);
-      expect(result.current.trainerOptions).toEqual(mockNationalCenterTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'National Center trainers',
+          options: mockNationalCenterTrainers,
+        },
+      ]);
     });
 
-    it('returns national center trainers with flat array structure', () => {
+    it('returns national center trainers with grouped structure', () => {
       const event = {
         regionId: 1,
         eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
@@ -388,8 +403,8 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
       expect(Array.isArray(result.current.trainerOptions)).toBe(true);
-      expect(result.current.trainerOptions).not.toContainEqual(
-        expect.objectContaining({ label: expect.any(String) })
+      expect(result.current.trainerOptions).toContainEqual(
+        expect.objectContaining({ label: 'National Center trainers' })
       );
     });
   });
@@ -410,7 +425,12 @@ describe('useEventAndSessionStaff', () => {
 
       // regional_tta_staff no longer sets trainers - comment indicates "already set to correct values"
       expect(result.current.optionsForValue).toEqual(mockRegionalTrainers);
-      expect(result.current.trainerOptions).toEqual(mockRegionalTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: mockRegionalTrainers,
+        },
+      ]);
     });
 
     it('returns empty arrays in all scenarios for regional_tta_staff with empty trainer data', () => {
@@ -427,7 +447,12 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event, false), { wrapper });
 
       expect(result.current.optionsForValue).toEqual([]);
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
     });
   });
 
@@ -613,7 +638,12 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event, false), { wrapper });
 
       expect(result.current.optionsForValue).toEqual([]);
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
     });
 
     it('handles both trainer arrays populated with REGIONAL_PD_WITH_NATIONAL_CENTERS and both facilitation', () => {
@@ -673,7 +703,7 @@ describe('useEventAndSessionStaff', () => {
   });
 
   describe('Return Value Structure Validation', () => {
-    it('validates flat array structure for national_center facilitation', () => {
+    it('validates grouped array structure for national_center facilitation', () => {
       const event = {
         regionId: 1,
         eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
@@ -686,9 +716,13 @@ describe('useEventAndSessionStaff', () => {
       const wrapper = createWrapper('national_center');
       const { result } = renderHook(() => useEventAndSessionStaff(event, false), { wrapper });
 
-      // Flat array should not have label property
-      expect(result.current.trainerOptions).toEqual(mockNationalCenterTrainers);
-      expect(result.current.trainerOptions.every((t) => !('label' in t))).toBe(true);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'National Center trainers',
+          options: mockNationalCenterTrainers,
+        },
+      ]);
+      expect(result.current.trainerOptions.every((t) => 'label' in t)).toBe(true);
     });
 
     it('validates empty array structure for regional_tta_staff', () => {
@@ -704,8 +738,12 @@ describe('useEventAndSessionStaff', () => {
       const wrapper = createWrapper('regional_tta_staff');
       const { result } = renderHook(() => useEventAndSessionStaff(event, false), { wrapper });
 
-      // regional_tta_staff returns empty arrays
-      expect(result.current.trainerOptions).toEqual(mockRegionalTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: mockRegionalTrainers,
+        },
+      ]);
       expect(result.current.optionsForValue).toEqual(mockRegionalTrainers);
     });
 
@@ -727,13 +765,13 @@ describe('useEventAndSessionStaff', () => {
       expect(result.current.optionsForValue.every((t) => !('label' in t))).toBe(true);
     });
 
-    it('trainerOptions structure varies correctly by scenario', () => {
+    it('trainerOptions stays grouped for national_center and both scenarios', () => {
       const event = {
         regionId: 1,
         eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
       };
 
-      // Test flat structure (national_center)
+      // Test grouped structure (national_center)
       useFetch
         .mockReturnValueOnce({ data: mockRegionalTrainers, loading: false, error: null })
         .mockReturnValueOnce({ data: mockNationalCenterTrainers, loading: false, error: null });
@@ -743,12 +781,12 @@ describe('useEventAndSessionStaff', () => {
         wrapper: wrapper1,
       });
 
-      const isFlatArray =
+      const isGroupedNationalCenter =
         Array.isArray(result1.current.trainerOptions) &&
         result1.current.trainerOptions.length > 0 &&
-        !('label' in result1.current.trainerOptions[0]);
+        'label' in result1.current.trainerOptions[0];
 
-      expect(isFlatArray).toBe(true);
+      expect(isGroupedNationalCenter).toBe(true);
 
       // Test grouped structure (both)
       useFetch

--- a/frontend/src/hooks/__tests__/useEventAndSessionStaff.js
+++ b/frontend/src/hooks/__tests__/useEventAndSessionStaff.js
@@ -79,7 +79,12 @@ describe('useEventAndSessionStaff', () => {
       const wrapper = createWrapper();
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
       expect(result.current.optionsForValue).toEqual([]);
     });
 
@@ -92,7 +97,12 @@ describe('useEventAndSessionStaff', () => {
       const wrapper = createWrapper();
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
       expect(result.current.optionsForValue).toEqual([]);
     });
 
@@ -132,7 +142,12 @@ describe('useEventAndSessionStaff', () => {
       const wrapper = createWrapper();
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
       expect(result.current.optionsForValue).toEqual([]);
     });
   });
@@ -183,7 +198,12 @@ describe('useEventAndSessionStaff', () => {
       const wrapper = createWrapper();
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
       expect(result.current.optionsForValue).toEqual([]);
     });
 
@@ -229,7 +249,12 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
       expect(result.current.optionsForValue).toEqual([]);
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
     });
   });
 
@@ -250,7 +275,12 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
       expect(result.current.optionsForValue).toEqual(mockRegionalTrainers);
-      expect(result.current.trainerOptions).toEqual(mockRegionalTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: mockRegionalTrainers,
+        },
+      ]);
     });
 
     it('returns empty arrays when regional trainers are empty', () => {
@@ -269,7 +299,12 @@ describe('useEventAndSessionStaff', () => {
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
       expect(result.current.optionsForValue).toEqual([]);
-      expect(result.current.trainerOptions).toEqual([]);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: [],
+        },
+      ]);
     });
 
     it('ignores facilitation value and uses only regional trainers', () => {
@@ -287,7 +322,12 @@ describe('useEventAndSessionStaff', () => {
       const wrapper = createWrapper('national_center');
       const { result } = renderHook(() => useEventAndSessionStaff(event), { wrapper });
 
-      expect(result.current.trainerOptions).toEqual(mockRegionalTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: mockRegionalTrainers,
+        },
+      ]);
     });
   });
 
@@ -906,7 +946,12 @@ describe('useEventAndSessionStaff', () => {
 
       // AA user should be included for Event Collaborators
       expect(result.current.optionsForValue).toEqual(mockRegionalTrainersWithRoles);
-      expect(result.current.trainerOptions).toEqual(mockRegionalTrainersWithRoles);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: mockRegionalTrainersWithRoles,
+        },
+      ]);
       expect(result.current.optionsForValue.find((u) => u.id === 5)).toBeDefined();
     });
 
@@ -928,7 +973,12 @@ describe('useEventAndSessionStaff', () => {
       // AA user should NOT be included for Session Trainers
       const expectedTrainers = mockRegionalTrainersWithRoles.filter((u) => u.id !== 5);
       expect(result.current.optionsForValue).toEqual(expectedTrainers);
-      expect(result.current.trainerOptions).toEqual(expectedTrainers);
+      expect(result.current.trainerOptions).toEqual([
+        {
+          label: 'Regional trainers',
+          options: expectedTrainers,
+        },
+      ]);
       expect(result.current.optionsForValue.find((u) => u.id === 5)).toBeUndefined();
     });
 

--- a/frontend/src/hooks/__tests__/useSessionApprovers.tsx
+++ b/frontend/src/hooks/__tests__/useSessionApprovers.tsx
@@ -308,6 +308,45 @@ describe('useSessionApprovers', () => {
     });
   });
 
+  describe('Event Organizer: REGIONAL_PD_WITH_NATIONAL_CENTERS with facilitation=national_center', () => {
+    it('flattens grouped approvers before filtering current user and event owner', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: [mockUser, mockEventOwner, mockApprover1, mockApprover2],
+          },
+        ],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
+        },
+        ownerId: mockEventOwner.id,
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper('national_center');
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return 'national_center';
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+      expect(result.current).not.toContain(mockUser);
+      expect(result.current).not.toContain(mockEventOwner);
+    });
+  });
+
   describe('Admin User Handling', () => {
     it('does not filter out current user when isAdmin is true', () => {
       const adminUser = {

--- a/frontend/src/hooks/__tests__/useSessionApprovers.tsx
+++ b/frontend/src/hooks/__tests__/useSessionApprovers.tsx
@@ -133,7 +133,12 @@ describe('useSessionApprovers', () => {
       ];
 
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: approversWithRoles,
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: approversWithRoles,
+          },
+        ],
       });
 
       const event = {
@@ -170,7 +175,12 @@ describe('useSessionApprovers', () => {
       ];
 
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: approversWithRoles,
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: approversWithRoles,
+          },
+        ],
       });
 
       const event = {
@@ -420,7 +430,12 @@ describe('useSessionApprovers', () => {
       ];
 
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: approversWithOwner,
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: approversWithOwner,
+          },
+        ],
       });
 
       const event = {
@@ -452,7 +467,12 @@ describe('useSessionApprovers', () => {
 
     it('handles case where event owner is not in approver list', () => {
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: [mockApprover1, mockApprover2],
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: [mockApprover1, mockApprover2],
+          },
+        ],
       });
 
       const event = {
@@ -485,7 +505,12 @@ describe('useSessionApprovers', () => {
       const approversWithOwner = [mockEventOwner, mockApprover1, mockApprover2];
 
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: approversWithOwner,
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: approversWithOwner,
+          },
+        ],
       });
 
       const event = {
@@ -526,7 +551,12 @@ describe('useSessionApprovers', () => {
       ];
 
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: approversWithAllTypes,
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: approversWithAllTypes,
+          },
+        ],
       });
 
       const event = {
@@ -632,7 +662,12 @@ describe('useSessionApprovers', () => {
       };
 
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: [approverWithECM1, approverWithECM2, mockApprover3],
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: [approverWithECM1, approverWithECM2, mockApprover3],
+          },
+        ],
       });
 
       const event = {
@@ -669,7 +704,12 @@ describe('useSessionApprovers', () => {
       };
 
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: [userWithMultipleRoles],
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: [userWithMultipleRoles],
+          },
+        ],
       });
 
       const event = {
@@ -701,7 +741,12 @@ describe('useSessionApprovers', () => {
   describe('Event Organizer Data Structure Variants', () => {
     it('extracts eventOrganizer from event.data when present', () => {
       (useEventAndSessionStaff as jest.Mock).mockReturnValue({
-        trainerOptions: [mockApprover1, mockApprover2, mockApprover3],
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: [mockApprover1, mockApprover2, mockApprover3],
+          },
+        ],
       });
 
       const event = {

--- a/frontend/src/hooks/__tests__/useSessionApprovers.tsx
+++ b/frontend/src/hooks/__tests__/useSessionApprovers.tsx
@@ -1,0 +1,774 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { TRAINING_EVENT_ORGANIZER } from '../../Constants';
+import UserContext from '../../UserContext';
+import useEventAndSessionStaff from '../useEventAndSessionStaff';
+import useSessionApprovers from '../useSessionApprovers';
+
+jest.mock('../useEventAndSessionStaff');
+
+// Mock user for context
+const mockUser = {
+  id: 999,
+  name: 'Current User',
+  roles: [{ name: 'TTAC' }],
+};
+
+const mockOtherUser = {
+  id: 1,
+  name: 'Other User',
+  roles: [{ name: 'ECM' }],
+};
+
+const mockApprover1 = {
+  id: 2,
+  name: 'Approver 1',
+  roles: [{ name: 'GSM' }],
+};
+
+const mockApprover2 = {
+  id: 3,
+  name: 'Approver 2',
+  roles: [{ name: 'TTAC' }],
+};
+
+const mockApprover3 = {
+  id: 4,
+  name: 'Approver 3',
+  roles: [{ name: 'AA' }],
+};
+
+const mockEventOwner = {
+  id: 100,
+  name: 'Event Owner',
+  roles: [{ name: 'ECM' }],
+};
+
+// Regional trainer group structure
+const mockRegionalTrainersGroup = {
+  label: 'Regional trainers',
+  options: [mockApprover1, mockApprover2],
+};
+
+const mockNationalTrainersGroup = {
+  label: 'National Center trainers',
+  options: [mockOtherUser],
+};
+
+// Wrapper component to provide form and user context
+const createWrapper =
+  (facilitation = null, user = mockUser) =>
+  ({ children }) => {
+    const methods = useForm({
+      defaultValues: {
+        facilitation,
+        event: null,
+      },
+    });
+    return (
+      <UserContext.Provider value={{ user }}>
+        <FormProvider {...methods}>{children}</FormProvider>
+      </UserContext.Provider>
+    );
+  };
+
+describe('useSessionApprovers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+      trainerOptions: [mockApprover1, mockApprover2],
+    });
+  });
+
+  describe('Basic Functionality', () => {
+    it('returns approvers when no event organizer is set', () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return null;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should filter out current user
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+    });
+
+    it('returns empty array when no approvers are available', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [],
+      });
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return null;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      expect(result.current).toEqual([]);
+    });
+  });
+
+  describe('Event Organizer: REGIONAL_TTA_NO_NATIONAL_CENTERS', () => {
+    it('filters approvers to only those with manager roles', () => {
+      const approversWithRoles = [
+        mockApprover1, // GSM - manager role
+        mockApprover2, // TTAC - manager role
+        mockApprover3, // AA - not a manager role
+      ];
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: approversWithRoles,
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should only include manager roles
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+      expect(result.current).not.toContain(mockApprover3);
+    });
+
+    it('filters out current user from manager role approvers', () => {
+      const approversWithRoles = [
+        mockUser, // Current user - should be filtered
+        mockApprover1, // GSM - manager role
+        mockApprover2, // TTAC - manager role
+      ];
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: approversWithRoles,
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Current user should be filtered out
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+      expect(result.current).not.toContain(mockUser);
+    });
+  });
+
+  describe('Event Organizer: REGIONAL_PD_WITH_NATIONAL_CENTERS with facilitation=both', () => {
+    it('filters to regional trainers with manager roles', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockRegionalTrainersGroup, mockNationalTrainersGroup],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper('both');
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return 'both';
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should only include regional trainers with manager roles
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+      expect(result.current).not.toContain(mockOtherUser);
+    });
+
+    it('flattens regional trainer options correctly', () => {
+      const regionalTrainerWithManager = {
+        id: 5,
+        name: 'Regional Manager',
+        roles: [{ name: 'ECM' }],
+      };
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [
+          {
+            label: 'Regional trainers',
+            options: [mockApprover1, regionalTrainerWithManager],
+          },
+          mockNationalTrainersGroup,
+        ],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper('both');
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return 'both';
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should flatten regional trainers
+      expect(result.current).toContain(mockApprover1);
+      expect(result.current).toContain(regionalTrainerWithManager);
+    });
+  });
+
+  describe('Event Organizer: REGIONAL_PD_WITH_NATIONAL_CENTERS with facilitation=regional_tta_staff', () => {
+    it('filters to regional trainers with manager roles', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockRegionalTrainersGroup, mockNationalTrainersGroup],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper('regional_tta_staff');
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return 'regional_tta_staff';
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should only include regional trainers with manager roles
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+    });
+  });
+
+  describe('Admin User Handling', () => {
+    it('does not filter out current user when isAdmin is true', () => {
+      const adminUser = {
+        id: 999,
+        name: 'Admin User',
+        roles: [{ name: 'ECM' }],
+      };
+
+      const approversWithRoles = [
+        adminUser, // Current admin user
+        mockApprover1,
+        mockApprover2,
+      ];
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: approversWithRoles,
+      });
+
+      const wrapper = createWrapper(null, adminUser);
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return null;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: true,
+          }),
+        { wrapper }
+      );
+
+      // Admin user should be included
+      expect(result.current).toContain(adminUser);
+      expect(result.current).toEqual([adminUser, mockApprover1, mockApprover2]);
+    });
+
+    it('filters out current user when isAdmin is false', () => {
+      const approversWithRoles = [mockUser, mockApprover1, mockApprover2];
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: approversWithRoles,
+      });
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return null;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Current user should be filtered out
+      expect(result.current).not.toContain(mockUser);
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+    });
+  });
+
+  describe('Event Owner Filtering', () => {
+    it('filters out the event owner from approver list', () => {
+      const approversWithOwner = [
+        mockEventOwner, // Event owner
+        mockApprover1,
+        mockApprover2,
+      ];
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: approversWithOwner,
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        ownerId: 100,
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Event owner should be filtered out
+      expect(result.current).not.toContain(mockEventOwner);
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+    });
+
+    it('handles case where event owner is not in approver list', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockApprover1, mockApprover2],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        ownerId: 999,
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should still return all approvers
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+    });
+
+    it('does not filter event owner when ownerId is undefined', () => {
+      const approversWithOwner = [mockEventOwner, mockApprover1, mockApprover2];
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: approversWithOwner,
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Event owner should not be filtered (no ownerId)
+      expect(result.current).toContain(mockEventOwner);
+      expect(result.current).toEqual(approversWithOwner);
+    });
+  });
+
+  describe('Combined Filters', () => {
+    it('applies multiple filters together', () => {
+      const approversWithAllTypes = [
+        mockUser, // Current user - should be filtered
+        mockEventOwner, // Event owner - should be filtered
+        mockApprover1, // Should be kept (ECM role)
+        mockApprover2, // Should be kept (TTAC role)
+        mockApprover3, // Should be filtered (AA role - not manager)
+      ];
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: approversWithAllTypes,
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        ownerId: mockEventOwner.id,
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Only manager role approvers should remain (not current user or owner)
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+      expect(result.current).not.toContain(mockUser);
+      expect(result.current).not.toContain(mockEventOwner);
+      expect(result.current).not.toContain(mockApprover3);
+    });
+
+    it('returns empty array when all approvers are filtered out', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockUser, mockEventOwner, mockApprover3],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        ownerId: mockEventOwner.id,
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // All approvers filtered out
+      expect(result.current).toEqual([]);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles undefined event data gracefully', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockApprover1, mockApprover2],
+      });
+
+      const event = {
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should return all approvers minus current user
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+    });
+
+    it('handles multiple users with the same role', () => {
+      const approverWithECM1 = {
+        id: 10,
+        name: 'ECM User 1',
+        roles: [{ name: 'ECM' }],
+      };
+
+      const approverWithECM2 = {
+        id: 11,
+        name: 'ECM User 2',
+        roles: [{ name: 'ECM' }],
+      };
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [approverWithECM1, approverWithECM2, mockApprover3],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Both ECM users should be included, AA user filtered
+      expect(result.current).toEqual([approverWithECM1, approverWithECM2]);
+      expect(result.current).not.toContain(mockApprover3);
+    });
+
+    it('handles users with multiple roles where one is a manager role', () => {
+      const userWithMultipleRoles = {
+        id: 12,
+        name: 'Multi-role User',
+        roles: [{ name: 'AA' }, { name: 'GSM' }],
+      };
+
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [userWithMultipleRoles],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // User should be included because one of their roles is a manager role
+      expect(result.current).toContain(userWithMultipleRoles);
+    });
+  });
+
+  describe('Event Organizer Data Structure Variants', () => {
+    it('extracts eventOrganizer from event.data when present', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockApprover1, mockApprover2, mockApprover3],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        eventOrganizer: 'different-value',
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      // Should use event.data.eventOrganizer, filtering to manager roles
+      expect(result.current).toEqual([mockApprover1, mockApprover2]);
+      expect(result.current).not.toContain(mockApprover3);
+    });
+  });
+
+  describe('Memoization', () => {
+    it('returns the same reference when inputs do not change', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockApprover1, mockApprover2],
+      });
+
+      const event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        ownerId: 100,
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result, rerender } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      const firstResult = result.current;
+      rerender();
+      const secondResult = result.current;
+
+      // Should be the same reference due to memoization
+      expect(firstResult).toBe(secondResult);
+    });
+
+    it('returns a different reference when event changes', () => {
+      (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+        trainerOptions: [mockApprover1, mockApprover2],
+      });
+
+      let event = {
+        data: {
+          eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+        },
+        ownerId: 100,
+        regionId: 1,
+      };
+
+      const wrapper = createWrapper();
+      const { result, rerender } = renderHook(
+        () =>
+          useSessionApprovers({
+            watch: (field) => {
+              if (field === 'event') return event;
+              if (field === 'facilitation') return null;
+              return null;
+            },
+            isAdmin: false,
+          }),
+        { wrapper }
+      );
+
+      const firstResult = result.current;
+
+      // Change event
+      event = {
+        ...event,
+        ownerId: 200,
+      };
+
+      rerender();
+      const secondResult = result.current;
+
+      // Should be a different reference
+      expect(firstResult).not.toBe(secondResult);
+    });
+  });
+});

--- a/frontend/src/hooks/useEventAndSessionStaff.js
+++ b/frontend/src/hooks/useEventAndSessionStaff.js
@@ -10,11 +10,11 @@ export default function useEventAndSessionStaff(event, isEvent = false) {
   const facilitation = watch('facilitation');
 
   const eventOrganizer = useMemo(() => {
-    if (event && event.data && event.data.eventOrganizer) {
+    if (event?.data?.eventOrganizer) {
       return event.data.eventOrganizer;
     }
 
-    if (event && event.eventOrganizer) {
+    if (event?.eventOrganizer) {
       return event.eventOrganizer;
     }
 
@@ -61,12 +61,22 @@ export default function useEventAndSessionStaff(event, isEvent = false) {
     if (eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS) {
       if (facilitation === 'regional_tta_staff') {
         optionsForValue = regionalTrainersForDisplay;
-        trainerOptions = regionalTrainersForDisplay;
+        trainerOptions = [
+          {
+            label: 'Regional trainers',
+            options: regionalTrainersForDisplay,
+          },
+        ];
       }
 
       if (facilitation === 'national_center' || isEvent) {
         optionsForValue = nationalCenterTrainers;
-        trainerOptions = nationalCenterTrainers;
+        trainerOptions = [
+          {
+            label: 'National Center trainers',
+            options: nationalCenterTrainers,
+          },
+        ];
       }
 
       if (facilitation === 'both') {

--- a/frontend/src/hooks/useEventAndSessionStaff.js
+++ b/frontend/src/hooks/useEventAndSessionStaff.js
@@ -55,7 +55,12 @@ export default function useEventAndSessionStaff(event, isEvent = false) {
 
     if (eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS) {
       optionsForValue = regionalTrainersForDisplay;
-      trainerOptions = regionalTrainersForDisplay;
+      trainerOptions = [
+        {
+          label: 'Regional trainers',
+          options: regionalTrainersForDisplay,
+        },
+      ];
     }
 
     if (eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS) {

--- a/frontend/src/hooks/useSessionApprovers.ts
+++ b/frontend/src/hooks/useSessionApprovers.ts
@@ -74,6 +74,10 @@ export default function useSessionApprovers({
         );
     }
 
+    approverOptions = approverOptions.flatMap((option: any) =>
+      Array.isArray(option?.options) ? option.options : option
+    );
+
     // filter current user out of approver list
     if (!isAdmin) {
       approverOptions = approverOptions.filter((a: { id: number }) => a.id !== user.id);

--- a/frontend/src/hooks/useSessionApprovers.ts
+++ b/frontend/src/hooks/useSessionApprovers.ts
@@ -36,15 +36,10 @@ export default function useSessionApprovers({
   return useMemo(() => {
     let approverOptions = approvers;
 
-    if (eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS) {
-      approverOptions = approvers.filter((o: UserOptionType) =>
-        o.roles.some((or: { name: string }) => MANAGER_ROLES.includes(or.name))
-      );
-    }
-
     if (
-      eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS &&
-      facilitation === 'both'
+      (eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS &&
+        facilitation === 'both') ||
+      eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS
     ) {
       // format approvers and flatten national and regional trainers into a single list
       approverOptions = approvers

--- a/frontend/src/hooks/useSessionApprovers.ts
+++ b/frontend/src/hooks/useSessionApprovers.ts
@@ -1,0 +1,89 @@
+import { useContext, useMemo } from 'react';
+import { TRAINING_EVENT_ORGANIZER } from '../Constants';
+import UserContext from '../UserContext';
+import useEventAndSessionStaff from './useEventAndSessionStaff';
+
+const MANAGER_ROLES = ['ECM', 'GSM', 'TTAC'];
+
+type UserOptionType = {
+  id: number;
+  roles: {
+    name: string;
+  }[];
+};
+
+export default function useSessionApprovers({
+  watch,
+  isAdmin,
+}: {
+  watch: (field: string) => any;
+  isAdmin: boolean;
+}) {
+  const event = watch('event');
+  const facilitation = watch('facilitation');
+
+  const eventOrganizer = useMemo(() => {
+    if (event?.data) {
+      return event.data.eventOrganizer;
+    }
+    return '';
+  }, [event]);
+
+  const { trainerOptions: approvers } = useEventAndSessionStaff(event);
+
+  const { user } = useContext(UserContext);
+
+  return useMemo(() => {
+    let approverOptions = approvers;
+
+    if (eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS) {
+      approverOptions = approvers.filter((o: UserOptionType) =>
+        o.roles.some((or: { name: string }) => MANAGER_ROLES.includes(or.name))
+      );
+    }
+
+    if (
+      eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS &&
+      facilitation === 'both'
+    ) {
+      // format approvers and flatten national and regional trainers into a single list
+      approverOptions = approvers
+        .filter(
+          (approverGroup: { label: string; options: UserOptionType[] }) =>
+            approverGroup.label === 'Regional trainers'
+        )
+        .flatMap((group: { label: string; options: UserOptionType[] }) => group.options)
+        .filter((o: UserOptionType) =>
+          o.roles.some((or: { name: string }) => MANAGER_ROLES.includes(or.name))
+        );
+    }
+
+    if (
+      eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS &&
+      facilitation === 'regional_tta_staff'
+    ) {
+      // format approvers and flatten national and regional trainers into a single list
+      approverOptions = approvers
+        .filter(
+          (approverGroup: { label: string; options: UserOptionType[] }) =>
+            approverGroup.label === 'Regional trainers'
+        )
+        .flatMap((group: { label: string; options: UserOptionType[] }) => group.options)
+        .filter((o: UserOptionType) =>
+          o.roles.some((or: { name: string }) => MANAGER_ROLES.includes(or.name))
+        );
+    }
+
+    // filter current user out of approver list
+    if (!isAdmin) {
+      approverOptions = approverOptions.filter((a: { id: number }) => a.id !== user.id);
+    }
+
+    // filter out event owner from approver list (owner cannot approve their own event's sessions)
+    const eventOwnerId = event?.ownerId;
+    if (eventOwnerId) {
+      approverOptions = approverOptions.filter((a: { id: number }) => a.id !== eventOwnerId);
+    }
+    return approverOptions;
+  }, [approvers, event, facilitation, isAdmin, user.id, eventOrganizer]);
+}

--- a/frontend/src/pages/SessionForm/__tests__/index.js
+++ b/frontend/src/pages/SessionForm/__tests__/index.js
@@ -45,6 +45,9 @@ const istAndPocFields = {
   supportingAttachments: [],
   recipientNextSteps: [],
   specialistNextSteps: [],
+  otherTrainers: '',
+  approvalStatus: '',
+  ttaType: [],
   pocComplete: false,
   collabComplete: false,
   istSelectionComplete: false,
@@ -70,8 +73,6 @@ const istAndPocFields = {
   submitted: false,
   additionalStates: [],
 };
-
-const keysInSessionFixture = (keys) => keys.filter((key) => Object.hasOwn(istAndPocFields, key));
 
 const completeFormData = {
   eventId: '1',
@@ -768,7 +769,7 @@ describe('SessionReportForm', () => {
     // Assert the put contains the correct data
     const putBody = fetchMock.lastOptions(url).body;
     const putBodyJson = JSON.parse(putBody);
-    const allKeys = keysInSessionFixture([...istKeys, ...pocKeys]);
+    const allKeys = [...istKeys, ...pocKeys];
     allKeys.forEach((key) => {
       expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
     });
@@ -814,9 +815,7 @@ describe('SessionReportForm', () => {
     const putBodyJson = JSON.parse(putBody);
     // Assert the body has istkey properties using the hasOwnProperty method
     // Owner (not admin) should only get IST keys, and pocComplete should be removed.
-    const istKeysWithoutPocComplete = keysInSessionFixture(
-      istKeys.filter((key) => key !== 'pocComplete')
-    );
+    const istKeysWithoutPocComplete = istKeys.filter((key) => key !== 'pocComplete');
     istKeysWithoutPocComplete.forEach((key) => {
       expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
     });
@@ -868,9 +867,7 @@ describe('SessionReportForm', () => {
 
     // Assert the body has POC key properties using the hasOwnProperty method
     // POC (not admin) should only get POC keys, and collabComplete should be removed.
-    const pocKeysWithoutcollabComplete = keysInSessionFixture(
-      pocKeys.filter((key) => key !== 'collabComplete')
-    );
+    const pocKeysWithoutcollabComplete = pocKeys.filter((key) => key !== 'collabComplete');
     pocKeysWithoutcollabComplete.forEach((key) => {
       expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
     });
@@ -1614,17 +1611,13 @@ describe('SessionReportForm', () => {
       const putBodyJson = JSON.parse(putBody);
 
       // Verify IST keys are included
-      const istKeysWithoutPocComplete = keysInSessionFixture(
-        istKeys.filter((key) => key !== 'pocComplete')
-      );
+      const istKeysWithoutPocComplete = istKeys.filter((key) => key !== 'pocComplete');
       istKeysWithoutPocComplete.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });
 
       // Verify POC keys are included
-      const pocKeysWithoutcollabComplete = keysInSessionFixture(
-        pocKeys.filter((key) => key !== 'collabComplete')
-      );
+      const pocKeysWithoutcollabComplete = pocKeys.filter((key) => key !== 'collabComplete');
       pocKeysWithoutcollabComplete.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });
@@ -1716,7 +1709,7 @@ describe('SessionReportForm', () => {
       const putBodyJson = JSON.parse(putBody);
 
       // Verify both IST and POC keys are included
-      const allKeys = keysInSessionFixture([...istKeys, ...pocKeys]);
+      const allKeys = [...istKeys, ...pocKeys];
       const allKeysWithoutComplete = allKeys.filter(
         (key) => key !== 'pocComplete' && key !== 'collabComplete'
       );
@@ -1771,9 +1764,7 @@ describe('SessionReportForm', () => {
       const putBodyJson = JSON.parse(putBody);
 
       // Verify POC keys are included
-      const pocKeysWithoutcollabComplete = keysInSessionFixture(
-        pocKeys.filter((key) => key !== 'collabComplete')
-      );
+      const pocKeysWithoutcollabComplete = pocKeys.filter((key) => key !== 'collabComplete');
       pocKeysWithoutcollabComplete.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });
@@ -1826,7 +1817,7 @@ describe('SessionReportForm', () => {
       const putBody = fetchMock.lastOptions(url).body;
       const putBodyJson = JSON.parse(putBody);
 
-      const allKeys = keysInSessionFixture([...istKeys, ...pocKeys]);
+      const allKeys = [...istKeys, ...pocKeys];
       allKeys.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });

--- a/frontend/src/pages/SessionForm/__tests__/index.js
+++ b/frontend/src/pages/SessionForm/__tests__/index.js
@@ -71,6 +71,8 @@ const istAndPocFields = {
   additionalStates: [],
 };
 
+const keysInSessionFixture = (keys) => keys.filter((key) => Object.hasOwn(istAndPocFields, key));
+
 const completeFormData = {
   eventId: '1',
   eventDisplayId: 'R-EVENT',
@@ -766,7 +768,7 @@ describe('SessionReportForm', () => {
     // Assert the put contains the correct data
     const putBody = fetchMock.lastOptions(url).body;
     const putBodyJson = JSON.parse(putBody);
-    const allKeys = [...istKeys, ...pocKeys];
+    const allKeys = keysInSessionFixture([...istKeys, ...pocKeys]);
     allKeys.forEach((key) => {
       expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
     });
@@ -812,7 +814,9 @@ describe('SessionReportForm', () => {
     const putBodyJson = JSON.parse(putBody);
     // Assert the body has istkey properties using the hasOwnProperty method
     // Owner (not admin) should only get IST keys, and pocComplete should be removed.
-    const istKeysWithoutPocComplete = istKeys.filter((key) => key !== 'pocComplete');
+    const istKeysWithoutPocComplete = keysInSessionFixture(
+      istKeys.filter((key) => key !== 'pocComplete')
+    );
     istKeysWithoutPocComplete.forEach((key) => {
       expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
     });
@@ -864,7 +868,9 @@ describe('SessionReportForm', () => {
 
     // Assert the body has POC key properties using the hasOwnProperty method
     // POC (not admin) should only get POC keys, and collabComplete should be removed.
-    const pocKeysWithoutcollabComplete = pocKeys.filter((key) => key !== 'collabComplete');
+    const pocKeysWithoutcollabComplete = keysInSessionFixture(
+      pocKeys.filter((key) => key !== 'collabComplete')
+    );
     pocKeysWithoutcollabComplete.forEach((key) => {
       expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
     });
@@ -1608,13 +1614,17 @@ describe('SessionReportForm', () => {
       const putBodyJson = JSON.parse(putBody);
 
       // Verify IST keys are included
-      const istKeysWithoutPocComplete = istKeys.filter((key) => key !== 'pocComplete');
+      const istKeysWithoutPocComplete = keysInSessionFixture(
+        istKeys.filter((key) => key !== 'pocComplete')
+      );
       istKeysWithoutPocComplete.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });
 
       // Verify POC keys are included
-      const pocKeysWithoutcollabComplete = pocKeys.filter((key) => key !== 'collabComplete');
+      const pocKeysWithoutcollabComplete = keysInSessionFixture(
+        pocKeys.filter((key) => key !== 'collabComplete')
+      );
       pocKeysWithoutcollabComplete.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });
@@ -1706,7 +1716,7 @@ describe('SessionReportForm', () => {
       const putBodyJson = JSON.parse(putBody);
 
       // Verify both IST and POC keys are included
-      const allKeys = [...istKeys, ...pocKeys];
+      const allKeys = keysInSessionFixture([...istKeys, ...pocKeys]);
       const allKeysWithoutComplete = allKeys.filter(
         (key) => key !== 'pocComplete' && key !== 'collabComplete'
       );
@@ -1761,7 +1771,9 @@ describe('SessionReportForm', () => {
       const putBodyJson = JSON.parse(putBody);
 
       // Verify POC keys are included
-      const pocKeysWithoutcollabComplete = pocKeys.filter((key) => key !== 'collabComplete');
+      const pocKeysWithoutcollabComplete = keysInSessionFixture(
+        pocKeys.filter((key) => key !== 'collabComplete')
+      );
       pocKeysWithoutcollabComplete.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });
@@ -1814,7 +1826,7 @@ describe('SessionReportForm', () => {
       const putBody = fetchMock.lastOptions(url).body;
       const putBodyJson = JSON.parse(putBody);
 
-      const allKeys = [...istKeys, ...pocKeys];
+      const allKeys = keysInSessionFixture([...istKeys, ...pocKeys]);
       allKeys.forEach((key) => {
         expect(Object.hasOwn(putBodyJson.data, key)).toBe(true);
       });

--- a/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
@@ -32,25 +32,19 @@ export default function SessionTrainers({
   const { trainerOptions } = useEventAndSessionStaff(event);
 
   const trainerOptionsComputed = useMemo(() => {
-    if (
-      event?.data?.eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS
-    ) {
-      return [
-        ...trainerOptions,
-        {
-          label: 'Other trainers',
-          options: [
-            {
-              fullName: 'Other',
-              id: 'other',
-            },
-          ],
-        },
-      ];
-    }
-
-    return trainerOptions;
-  }, [trainerOptions, event]);
+    return [
+      ...trainerOptions,
+      {
+        label: 'Other trainers',
+        options: [
+          {
+            fullName: 'Other',
+            id: 'other',
+          },
+        ],
+      },
+    ];
+  }, [trainerOptions]);
 
   const showOtherTrainers = useMemo(() => {
     return trainers?.length && trainers.some((t: TrainerOption) => t.id === 'other');

--- a/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
@@ -113,7 +113,9 @@ export default function SessionTrainers({
             <Textarea
               id="otherTrainers"
               name="otherTrainers"
-              inputRef={register({ required: 'Enter other trainers' })}
+              inputRef={register({
+                validate: (value) => (value?.trim() ? true : 'Enter other trainers'),
+              })}
             />
           </FormItem>
         </div>

--- a/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
@@ -1,0 +1,122 @@
+import { Textarea } from '@trussworks/react-uswds';
+import React, { useEffect, useMemo } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import Select from 'react-select';
+import { TRAINING_EVENT_ORGANIZER } from '../../../Constants';
+import FormItem from '../../../components/FormItem';
+import selectOptionsReset from '../../../components/selectOptionsReset';
+import useEventAndSessionStaff from '../../../hooks/useEventAndSessionStaff';
+
+export default function SessionTrainers({
+  event,
+}: {
+  event: {
+    regionId: number;
+    data: {
+      endDate: string;
+      eventOrganizer: string;
+      facilitation: string;
+    };
+  };
+}): React.ReactElement {
+  const { watch, register, control, setValue } = useFormContext();
+
+  const otherTrainers = watch('otherTrainers');
+  const trainers = watch('trainers');
+
+  const { trainerOptions } = useEventAndSessionStaff(event);
+
+  const trainerOptionsComputed = useMemo(() => {
+    if (
+      event?.data?.eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS
+    ) {
+      return [
+        ...trainerOptions,
+        {
+          label: 'Other trainers',
+          options: [
+            {
+              fullName: 'Other',
+              id: 'other',
+            },
+          ],
+        },
+      ];
+    }
+
+    return trainerOptions;
+  }, [trainerOptions, event]);
+
+  const showOtherTrainers = useMemo(() => {
+    return trainers?.length && trainers.some((t) => t.id === 'other');
+  }, [trainers]);
+
+  useEffect(() => {
+    if (!showOtherTrainers && otherTrainers) {
+      // Clear otherTrainers if "Other" is not selected
+      setValue('otherTrainers', '');
+    }
+  }, [showOtherTrainers, otherTrainers, setValue]);
+
+  return (
+    <>
+      <div>
+        <FormItem label="Who provided the TTA?" name="trainers" required>
+          <Controller
+            render={({ onChange: controllerOnChange, value, onBlur }) => (
+              <Select
+                value={(() => {
+                  if (
+                    otherTrainers &&
+                    value?.every((t: { id: number | 'other' }) => t.id !== 'other')
+                  ) {
+                    return [...value, { fullName: 'Other', id: 'other' }];
+                  }
+
+                  return value;
+                })()}
+                inputId="trainers"
+                name="trainers"
+                className="usa-select"
+                styles={selectOptionsReset}
+                onBlur={onBlur}
+                components={{
+                  DropdownIndicator: null,
+                }}
+                onChange={controllerOnChange}
+                options={trainerOptionsComputed}
+                getOptionLabel={(option) => option.fullName}
+                getOptionValue={(option) => option.id}
+                isMulti
+                required
+              />
+            )}
+            control={control}
+            rules={{
+              validate: (value) => {
+                if (!value || value.length === 0) {
+                  return 'Select at least one trainer';
+                }
+                return true;
+              },
+            }}
+            name="trainers"
+            defaultValue={[]}
+          />
+        </FormItem>
+      </div>
+
+      {!!showOtherTrainers && (
+        <div>
+          <FormItem label="Other trainers" name="otherTrainers" required>
+            <Textarea
+              id="otherTrainers"
+              name="otherTrainers"
+              inputRef={register({ required: 'Enter other trainers' })}
+            />
+          </FormItem>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/SessionTrainers.tsx
@@ -7,6 +7,11 @@ import FormItem from '../../../components/FormItem';
 import selectOptionsReset from '../../../components/selectOptionsReset';
 import useEventAndSessionStaff from '../../../hooks/useEventAndSessionStaff';
 
+type TrainerOption = {
+  fullName: string;
+  id: number | 'other';
+};
+
 export default function SessionTrainers({
   event,
 }: {
@@ -48,15 +53,14 @@ export default function SessionTrainers({
   }, [trainerOptions, event]);
 
   const showOtherTrainers = useMemo(() => {
-    return trainers?.length && trainers.some((t) => t.id === 'other');
+    return trainers?.length && trainers.some((t: TrainerOption) => t.id === 'other');
   }, [trainers]);
 
   useEffect(() => {
-    if (!showOtherTrainers && otherTrainers) {
-      // Clear otherTrainers if "Other" is not selected
-      setValue('otherTrainers', '');
+    if (otherTrainers && trainers?.every((t: TrainerOption) => t.id !== 'other')) {
+      setValue('trainers', [...trainers, { fullName: 'Other', id: 'other' }]);
     }
-  }, [showOtherTrainers, otherTrainers, setValue]);
+  }, [otherTrainers, trainers, setValue]);
 
   return (
     <>
@@ -65,16 +69,7 @@ export default function SessionTrainers({
           <Controller
             render={({ onChange: controllerOnChange, value, onBlur }) => (
               <Select
-                value={(() => {
-                  if (
-                    otherTrainers &&
-                    value?.every((t: { id: number | 'other' }) => t.id !== 'other')
-                  ) {
-                    return [...value, { fullName: 'Other', id: 'other' }];
-                  }
-
-                  return value;
-                })()}
+                value={value}
                 inputId="trainers"
                 name="trainers"
                 className="usa-select"
@@ -83,7 +78,13 @@ export default function SessionTrainers({
                 components={{
                   DropdownIndicator: null,
                 }}
-                onChange={controllerOnChange}
+                onChange={(selectedOptions) => {
+                  if (!selectedOptions.some((t: TrainerOption) => t.id === 'other')) {
+                    setValue('otherTrainers', '');
+                  }
+
+                  controllerOnChange(selectedOptions);
+                }}
                 options={trainerOptionsComputed}
                 getOptionLabel={(option) => option.fullName}
                 getOptionValue={(option) => option.id}
@@ -93,7 +94,7 @@ export default function SessionTrainers({
             )}
             control={control}
             rules={{
-              validate: (value) => {
+              validate: (value: TrainerOption[]) => {
                 if (!value || value.length === 0) {
                   return 'Select at least one trainer';
                 }

--- a/frontend/src/pages/SessionForm/components/Submit.js
+++ b/frontend/src/pages/SessionForm/components/Submit.js
@@ -1,13 +1,13 @@
 import { Button } from '@trussworks/react-uswds';
-import React from 'react';
+import React, { useContext } from 'react';
 import { useFormContext } from 'react-hook-form';
-
 import FormItem from '../../../components/FormItem';
 import HookFormRichEditor from '../../../components/HookFormRichEditor';
 import IncompletePages from '../../../components/IncompletePages';
 import SingleApproverSelect from '../../../components/SingleApproverSelect';
 import useCanSelectApprover from '../../../hooks/useCanSelectApprover';
 import useSessionApprovers from '../../../hooks/useSessionApprovers';
+import UserContext from '../../../UserContext';
 import { reviewSubmitComponentProps } from './constants';
 
 const path = 'submitter-session-report';

--- a/frontend/src/pages/SessionForm/components/Submit.js
+++ b/frontend/src/pages/SessionForm/components/Submit.js
@@ -1,19 +1,16 @@
 import { Button } from '@trussworks/react-uswds';
-import React, { useContext } from 'react';
+import React from 'react';
 import { useFormContext } from 'react-hook-form';
-import { TRAINING_EVENT_ORGANIZER } from '../../../Constants';
+
 import FormItem from '../../../components/FormItem';
 import HookFormRichEditor from '../../../components/HookFormRichEditor';
 import IncompletePages from '../../../components/IncompletePages';
 import SingleApproverSelect from '../../../components/SingleApproverSelect';
 import useCanSelectApprover from '../../../hooks/useCanSelectApprover';
-import useEventAndSessionStaff from '../../../hooks/useEventAndSessionStaff';
-import UserContext from '../../../UserContext';
+import useSessionApprovers from '../../../hooks/useSessionApprovers';
 import { reviewSubmitComponentProps } from './constants';
 
 const path = 'submitter-session-report';
-
-const MANAGER_ROLES = ['ECM', 'GSM', 'TTAC'];
 
 export default function Submit({
   onSaveDraft,
@@ -26,20 +23,11 @@ export default function Submit({
 }) {
   const { watch, trigger } = useFormContext();
   const pageState = watch('pageState');
-  const event = watch('event');
-  const facilitation = watch('facilitation');
 
   // POCs can select approver when facilitation includes regional staff
   const canSelectApprover = useCanSelectApprover({ isPoc, watch });
 
-  let eventOrganizer = '';
-
-  if (event && event.data) {
-    eventOrganizer = event.data.eventOrganizer;
-  }
-
-  const { trainerOptions: approvers } = useEventAndSessionStaff(event);
-  const { user } = useContext(UserContext);
+  const approverOptions = useSessionApprovers({ watch, isAdmin });
 
   const filtered = Object.entries(pageState || {})
     .filter(([, status]) => status !== 'Complete')
@@ -49,47 +37,6 @@ export default function Submit({
     .filter((page) => filtered.includes(page.position))
     .map(({ label }) => label);
   const hasIncompletePages = incompletePages.length > 0;
-
-  let approverOptions = approvers;
-
-  if (eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS) {
-    // eslint-disable-next-line max-len
-    approverOptions = approvers.filter((o) =>
-      o.roles.some((or) => MANAGER_ROLES.includes(or.name))
-    );
-  }
-
-  if (
-    eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS &&
-    facilitation === 'both'
-  ) {
-    // format approvers and flatten national and regional trainers into a single list
-    approverOptions = approvers
-      .filter((approverGroup) => approverGroup.label === 'Regional trainers')
-      .flatMap((group) => group.options)
-      .filter((o) => o.roles.some((or) => MANAGER_ROLES.includes(or.name)));
-  }
-
-  if (
-    eventOrganizer === TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS &&
-    facilitation === 'regional_tta_staff'
-  ) {
-    // format approvers and flatten national and regional trainers into a single list
-    approverOptions = approvers.filter((o) =>
-      o.roles.some((or) => MANAGER_ROLES.includes(or.name))
-    );
-  }
-
-  // filter current user out of approver list
-  if (!isAdmin) {
-    approverOptions = approverOptions.filter((a) => a.id !== user.id);
-  }
-
-  // filter out event owner from approver list (owner cannot approve their own event's sessions)
-  const eventOwnerId = event?.ownerId;
-  if (eventOwnerId) {
-    approverOptions = approverOptions.filter((a) => a.id !== eventOwnerId);
-  }
 
   const onFormSubmit = async () => {
     const valid = await trigger();

--- a/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
@@ -135,4 +135,17 @@ describe('SessionTrainers', () => {
       expect(screen.queryByLabelText(/Other trainers/i)).not.toBeInTheDocument();
     });
   });
+
+  it('rejects whitespace-only other trainers input', async () => {
+    render(<RenderSessionTrainers />);
+
+    const trainers = await screen.findByLabelText(/Who provided the TTA/i);
+    await selectEvent.select(trainers, ['Other']);
+
+    const otherTrainers = await screen.findByLabelText(/Other trainers/i);
+    userEvent.type(otherTrainers, '   ');
+    userEvent.tab();
+
+    expect(await screen.findByText('Enter other trainers')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
@@ -1,0 +1,135 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import selectEvent from 'react-select-event';
+import { TRAINING_EVENT_ORGANIZER } from '../../../../Constants';
+import useEventAndSessionStaff from '../../../../hooks/useEventAndSessionStaff';
+import SessionTrainers from '../SessionTrainers';
+
+jest.mock('../../../../hooks/useEventAndSessionStaff');
+
+const defaultEvent = {
+  regionId: 1,
+  data: {
+    endDate: '01/01/2026',
+    eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_PD_WITH_NATIONAL_CENTERS,
+    facilitation: 'regional_tta_staff',
+  },
+};
+
+const defaultTrainerOptions = [
+  {
+    label: 'Regional trainers',
+    options: [
+      { id: 1, fullName: 'Regional Trainer 1' },
+      { id: 2, fullName: 'Regional Trainer 2' },
+    ],
+  },
+];
+
+function FormStateHarness() {
+  const { setValue } = useFormContext();
+
+  return (
+    <button
+      type="button"
+      onClick={() => setValue('trainers', [{ id: 1, fullName: 'Regional Trainer 1' }])}
+    >
+      remove other trainer
+    </button>
+  );
+}
+
+function RenderSessionTrainers({
+  event = defaultEvent,
+  defaultValues = { trainers: [], otherTrainers: '' },
+  showHarness = false,
+}) {
+  const hookForm = useForm({
+    mode: 'onBlur',
+    defaultValues,
+  });
+
+  return (
+    <FormProvider {...hookForm}>
+      <SessionTrainers event={event} />
+      {showHarness ? <FormStateHarness /> : null}
+    </FormProvider>
+  );
+}
+
+describe('SessionTrainers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useEventAndSessionStaff as jest.Mock).mockReturnValue({
+      trainerOptions: defaultTrainerOptions,
+      optionsForValue: defaultTrainerOptions,
+    });
+  });
+
+  it('renders trainer selector', async () => {
+    render(<RenderSessionTrainers />);
+    expect(await screen.findByLabelText(/Who provided the TTA/i)).toBeInTheDocument();
+  });
+
+  it('includes "Other" trainer option for regional PD with national centers', async () => {
+    render(<RenderSessionTrainers />);
+
+    const trainers = await screen.findByLabelText(/Who provided the TTA/i);
+    userEvent.click(trainers);
+
+    expect(await screen.findByText('Other')).toBeInTheDocument();
+  });
+
+  it('does not include "Other" trainer option for regional TTA with no national centers', async () => {
+    render(
+      <RenderSessionTrainers
+        event={{
+          ...defaultEvent,
+          data: {
+            ...defaultEvent.data,
+            eventOrganizer: TRAINING_EVENT_ORGANIZER.REGIONAL_TTA_NO_NATIONAL_CENTERS,
+          },
+        }}
+      />
+    );
+
+    const trainers = await screen.findByLabelText(/Who provided the TTA/i);
+    userEvent.click(trainers);
+
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
+  });
+
+  it('shows the "Other trainers" textarea when selecting Other', async () => {
+    render(<RenderSessionTrainers />);
+
+    const trainers = await screen.findByLabelText(/Who provided the TTA/i);
+    await selectEvent.select(trainers, ['Other']);
+
+    expect(await screen.findByLabelText(/Other trainers/i)).toBeInTheDocument();
+  });
+
+  it('hides otherTrainers input when Other is no longer selected', async () => {
+    render(
+      <RenderSessionTrainers
+        defaultValues={{
+          trainers: [{ id: 'other', fullName: 'Other' }],
+          otherTrainers: 'Custom Trainer',
+        }}
+        showHarness
+      />
+    );
+
+    expect(await screen.findByLabelText(/Other trainers/i)).toBeInTheDocument();
+
+    userEvent.click(screen.getByRole('button', { name: /remove other trainer/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/Other trainers/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
@@ -37,7 +37,10 @@ function FormStateHarness() {
   return (
     <button
       type="button"
-      onClick={() => setValue('trainers', [{ id: 1, fullName: 'Regional Trainer 1' }])}
+      onClick={() => {
+        setValue('otherTrainers', '');
+        setValue('trainers', [{ id: 1, fullName: 'Regional Trainer 1' }]);
+      }}
     >
       remove other trainer
     </button>

--- a/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
+++ b/frontend/src/pages/SessionForm/components/__tests__/SessionTrainers.tsx
@@ -88,7 +88,7 @@ describe('SessionTrainers', () => {
     expect(await screen.findByText('Other')).toBeInTheDocument();
   });
 
-  it('does not include "Other" trainer option for regional TTA with no national centers', async () => {
+  it('includes "Other" trainer option for regional TTA with no national centers', async () => {
     render(
       <RenderSessionTrainers
         event={{
@@ -104,7 +104,7 @@ describe('SessionTrainers', () => {
     const trainers = await screen.findByLabelText(/Who provided the TTA/i);
     userEvent.click(trainers);
 
-    expect(screen.queryByText('Other')).not.toBeInTheDocument();
+    expect(await screen.findByText('Other')).toBeInTheDocument();
   });
 
   it('shows the "Other trainers" textarea when selecting Other', async () => {

--- a/frontend/src/pages/SessionForm/constants.js
+++ b/frontend/src/pages/SessionForm/constants.js
@@ -92,6 +92,11 @@ export const pageComplete = (hookForm, fields) =>
     if (Array.isArray(val)) {
       return val.length > 0;
     }
+
+    if (typeof val === 'string') {
+      return !!val.trim();
+    }
+
     return !!val;
   });
 

--- a/frontend/src/pages/SessionForm/constants.js
+++ b/frontend/src/pages/SessionForm/constants.js
@@ -119,6 +119,7 @@ export const defaultKeys = [
   'reviewStatus',
   'approvalStatus',
   'trainers',
+  'otherTrainers',
 ];
 
 export const istKeys = [

--- a/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
@@ -99,6 +99,15 @@ describe('sessionSummary', () => {
 
       expect(isPageComplete(hookForm)).toBe(true);
     });
+
+    it('returns false when Other trainer is selected and otherTrainers is whitespace only', () => {
+      const hookForm = makeHookForm({
+        trainers: [{ id: 'other', fullName: 'Other' }],
+        otherTrainers: '   ',
+      });
+
+      expect(isPageComplete(hookForm)).toBe(false);
+    });
   });
 
   describe('render', () => {

--- a/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
@@ -99,15 +99,6 @@ describe('sessionSummary', () => {
 
       expect(isPageComplete(hookForm)).toBe(true);
     });
-
-    it('returns false when Other trainer is selected and otherTrainers is whitespace only', () => {
-      const hookForm = makeHookForm({
-        trainers: [{ id: 'other', fullName: 'Other' }],
-        otherTrainers: '   ',
-      });
-
-      expect(isPageComplete(hookForm)).toBe(false);
-    });
   });
 
   describe('render', () => {

--- a/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
@@ -50,19 +50,54 @@ const flushPromises = async (rerender, ui) => {
 
 describe('sessionSummary', () => {
   describe('isPageComplete', () => {
-    it('returns true if form state is valid', () => {
+    const makeHookForm = ({ useIpdCourses = false, trainers = [], otherTrainers = '' } = {}) => ({
+      getValues: jest.fn((field) => {
+        if (!field) {
+          return { useIpdCourses, trainers };
+        }
+
+        if (field === 'useIpdCourses') {
+          return useIpdCourses;
+        }
+
+        if (field === 'trainers') {
+          return trainers;
+        }
+
+        if (field === 'otherTrainers') {
+          return otherTrainers;
+        }
+
+        return 'filled';
+      }),
+    });
+
+    it('returns true when required fields are complete and Other trainer is not selected', () => {
       expect(
-        isPageComplete({
-          getValues: jest.fn(() => ({
-            objectiveTrainers: [1],
-            objectiveTopics: [1],
-          })),
-        })
+        isPageComplete(
+          makeHookForm({
+            trainers: [{ id: 1, fullName: 'Regional Trainer 1' }],
+          })
+        )
       ).toBe(true);
     });
 
-    it('returns false otherwise', () => {
-      expect(isPageComplete({ getValues: jest.fn(() => false) })).toBe(false);
+    it('returns false when Other trainer is selected and otherTrainers is empty', () => {
+      const hookForm = makeHookForm({
+        trainers: [{ id: 'other', fullName: 'Other' }],
+        otherTrainers: '',
+      });
+
+      expect(isPageComplete(hookForm)).toBe(false);
+    });
+
+    it('returns true when Other trainer is selected and otherTrainers is provided', () => {
+      const hookForm = makeHookForm({
+        trainers: [{ id: 'other', fullName: 'Other' }],
+        otherTrainers: 'Custom Trainer',
+      });
+
+      expect(isPageComplete(hookForm)).toBe(true);
     });
   });
 

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -32,10 +32,10 @@ import SupportTypeDrawer from '../../../components/SupportTypeDrawer';
 import selectOptionsReset from '../../../components/selectOptionsReset';
 import { deleteSessionObjectiveFile, uploadSessionObjectiveFiles } from '../../../fetchers/session';
 import { getTopics } from '../../../fetchers/topics';
-import useEventAndSessionStaff from '../../../hooks/useEventAndSessionStaff';
 import useGoalTemplates from '../../../hooks/useGoalTemplates';
 import ReviewPage from '../../ActivityReport/Pages/Review/ReviewPage';
 import SessionObjectiveResource from '../components/SessionObjectiveResource';
+import SessionTrainers from '../components/SessionTrainers';
 import {
   NO_ERROR,
   pageComplete,
@@ -66,8 +66,6 @@ const SessionSummary = ({ datePickerKey, event }) => {
   const endDate = watch('endDate');
   const courses = watch('courses');
 
-  const { trainerOptions } = useEventAndSessionStaff(event);
-
   const { startDate: eventStartDate } = (event || { data: { startDate: null } }).data;
 
   const topicsDrawerTriggerRef = useRef(null);
@@ -94,7 +92,7 @@ const SessionSummary = ({ datePickerKey, event }) => {
         const topics = await getTopics();
         topics.sort((a, b) => a.name.localeCompare(b.name));
         setTopicOptions(topics);
-      } catch (err) {
+      } catch (_error) {
         setError('objectiveTopics', { message: 'There was an error fetching topics' });
         setTopicOptions([]);
       }
@@ -185,7 +183,7 @@ const SessionSummary = ({ datePickerKey, event }) => {
       const uploadResults = await uploadSessionObjectiveFiles(id, uploadedFiles);
       appendFile(uploadResults);
       setFileUploadErrorMessage(null);
-    } catch (error) {
+    } catch (_error) {
       setFileUploadErrorMessage('File could not be uploaded');
     } finally {
       setIsAppLoading(false);
@@ -198,7 +196,7 @@ const SessionSummary = ({ datePickerKey, event }) => {
       setIsAppLoading(true);
       await deleteSessionObjectiveFile(String(id), String(files[fileIndex].id));
       removeFile(fileIndex);
-    } catch (error) {
+    } catch (_error) {
       setFileUploadErrorMessage('File could not be deleted');
     } finally {
       setIsAppLoading(false);
@@ -442,43 +440,8 @@ const SessionSummary = ({ datePickerKey, event }) => {
         </FormItem>
       </div>
 
-      <div>
-        <FormItem label="Who provided the TTA?" name="trainers" required>
-          <Controller
-            render={({ onChange: controllerOnChange, value, onBlur }) => (
-              <Select
-                value={value}
-                inputId="trainers"
-                name="trainers"
-                className="usa-select"
-                styles={selectOptionsReset}
-                onBlur={onBlur}
-                components={{
-                  DropdownIndicator: null,
-                }}
-                onChange={controllerOnChange}
-                inputRef={register({ required: 'Select at least one trainer' })}
-                options={trainerOptions}
-                getOptionLabel={(option) => option.fullName}
-                getOptionValue={(option) => option.id}
-                isMulti
-                required
-              />
-            )}
-            control={control}
-            rules={{
-              validate: (value) => {
-                if (!value || value.length === 0) {
-                  return 'Select at least one trainer';
-                }
-                return true;
-              },
-            }}
-            name="trainers"
-            defaultValue={[]}
-          />
-        </FormItem>
-      </div>
+      <SessionTrainers event={event} />
+
       <IpdCourseSelect
         error={errors.courses ? <ErrorMessage>{errors.courses.message}</ErrorMessage> : NO_ERROR}
         inputName={objectiveIpdCoursesInputName}
@@ -590,9 +553,7 @@ const SessionSummary = ({ datePickerKey, event }) => {
         <SupportTypeDrawer drawerTriggerRef={supportTypeDrawerTriggerRef} />
         <div className="display-flex flex-align-baseline">
           <Label htmlFor="objectiveSupportType">
-            <>
-              Support type <Req />
-            </>
+            Support type <Req />
           </Label>
           <button
             type="button"
@@ -666,12 +627,22 @@ const ReviewSection = () => {
 
   // eslint-disable-next-line max-len
   const objectiveFiles = (files || []).map((f) =>
-    f.url ? <Link href={f.url.url}>{f.originalFileName}</Link> : f.originalFileName
+    f.url ? (
+      <Link key={`f-${f.url.url}`} href={f.url.url}>
+        {f.originalFileName}
+      </Link>
+    ) : (
+      f.originalFileName
+    )
   );
   // eslint-disable-next-line max-len
   const resources = (objectiveResources || [])
     .filter((r) => r.value)
-    .map((r) => <Link href={r.value}>{r.value}</Link>);
+    .map((r) => (
+      <Link key={`r-${r.value}`} href={r.value}>
+        {r.value}
+      </Link>
+    ));
   const supportingGoals = (goalTemplates || []).map((g) => g.standard);
   const objectiveTrainers = (trainers || []).map((t) => t.fullName);
 
@@ -720,9 +691,14 @@ const ReviewSection = () => {
 
 export const isPageComplete = (hookForm) => {
   const { useIpdCourses } = hookForm.getValues();
+  const { trainers } = hookForm.getValues();
 
   if (useIpdCourses) {
     return pageComplete(hookForm, [...requiredFields, 'courses']);
+  }
+
+  if (trainers?.some((trainer) => trainer.id === 'other')) {
+    return pageComplete(hookForm, [...requiredFields, 'otherTrainers']);
   }
 
   return pageComplete(hookForm, requiredFields);
@@ -765,19 +741,17 @@ export default {
         </Button>
         {
           // if status is 'Completed' then don't show the save draft button.
-          additionalData &&
-            additionalData.status &&
-            additionalData.status !== TRAINING_REPORT_STATUSES.COMPLETE && (
-              <Button
-                id={`${path}-save-draft`}
-                className="usa-button--outline usa-button--no-margin-top "
-                type="button"
-                disabled={isAppLoading}
-                onClick={onSaveDraft}
-              >
-                Save draft
-              </Button>
-            )
+          additionalData?.status && additionalData.status !== TRAINING_REPORT_STATUSES.COMPLETE && (
+            <Button
+              id={`${path}-save-draft`}
+              className="usa-button--outline usa-button--no-margin-top "
+              type="button"
+              disabled={isAppLoading}
+              onClick={onSaveDraft}
+            >
+              Save draft
+            </Button>
+          )
         }
       </div>
     </div>

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -703,15 +703,17 @@ export const isPageComplete = (hookForm) => {
   const { useIpdCourses } = hookForm.getValues();
   const { trainers } = hookForm.getValues();
 
+  const required = [...requiredFields];
+
   if (useIpdCourses) {
-    return pageComplete(hookForm, [...requiredFields, 'courses']);
+    required.push('courses');
   }
 
   if (trainers?.some((trainer) => trainer.id === 'other')) {
-    return pageComplete(hookForm, requiredFields) && !!hookForm.getValues('otherTrainers')?.trim();
+    required.push('otherTrainers');
   }
 
-  return pageComplete(hookForm, requiredFields);
+  return pageComplete(hookForm, required);
 };
 
 export default {

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -708,7 +708,7 @@ export const isPageComplete = (hookForm) => {
   }
 
   if (trainers?.some((trainer) => trainer.id === 'other')) {
-    return pageComplete(hookForm, [...requiredFields, 'otherTrainers']);
+    return pageComplete(hookForm, requiredFields) && !!hookForm.getValues('otherTrainers')?.trim();
   }
 
   return pageComplete(hookForm, requiredFields);

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -666,7 +666,7 @@ const ReviewSection = () => {
         { label: 'Supporting goals', name: 'goals', customValue: { goals: supportingGoals } },
         { label: 'Topics', name: 'objectiveTopics', customValue: { objectiveTopics } },
         { label: 'Trainers', name: 'objectiveTrainers', customValue: { objectiveTrainers } },
-        ...(trainers?.some((trainer) => trainer.id === 'other')
+        ...(otherTrainers && otherTrainers.trim() !== ''
           ? [
               {
                 label: 'Other trainers',

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -645,7 +645,7 @@ const ReviewSection = () => {
       </Link>
     ));
   const supportingGoals = (goalTemplates || []).map((g) => g.standard);
-  const objectiveTrainers = (trainers || []).map((t) => t.fullName);
+  const objectiveTrainers = (trainers || []).map((t) => t.fullName).filter((t) => t !== 'Other');
 
   const sections = [
     {

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -623,6 +623,7 @@ const ReviewSection = () => {
     files,
     ttaProvided,
     objectiveSupportType,
+    otherTrainers,
   } = watch();
 
   // eslint-disable-next-line max-len
@@ -665,6 +666,15 @@ const ReviewSection = () => {
         { label: 'Supporting goals', name: 'goals', customValue: { goals: supportingGoals } },
         { label: 'Topics', name: 'objectiveTopics', customValue: { objectiveTopics } },
         { label: 'Trainers', name: 'objectiveTrainers', customValue: { objectiveTrainers } },
+        ...(trainers?.some((trainer) => trainer.id === 'other')
+          ? [
+              {
+                label: 'Other trainers',
+                name: 'otherTrainers',
+                customValue: { otherTrainers },
+              },
+            ]
+          : []),
         {
           label: 'iPD courses',
           name: 'courses',

--- a/frontend/src/pages/TrainingReportForm/pages/__tests__/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/__tests__/eventSummary.js
@@ -166,6 +166,35 @@ describe('eventSummary', () => {
       expect(onSaveDraft).toHaveBeenCalled();
     });
 
+    it('filters the event owner out of grouped collaborator options', async () => {
+      const adminUser = {
+        ...defaultUser,
+        permissions: [{ regionId: 1, scopeId: ADMIN }],
+      };
+
+      fetchMock.restore();
+      fetchMock.get('/api/users/trainers/regional/region/1', []);
+      fetchMock.getOnce('/api/users/trainers/national-center/region/1', [
+        { id: 2, fullName: 'Owner Collaborator' },
+        { id: 3, fullName: 'Tedwina User' },
+      ]);
+
+      const formValues = {
+        ...defaultFormValues,
+        ownerId: 2,
+      };
+
+      act(() => {
+        render(<RenderEventSummary user={adminUser} defaultValues={formValues} />);
+      });
+
+      const collaborators = await screen.findByLabelText(/Event collaborators/i);
+      userEvent.click(collaborators);
+
+      expect(await screen.findByText('Tedwina User')).toBeVisible();
+      expect(screen.queryByText('Owner Collaborator')).not.toBeInTheDocument();
+    });
+
     it('admin users can edit all fields', async () => {
       const adminUser = {
         ...defaultUser,

--- a/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
@@ -317,7 +317,7 @@ const EventSummary = ({
                   }}
                   onBlur={onBlur}
                   inputRef={register({ required: 'Select at least one collaborator' })}
-                  options={trainerOptions.filter((option) => option.id !== data.ownerId)}
+                  options={optionsForValue.filter((option) => option.id !== data.ownerId)}
                   getOptionLabel={(option) => option.fullName}
                   getOptionValue={(option) => option.id}
                   required

--- a/frontend/src/pages/TrainingReports/components/SessionCard.js
+++ b/frontend/src/pages/TrainingReports/components/SessionCard.js
@@ -35,7 +35,16 @@ function SessionCard({
 }) {
   const modalRef = useRef();
   const { goalTemplates, trainers } = session;
-  const { sessionName, startDate, endDate, objective, objectiveSupportType, status } = session.data;
+
+  const {
+    sessionName,
+    startDate,
+    endDate,
+    objective,
+    objectiveSupportType,
+    status,
+    otherTrainers,
+  } = session.data;
 
   const getSessionDisplayStatusText = () => {
     switch (status) {
@@ -146,6 +155,7 @@ function SessionCard({
 
         <CardData label="Trainers">
           {objectiveTrainers && objectiveTrainers.length > 0 ? objectiveTrainers.join('; ') : ''}
+          {otherTrainers ? `; Other` : ''}
         </CardData>
 
         <CardData label="Status">

--- a/frontend/src/pages/TrainingReports/components/SessionCard.js
+++ b/frontend/src/pages/TrainingReports/components/SessionCard.js
@@ -154,8 +154,9 @@ function SessionCard({
         </CardData>
 
         <CardData label="Trainers">
-          {objectiveTrainers && objectiveTrainers.length > 0 ? objectiveTrainers.join('; ') : ''}
-          {otherTrainers ? `; Other` : ''}
+          {objectiveTrainers?.length ? objectiveTrainers.join('; ') : ''}
+          {otherTrainers && objectiveTrainers?.length ? '; ' : ''}
+          {otherTrainers ? 'Other' : ''}
         </CardData>
 
         <CardData label="Status">

--- a/frontend/src/pages/ViewTrainingReport/TrainingReportV2.js
+++ b/frontend/src/pages/ViewTrainingReport/TrainingReportV2.js
@@ -276,6 +276,9 @@ export default function TrainingReportV2({
                     (session.trainers || []).map((t) => t.fullName),
                     '; '
                   ),
+                  ...(session.data.otherTrainers && session.data.otherTrainers.trim() !== ''
+                    ? { 'Other trainers': session.data.otherTrainers }
+                    : {}),
                   'iPD Courses':
                     session.data.courses && session.data.courses.length
                       ? session.data.courses.map((o) => o.name).join(', ')

--- a/frontend/src/pages/ViewTrainingReport/TrainingReportV2.js
+++ b/frontend/src/pages/ViewTrainingReport/TrainingReportV2.js
@@ -273,7 +273,7 @@ export default function TrainingReportV2({
                   'Supporting goals': formatSupportingGoals(session.goalTemplates),
                   Topics: handleArrayJoin(session.data.objectiveTopics, ', '),
                   Trainers: handleArrayJoin(
-                    (session.trainers || []).map((t) => t.fullName),
+                    (session.trainers || []).map((t) => t.fullName).filter((t) => t !== 'Other'),
                     '; '
                   ),
                   ...(session.data.otherTrainers && session.data.otherTrainers.trim() !== ''

--- a/frontend/src/pages/ViewTrainingReport/__tests__/index.js
+++ b/frontend/src/pages/ViewTrainingReport/__tests__/index.js
@@ -626,6 +626,159 @@ describe('ViewTrainingReport', () => {
     expect(await screen.findByRole('heading', { name: 'Session 1' })).toBeInTheDocument();
   });
 
+  it('filters out other trainers that are just empty strings', async () => {
+    const e = mockEvent();
+    e.sessionReports = [
+      {
+        id: 7,
+        eventId: 1,
+        trainers: [{ fullName: 'Trainer 1, NC' }, { fullName: 'Trainer 2, GS' }],
+        data: {
+          id: 7,
+          otherTrainers: '   ',
+          files: [
+            {
+              id: 25643,
+              key: '57cdfafa-d93f-4d61-ae56-c7fbb0432a47pdf',
+              url: {
+                url: 'http://file-url',
+                error: null,
+              },
+              status: 'UPLOADING',
+              fileSize: 954060,
+              createdAt: '2023-06-27T13:48:54.745Z',
+              updatedAt: '2023-06-27T13:48:54.745Z',
+              originalFileName: 'test-file.pdf',
+            },
+          ],
+          status: TRAINING_REPORT_STATUSES.COMPLETE,
+          context: 'Session 1 context',
+          endDate: '06/16/2023',
+          eventId: 33,
+          ownerId: null,
+          duration: 1,
+          regionId: 3,
+          eventName:
+            'Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective',
+          objective: 'Session 1 objective',
+          pageState: { 1: 'Complete', 2: 'Complete', 3: 'Complete' },
+          startDate: '06/12/2023',
+          eventOwner: 355,
+          recipients: [{ label: 'Altenwerth LLC - 05insect010586  - EHS, HS', value: 10586 }],
+          sessionName: 'Session Name # 1',
+          ttaProvided: 'Session 1 TTA provided',
+          participants: ['Direct Service: Other'],
+          deliveryMethod: 'in-person',
+          eventDisplayId: 'R03-PD-23-1037',
+          objectiveTopics: ['Behavioral / Mental Health / Trauma', 'CLASS: Emotional Support'],
+          objectiveResources: [{ value: 'http://random-resource-url' }],
+          recipientNextSteps: [
+            { note: 'r-step1session1', completeDate: '06/20/2025' },
+            { id: null, note: 'asdfasdf', completeDate: '06/21/2023' },
+          ],
+          specialistNextSteps: [{ note: 's-step1session1', completeDate: '06/14/2026' }],
+          numberOfParticipants: 3,
+          objectiveSupportType: SUPPORT_TYPES[2],
+          ttaType: ['training', 'technical-assistance'],
+          courses: [
+            { id: 1, name: 'course 1' },
+            { id: 2, name: 'course 2' },
+          ],
+        },
+        goalTemplates: [{ standard: 'Goal Template 1' }, { standard: 'Goal Template 2' }],
+        createdAt: '2023-06-27T13:48:31.490Z',
+        updatedAt: '2023-06-27T13:49:18.579Z',
+      },
+    ];
+
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', mockEvent());
+
+    fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
+    fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
+
+    renderTrainingReport();
+
+    await screen.findByRole('heading', { name: 'Training event report R03-PD-23-1037' });
+    expect(screen.queryByText('Other trainers')).not.toBeInTheDocument();
+    expect(screen.queryByText('Misc Trainer')).not.toBeInTheDocument();
+  });
+
+  it('displays other trainers', async () => {
+    const e = mockEvent();
+    e.sessionReports = [
+      {
+        id: 7,
+        eventId: 1,
+        trainers: [{ fullName: 'Trainer 1, NC' }, { fullName: 'Trainer 2, GS' }],
+        data: {
+          id: 7,
+          otherTrainers: 'Misc Trainer',
+          files: [
+            {
+              id: 25643,
+              key: '57cdfafa-d93f-4d61-ae56-c7fbb0432a47pdf',
+              url: {
+                url: 'http://file-url',
+                error: null,
+              },
+              status: 'UPLOADING',
+              fileSize: 954060,
+              createdAt: '2023-06-27T13:48:54.745Z',
+              updatedAt: '2023-06-27T13:48:54.745Z',
+              originalFileName: 'test-file.pdf',
+            },
+          ],
+          status: TRAINING_REPORT_STATUSES.COMPLETE,
+          context: 'Session 1 context',
+          endDate: '06/16/2023',
+          eventId: 33,
+          ownerId: null,
+          duration: 1,
+          regionId: 3,
+          eventName:
+            'Health Webinar Series: Oral Health and Dental Care from a Regional and State Perspective',
+          objective: 'Session 1 objective',
+          pageState: { 1: 'Complete', 2: 'Complete', 3: 'Complete' },
+          startDate: '06/12/2023',
+          eventOwner: 355,
+          recipients: [{ label: 'Altenwerth LLC - 05insect010586  - EHS, HS', value: 10586 }],
+          sessionName: 'Session Name # 1',
+          ttaProvided: 'Session 1 TTA provided',
+          participants: ['Direct Service: Other'],
+          deliveryMethod: 'in-person',
+          eventDisplayId: 'R03-PD-23-1037',
+          objectiveTopics: ['Behavioral / Mental Health / Trauma', 'CLASS: Emotional Support'],
+          objectiveResources: [{ value: 'http://random-resource-url' }],
+          recipientNextSteps: [
+            { note: 'r-step1session1', completeDate: '06/20/2025' },
+            { id: null, note: 'asdfasdf', completeDate: '06/21/2023' },
+          ],
+          specialistNextSteps: [{ note: 's-step1session1', completeDate: '06/14/2026' }],
+          numberOfParticipants: 3,
+          objectiveSupportType: SUPPORT_TYPES[2],
+          ttaType: ['training', 'technical-assistance'],
+          courses: [
+            { id: 1, name: 'course 1' },
+            { id: 2, name: 'course 2' },
+          ],
+        },
+        goalTemplates: [{ standard: 'Goal Template 1' }, { standard: 'Goal Template 2' }],
+        createdAt: '2023-06-27T13:48:31.490Z',
+        updatedAt: '2023-06-27T13:49:18.579Z',
+      },
+    ];
+
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
+
+    fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
+    fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
+
+    renderTrainingReport();
+
+    await screen.findByRole('heading', { name: 'Training event report R03-PD-23-1037' });
+    expect(await screen.findByText('Misc Trainer')).toBeInTheDocument();
+  });
+
   it('will not fetch if there are eventReportPilotNationalCenterUsers in the response that match the IDs', async () => {
     const e = mockEvent();
     e.eventReportPilotNationalCenterUsers = [

--- a/frontend/src/pages/ViewTrainingReport/__tests__/index.js
+++ b/frontend/src/pages/ViewTrainingReport/__tests__/index.js
@@ -691,7 +691,7 @@ describe('ViewTrainingReport', () => {
       },
     ];
 
-    fetchMock.getOnce('/api/events/id/1?readOnly=true', mockEvent());
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
 
     fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
     fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -275,16 +275,9 @@ export async function updateSession(id: number, request) {
       id,
       SessionReportPilotTrainer,
       'userId',
-      trainers.map((trainer: { id: number }) => trainer.id)
-    );
-  }
-
-  if (trainers) {
-    await updateSessionReportRelatedModels(
-      id,
-      SessionReportPilotTrainer,
-      'userId',
-      trainers.map((trainer: { id: number }) => trainer.id)
+      trainers
+        .map((trainer: { id: number | 'other' }) => trainer.id)
+        .filter((id: number | 'other') => id !== 'other')
     );
   }
 


### PR DESCRIPTION
## Description of change
Add "other" option to "who provided the training?" in session summary, which conditionally reveals "Other trainers" field

## How to test
Confirm that the dropdown control functions as expected and that the other trainers conditionally displays in the review and submit page and the "View training report" page. (see mockup)

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5513


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Linked Jira issue
- [ ] JIRA issue status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
