### PR TITLE
[PROD] TTAHUB-5403 Update start and end date filters to support TR

### DIFF
--- a/frontend/src/components/filter/__tests__/FilterMenu.js
+++ b/frontend/src/components/filter/__tests__/FilterMenu.js
@@ -167,7 +167,7 @@ describe('Filter Menu', () => {
     userEvent.selectOptions(condition, 'is on or after');
 
     const del = screen.getByRole('button', {
-      name: /remove date started \(ar\) is on or after filter\. click apply filters to make your changes/i,
+      name: /remove date started is on or after filter\. click apply filters to make your changes/i,
     });
     userEvent.click(del);
 

--- a/frontend/src/components/filter/__tests__/FilterPills.js
+++ b/frontend/src/components/filter/__tests__/FilterPills.js
@@ -53,7 +53,7 @@ describe('Filter Pills', () => {
       expect(await screen.findByText(/10\/01\/2021-10\/31\/2021/i)).toBeVisible();
       expect(
         await screen.findByRole('button', {
-          name: /this button removes the filter: date started \(ar\) is within/i,
+          name: /this button removes the filter: date started is within/i,
         })
       ).toBeVisible();
     });
@@ -86,7 +86,7 @@ describe('Filter Pills', () => {
 
       // Remove filter pill.
       const remoteButton = await screen.findByRole('button', {
-        name: /this button removes the filter: date started \(ar\) is on or after /i,
+        name: /this button removes the filter: date started is on or after /i,
       });
       userEvent.click(remoteButton);
       expect(onRemoveFilter).toHaveBeenCalledWith('2');

--- a/frontend/src/pages/RecipientRecord/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/__tests__/index.js
@@ -238,7 +238,7 @@ describe('recipient record page', () => {
     });
 
     const remove = screen.getByRole('button', {
-      name: /this button removes the filter: date started \(ar\) is within/i,
+      name: /this button removes the filter: date started is within/i,
     });
 
     userEvent.click(remove);

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -28,8 +28,8 @@ export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) =>
   ].sort((a, b) => a.display.localeCompare(b.display));
 
 const TTAHISTORY_FILTER_CONFIG = [
-  startDateFilter,
-  endDateFilter,
+  { ...startDateFilter, display: 'Date started' },
+  { ...endDateFilter, display: 'Date ended' },
   activityReportGoalResponseFilter,
   myReportsFilter,
   specialistRoleFilter,

--- a/src/scopes/trainingReports/dateUtils.js
+++ b/src/scopes/trainingReports/dateUtils.js
@@ -1,0 +1,114 @@
+import moment from 'moment';
+import { Op } from 'sequelize';
+import { sequelize } from '../../models';
+
+const INPUT_DATE_FORMATS = [
+  'YYYY/MM/DD',
+  'YYYY-MM-DD',
+  'YYYY/M/D',
+  'YYYY-M-D',
+  'MM/DD/YYYY',
+  'M/D/YYYY',
+];
+
+export function toIsoFormat(dateStr) {
+  const parsed = moment(dateStr, INPUT_DATE_FORMATS, true);
+  if (!parsed.isValid()) {
+    return null;
+  }
+
+  return parsed.format('YYYY-MM-DD');
+}
+
+function toIsoRange(rangeValue) {
+  if (typeof rangeValue !== 'string') {
+    return null;
+  }
+
+  const value = rangeValue.trim();
+  if (!value) {
+    return null;
+  }
+
+  // We support "date-date" ranges where each side can itself contain dashes.
+  const candidates = [];
+  for (let i = 1; i < value.length; i += 1) {
+    if (value[i] !== '-') {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const left = value.slice(0, i).trim();
+    const right = value.slice(i + 1).trim();
+    const startDate = toIsoFormat(left);
+    const endDate = toIsoFormat(right);
+
+    if (startDate && endDate) {
+      candidates.push([startDate, endDate]);
+    }
+  }
+
+  if (candidates.length !== 1) {
+    return null;
+  }
+
+  return candidates[0];
+}
+
+function eventReportDateExpression(fieldName) {
+  const path = `"EventReportPilot"."data"->>'${fieldName}'`;
+  return `(
+    CASE
+      WHEN NULLIF(${path}, '') IS NULL THEN NULL
+      WHEN ${path} ~ '^\\d{4}-\\d{1,2}-\\d{1,2}$' THEN (${path})::date
+      WHEN ${path} ~ '^\\d{1,2}/\\d{1,2}/\\d{2}$' THEN TO_DATE(${path}, 'MM/DD/YY')
+      WHEN ${path} ~ '^\\d{1,2}/\\d{1,2}/\\d{4}$' THEN TO_DATE(${path}, 'MM/DD/YYYY')
+      ELSE NULL
+    END
+  )`;
+}
+
+export function beforeDateScope(fieldName, date) {
+  const converted = toIsoFormat(date[0]);
+  if (!converted) {
+    return {};
+  }
+
+  return {
+    [Op.and]: [
+      sequelize.literal(
+        `${eventReportDateExpression(fieldName)} <= ${sequelize.escape(converted)}::date`
+      ),
+    ],
+  };
+}
+
+export function afterDateScope(fieldName, date) {
+  const converted = toIsoFormat(date[0]);
+  if (!converted) {
+    return {};
+  }
+
+  return {
+    [Op.and]: [
+      sequelize.literal(
+        `${eventReportDateExpression(fieldName)} >= ${sequelize.escape(converted)}::date`
+      ),
+    ],
+  };
+}
+
+export function withinDateScope(fieldName, dates) {
+  const [startDate, endDate] = toIsoRange(dates[0]) || [];
+  if (!startDate || !endDate) {
+    return {};
+  }
+
+  return {
+    [Op.and]: [
+      sequelize.literal(
+        `${eventReportDateExpression(fieldName)} BETWEEN ${sequelize.escape(startDate)}::date AND ${sequelize.escape(endDate)}::date`
+      ),
+    ],
+  };
+}

--- a/src/scopes/trainingReports/endDate.js
+++ b/src/scopes/trainingReports/endDate.js
@@ -1,0 +1,13 @@
+import { afterDateScope, beforeDateScope, withinDateScope } from './dateUtils';
+
+export function beforeEndDate(date) {
+  return beforeDateScope('endDate', date);
+}
+
+export function afterEndDate(date) {
+  return afterDateScope('endDate', date);
+}
+
+export function withinEndDates(dates) {
+  return withinDateScope('endDate', dates);
+}

--- a/src/scopes/trainingReports/endDate.test.js
+++ b/src/scopes/trainingReports/endDate.test.js
@@ -1,8 +1,7 @@
 /* eslint-disable max-len */
 import { EventReportPilot, filtersToScopes, mockUser, Op, sequelize, User } from './testHelpers';
-import { filterAssociation } from './utils';
 
-describe('trainingReports/startDate', () => {
+describe('trainingReports/endDate', () => {
   let lteEventReportPilot;
   let gteEventReportPilot;
   let superGteEventReportPilot;
@@ -20,7 +19,7 @@ describe('trainingReports/startDate', () => {
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: '06/06/2021',
+        endDate: '06/06/2021',
       },
     });
 
@@ -31,18 +30,18 @@ describe('trainingReports/startDate', () => {
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: '06/08/2021',
+        endDate: '06/08/2021',
       },
     });
 
-    // create gte report.
+    // create super gte report (chronologically earlier).
     superGteEventReportPilot = await EventReportPilot.create({
       ownerId: mockUser.id,
       pocIds: [mockUser.id],
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: '09/08/2019',
+        endDate: '09/08/2019',
       },
     });
 
@@ -53,7 +52,7 @@ describe('trainingReports/startDate', () => {
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: '06/07/2021',
+        endDate: '06/07/2021',
       },
     });
 
@@ -84,8 +83,8 @@ describe('trainingReports/startDate', () => {
     await sequelize.close();
   });
 
-  it('before returns reports with start dates before the given date', async () => {
-    const filters = { 'startDate.bef': '2021/06/06' };
+  it('before returns reports with end dates before the given date', async () => {
+    const filters = { 'endDate.bef': '2021/06/06' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     const found = await EventReportPilot.findAll({
       where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -98,8 +97,8 @@ describe('trainingReports/startDate', () => {
     expect(foundIds).toContain(superGteEventReportPilot.id);
   });
 
-  it('within returns reports with start dates between the given dates', async () => {
-    const filters = { 'startDate.win': '2021/06/07-2021/06/07' };
+  it('within returns reports with end dates between the given dates', async () => {
+    const filters = { 'endDate.win': '2021/06/07-2021/06/07' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     const found = await EventReportPilot.findAll({
       where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -109,7 +108,7 @@ describe('trainingReports/startDate', () => {
   });
 
   it('within supports dashed input date ranges', async () => {
-    const filters = { 'startDate.win': '2021-06-07-2021-06-07' };
+    const filters = { 'endDate.win': '2021-06-07-2021-06-07' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     const found = await EventReportPilot.findAll({
       where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -118,8 +117,8 @@ describe('trainingReports/startDate', () => {
     expect(found[0].id).toBe(betweenEventReportPilot.id);
   });
 
-  it('before returns reports with start dates after the given date', async () => {
-    const filters = { 'startDate.aft': '2021/06/08' };
+  it('after returns reports with end dates after the given date', async () => {
+    const filters = { 'endDate.aft': '2021/06/08' };
     const { trainingReport: scope } = await filtersToScopes(filters);
 
     const found = await EventReportPilot.findAll({
@@ -130,43 +129,43 @@ describe('trainingReports/startDate', () => {
   });
 
   it('returns an empty object when date range is invalid', async () => {
-    const filters = { 'startDate.win': '2021/06/07' };
+    const filters = { 'endDate.win': '2021/06/07' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     expect(scope).toEqual([{}]);
   });
 
   it('returns an empty object for malformed date in before filter', async () => {
-    const filters = { 'startDate.bef': 'not-a-date' };
+    const filters = { 'endDate.bef': 'not-a-date' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     expect(scope).toEqual([{}]);
   });
 
   it('returns an empty object for malformed date in after filter', async () => {
-    const filters = { 'startDate.aft': 'invalid' };
+    const filters = { 'endDate.aft': 'invalid' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     expect(scope).toEqual([{}]);
   });
 
   it('returns an empty object for malformed dates in within filter', async () => {
-    const filters = { 'startDate.win': 'bad-date-worse-date' };
+    const filters = { 'endDate.win': 'bad-date-worse-date' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     expect(scope).toEqual([{}]);
   });
 
   it('returns an empty object when only start date is invalid in within filter', async () => {
-    const filters = { 'startDate.win': 'invalid-2021/06/07' };
+    const filters = { 'endDate.win': 'invalid-2021/06/07' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     expect(scope).toEqual([{}]);
   });
 
   it('returns an empty object when only end date is invalid in within filter', async () => {
-    const filters = { 'startDate.win': '2021/06/07-invalid' };
+    const filters = { 'endDate.win': '2021/06/07-invalid' };
     const { trainingReport: scope } = await filtersToScopes(filters);
     expect(scope).toEqual([{}]);
   });
 
   describe('supported date input formats', () => {
-    // All these formats should find gteEventReportPilot (startDate: '06/08/2021')
+    // All these formats should find gteEventReportPilot (endDate: '06/08/2021')
     it.each([
       ['YYYY/MM/DD', '2021/06/08'],
       ['YYYY-MM-DD', '2021-06-08'],
@@ -175,7 +174,7 @@ describe('trainingReports/startDate', () => {
       ['MM/DD/YYYY', '06/08/2021'],
       ['M/D/YYYY', '6/8/2021'],
     ])('parses %s format (%s) correctly in after filter', async (formatName, dateValue) => {
-      const filters = { 'startDate.aft': dateValue };
+      const filters = { 'endDate.aft': dateValue };
       const { trainingReport: scope } = await filtersToScopes(filters);
       const found = await EventReportPilot.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -192,7 +191,7 @@ describe('trainingReports/startDate', () => {
       ['MM/DD/YYYY', '06/06/2021'],
       ['M/D/YYYY', '6/6/2021'],
     ])('parses %s format (%s) correctly in before filter', async (formatName, dateValue) => {
-      const filters = { 'startDate.bef': dateValue };
+      const filters = { 'endDate.bef': dateValue };
       const { trainingReport: scope } = await filtersToScopes(filters);
       const found = await EventReportPilot.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -210,7 +209,7 @@ describe('trainingReports/startDate', () => {
       ['YYYY/MM/DD', '2021/06/07-2021/06/07'],
       ['MM/DD/YYYY', '06/07/2021-06/07/2021'],
     ])('parses %s format (%s) correctly in within filter', async (formatName, dateRange) => {
-      const filters = { 'startDate.win': dateRange };
+      const filters = { 'endDate.win': dateRange };
       const { trainingReport: scope } = await filtersToScopes(filters);
       const found = await EventReportPilot.findAll({
         where: { [Op.and]: [scope, { id: possibleIds }] },
@@ -220,24 +219,14 @@ describe('trainingReports/startDate', () => {
     });
   });
 
-  it('uses default comparator when none is provided', async () => {
-    const out = filterAssociation('asdf', ['1', '2'], false);
-    expect(out.where[Op.or][0]).toStrictEqual(
-      sequelize.literal('"EventReportPilot"."id" IN (asdf ~* \'1\')')
-    );
-    expect(out.where[Op.or][1]).toStrictEqual(
-      sequelize.literal('"EventReportPilot"."id" IN (asdf ~* \'2\')')
-    );
-  });
-
-  it('handles mixed stored startDate formats and malformed values without throwing', async () => {
+  it('handles mixed stored endDate formats and malformed values without throwing', async () => {
     const isoEventReportPilot = await EventReportPilot.create({
       ownerId: mockUser.id,
       pocIds: [mockUser.id],
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: '2021-06-09',
+        endDate: '2021-06-09',
       },
     });
 
@@ -247,7 +236,7 @@ describe('trainingReports/startDate', () => {
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: '6/9/21',
+        endDate: '6/9/21',
       },
     });
 
@@ -257,7 +246,7 @@ describe('trainingReports/startDate', () => {
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: '',
+        endDate: '',
       },
     });
 
@@ -267,7 +256,7 @@ describe('trainingReports/startDate', () => {
       collaboratorIds: [],
       regionId: mockUser.homeRegionId,
       data: {
-        startDate: 'this-is-not-a-date',
+        endDate: 'this-is-not-a-date',
       },
     });
 
@@ -280,7 +269,7 @@ describe('trainingReports/startDate', () => {
     });
 
     try {
-      const filters = { 'startDate.aft': '2021/06/08' };
+      const filters = { 'endDate.aft': '2021/06/08' };
       const { trainingReport: scope } = await filtersToScopes(filters);
       const found = await EventReportPilot.findAll({
         where: {

--- a/src/scopes/trainingReports/index.js
+++ b/src/scopes/trainingReports/index.js
@@ -6,6 +6,7 @@ import { withEventId, withoutEventId } from './eventId';
 import { withGoalName, withoutGoalName } from './goalName';
 import { withoutRegion, withRegion } from './region';
 import { withoutStandard, withStandard } from './standard';
+import { afterEndDate, beforeEndDate, withinEndDates } from './endDate';
 import { afterStartDate, beforeStartDate, withinStartDates } from './startDate';
 
 export const topicToQuery = {
@@ -36,6 +37,12 @@ export const topicToQuery = {
   standard: {
     in: (query) => withStandard(query),
     nin: (query) => withoutStandard(query),
+  },
+  endDate: {
+    bef: (query) => beforeEndDate(query),
+    aft: (query) => afterEndDate(query),
+    win: (query) => withinEndDates(query),
+    in: (query) => withinEndDates(query),
   },
 };
 

--- a/src/scopes/trainingReports/startDate.js
+++ b/src/scopes/trainingReports/startDate.js
@@ -1,71 +1,13 @@
-import moment from 'moment';
-import { Op } from 'sequelize';
-import { sequelize } from '../../models';
-
-const INPUT_DATE_FORMATS = [
-  'YYYY/MM/DD',
-  'YYYY-MM-DD',
-  'YYYY/M/D',
-  'YYYY-M-D',
-  'MM/DD/YYYY',
-  'M/D/YYYY',
-];
-
-/**
- * Converts input date to ISO format (YYYY-MM-DD) for PostgreSQL comparison.
- * Dates are stored in the JSONB column as MM/DD/YYYY, but we use TO_DATE
- * in PostgreSQL to properly compare dates chronologically.
- */
-function toIsoFormat(dateStr) {
-  const parsed = moment(dateStr, INPUT_DATE_FORMATS, true);
-  if (!parsed.isValid()) {
-    return null;
-  }
-  return parsed.format('YYYY-MM-DD');
-}
+import { afterDateScope, beforeDateScope, withinDateScope } from './dateUtils';
 
 export function beforeStartDate(date) {
-  const converted = toIsoFormat(date[0]);
-  if (!converted) return {};
-  // Use TO_DATE to convert stored MM/DD/YYYY to a proper date for comparison
-  return {
-    [Op.and]: [
-      sequelize.literal(
-        `TO_DATE("EventReportPilot"."data"->>'startDate', 'MM/DD/YYYY') <= ${sequelize.escape(converted)}::date`
-      ),
-    ],
-  };
+  return beforeDateScope('startDate', date);
 }
 
 export function afterStartDate(date) {
-  const converted = toIsoFormat(date[0]);
-  if (!converted) return {};
-  // Use TO_DATE to convert stored MM/DD/YYYY to a proper date for comparison
-  return {
-    [Op.and]: [
-      sequelize.literal(
-        `TO_DATE("EventReportPilot"."data"->>'startDate', 'MM/DD/YYYY') >= ${sequelize.escape(converted)}::date`
-      ),
-    ],
-  };
+  return afterDateScope('startDate', date);
 }
 
 export function withinStartDates(dates) {
-  const splitDates = dates[0].split('-');
-  if (splitDates.length !== 2) {
-    return {};
-  }
-  const startDate = toIsoFormat(splitDates[0]);
-  const endDate = toIsoFormat(splitDates[1]);
-  if (!startDate || !endDate) {
-    return {};
-  }
-  // Use TO_DATE to convert stored MM/DD/YYYY to a proper date for comparison
-  return {
-    [Op.and]: [
-      sequelize.literal(
-        `TO_DATE("EventReportPilot"."data"->>'startDate', 'MM/DD/YYYY') BETWEEN ${sequelize.escape(startDate)}::date AND ${sequelize.escape(endDate)}::date`
-      ),
-    ],
-  };
+  return withinDateScope('startDate', dates);
 }

--- a/tests/e2e/recipient-record.spec.ts
+++ b/tests/e2e/recipient-record.spec.ts
@@ -13,7 +13,7 @@ test.describe('Recipient record', () => {
     // remove a filter
     await page
       .getByRole('button', {
-        name: /This button removes the filter: Date started \(ar\) is within/i,
+        name: /This button removes the filter: Date started is within/i,
       })
       .click();
 


### PR DESCRIPTION
## Description of change

**TTAHUB-5403:** Update start and end date filters on TTA History tab to filter AR and TR.

## How to test

**TTAHUB-5403:**  Make sure the date filters also alter the TR counts.

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5403


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [x] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
