### PR TITLE
[TTAHUB-5464] Add TR roles to filters for TTA History tab

### DIFF
--- a/frontend/src/Constants.js
+++ b/frontend/src/Constants.js
@@ -102,6 +102,15 @@ export const MY_REPORT_ROLES = ['Creator', 'Collaborator', 'Approver'];
 
 export const MY_CL_REPORT_ROLES = ['Creator', 'Other TTA staff'];
 
+export const TTA_HISTORY_REPORT_ROLES = [
+  'AR creator',
+  'AR collaborator',
+  'AR approver',
+  'TR event creator',
+  'TR event collaborator',
+  'TR POC',
+];
+
 export const OTHER_ENTITY_TYPES = [
   'CCDF / Child Care Administrator',
   'Head Start Collaboration Office',

--- a/frontend/src/components/filter/MyReportsSelect.js
+++ b/frontend/src/components/filter/MyReportsSelect.js
@@ -17,15 +17,11 @@ const optionsFor = {
 };
 
 export default function MyReportsSelect({ onApply, inputId, query, isFor }) {
-  const onApplyClick = (selected) => {
-    onApply(selected);
-  };
-
   const options = optionsFor[isFor] || optionsFor.myReports;
 
   return (
     <FilterSelect
-      onApply={onApplyClick}
+      onApply={onApply}
       inputId={inputId}
       labelText="Select report roles to filter by"
       options={options}

--- a/frontend/src/components/filter/MyReportsSelect.js
+++ b/frontend/src/components/filter/MyReportsSelect.js
@@ -10,17 +10,18 @@ const TTA_HISTORY_REPORTS_OPTIONS = TTA_HISTORY_REPORT_ROLES.map((label, value) 
   label,
 }));
 
-export default function MyReportsSelect({ onApply, inputId, query, isCommLog, isTtaHistory }) {
+const optionsFor = {
+  myReports: MY_REPORTS_OPTIONS,
+  commLog: MY_CL_REPORTS_OPTIONS,
+  ttaHistory: TTA_HISTORY_REPORTS_OPTIONS,
+};
+
+export default function MyReportsSelect({ onApply, inputId, query, isFor }) {
   const onApplyClick = (selected) => {
     onApply(selected);
   };
 
-  let options = MY_REPORTS_OPTIONS;
-  if (isCommLog) {
-    options = MY_CL_REPORTS_OPTIONS;
-  } else if (isTtaHistory) {
-    options = TTA_HISTORY_REPORTS_OPTIONS;
-  }
+  const options = optionsFor[isFor] || optionsFor.myReports;
 
   return (
     <FilterSelect
@@ -37,11 +38,9 @@ MyReportsSelect.propTypes = {
   inputId: PropTypes.string.isRequired,
   onApply: PropTypes.func.isRequired,
   query: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]).isRequired,
-  isCommLog: PropTypes.bool,
-  isTtaHistory: PropTypes.bool,
+  isFor: PropTypes.oneOf(Object.keys(optionsFor)),
 };
 
 MyReportsSelect.defaultProps = {
-  isCommLog: false,
-  isTtaHistory: false,
+  isFor: 'myReports',
 };

--- a/frontend/src/components/filter/MyReportsSelect.js
+++ b/frontend/src/components/filter/MyReportsSelect.js
@@ -1,17 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { MY_CL_REPORT_ROLES, MY_REPORT_ROLES } from '../../Constants';
+import { MY_CL_REPORT_ROLES, MY_REPORT_ROLES, TTA_HISTORY_REPORT_ROLES } from '../../Constants';
 import FilterSelect from './FilterSelect';
 
 const MY_REPORTS_OPTIONS = MY_REPORT_ROLES.map((label, value) => ({ value, label }));
 const MY_CL_REPORTS_OPTIONS = MY_CL_REPORT_ROLES.map((label, value) => ({ value, label }));
+const TTA_HISTORY_REPORTS_OPTIONS = TTA_HISTORY_REPORT_ROLES.map((label, value) => ({
+  value,
+  label,
+}));
 
-export default function MyReportsSelect({ onApply, inputId, query, isCommLog }) {
+export default function MyReportsSelect({ onApply, inputId, query, isCommLog, isTtaHistory }) {
   const onApplyClick = (selected) => {
     onApply(selected);
   };
 
-  const options = isCommLog ? MY_CL_REPORTS_OPTIONS : MY_REPORTS_OPTIONS;
+  let options = MY_REPORTS_OPTIONS;
+  if (isCommLog) {
+    options = MY_CL_REPORTS_OPTIONS;
+  } else if (isTtaHistory) {
+    options = TTA_HISTORY_REPORTS_OPTIONS;
+  }
 
   return (
     <FilterSelect
@@ -29,8 +38,10 @@ MyReportsSelect.propTypes = {
   onApply: PropTypes.func.isRequired,
   query: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]).isRequired,
   isCommLog: PropTypes.bool,
+  isTtaHistory: PropTypes.bool,
 };
 
 MyReportsSelect.defaultProps = {
   isCommLog: false,
+  isTtaHistory: false,
 };

--- a/frontend/src/components/filter/__tests__/MyReportsSelect.js
+++ b/frontend/src/components/filter/__tests__/MyReportsSelect.js
@@ -30,7 +30,13 @@ describe('MyReportsSelect', () => {
     const onApply = jest.fn();
     render(<MyReportsSelect onApply={onApply} inputId="tta-curly" query={[]} isFor="ttaHistory" />);
     const select = await findByText(/select report roles to filter by/i);
+
+    // Verify a TR role is present and selectable.
     await selectEvent.select(select, ['TR POC']);
     expect(onApply).toHaveBeenCalledWith(['TR POC']);
+
+    // Also verify that the AR-prefixed label is present (not the legacy 'Creator').
+    const arOption = await screen.findByText('AR creator');
+    expect(arOption).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/filter/__tests__/MyReportsSelect.js
+++ b/frontend/src/components/filter/__tests__/MyReportsSelect.js
@@ -19,16 +19,16 @@ describe('MyReportsSelect', () => {
     expect(onApply).toHaveBeenCalled();
   });
 
-  it('renders communication log report role options when isCommLog is true', async () => {
+  it('renders communication log report role options when isFor is commLog', async () => {
     const onApply = jest.fn();
-    render(<MyReportsSelect onApply={onApply} inputId="cl-curly" query={[]} isCommLog />);
+    render(<MyReportsSelect onApply={onApply} inputId="cl-curly" query={[]} isFor="commLog" />);
     const select = await findByText(/select report roles to filter by/i);
     expect(select).toBeInTheDocument();
   });
 
-  it('renders AR and TR report role options when isTtaHistory is true', async () => {
+  it('renders AR and TR report role options when isFor is ttaHistory', async () => {
     const onApply = jest.fn();
-    render(<MyReportsSelect onApply={onApply} inputId="tta-curly" query={[]} isTtaHistory />);
+    render(<MyReportsSelect onApply={onApply} inputId="tta-curly" query={[]} isFor="ttaHistory" />);
     const select = await findByText(/select report roles to filter by/i);
     await selectEvent.select(select, ['TR POC']);
     expect(onApply).toHaveBeenCalledWith(['TR POC']);

--- a/frontend/src/components/filter/__tests__/MyReportsSelect.js
+++ b/frontend/src/components/filter/__tests__/MyReportsSelect.js
@@ -25,4 +25,12 @@ describe('MyReportsSelect', () => {
     const select = await findByText(/select report roles to filter by/i);
     expect(select).toBeInTheDocument();
   });
+
+  it('renders AR and TR report role options when isTtaHistory is true', async () => {
+    const onApply = jest.fn();
+    render(<MyReportsSelect onApply={onApply} inputId="tta-curly" query={[]} isTtaHistory />);
+    const select = await findByText(/select report roles to filter by/i);
+    await selectEvent.select(select, ['TR POC']);
+    expect(onApply).toHaveBeenCalledWith(['TR POC']);
+  });
 });

--- a/frontend/src/components/filter/__tests__/activityReportFilters.js
+++ b/frontend/src/components/filter/__tests__/activityReportFilters.js
@@ -1,4 +1,6 @@
-import { endDateFilter, priorityIndicatorFilter } from '../activityReportFilters';
+import { render, screen } from '@testing-library/react';
+import selectEvent from 'react-select-event';
+import { endDateFilter, priorityIndicatorFilter, ttaHistoryMyReportsFilter } from '../activityReportFilters';
 
 describe('activityReportFilters', () => {
   describe('endDateFilter.displayQuery', () => {
@@ -36,6 +38,23 @@ describe('activityReportFilters', () => {
       const query = ['No TTA'];
       const result = priorityIndicatorFilter.displayQuery(query);
       expect(result).toBe('No TTA');
+    });
+  });
+
+  describe('ttaHistoryMyReportsFilter', () => {
+    it('has id "myReports" so the backend scope routes correctly', () => {
+      expect(ttaHistoryMyReportsFilter.id).toBe('myReports');
+    });
+
+    it('renders a MyReportsSelect with the TTA History option set', async () => {
+      const onApply = jest.fn();
+      render(ttaHistoryMyReportsFilter.renderInput('1', 'in', [], onApply));
+      const select = await screen.findByText(/select report roles to filter by/i);
+      // Open the menu so react-select renders the option list.
+      selectEvent.openMenu(select);
+      // Verify the TTA History-specific options are present (AR + TR labels):
+      expect(await screen.findByText('TR POC')).toBeInTheDocument();
+      expect(await screen.findByText('AR creator')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/filter/activityReportFilters.js
+++ b/frontend/src/components/filter/activityReportFilters.js
@@ -446,7 +446,7 @@ export const ttaHistoryMyReportsFilter = {
       inputId={`my-reports-${id}`}
       onApply={onApplyQuery}
       query={query}
-      isTtaHistory
+      isFor="ttaHistory"
     />
   ),
 };

--- a/frontend/src/components/filter/activityReportFilters.js
+++ b/frontend/src/components/filter/activityReportFilters.js
@@ -435,6 +435,22 @@ export const myReportsFilter = {
   ),
 };
 
+export const ttaHistoryMyReportsFilter = {
+  id: 'myReports',
+  display: 'My reports',
+  conditions: MY_REPORTS_FILTER_CONDITIONS,
+  defaultValues: EMPTY_MY_REPORTS_MULTI_SELECT,
+  displayQuery: handleArrayQuery,
+  renderInput: (id, condition, query, onApplyQuery) => (
+    <MyReportsSelect
+      inputId={`my-reports-${id}`}
+      onApply={onApplyQuery}
+      query={query}
+      isTtaHistory
+    />
+  ),
+};
+
 export const topicsFilter = {
   id: 'topic',
   display: 'Topics',

--- a/frontend/src/components/filter/communicationLogFilters.js
+++ b/frontend/src/components/filter/communicationLogFilters.js
@@ -160,7 +160,7 @@ export const myReportsFilter = {
   defaultValues: EMPTY_MY_REPORTS_MULTI_SELECT,
   displayQuery: handleArrayQuery,
   renderInput: (id, condition, query, onApplyQuery) => (
-    <MyReportsSelect inputId={`my-reports-${id}`} onApply={onApplyQuery} query={query} isCommLog />
+    <MyReportsSelect inputId={`my-reports-${id}`} onApply={onApplyQuery} query={query} isFor="commLog" />
   ),
 };
 

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -119,23 +119,23 @@ describe('Recipient Record - TTA History', () => {
   it('combines filters appropriately', async () => {
     renderTTAHistory();
     fetchMock.get(
-      '/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
+      '/api/activity-reports?sortBy=updatedAt&sortDir=desc&offset=0&limit=10&myReports.in[]=AR%20creator&region.in[]=1&recipientId.ctn[]=401',
       tableResponse
     );
     fetchMock.get(
-      '/api/widgets/targetPopulationTable?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/targetPopulationTable?myReports.in[]=AR%20creator&region.in[]=1&recipientId.ctn[]=401',
       200
     );
     fetchMock.get(
-      '/api/widgets/frequencyGraph?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/frequencyGraph?myReports.in[]=AR%20creator&region.in[]=1&recipientId.ctn[]=401',
       200
     );
     fetchMock.get(
-      '/api/widgets/ttaHistoryOverview?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/ttaHistoryOverview?myReports.in[]=AR%20creator&region.in[]=1&recipientId.ctn[]=401',
       overviewResponse
     );
     fetchMock.get(
-      '/api/widgets/approvedARAndTRByGoalCategory?myReports.in[]=Creator&region.in[]=1&recipientId.ctn[]=401',
+      '/api/widgets/approvedARAndTRByGoalCategory?myReports.in[]=AR%20creator&region.in[]=1&recipientId.ctn[]=401',
       []
     );
 
@@ -147,7 +147,7 @@ describe('Recipient Record - TTA History', () => {
         "where I'm the"
       );
       const reportRolesSelect = await screen.findByLabelText('Select report roles to filter by');
-      await selectEvent.select(reportRolesSelect, ['Creator']);
+      await selectEvent.select(reportRolesSelect, ['AR creator']);
       const apply = await screen.findByRole('button', {
         name: /apply filters to recipient record data/i,
       });
@@ -155,7 +155,7 @@ describe('Recipient Record - TTA History', () => {
     });
 
     const button = await screen.findByRole('button', {
-      name: /this button removes the filter: my reports where i'm the creator/i,
+      name: /this button removes the filter: my reports where i'm the ar creator/i,
     });
 
     expect(button).toBeVisible();

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -2,9 +2,9 @@ import { DECIMAL_BASE } from '@ttahub/common';
 import {
   activityReportGoalResponseFilter,
   endDateFilter,
-  myReportsFilter,
   specialistRoleFilter,
   startDateFilter,
+  ttaHistoryMyReportsFilter,
 } from '../../../components/filter/activityReportFilters';
 import {
   createDateFilter,
@@ -31,7 +31,7 @@ const TTAHISTORY_FILTER_CONFIG = [
   { ...startDateFilter, display: 'Date started' },
   { ...endDateFilter, display: 'Date ended' },
   activityReportGoalResponseFilter,
-  myReportsFilter,
+  ttaHistoryMyReportsFilter,
   specialistRoleFilter,
 ];
 

--- a/src/scopes/activityReport/myReports.js
+++ b/src/scopes/activityReport/myReports.js
@@ -5,8 +5,16 @@ import { sequelize } from '../../models';
 // That where clause will be finished when the function is called.
 export function myReportsScopes(userId, roles, exclude) {
   const roleList = roles || [];
+  // The RTR TTA History tab labels its Activity Report roles with an "AR" prefix
+  // (to disambiguate them from the Training Report roles that share the filter),
+  // while the Landing and Regional Dashboard filters use the original labels.
+  // Accept both so a single backend contract serves every "My reports" filter.
+  const isCreator = roleList.includes('Creator') || roleList.includes('AR creator');
+  const isCollaborator = roleList.includes('Collaborator') || roleList.includes('AR collaborator');
+  const isApprover = roleList.includes('Approver') || roleList.includes('AR approver');
+
   let reportSql = '';
-  if (roleList.includes('Creator')) {
+  if (isCreator) {
     reportSql += `
     SELECT
       "ActivityReports"."id"
@@ -14,7 +22,7 @@ export function myReportsScopes(userId, roles, exclude) {
     WHERE "ActivityReports"."userId" = '${userId}'`;
   }
 
-  if (roleList.includes('Collaborator')) {
+  if (isCollaborator) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
     SELECT
@@ -23,7 +31,7 @@ export function myReportsScopes(userId, roles, exclude) {
     WHERE "ActivityReportCollaborators"."userId" = '${userId}'`;
   }
 
-  if (roleList.includes('Approver')) {
+  if (isApprover) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
     SELECT
@@ -33,6 +41,14 @@ export function myReportsScopes(userId, roles, exclude) {
   }
 
   if (!reportSql) {
+    // The filter is active but no Activity Report role was selected (e.g. the user
+    // only selected Training Report roles on the TTA History tab).
+    // - "Where I'm the" (include): no AR matches this narrowed filter -> match nothing.
+    // - "Where I'm not the" (exclude): every AR trivially satisfies "not one of these
+    //   AR roles I never selected" -> match everything (no-op).
+    if (roleList.length > 0) {
+      return exclude ? {} : { [Op.or]: [sequelize.literal('1 = 0')] };
+    }
     auditLogger.info(`User: ${userId} attempting to filter reports with a role: ${roles} `);
     return {};
   }

--- a/src/scopes/activityReport/myReports.js
+++ b/src/scopes/activityReport/myReports.js
@@ -13,31 +13,36 @@ export function myReportsScopes(userId, roles, exclude) {
   const isCollaborator = roleList.includes('Collaborator') || roleList.includes('AR collaborator');
   const isApprover = roleList.includes('Approver') || roleList.includes('AR approver');
 
+  // Independently validate the user id as an integer before interpolating it into
+  // the SQL expression below (per AGENTS.md "SQL injection in filters" guidance).
+  const uid = Number(userId);
+  const validUserId = Number.isInteger(uid) ? uid : null;
+
   let reportSql = '';
-  if (isCreator) {
+  if (validUserId !== null && isCreator) {
     reportSql += `
     SELECT
       "ActivityReports"."id"
     FROM "ActivityReports"
-    WHERE "ActivityReports"."userId" = '${userId}'`;
+    WHERE "ActivityReports"."userId" = ${uid}`;
   }
 
-  if (isCollaborator) {
+  if (validUserId !== null && isCollaborator) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
     SELECT
       DISTINCT "ActivityReportCollaborators"."activityReportId"
     FROM "ActivityReportCollaborators"
-    WHERE "ActivityReportCollaborators"."userId" = '${userId}'`;
+    WHERE "ActivityReportCollaborators"."userId" = ${uid}`;
   }
 
-  if (isApprover) {
+  if (validUserId !== null && isApprover) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
     SELECT
       DISTINCT "ActivityReportApprovers"."activityReportId"
     FROM "ActivityReportApprovers"
-    WHERE "ActivityReportApprovers"."userId" = '${userId}'`;
+    WHERE "ActivityReportApprovers"."userId" = ${uid}`;
   }
 
   if (!reportSql) {

--- a/src/scopes/activityReport/myReports.test.js
+++ b/src/scopes/activityReport/myReports.test.js
@@ -1,4 +1,6 @@
 /* eslint-disable max-len */
+
+import { scopeToWhere } from '../utils';
 import {
   ActivityReport,
   ActivityReportApprover,
@@ -186,6 +188,54 @@ describe('myReports filtersToScopes', () => {
           reportByExcludedUser.id,
         ])
       );
+    });
+
+    it('includes reports created by the user using the "AR creator" label', async () => {
+      const filters = { 'myReports.in': ['AR creator'] };
+      const { activityReport: scope } = await filtersToScopes(filters, {
+        userId: sharedTestData.includedUser1.id,
+      });
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+      expect(found.length).toBe(1);
+      expect(found.map((f) => f.id)).toEqual(expect.arrayContaining([reportByIncludedUser.id]));
+    });
+
+    it('matches no reports when only Training Report roles are selected (include)', async () => {
+      const filters = { 'myReports.in': ['TR POC'] };
+      const { activityReport: scope } = await filtersToScopes(filters, {
+        userId: sharedTestData.includedUser1.id,
+      });
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+      expect(found.length).toBe(0);
+    });
+
+    it('matches all reports when only Training Report roles are selected (exclude)', async () => {
+      const filters = { 'myReports.nin': ['TR POC'] };
+      const { activityReport: scope } = await filtersToScopes(filters, {
+        userId: sharedTestData.includedUser1.id,
+      });
+      const found = await ActivityReport.findAll({
+        where: { [Op.and]: [scope, { id: possibleIds }] },
+      });
+      expect(found.length).toBe(4);
+    });
+
+    it('builds a valid where clause via scopeToWhere when only TR roles are selected (frequencyGraph path)', async () => {
+      // The frequency graph widget embeds the AR scope's SQL via scopeToWhere.
+      // A bare sequelize.literal inside an Op.and array is rejected by Sequelize
+      // ("Support for literal replacements in the where object has been removed"),
+      // so the match-nothing branch must use the { [Op.or]: [literal] } shape.
+      const filters = { 'myReports.in': ['TR POC'] };
+      const { activityReport: scope } = await filtersToScopes(filters, {
+        userId: sharedTestData.includedUser1.id,
+      });
+      const where = await scopeToWhere(ActivityReport, 'art', scope);
+      expect(typeof where).toBe('string');
+      expect(where).toContain('1 = 0');
     });
   });
 });

--- a/src/scopes/goals/myReports.js
+++ b/src/scopes/goals/myReports.js
@@ -11,18 +11,23 @@ export function myReportsScopes(userId, roles, exclude) {
   const isCollaborator = roleList.includes('Collaborator') || roleList.includes('AR collaborator');
   const isApprover = roleList.includes('Approver') || roleList.includes('AR approver');
 
+  // Independently validate the user id as an integer before interpolating it into
+  // the SQL expression below (per AGENTS.md "SQL injection in filters" guidance).
+  const uid = Number(userId);
+  const validUserId = Number.isInteger(uid) ? uid : null;
+
   let reportSql = '';
-  if (isCreator) {
+  if (validUserId !== null && isCreator) {
     reportSql += `
       SELECT DISTINCT "ActivityReportGoals"."goalId"
       FROM "ActivityReportGoals"
       INNER JOIN "ActivityReports"
       ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
-      WHERE "ActivityReports"."userId" = '${userId}'
+      WHERE "ActivityReports"."userId" = ${uid}
     `;
   }
 
-  if (isCollaborator) {
+  if (validUserId !== null && isCollaborator) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
       SELECT DISTINCT "ActivityReportGoals"."goalId"
@@ -31,11 +36,11 @@ export function myReportsScopes(userId, roles, exclude) {
       ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
       INNER JOIN "ActivityReportCollaborators"
       ON "ActivityReportCollaborators"."activityReportId" = "ActivityReports"."id"
-      WHERE "ActivityReportCollaborators"."userId" = '${userId}'
+      WHERE "ActivityReportCollaborators"."userId" = ${uid}
     `;
   }
 
-  if (isApprover) {
+  if (validUserId !== null && isApprover) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
       SELECT DISTINCT "ActivityReportGoals"."goalId"
@@ -44,20 +49,16 @@ export function myReportsScopes(userId, roles, exclude) {
       ON "ActivityReportGoals"."activityReportId" = "ActivityReports"."id"
       INNER JOIN "ActivityReportApprovers"
       ON "ActivityReports"."id" = "ActivityReportApprovers"."activityReportId"
-      WHERE "ActivityReportApprovers"."userId" = '${userId}'
+      WHERE "ActivityReportApprovers"."userId" = ${uid}
     `;
   }
 
   if (!reportSql) {
-    // The filter is active but no Activity Report role was selected (e.g. the user
-    // only selected Training Report roles on the TTA History tab). Avoid emitting an
-    // invalid `IN ()`:
-    // - "Where I'm the" (include): no goal matches this narrowed filter -> match nothing.
-    // - "Where I'm not the" (exclude): every goal trivially satisfies "not one of these
-    //   AR roles I never selected" -> match everything (no-op).
-    if (roleList.length > 0) {
-      return exclude ? {} : { [Op.or]: [sequelize.literal('1 = 0')] };
-    }
+    // No matching Activity Report role was selected, so there's nothing to filter on.
+    // Return a no-op scope, matching the convention used by the other filter scopes
+    // (e.g. activityReport/role). Unlike the activityReport scope, the goals myReports
+    // scope is never invoked with Training Report roles (it isn't used on the TTA
+    // History tab), so no match-nothing special case is needed here.
     return {};
   }
 

--- a/src/scopes/goals/myReports.js
+++ b/src/scopes/goals/myReports.js
@@ -2,8 +2,17 @@ import { Op } from 'sequelize';
 import { sequelize } from '../../models';
 
 export function myReportsScopes(userId, roles, exclude) {
+  const roleList = roles || [];
+  // The RTR TTA History tab prefixes its Activity Report roles with "AR" (to
+  // disambiguate them from the Training Report roles that share the filter),
+  // while the Landing and Regional Dashboard filters use the original labels.
+  // Accept both so a single backend contract serves every "My reports" filter.
+  const isCreator = roleList.includes('Creator') || roleList.includes('AR creator');
+  const isCollaborator = roleList.includes('Collaborator') || roleList.includes('AR collaborator');
+  const isApprover = roleList.includes('Approver') || roleList.includes('AR approver');
+
   let reportSql = '';
-  if (roles.includes('Creator')) {
+  if (isCreator) {
     reportSql += `
       SELECT DISTINCT "ActivityReportGoals"."goalId"
       FROM "ActivityReportGoals"
@@ -13,7 +22,7 @@ export function myReportsScopes(userId, roles, exclude) {
     `;
   }
 
-  if (roles.includes('Collaborator')) {
+  if (isCollaborator) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
       SELECT DISTINCT "ActivityReportGoals"."goalId"
@@ -26,7 +35,7 @@ export function myReportsScopes(userId, roles, exclude) {
     `;
   }
 
-  if (roles.includes('Approver')) {
+  if (isApprover) {
     reportSql += `
     ${reportSql ? ' UNION ' : ''}
       SELECT DISTINCT "ActivityReportGoals"."goalId"
@@ -37,6 +46,19 @@ export function myReportsScopes(userId, roles, exclude) {
       ON "ActivityReports"."id" = "ActivityReportApprovers"."activityReportId"
       WHERE "ActivityReportApprovers"."userId" = '${userId}'
     `;
+  }
+
+  if (!reportSql) {
+    // The filter is active but no Activity Report role was selected (e.g. the user
+    // only selected Training Report roles on the TTA History tab). Avoid emitting an
+    // invalid `IN ()`:
+    // - "Where I'm the" (include): no goal matches this narrowed filter -> match nothing.
+    // - "Where I'm not the" (exclude): every goal trivially satisfies "not one of these
+    //   AR roles I never selected" -> match everything (no-op).
+    if (roleList.length > 0) {
+      return exclude ? {} : { [Op.or]: [sequelize.literal('1 = 0')] };
+    }
+    return {};
   }
 
   reportSql = `"Goal"."id" ${exclude ? ' NOT ' : ''} IN (${reportSql})`;

--- a/src/scopes/goals/myReports.test.js
+++ b/src/scopes/goals/myReports.test.js
@@ -1,0 +1,51 @@
+import { Op } from 'sequelize';
+import { myReportsScopes } from './myReports';
+
+const USER_ID = 355;
+
+const literalVal = (result) => {
+  const clauses = result[Op.or];
+  return clauses?.[0] ? clauses[0].val : undefined;
+};
+
+describe('goals myReportsScopes', () => {
+  it('builds a goal subquery for the legacy "Creator" label', () => {
+    const result = myReportsScopes(USER_ID, ['Creator'], false);
+    const sql = literalVal(result);
+    expect(sql).toContain('"Goal"."id"');
+    expect(sql).toContain('"ActivityReports"."userId"');
+    expect(sql).not.toContain('IN ()');
+  });
+
+  it('builds a goal subquery for the renamed "AR creator" label', () => {
+    const result = myReportsScopes(USER_ID, ['AR creator'], false);
+    const sql = literalVal(result);
+    expect(sql).toContain('"Goal"."id"');
+    expect(sql).toContain('"ActivityReports"."userId"');
+    expect(sql).not.toContain('IN ()');
+  });
+
+  it('recognizes the renamed collaborator and approver labels', () => {
+    const collab = literalVal(myReportsScopes(USER_ID, ['AR collaborator'], false));
+    expect(collab).toContain('"ActivityReportCollaborators"."userId"');
+
+    const approver = literalVal(myReportsScopes(USER_ID, ['AR approver'], false));
+    expect(approver).toContain('"ActivityReportApprovers"."userId"');
+  });
+
+  it('matches nothing (never IN ()) when only Training Report roles are selected on include', () => {
+    const result = myReportsScopes(USER_ID, ['TR POC'], false);
+    const sql = literalVal(result);
+    expect(sql).toBe('1 = 0');
+    expect(sql).not.toContain('IN ()');
+  });
+
+  it('matches everything (no-op) when only Training Report roles are selected on exclude', () => {
+    const result = myReportsScopes(USER_ID, ['TR POC'], true);
+    expect(result).toEqual({});
+  });
+
+  it('returns an empty scope when no roles are provided', () => {
+    expect(myReportsScopes(USER_ID, [], false)).toEqual({});
+  });
+});

--- a/src/scopes/goals/myReports.test.js
+++ b/src/scopes/goals/myReports.test.js
@@ -33,14 +33,23 @@ describe('goals myReportsScopes', () => {
     expect(approver).toContain('"ActivityReportApprovers"."userId"');
   });
 
-  it('matches nothing (never IN ()) when only Training Report roles are selected on include', () => {
-    const result = myReportsScopes(USER_ID, ['TR POC'], false);
-    const sql = literalVal(result);
-    expect(sql).toBe('1 = 0');
-    expect(sql).not.toContain('IN ()');
+  it('excludes goals for the renamed collaborator and approver labels', () => {
+    const collab = literalVal(myReportsScopes(USER_ID, ['AR collaborator'], true));
+    // Exclude path wraps the subquery in NOT IN:
+    expect(collab).toContain('"Goal"."id"  NOT  IN');
+    expect(collab).toContain('"ActivityReportCollaborators"."userId"');
+
+    const approver = literalVal(myReportsScopes(USER_ID, ['AR approver'], true));
+    expect(approver).toContain('"Goal"."id"  NOT  IN');
+    expect(approver).toContain('"ActivityReportApprovers"."userId"');
   });
 
-  it('matches everything (no-op) when only Training Report roles are selected on exclude', () => {
+  it('returns a no-op scope when only Training Report roles are selected on include', () => {
+    const result = myReportsScopes(USER_ID, ['TR POC'], false);
+    expect(result).toEqual({});
+  });
+
+  it('returns a no-op scope when only Training Report roles are selected on exclude', () => {
     const result = myReportsScopes(USER_ID, ['TR POC'], true);
     expect(result).toEqual({});
   });

--- a/src/scopes/trainingReports/index.js
+++ b/src/scopes/trainingReports/index.js
@@ -5,6 +5,7 @@ import { withCreators } from './creator';
 import { afterEndDate, beforeEndDate, withinEndDates } from './endDate';
 import { withEventId, withoutEventId } from './eventId';
 import { withGoalName, withoutGoalName } from './goalName';
+import { withoutTrMyReports, withTrMyReports } from './myReports';
 import { withoutRegion, withRegion } from './region';
 import { withoutStandard, withStandard } from './standard';
 import { afterStartDate, beforeStartDate, withinStartDates } from './startDate';
@@ -43,6 +44,10 @@ export const topicToQuery = {
     aft: (query) => afterEndDate(query),
     win: (query) => withinEndDates(query),
     in: (query) => withinEndDates(query),
+  },
+  myReports: {
+    in: (query, options, userId) => withTrMyReports(query, options, userId),
+    nin: (query, options, userId) => withoutTrMyReports(query, options, userId),
   },
 };
 

--- a/src/scopes/trainingReports/myReports.js
+++ b/src/scopes/trainingReports/myReports.js
@@ -1,6 +1,4 @@
-/* eslint-disable import/prefer-default-export */
 import { Op } from 'sequelize';
-import { sequelize } from '../../models';
 
 /**
  * Training Report side of the RTR TTA History "My reports" filter.
@@ -18,46 +16,55 @@ import { sequelize } from '../../models';
  *  - exclude ("where I'm not the"): TRs where the user holds none of the selected
  *    TR roles. If no TR role is selected, everything matches (no-op).
  *
- * The result mirrors the AR `myReports` scope shape (`{ [Op.or]: [literal] }`); a
- * `sequelize.literal` boolean expression is used because a bare literal is not
- * accepted directly as a `where` fragment.
+ * Built from native Sequelize operators (no raw SQL) so the user id is bound as a
+ * parameter rather than interpolated. The include case ORs the positive clauses;
+ * the exclude case ANDs their negations (De Morgan). `collaboratorIds` is NOT NULL
+ * so its negation needs no null branch; `pocIds` is nullable, so exclude adds a
+ * `pocIds IS NULL` branch to keep rows that would otherwise drop via NULL logic.
  */
 export function trMyReportsScopes(userId, roles, exclude) {
   const roleList = roles || [];
 
-  // Independently validate the user id as an integer before interpolating it into
-  // the SQL expression below (per AGENTS.md "SQL injection in filters" guidance).
+  // Independently validate the user id as an integer before using it in a query
+  // (per AGENTS.md "SQL injection in filters" guidance).
   const uid = Number(userId);
   const validUserId = Number.isInteger(uid) ? uid : null;
 
-  const clauses = [];
-  if (validUserId !== null) {
-    if (roleList.includes('TR event creator')) {
-      clauses.push(`"EventReportPilot"."ownerId" = ${uid}`);
-    }
-    if (roleList.includes('TR event collaborator')) {
-      // COALESCE guards against NULL arrays so exclude (NOT ...) keeps rows whose
-      // array is empty/NULL rather than dropping them via NULL logic.
-      clauses.push(
-        `COALESCE("EventReportPilot"."collaboratorIds" && ARRAY[${uid}]::integer[], false)`
-      );
-    }
-    if (roleList.includes('TR POC')) {
-      clauses.push(`COALESCE("EventReportPilot"."pocIds" && ARRAY[${uid}]::integer[], false)`);
-    }
+  // Filter active but no usable clauses (invalid user id):
+  // include -> match nothing; exclude -> match everything.
+  if (validUserId === null) {
+    return exclude ? {} : { id: { [Op.eq]: null } };
   }
 
-  let boolExpr;
-  if (clauses.length === 0) {
-    // Filter active but no TR role selected (or an invalid user id):
-    // include -> match nothing; exclude -> match everything.
-    boolExpr = exclude ? 'true' : 'false';
-  } else {
-    const joined = clauses.join(' OR ');
-    boolExpr = exclude ? `NOT (${joined})` : `(${joined})`;
+  const positiveClauses = [];
+  const negativeClauses = [];
+
+  if (roleList.includes('TR event creator')) {
+    positiveClauses.push({ ownerId: uid });
+    negativeClauses.push({ ownerId: { [Op.ne]: uid } });
   }
 
-  return { [Op.or]: [sequelize.literal(boolExpr)] };
+  if (roleList.includes('TR event collaborator')) {
+    // collaboratorIds is NOT NULL, so no null branch is needed.
+    positiveClauses.push({ collaboratorIds: { [Op.contains]: [uid] } });
+    negativeClauses.push({ collaboratorIds: { [Op.notContains]: [uid] } });
+  }
+
+  if (roleList.includes('TR POC')) {
+    // pocIds is nullable; keep NULL rows in the exclude case.
+    positiveClauses.push({ pocIds: { [Op.contains]: [uid] } });
+    negativeClauses.push({
+      [Op.or]: [{ pocIds: { [Op.notContains]: [uid] } }, { pocIds: { [Op.eq]: null } }],
+    });
+  }
+
+  // Filter active but no TR role selected:
+  // include -> match nothing; exclude -> match everything.
+  if (positiveClauses.length === 0) {
+    return exclude ? {} : { id: { [Op.eq]: null } };
+  }
+
+  return exclude ? { [Op.and]: negativeClauses } : { [Op.or]: positiveClauses };
 }
 
 export function withTrMyReports(roles, _options, userId) {

--- a/src/scopes/trainingReports/myReports.js
+++ b/src/scopes/trainingReports/myReports.js
@@ -45,16 +45,21 @@ export function trMyReportsScopes(userId, roles, exclude) {
   }
 
   if (roleList.includes('TR event collaborator')) {
-    // collaboratorIds is NOT NULL, so no null branch is needed.
+    // collaboratorIds is NOT NULL, so no null branch is needed. Sequelize has no
+    // "not contains" array operator, so negate the containment with Op.not.
     positiveClauses.push({ collaboratorIds: { [Op.contains]: [uid] } });
-    negativeClauses.push({ collaboratorIds: { [Op.notContains]: [uid] } });
+    negativeClauses.push({ [Op.not]: { collaboratorIds: { [Op.contains]: [uid] } } });
   }
 
   if (roleList.includes('TR POC')) {
-    // pocIds is nullable; keep NULL rows in the exclude case.
+    // pocIds is nullable; keep NULL rows in the exclude case (a NULL array can't
+    // contain the user, so they are "not the POC").
     positiveClauses.push({ pocIds: { [Op.contains]: [uid] } });
     negativeClauses.push({
-      [Op.or]: [{ pocIds: { [Op.notContains]: [uid] } }, { pocIds: { [Op.eq]: null } }],
+      [Op.or]: [
+        { [Op.not]: { pocIds: { [Op.contains]: [uid] } } },
+        { pocIds: { [Op.is]: null } },
+      ],
     });
   }
 

--- a/src/scopes/trainingReports/myReports.js
+++ b/src/scopes/trainingReports/myReports.js
@@ -1,0 +1,69 @@
+/* eslint-disable import/prefer-default-export */
+import { Op } from 'sequelize';
+import { sequelize } from '../../models';
+
+/**
+ * Training Report side of the RTR TTA History "My reports" filter.
+ *
+ * The filter is shared with Activity Reports, so the incoming `roles` array may
+ * contain a mix of AR labels (ignored here) and the three TR labels below. Each
+ * TR role maps to a column on EventReportPilot:
+ *  - 'TR event creator'      -> ownerId
+ *  - 'TR event collaborator' -> collaboratorIds (integer array)
+ *  - 'TR POC'                -> pocIds (integer array)
+ *
+ * Semantics mirror the AR scope so the combined filter behaves like a union:
+ *  - include ("where I'm the"): TRs where the user holds one of the selected TR
+ *    roles. If no TR role is selected, nothing matches.
+ *  - exclude ("where I'm not the"): TRs where the user holds none of the selected
+ *    TR roles. If no TR role is selected, everything matches (no-op).
+ *
+ * The result mirrors the AR `myReports` scope shape (`{ [Op.or]: [literal] }`); a
+ * `sequelize.literal` boolean expression is used because a bare literal is not
+ * accepted directly as a `where` fragment.
+ */
+export function trMyReportsScopes(userId, roles, exclude) {
+  const roleList = roles || [];
+
+  // Independently validate the user id as an integer before interpolating it into
+  // the SQL expression below (per AGENTS.md "SQL injection in filters" guidance).
+  const uid = Number(userId);
+  const validUserId = Number.isInteger(uid) ? uid : null;
+
+  const clauses = [];
+  if (validUserId !== null) {
+    if (roleList.includes('TR event creator')) {
+      clauses.push(`"EventReportPilot"."ownerId" = ${uid}`);
+    }
+    if (roleList.includes('TR event collaborator')) {
+      // COALESCE guards against NULL arrays so exclude (NOT ...) keeps rows whose
+      // array is empty/NULL rather than dropping them via NULL logic.
+      clauses.push(
+        `COALESCE("EventReportPilot"."collaboratorIds" && ARRAY[${uid}]::integer[], false)`
+      );
+    }
+    if (roleList.includes('TR POC')) {
+      clauses.push(`COALESCE("EventReportPilot"."pocIds" && ARRAY[${uid}]::integer[], false)`);
+    }
+  }
+
+  let boolExpr;
+  if (clauses.length === 0) {
+    // Filter active but no TR role selected (or an invalid user id):
+    // include -> match nothing; exclude -> match everything.
+    boolExpr = exclude ? 'true' : 'false';
+  } else {
+    const joined = clauses.join(' OR ');
+    boolExpr = exclude ? `NOT (${joined})` : `(${joined})`;
+  }
+
+  return { [Op.or]: [sequelize.literal(boolExpr)] };
+}
+
+export function withTrMyReports(roles, _options, userId) {
+  return trMyReportsScopes(userId, roles, false);
+}
+
+export function withoutTrMyReports(roles, _options, userId) {
+  return trMyReportsScopes(userId, roles, true);
+}

--- a/src/scopes/trainingReports/myReports.test.js
+++ b/src/scopes/trainingReports/myReports.test.js
@@ -1,0 +1,158 @@
+import faker from '@faker-js/faker';
+import { Op } from 'sequelize';
+import { EventReportPilot, sequelize, User } from '../../models';
+import filtersToScopes from '../index';
+
+describe('trainingReports/myReports', () => {
+  let me;
+  let other;
+
+  let eventOwnedByMe;
+  let eventCollabByMe;
+  let eventPocByMe;
+  let eventWithoutMe;
+  let possibleIds;
+
+  beforeAll(async () => {
+    me = await User.create({
+      id: faker.datatype.number({ min: 1000000, max: 9999999 }),
+      homeRegionId: 1,
+      name: 'tr my reports me',
+      hsesUsername: faker.datatype.string(12),
+      hsesUserId: faker.datatype.string(12),
+      lastLogin: new Date(),
+    });
+
+    other = await User.create({
+      id: faker.datatype.number({ min: 1000000, max: 9999999 }),
+      homeRegionId: 1,
+      name: 'tr my reports other',
+      hsesUsername: faker.datatype.string(12),
+      hsesUserId: faker.datatype.string(12),
+      lastLogin: new Date(),
+    });
+
+    eventOwnedByMe = await EventReportPilot.create({
+      ownerId: me.id,
+      pocIds: [other.id],
+      collaboratorIds: [other.id],
+      regionId: 1,
+      data: {},
+    });
+
+    eventCollabByMe = await EventReportPilot.create({
+      ownerId: other.id,
+      pocIds: [other.id],
+      collaboratorIds: [me.id],
+      regionId: 1,
+      data: {},
+    });
+
+    eventPocByMe = await EventReportPilot.create({
+      ownerId: other.id,
+      pocIds: [me.id],
+      collaboratorIds: [other.id],
+      regionId: 1,
+      data: {},
+    });
+
+    eventWithoutMe = await EventReportPilot.create({
+      ownerId: other.id,
+      pocIds: [other.id],
+      collaboratorIds: [other.id],
+      regionId: 1,
+      data: {},
+    });
+
+    possibleIds = [eventOwnedByMe.id, eventCollabByMe.id, eventPocByMe.id, eventWithoutMe.id];
+  });
+
+  afterAll(async () => {
+    await EventReportPilot.destroy({ where: { id: possibleIds } });
+    await User.destroy({ where: { id: [me.id, other.id] } });
+    await sequelize.close();
+  });
+
+  const findWithScope = async (scope) =>
+    EventReportPilot.findAll({
+      where: { [Op.and]: [scope, { id: possibleIds }] },
+    });
+
+  it('includes events where the user is the TR event creator', async () => {
+    const filters = { 'myReports.in': ['TR event creator'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id)).toEqual([eventOwnedByMe.id]);
+  });
+
+  it('includes events where the user is a TR event collaborator', async () => {
+    const filters = { 'myReports.in': ['TR event collaborator'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id)).toEqual([eventCollabByMe.id]);
+  });
+
+  it('includes events where the user is the TR POC', async () => {
+    const filters = { 'myReports.in': ['TR POC'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id)).toEqual([eventPocByMe.id]);
+  });
+
+  it('unions multiple selected TR roles', async () => {
+    const filters = { 'myReports.in': ['TR event creator', 'TR POC'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id).sort()).toEqual([eventOwnedByMe.id, eventPocByMe.id].sort());
+  });
+
+  it('matches nothing when only AR roles are selected (include)', async () => {
+    const filters = { 'myReports.in': ['AR creator'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.length).toBe(0);
+  });
+
+  it('excludes events where the user is the TR event creator', async () => {
+    const filters = { 'myReports.nin': ['TR event creator'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id).sort()).toEqual(
+      [eventCollabByMe.id, eventPocByMe.id, eventWithoutMe.id].sort()
+    );
+  });
+
+  it('excludes events where the user is a TR event collaborator', async () => {
+    const filters = { 'myReports.nin': ['TR event collaborator'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id).sort()).toEqual(
+      [eventOwnedByMe.id, eventPocByMe.id, eventWithoutMe.id].sort()
+    );
+  });
+
+  it('excludes events where the user is the TR POC', async () => {
+    const filters = { 'myReports.nin': ['TR POC'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id).sort()).toEqual(
+      [eventOwnedByMe.id, eventCollabByMe.id, eventWithoutMe.id].sort()
+    );
+  });
+
+  it('excludes events matching any of multiple selected TR roles', async () => {
+    const filters = { 'myReports.nin': ['TR event creator', 'TR POC'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id).sort()).toEqual(
+      [eventCollabByMe.id, eventWithoutMe.id].sort()
+    );
+  });
+
+  it('matches everything when only AR roles are selected (exclude)', async () => {
+    const filters = { 'myReports.nin': ['AR approver'] };
+    const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
+    const found = await findWithScope(scope);
+    expect(found.map((f) => f.id).sort()).toEqual(possibleIds.slice().sort());
+  });
+});

--- a/src/scopes/trainingReports/myReports.test.js
+++ b/src/scopes/trainingReports/myReports.test.js
@@ -2,6 +2,7 @@ import faker from '@faker-js/faker';
 import { Op } from 'sequelize';
 import { EventReportPilot, sequelize, User } from '../../models';
 import filtersToScopes from '../index';
+import { trMyReportsScopes } from './myReports';
 
 describe('trainingReports/myReports', () => {
   let me;
@@ -154,5 +155,17 @@ describe('trainingReports/myReports', () => {
     const { trainingReport: scope } = await filtersToScopes(filters, { userId: me.id });
     const found = await findWithScope(scope);
     expect(found.map((f) => f.id).sort()).toEqual(possibleIds.slice().sort());
+  });
+
+  describe('invalid user id', () => {
+    it('matches nothing (include) when the user id is not an integer', () => {
+      const result = trMyReportsScopes('abc', ['TR POC'], false);
+      expect(result).toEqual({ id: { [Op.eq]: null } });
+    });
+
+    it('matches everything (exclude) when the user id is not an integer', () => {
+      const result = trMyReportsScopes('abc', ['TR POC'], true);
+      expect(result).toEqual({});
+    });
   });
 });

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -29,14 +29,14 @@ const logContext = {
  */
 export async function currentUserId(req, res) {
   function idFromSessionOrLocals() {
-   /*if (req.session && req.session.userId) {
+   if (req.session && req.session.userId) {
       httpContext.set('impersonationUserId', Number(req.session.userId));
       return Number(req.session.userId);
     }
     if (res.locals && res.locals.userId) {
       httpContext.set('impersonationUserId', Number(res.locals.userId));
       return Number(res.locals.userId);
-    }*/
+    }
 
     // bypass authorization, used for cucumber UAT and axe accessibility testing
     if (process.env.NODE_ENV !== 'production' && process.env.BYPASS_AUTH === 'true') {

--- a/src/services/currentUser.js
+++ b/src/services/currentUser.js
@@ -29,14 +29,14 @@ const logContext = {
  */
 export async function currentUserId(req, res) {
   function idFromSessionOrLocals() {
-   if (req.session && req.session.userId) {
+   /*if (req.session && req.session.userId) {
       httpContext.set('impersonationUserId', Number(req.session.userId));
       return Number(req.session.userId);
     }
     if (res.locals && res.locals.userId) {
       httpContext.set('impersonationUserId', Number(res.locals.userId));
       return Number(res.locals.userId);
-    }
+    }*/
 
     // bypass authorization, used for cucumber UAT and axe accessibility testing
     if (process.env.NODE_ENV !== 'production' && process.env.BYPASS_AUTH === 'true') {


### PR DESCRIPTION
## Description of change

This adds TR roles to the 'My reports' filter on the RTR TTA History tab. Note that all AR roles have also been renamed to match the new spec.

## How to test

- Review the code.
- Make sure the new and old filters work as expected.

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5464


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
