### PR TITLE
[TTAHUB-5517/5518] Remove FEI and Specialist role filters from TTA History

### DIFF
--- a/frontend/src/components/filter/__tests__/FilterItem.js
+++ b/frontend/src/components/filter/__tests__/FilterItem.js
@@ -3,11 +3,21 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { TTAHISTORY_FILTER_CONFIG } from '../../../pages/RecipientRecord/pages/constants';
+import { activityReportGoalResponseFilter, specialistRoleFilter } from '../activityReportFilters';
 import FilterErrorContext from '../FilterErrorContext';
 import FilterItem from '../FilterItem';
 
-const selectedTopic = TTAHISTORY_FILTER_CONFIG[0];
-const topicOptions = TTAHISTORY_FILTER_CONFIG.map(({ id: filterId, display }) => (
+// The Specialist roles and FEI root cause filters were removed from the TTA History
+// filter config but still exist for other pages. Append them here so these generic
+// FilterItem tests continue to exercise those filter types.
+const FILTER_CONFIG = [
+  ...TTAHISTORY_FILTER_CONFIG,
+  specialistRoleFilter,
+  activityReportGoalResponseFilter,
+];
+
+const selectedTopic = FILTER_CONFIG[0];
+const topicOptions = FILTER_CONFIG.map(({ id: filterId, display }) => (
   <option key={filterId} value={filterId}>
     {display}
   </option>

--- a/frontend/src/components/filter/__tests__/FilterMenu.js
+++ b/frontend/src/components/filter/__tests__/FilterMenu.js
@@ -23,6 +23,7 @@ import {
   recipientFilter,
   reportTextFilter,
   singleOrMultiRecipientsFilter,
+  specialistRoleFilter,
   stateCodeFilter,
   targetPopulationsFilter,
   topicsFilter,
@@ -43,6 +44,15 @@ import {
 } from '../trainingReportFilters';
 
 const { READ_ACTIVITY_REPORTS } = SCOPE_IDS;
+
+// The Specialist roles and FEI root cause filters were removed from the TTA History
+// filter config but still exist for other pages. Append them here so these generic
+// FilterMenu tests continue to exercise those filter types.
+const TTA_HISTORY_TEST_CONFIG = [
+  ...TTAHISTORY_FILTER_CONFIG,
+  specialistRoleFilter,
+  activityReportGoalResponseFilter,
+];
 
 describe('Filter Menu', () => {
   afterAll(() => {
@@ -101,7 +111,7 @@ describe('Filter Menu', () => {
   const renderFilterMenu = (
     filters = [],
     onApplyFilters = jest.fn(),
-    filterConfig = TTAHISTORY_FILTER_CONFIG
+    filterConfig = TTA_HISTORY_TEST_CONFIG
   ) => {
     const user = {
       permissions: [

--- a/frontend/src/components/filter/__tests__/FilterPills.js
+++ b/frontend/src/components/filter/__tests__/FilterPills.js
@@ -3,7 +3,17 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { TTAHISTORY_FILTER_CONFIG } from '../../../pages/RecipientRecord/pages/constants';
+import { activityReportGoalResponseFilter, specialistRoleFilter } from '../activityReportFilters';
 import FilterPills from '../FilterPills';
+
+// The Specialist roles and FEI root cause filters were removed from the TTA History
+// filter config but still exist for other pages. Append them here so these generic
+// FilterPills tests continue to exercise those filter types.
+const FILTER_CONFIG = [
+  ...TTAHISTORY_FILTER_CONFIG,
+  specialistRoleFilter,
+  activityReportGoalResponseFilter,
+];
 
 describe('Filter Pills', () => {
   afterAll(() => {
@@ -15,7 +25,7 @@ describe('Filter Pills', () => {
       render(
         <FilterPills
           filters={filters}
-          filterConfig={TTAHISTORY_FILTER_CONFIG}
+          filterConfig={FILTER_CONFIG}
           onRemoveFilter={onRemoveFilter}
         />
       );

--- a/frontend/src/hooks/__tests__/useSanitizedFilters.js
+++ b/frontend/src/hooks/__tests__/useSanitizedFilters.js
@@ -1,0 +1,94 @@
+/* eslint-disable react/prop-types */
+import '@testing-library/jest-dom';
+import { render, act } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router';
+import useSanitizedFilters from '../useSanitizedFilters';
+
+const VALID_TOPICS = new Set(['startDate', 'endDate']);
+
+const defaultFilters = [
+  {
+    id: 'default-1',
+    topic: 'startDate',
+    condition: 'is within',
+    query: '2026/01/01-2026/07/01',
+  },
+];
+
+let renderCount = 0;
+
+const SanitizedFilters = ({ topics = VALID_TOPICS }) => {
+  renderCount += 1;
+  const [filters] = useSanitizedFilters('test-key', defaultFilters, topics);
+  return <pre id="filters">{JSON.stringify(filters)}</pre>;
+};
+
+const renderWithHistory = (history) =>
+  render(
+    <Router history={history}>
+      <SanitizedFilters />
+    </Router>
+  );
+
+const readFilters = () => JSON.parse(document.querySelector('#filters').textContent);
+
+describe('useSanitizedFilters', () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+    renderCount = 0;
+  });
+
+  it('returns the default filters when the URL has none', () => {
+    const history = createMemoryHistory({ initialEntries: ['/history'] });
+    act(() => {
+      renderWithHistory(history);
+    });
+
+    expect(readFilters()).toEqual(defaultFilters);
+  });
+
+  it('strips filters whose topic is not allowed', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/history?endDate.aft=2026%2F07%2F02&role.nin[]=Specialist'],
+    });
+
+    act(() => {
+      renderWithHistory(history);
+    });
+
+    const filters = readFilters();
+    expect(filters).toHaveLength(1);
+    expect(filters[0].topic).toBe('endDate');
+    expect(filters.some((f) => f.topic === 'role')).toBe(false);
+  });
+
+  it('cleans invalid filters out of the URL', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/history?endDate.aft=2026%2F07%2F02&role.nin[]=Specialist'],
+    });
+
+    act(() => {
+      renderWithHistory(history);
+    });
+
+    expect(history.location.search).not.toContain('role.nin');
+    expect(history.location.search).toContain('endDate.aft');
+  });
+
+  it('does not rewrite the URL when all filters are valid', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/history?endDate.aft=2026%2F07%2F02'],
+    });
+
+    act(() => {
+      renderWithHistory(history);
+    });
+
+    const rendersAfterMount = renderCount;
+    expect(history.location.search).toContain('endDate.aft');
+    // No extra write-back render should have been triggered.
+    expect(rendersAfterMount).toBe(1);
+  });
+});

--- a/frontend/src/hooks/__tests__/useSanitizedFilters.js
+++ b/frontend/src/hooks/__tests__/useSanitizedFilters.js
@@ -17,10 +17,7 @@ const defaultFilters = [
   },
 ];
 
-let renderCount = 0;
-
 const SanitizedFilters = ({ topics = VALID_TOPICS }) => {
-  renderCount += 1;
   const [filters] = useSanitizedFilters('test-key', defaultFilters, topics);
   return <pre id="filters">{JSON.stringify(filters)}</pre>;
 };
@@ -37,7 +34,6 @@ const readFilters = () => JSON.parse(document.querySelector('#filters').textCont
 describe('useSanitizedFilters', () => {
   afterEach(() => {
     window.sessionStorage.clear();
-    renderCount = 0;
   });
 
   it('returns the default filters when the URL has none', () => {
@@ -86,9 +82,9 @@ describe('useSanitizedFilters', () => {
       renderWithHistory(history);
     });
 
-    const rendersAfterMount = renderCount;
-    expect(history.location.search).toContain('endDate.aft');
-    // No extra write-back render should have been triggered.
-    expect(rendersAfterMount).toBe(1);
+    // The URL is untouched and no new history entry is pushed when the filters
+    // are already valid.
+    expect(history.location.search).toBe('?endDate.aft=2026%2F07%2F02');
+    expect(history.length).toBe(1);
   });
 });

--- a/frontend/src/hooks/useSanitizedFilters.js
+++ b/frontend/src/hooks/useSanitizedFilters.js
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import useSessionFiltersAndReflectInUrl from './useSessionFiltersAndReflectInUrl';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 /**
  * useSanitizedFilters wraps useSessionFiltersAndReflectInUrl and removes any
@@ -14,38 +15,16 @@ import useSessionFiltersAndReflectInUrl from './useSessionFiltersAndReflectInUrl
  * @returns {[ Object[], Function ]}
  */
 export default function useSanitizedFilters(key, defaultFilters, validTopics) {
+
   const [filters, setFilters] = useSessionFiltersAndReflectInUrl(key, defaultFilters);
 
-  const allowedTopics = useMemo(
-    () => (validTopics instanceof Set ? validTopics : new Set(validTopics)),
-    [validTopics]
-  );
-
-  // Keep the sanitized array referentially stable when its contents are
-  // unchanged. Consumers compare the filters prop by reference, so returning a
-  // fresh array every render would fire redundant, identical fetches.
-  const previousSanitized = useRef(null);
   const sanitizedFilters = useMemo(() => {
-    const next = filters.filter((f) => allowedTopics.has(f.topic));
-    const previous = previousSanitized.current;
-    if (
-      previous
-      && previous.length === next.length
-      && previous.every((filter, index) => filter === next[index])
-    ) {
-      return previous;
-    }
-    previousSanitized.current = next;
-    return next;
-  }, [filters, allowedTopics]);
+    return filters.filter((f) => validTopics.has(f.topic));
+  }, [filters, validTopics]);
 
-  // Write the sanitized list back so the URL and session storage reflect only
-  // valid filters. Guarded on length so we only write when something changed.
-  useEffect(() => {
-    if (sanitizedFilters.length !== filters.length) {
-      setFilters(sanitizedFilters);
-    }
-  }, [sanitizedFilters, filters.length, setFilters]);
+  useDeepCompareEffect(() => {
+    setFilters(sanitizedFilters);
+  }, [sanitizedFilters, setFilters]);
 
-  return [sanitizedFilters, setFilters];
+  return [filters, setFilters];
 }

--- a/frontend/src/hooks/useSanitizedFilters.js
+++ b/frontend/src/hooks/useSanitizedFilters.js
@@ -1,0 +1,51 @@
+import { useEffect, useMemo, useRef } from 'react';
+import useSessionFiltersAndReflectInUrl from './useSessionFiltersAndReflectInUrl';
+
+/**
+ * useSanitizedFilters wraps useSessionFiltersAndReflectInUrl and removes any
+ * filter whose topic is not in the allowed set. Invalid filters (for example
+ * from an old bookmarked URL or a filter that has since been removed from the
+ * config) are stripped from the returned value, the URL and session storage so
+ * they never reach the UI or the API.
+ *
+ * @param {String} key session storage key
+ * @param {Object[]} defaultFilters
+ * @param {Set<string>|string[]} validTopics allowed filter topic ids
+ * @returns {[ Object[], Function ]}
+ */
+export default function useSanitizedFilters(key, defaultFilters, validTopics) {
+  const [filters, setFilters] = useSessionFiltersAndReflectInUrl(key, defaultFilters);
+
+  const allowedTopics = useMemo(
+    () => (validTopics instanceof Set ? validTopics : new Set(validTopics)),
+    [validTopics]
+  );
+
+  // Keep the sanitized array referentially stable when its contents are
+  // unchanged. Consumers compare the filters prop by reference, so returning a
+  // fresh array every render would fire redundant, identical fetches.
+  const previousSanitized = useRef(null);
+  const sanitizedFilters = useMemo(() => {
+    const next = filters.filter((f) => allowedTopics.has(f.topic));
+    const previous = previousSanitized.current;
+    if (
+      previous
+      && previous.length === next.length
+      && previous.every((filter, index) => filter === next[index])
+    ) {
+      return previous;
+    }
+    previousSanitized.current = next;
+    return next;
+  }, [filters, allowedTopics]);
+
+  // Write the sanitized list back so the URL and session storage reflect only
+  // valid filters. Guarded on length so we only write when something changed.
+  useEffect(() => {
+    if (sanitizedFilters.length !== filters.length) {
+      setFilters(sanitizedFilters);
+    }
+  }, [sanitizedFilters, filters.length, setFilters]);
+
+  return [sanitizedFilters, setFilters];
+}

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -1,6 +1,6 @@
 import { Grid } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { v4 as uuidv4 } from 'uuid';
 import ActivityReportsTable from '../../../components/ActivityReportsTable';
@@ -25,7 +25,10 @@ const VALID_TOPICS = new Set(TTAHISTORY_FILTER_CONFIG.map((f) => f.id));
 
 export default function TTAHistory({ recipientName, recipientId, regionId }) {
   const [resetPagination, setResetPagination] = useState(false);
-  const filterKey = `ttahistory-filters-${recipientId}`;
+  // Bump the version suffix whenever filters are added or removed from the
+  // config so that stale filters saved in a browser tab's session storage are
+  // ignored rather than sent to the API.
+  const filterKey = `ttahistory-filters-v2-${recipientId}`;
   const { user } = useContext(UserContext);
   const regions = useMemo(() => getUserRegions(user), [user]);
 
@@ -38,32 +41,6 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
     },
   ]);
 
-  // Keep the sanitized filters referentially stable across renders when their
-  // contents are unchanged. Consumers such as ActivityReportsTable compare the
-  // filters prop by reference, so returning a fresh array every render (or on
-  // the extra render triggered by the cleanup effect below) would fire
-  // redundant, identical fetches.
-  const previousSanitizedFilters = useRef(null);
-  const sanitizedFilters = useMemo(() => {
-    const next = filters.filter((f) => VALID_TOPICS.has(f.topic));
-    const previous = previousSanitizedFilters.current;
-    if (
-      previous
-      && previous.length === next.length
-      && previous.every((filter, index) => filter === next[index])
-    ) {
-      return previous;
-    }
-    previousSanitizedFilters.current = next;
-    return next;
-  }, [filters]);
-
-  useEffect(() => {
-    if (sanitizedFilters.length !== filters.length) {
-      setFiltersInHook(sanitizedFilters);
-    }
-  }, [sanitizedFilters, filters.length, setFiltersInHook]);
-
   const setFilters = useCallback(
     (newFilters) => {
       setFiltersInHook(newFilters);
@@ -74,7 +51,7 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
 
   const filtersToApply = useMemo(
     () => [
-      ...expandFilters(sanitizedFilters),
+      ...expandFilters(filters.filter((f) => VALID_TOPICS.has(f.topic))),
       {
         topic: 'region',
         condition: 'is',
@@ -86,7 +63,7 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
         query: recipientId,
       },
     ],
-    [sanitizedFilters, regionId, recipientId]
+    [filters, regionId, recipientId]
   );
 
   if (!recipientName) {
@@ -115,7 +92,7 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
           data-testid="filter-panel"
         >
           <FilterPanel
-            filters={sanitizedFilters}
+            filters={filters}
             onApplyFilters={onApply}
             onRemoveFilter={onRemoveFilter}
             filterConfig={TTAHISTORY_FILTER_CONFIG}

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -1,6 +1,6 @@
 import { Grid } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { v4 as uuidv4 } from 'uuid';
 import ActivityReportsTable from '../../../components/ActivityReportsTable';
@@ -38,10 +38,25 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
     },
   ]);
 
-  const sanitizedFilters = useMemo(
-    () => filters.filter((f) => VALID_TOPICS.has(f.topic)),
-    [filters]
-  );
+  // Keep the sanitized filters referentially stable across renders when their
+  // contents are unchanged. Consumers such as ActivityReportsTable compare the
+  // filters prop by reference, so returning a fresh array every render (or on
+  // the extra render triggered by the cleanup effect below) would fire
+  // redundant, identical fetches.
+  const previousSanitizedFilters = useRef(null);
+  const sanitizedFilters = useMemo(() => {
+    const next = filters.filter((f) => VALID_TOPICS.has(f.topic));
+    const previous = previousSanitizedFilters.current;
+    if (
+      previous
+      && previous.length === next.length
+      && previous.every((filter, index) => filter === next[index])
+    ) {
+      return previous;
+    }
+    previousSanitizedFilters.current = next;
+    return next;
+  }, [filters]);
 
   useEffect(() => {
     if (sanitizedFilters.length !== filters.length) {
@@ -57,23 +72,26 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
     [setFiltersInHook]
   );
 
+  const filtersToApply = useMemo(
+    () => [
+      ...expandFilters(sanitizedFilters),
+      {
+        topic: 'region',
+        condition: 'is',
+        query: regionId,
+      },
+      {
+        topic: 'recipientId',
+        condition: 'contains',
+        query: recipientId,
+      },
+    ],
+    [sanitizedFilters, regionId, recipientId]
+  );
+
   if (!recipientName) {
     return null;
   }
-
-  const filtersToApply = [
-    ...expandFilters(sanitizedFilters),
-    {
-      topic: 'region',
-      condition: 'is',
-      query: regionId,
-    },
-    {
-      topic: 'recipientId',
-      condition: 'contains',
-      query: recipientId,
-    },
-  ];
 
   const onRemoveFilter = (id) => {
     const newFilters = [...filters];

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -1,6 +1,6 @@
 import { Grid } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { v4 as uuidv4 } from 'uuid';
 import ActivityReportsTable from '../../../components/ActivityReportsTable';
@@ -20,6 +20,9 @@ const defaultDate = formatDateRange({
   yearToDate: true,
   forDateTime: true,
 });
+
+const VALID_TOPICS = new Set(TTAHISTORY_FILTER_CONFIG.map((f) => f.id));
+
 export default function TTAHistory({ recipientName, recipientId, regionId }) {
   const [resetPagination, setResetPagination] = useState(false);
   const filterKey = `ttahistory-filters-${recipientId}`;
@@ -35,6 +38,17 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
     },
   ]);
 
+  const sanitizedFilters = useMemo(
+    () => filters.filter((f) => VALID_TOPICS.has(f.topic)),
+    [filters]
+  );
+
+  useEffect(() => {
+    if (sanitizedFilters.length !== filters.length) {
+      setFiltersInHook(sanitizedFilters);
+    }
+  }, [sanitizedFilters, filters.length, setFiltersInHook]);
+
   const setFilters = useCallback(
     (newFilters) => {
       setFiltersInHook(newFilters);
@@ -48,7 +62,7 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
   }
 
   const filtersToApply = [
-    ...expandFilters(filters),
+    ...expandFilters(sanitizedFilters),
     {
       topic: 'region',
       condition: 'is',
@@ -83,7 +97,7 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
           data-testid="filter-panel"
         >
           <FilterPanel
-            filters={filters}
+            filters={sanitizedFilters}
             onApplyFilters={onApply}
             onRemoveFilter={onRemoveFilter}
             filterConfig={TTAHISTORY_FILTER_CONFIG}

--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import ActivityReportsTable from '../../../components/ActivityReportsTable';
 import FilterPanel from '../../../components/filter/FilterPanel';
 import FilterContext from '../../../FilterContext';
-import useSessionFiltersAndReflectInUrl from '../../../hooks/useSessionFiltersAndReflectInUrl';
+import useSanitizedFilters from '../../../hooks/useSanitizedFilters';
 import { getUserRegions } from '../../../permissions';
 import UserContext from '../../../UserContext';
 import { expandFilters, formatDateRange } from '../../../utils';
@@ -32,14 +32,18 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
   const { user } = useContext(UserContext);
   const regions = useMemo(() => getUserRegions(user), [user]);
 
-  const [filters, setFiltersInHook] = useSessionFiltersAndReflectInUrl(filterKey, [
-    {
-      id: uuidv4(),
-      topic: 'startDate',
-      condition: 'is within',
-      query: defaultDate,
-    },
-  ]);
+  const [filters, setFiltersInHook] = useSanitizedFilters(
+    filterKey,
+    [
+      {
+        id: uuidv4(),
+        topic: 'startDate',
+        condition: 'is within',
+        query: defaultDate,
+      },
+    ],
+    VALID_TOPICS
+  );
 
   const setFilters = useCallback(
     (newFilters) => {
@@ -51,7 +55,7 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
 
   const filtersToApply = useMemo(
     () => [
-      ...expandFilters(filters.filter((f) => VALID_TOPICS.has(f.topic))),
+      ...expandFilters(filters),
       {
         topic: 'region',
         condition: 'is',

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -11,6 +11,8 @@ import UserContext from '../../../../UserContext';
 import { formatDateRange } from '../../../../utils';
 import TTAHistory from '../TTAHistory';
 
+const SESSION_KEY = 'ttahistory-filters-401';
+
 const memoryHistory = createMemoryHistory();
 const yearToDate = encodeURIComponent(formatDateRange({ yearToDate: true, forDateTime: true }));
 
@@ -76,6 +78,7 @@ describe('Recipient Record - TTA History', () => {
 
   afterEach(() => {
     fetchMock.restore();
+    window.sessionStorage.removeItem(SESSION_KEY);
   });
 
   it('renders the TTA History page appropriately', async () => {
@@ -156,5 +159,46 @@ describe('Recipient Record - TTA History', () => {
     });
 
     expect(button).toBeVisible();
+  });
+
+  it('strips stale role and activityReportGoalResponse filters from session storage before fetching', async () => {
+    const defaultDateDecoded = formatDateRange({ yearToDate: true, forDateTime: true });
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify([
+        { id: 'stale-1', topic: 'role', condition: 'is', query: ['Grantee Specialist'] },
+        {
+          id: 'stale-2',
+          topic: 'activityReportGoalResponse',
+          condition: 'is',
+          query: ['Agree'],
+        },
+        { id: 'valid-1', topic: 'startDate', condition: 'is within', query: defaultDateDecoded },
+      ])
+    );
+
+    act(() => renderTTAHistory());
+
+    expect(fetchMock.called(/role\.in\[\]/)).toBe(false);
+    expect(fetchMock.called(/activityReportGoalResponse\.in\[\]/)).toBe(false);
+  });
+
+  it('strips stale role filter from URL params before fetching', async () => {
+    const staleHistory = createMemoryHistory();
+    staleHistory.push({ search: '?role.in[]=Grantee%20Specialist' });
+
+    // The beforeEach mocks only the clean startDate URL; if a role.in[] request
+    // were sent, fetchMock would throw on the unregistered URL.
+    act(() => {
+      render(
+        <UserContext.Provider value={{ user }}>
+          <Router history={staleHistory}>
+            <TTAHistory recipientName="Jim Recipient" recipientId="401" regionId="1" />
+          </Router>
+        </UserContext.Provider>
+      );
+    });
+
+    expect(fetchMock.called(/role\.in\[\]/)).toBe(false);
   });
 });

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -11,7 +11,7 @@ import UserContext from '../../../../UserContext';
 import { formatDateRange } from '../../../../utils';
 import TTAHistory from '../TTAHistory';
 
-const SESSION_KEY = 'ttahistory-filters-401';
+const SESSION_KEY = 'ttahistory-filters-v2-401';
 
 const memoryHistory = createMemoryHistory();
 const yearToDate = encodeURIComponent(formatDateRange({ yearToDate: true, forDateTime: true }));
@@ -181,24 +181,5 @@ describe('Recipient Record - TTA History', () => {
 
     expect(fetchMock.called(/role\.in\[\]/)).toBe(false);
     expect(fetchMock.called(/activityReportGoalResponse\.in\[\]/)).toBe(false);
-  });
-
-  it('strips stale role filter from URL params before fetching', async () => {
-    const staleHistory = createMemoryHistory();
-    staleHistory.push({ search: '?role.in[]=Grantee%20Specialist' });
-
-    // The beforeEach mocks only the clean startDate URL; if a role.in[] request
-    // were sent, fetchMock would throw on the unregistered URL.
-    act(() => {
-      render(
-        <UserContext.Provider value={{ user }}>
-          <Router history={staleHistory}>
-            <TTAHistory recipientName="Jim Recipient" recipientId="401" regionId="1" />
-          </Router>
-        </UserContext.Provider>
-      );
-    });
-
-    expect(fetchMock.called(/role\.in\[\]/)).toBe(false);
   });
 });

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -116,35 +116,35 @@ describe('Recipient Record - TTA History', () => {
   it('combines filters appropriately', async () => {
     renderTTAHistory();
     fetchMock.get(
-      '/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&role.in[]=Family%20Engagement%20Specialist&role.in[]=Grantee%20Specialist&region.in[]=1&recipientId.ctn[]=401',
+      '/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
       tableResponse
     );
     fetchMock.get(
-      '/api/widgets/targetPopulationTable?role.in[]=Family%20Engagement%20Specialist&role.in[]=Grantee%20Specialist&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/targetPopulationTable?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
       200
     );
     fetchMock.get(
-      '/api/widgets/frequencyGraph?role.in[]=Family%20Engagement%20Specialist&role.in[]=Grantee%20Specialist&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/frequencyGraph?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
       200
     );
     fetchMock.get(
-      '/api/widgets/ttaHistoryOverview?role.in[]=Family%20Engagement%20Specialist&role.in[]=Grantee%20Specialist&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/ttaHistoryOverview?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
       overviewResponse
     );
     fetchMock.get(
-      '/api/widgets/approvedARAndTRByGoalCategory?role.in[]=Family%20Engagement%20Specialist&role.in[]=Grantee%20Specialist&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/approvedARAndTRByGoalCategory?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
       []
     );
 
     await act(async () => {
       userEvent.click(await screen.findByRole('button', { name: /open filters for this page/i }));
-      userEvent.selectOptions(await screen.findByRole('combobox', { name: 'topic' }), 'role');
-      userEvent.selectOptions(await screen.findByRole('combobox', { name: 'condition' }), 'is');
-      const specialistSelect = await screen.findByLabelText('Select specialist role to filter by');
-      await selectEvent.select(specialistSelect, [
-        'Family Engagement Specialist (FES)',
-        'Grantee Specialist (GS)',
-      ]);
+      userEvent.selectOptions(await screen.findByRole('combobox', { name: 'topic' }), 'myReports');
+      userEvent.selectOptions(
+        await screen.findByRole('combobox', { name: 'condition' }),
+        "where I'm the"
+      );
+      const reportRolesSelect = await screen.findByLabelText('Select report roles to filter by');
+      await selectEvent.select(reportRolesSelect, ['Creator']);
       const apply = await screen.findByRole('button', {
         name: /apply filters to recipient record data/i,
       });
@@ -152,7 +152,7 @@ describe('Recipient Record - TTA History', () => {
     });
 
     const button = await screen.findByRole('button', {
-      name: /this button removes the filter: specialist roles is family engagement specialist, grantee specialist/i,
+      name: /this button removes the filter: my reports where i'm the creator/i,
     });
 
     expect(button).toBeVisible();

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -182,4 +182,23 @@ describe('Recipient Record - TTA History', () => {
     expect(fetchMock.called(/role\.in\[\]/)).toBe(false);
     expect(fetchMock.called(/activityReportGoalResponse\.in\[\]/)).toBe(false);
   });
+
+  it('strips stale role filter from URL params before fetching', async () => {
+    const staleHistory = createMemoryHistory();
+    staleHistory.push({ search: '?role.in[]=Grantee%20Specialist' });
+
+    // The beforeEach mocks only the clean startDate URL; if a role.in[] request
+    // were sent, fetchMock would throw on the unregistered URL.
+    act(() => {
+      render(
+        <UserContext.Provider value={{ user }}>
+          <Router history={staleHistory}>
+            <TTAHistory recipientName="Jim Recipient" recipientId="401" regionId="1" />
+          </Router>
+        </UserContext.Provider>
+      );
+    });
+
+    expect(fetchMock.called(/role\.in\[\]/)).toBe(false);
+  });
 });

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -1,9 +1,7 @@
 import { DECIMAL_BASE } from '@ttahub/common';
 import {
-  activityReportGoalResponseFilter,
   endDateFilter,
   myReportsFilter,
-  specialistRoleFilter,
   startDateFilter,
 } from '../../../components/filter/activityReportFilters';
 import {
@@ -30,9 +28,7 @@ export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) =>
 const TTAHISTORY_FILTER_CONFIG = [
   { ...startDateFilter, display: 'Date started' },
   { ...endDateFilter, display: 'Date ended' },
-  activityReportGoalResponseFilter,
   myReportsFilter,
-  specialistRoleFilter,
 ];
 
 TTAHISTORY_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));


### PR DESCRIPTION
## Description of change

This PR removes two filters from the TTA History tab (TTAHUB-5517/TTAHUB-5518). The FEI response and the Specialist role filters.

## How to test

- Review the code
- Make sure neither filter appears on the TTA History tab
- Make sure the existing filters till work


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5517
* https://jira.acf.gov/browse/TTAHUB-5518


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
