### PR TITLE
[TTAHUB-5270] In app notification for collaborators when added to an activity report

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -107,6 +107,15 @@ const GROUP_COLLABORATORS = {
  * `USER_SETTINGS.EMAIL.*` from `../constants`.
  */
 const NOTIFICATION_CONFIGURATION = {
+  [NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED]: {
+    textFn: ({ author, recipientName }) =>
+      `${author} added you as a Collaborator on their Activity Report for ${recipientName}. `,
+    actionable: false,
+    linkFn: ({ id }) => `/activity-reports/${id}`,
+    linkText: () => 'View AR',
+    displayId: ({ displayId }) => displayId,
+    settingsKey: 'inAppWhenCollaboratorAdded',
+  },
   [NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED_COLLABORATOR]: {
     textFn: ({ author }) => `${author} has submitted an Activity Report for approval.`,
     actionable: false,

--- a/src/constants.js
+++ b/src/constants.js
@@ -109,7 +109,7 @@ const GROUP_COLLABORATORS = {
 const NOTIFICATION_CONFIGURATION = {
   [NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED]: {
     textFn: ({ author, recipientName }) =>
-      `${author} added you as a Collaborator on their Activity Report for ${recipientName}. `,
+      `${author} added you as a Collaborator on their Activity Report for ${recipientName}.`,
     actionable: false,
     linkFn: ({ id }) => `/activity-reports/${id}`,
     linkText: () => 'View AR',

--- a/src/models/hooks/activityReportApprover.js
+++ b/src/models/hooks/activityReportApprover.js
@@ -13,6 +13,7 @@ const archiveNotification = async (sequelize, instance) => {
         [Op.in]: [
           NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
           NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED_COLLABORATOR,
+          NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
         ],
       },
     },

--- a/src/models/hooks/activityReportApprover.test.js
+++ b/src/models/hooks/activityReportApprover.test.js
@@ -492,6 +492,95 @@ describe('activityReportApprover hooks', () => {
       await ActivityReport.destroy({ where: { id: ar.id } });
     });
 
+    it('archives ACTIVITY_REPORT_COLLABORATOR_ADDED notifications when report transitions to APPROVED', async () => {
+      const ar = await ActivityReport.create({
+        ...draftObject,
+        submissionStatus: REPORT_STATUSES.SUBMITTED,
+      });
+
+      const notification = await Notification.create({
+        entityId: ar.id,
+        type: NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+      });
+
+      const userState = await NotificationUserState.create({
+        notificationId: notification.id,
+        userId: mockUserIds[0],
+        archivedAt: null,
+      });
+
+      const approvals = mockUserIds.map((userId) => ({
+        activityReportId: ar.id,
+        userId,
+        status: APPROVER_STATUSES.APPROVED,
+      }));
+
+      await ActivityReportApprover.bulkCreate(approvals);
+
+      const mockInstance = {
+        activityReportId: ar.id,
+        status: APPROVER_STATUSES.APPROVED,
+      };
+
+      await afterUpdate(sequelize, mockInstance);
+
+      const updatedUserState = await NotificationUserState.findByPk(userState.id);
+      expect(updatedUserState.archivedAt).not.toBeNull();
+
+      await ActivityReportApprover.destroy({ where: { activityReportId: ar.id }, force: true });
+      await NotificationUserState.destroy({ where: { id: userState.id } });
+      await Notification.destroy({ where: { id: notification.id } });
+      await ActivityReport.destroy({ where: { id: ar.id } });
+    });
+
+    it('creates archived notification state rows for unread ACTIVITY_REPORT_COLLABORATOR_ADDED notifications when report transitions to APPROVED', async () => {
+      const ar = await ActivityReport.create({
+        ...draftObject,
+        submissionStatus: REPORT_STATUSES.SUBMITTED,
+      });
+
+      const notification = await Notification.create({
+        entityId: ar.id,
+        type: NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        userId: mockUserIds[0],
+      });
+
+      const approvals = mockUserIds.map((userId) => ({
+        activityReportId: ar.id,
+        userId,
+        status: APPROVER_STATUSES.APPROVED,
+      }));
+
+      await ActivityReportApprover.bulkCreate(approvals);
+
+      const mockInstance = {
+        activityReportId: ar.id,
+        status: APPROVER_STATUSES.APPROVED,
+      };
+
+      await afterUpdate(sequelize, mockInstance);
+
+      const createdUserState = await NotificationUserState.findOne({
+        where: {
+          notificationId: notification.id,
+          userId: mockUserIds[0],
+        },
+      });
+
+      expect(createdUserState).not.toBeNull();
+      expect(createdUserState.archivedAt).not.toBeNull();
+
+      await ActivityReportApprover.destroy({ where: { activityReportId: ar.id }, force: true });
+      await NotificationUserState.destroy({
+        where: {
+          notificationId: notification.id,
+          userId: mockUserIds[0],
+        },
+      });
+      await Notification.destroy({ where: { id: notification.id } });
+      await ActivityReport.destroy({ where: { id: ar.id } });
+    });
+
     it('creates archived notification state rows for unread ACTIVITY_REPORT_SUBMITTED_COLLABORATOR notifications when report transitions to APPROVED', async () => {
       const ar = await ActivityReport.create({
         ...draftObject,

--- a/src/notificationConfiguration.test.js
+++ b/src/notificationConfiguration.test.js
@@ -26,6 +26,32 @@ describe('NOTIFICATION_CONFIGURATION', () => {
       expect(config.displayId({ displayId: 'AR-123' })).toBe('AR-123');
     });
   });
+  describe(NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED, () => {
+    const config =
+      NOTIFICATION_CONFIGURATION[NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED];
+
+    it('textFn interpolates author and recipientName', () => {
+      expect(config.textFn({ author: 'Alice', recipientName: 'Head Start Program' })).toBe(
+        'Alice added you as a Collaborator on their Activity Report for Head Start Program. '
+      );
+    });
+
+    it('actionable is false', () => {
+      expect(config.actionable).toBe(false);
+    });
+
+    it('linkFn returns the activity report path with the given id', () => {
+      expect(config.linkFn({ id: 42 })).toBe('/activity-reports/42');
+    });
+
+    it('linkText returns "View AR"', () => {
+      expect(config.linkText()).toBe('View AR');
+    });
+
+    it('displayId returns the displayId param', () => {
+      expect(config.displayId({ displayId: 'AR-123' })).toBe('AR-123');
+    });
+  });
   describe(NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION, () => {
     const config = NOTIFICATION_CONFIGURATION[NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION];
 

--- a/src/notificationConfiguration.test.js
+++ b/src/notificationConfiguration.test.js
@@ -32,7 +32,7 @@ describe('NOTIFICATION_CONFIGURATION', () => {
 
     it('textFn interpolates author and recipientName', () => {
       expect(config.textFn({ author: 'Alice', recipientName: 'Head Start Program' })).toBe(
-        'Alice added you as a Collaborator on their Activity Report for Head Start Program. '
+        'Alice added you as a Collaborator on their Activity Report for Head Start Program.'
       );
     });
 

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -45,6 +45,7 @@ import { groupsByRegion } from '../../services/groups';
 import {
   createApproverSubmittedNotification,
   createCollaboratorSubmittedNotification,
+  createNotificationForCollaborators,
 } from '../../services/notifications/activityReport';
 import { getObjectivesByReportId, saveObjectivesForReport } from '../../services/objectives';
 import { userSettingOverridesById } from '../../services/userSettings';
@@ -954,6 +955,14 @@ export async function saveReport(req, res) {
       });
 
       collaboratorAssignedNotification(savedReport, newCollaboratorsWithSettings);
+
+      /*
+       * If a user is added as a collaborator and then removed, the notification will persist. The user can click the CTA to clear it. OHS confirmed this shouldn't happen so frequently that we need to conditionally clear the notification if the user is removed as a collaborator.
+       * If a user is added as a collaborator and then removed and then added back, a new notification should trigger UNLESS they haven't cleared the original notification.
+       * We should not resend notifications if a report is unlocked.
+       */
+      // send IN-APP notifications to collaborators who were added
+      await createNotificationForCollaborators(newCollaborators, savedReport);
     }
 
     res.json(savedReport);

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -962,7 +962,10 @@ export async function saveReport(req, res) {
        * We should not resend notifications if a report is unlocked.
        */
       // send IN-APP notifications to collaborators who were added
-      await createNotificationForCollaborators(newCollaborators, savedReport);
+      await createNotificationForCollaborators(
+        savedReport.activityReportCollaborators,
+        savedReport
+      );
     }
 
     res.json(savedReport);

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -691,6 +691,122 @@ describe('Activity Report handlers', () => {
       );
     });
 
+    it('sends collaborator-added in-app notifications only for newly added collaborators', async () => {
+      const existingCollaborator = {
+        userId: 201,
+        user: { email: 'existing.collaborator@test.gov' },
+      };
+      const newCollaboratorOne = {
+        userId: 202,
+        user: { email: 'new.one@test.gov' },
+      };
+      const newCollaboratorTwo = {
+        userId: 203,
+        user: { email: 'new.two@test.gov' },
+      };
+      const existingReport = {
+        ...report,
+        activityReportCollaborators: [existingCollaborator],
+      };
+      const savedReport = {
+        ...report,
+        author: { name: 'Author Name' },
+        activityRecipients: [{ name: 'Recipient A' }, { name: 'Recipient B' }],
+        activityReportCollaborators: [existingCollaborator, newCollaboratorOne, newCollaboratorTwo],
+      };
+
+      ActivityReport.mockImplementationOnce(() => ({
+        canUpdate: () => true,
+      }));
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          dataValues: existingReport,
+          activityReportCollaborators: existingReport.activityReportCollaborators,
+        },
+        activityRecipients,
+      ]);
+      createOrUpdate.mockResolvedValue(savedReport);
+      userById.mockResolvedValue({ id: mockUser.id });
+      userSettingOverridesById.mockResolvedValue({
+        value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
+      });
+
+      await saveReport(request, mockResponse);
+
+      expect(createNotification).toHaveBeenCalledTimes(2);
+      expect(createNotification).toHaveBeenNthCalledWith(
+        1,
+        newCollaboratorOne.userId,
+        savedReport.id,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        {
+          metadata: {
+            id: savedReport.id,
+            displayId: savedReport.displayId,
+            author: savedReport.author.name,
+            recipientName: 'Recipient A, Recipient B',
+          },
+        }
+      );
+      expect(createNotification).toHaveBeenNthCalledWith(
+        2,
+        newCollaboratorTwo.userId,
+        savedReport.id,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        {
+          metadata: {
+            id: savedReport.id,
+            displayId: savedReport.displayId,
+            author: savedReport.author.name,
+            recipientName: 'Recipient A, Recipient B',
+          },
+        }
+      );
+    });
+
+    it('does not send collaborator-added in-app notifications when there are no newly added collaborators', async () => {
+      const existingCollaborator = {
+        userId: 201,
+        user: { email: 'existing.collaborator@test.gov' },
+      };
+      const existingReport = {
+        ...report,
+        activityReportCollaborators: [existingCollaborator],
+      };
+      const savedReport = {
+        ...report,
+        author: { name: 'Author Name' },
+        activityRecipients: [{ name: 'Recipient A' }],
+        activityReportCollaborators: [existingCollaborator],
+      };
+
+      ActivityReport.mockImplementationOnce(() => ({
+        canUpdate: () => true,
+      }));
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          dataValues: existingReport,
+          activityReportCollaborators: existingReport.activityReportCollaborators,
+        },
+        activityRecipients,
+      ]);
+      createOrUpdate.mockResolvedValue(savedReport);
+      userById.mockResolvedValue({ id: mockUser.id });
+      userSettingOverridesById.mockResolvedValue({
+        value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
+      });
+
+      await saveReport(request, mockResponse);
+
+      expect(createNotification).not.toHaveBeenCalledWith(
+        existingCollaborator.userId,
+        savedReport.id,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        expect.anything()
+      );
+      expect(createNotification).not.toHaveBeenCalled();
+    });
+
     it('handles unauthorized requests', async () => {
       activityReportAndRecipientsById.mockResolvedValue(byIdResponse);
       ActivityReport.mockImplementationOnce(() => ({

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -691,11 +691,7 @@ describe('Activity Report handlers', () => {
       );
     });
 
-    it('sends collaborator-added in-app notifications only for newly added collaborators', async () => {
-      const existingCollaborator = {
-        userId: 201,
-        user: { email: 'existing.collaborator@test.gov' },
-      };
+    it('sends collaborator-added in-app notification', async () => {
       const newCollaboratorOne = {
         userId: 202,
         user: { email: 'new.one@test.gov' },
@@ -706,13 +702,13 @@ describe('Activity Report handlers', () => {
       };
       const existingReport = {
         ...report,
-        activityReportCollaborators: [existingCollaborator],
+        activityReportCollaborators: [],
       };
       const savedReport = {
         ...report,
         author: { name: 'Author Name' },
         activityRecipients: [{ name: 'Recipient A' }, { name: 'Recipient B' }],
-        activityReportCollaborators: [existingCollaborator, newCollaboratorOne, newCollaboratorTwo],
+        activityReportCollaborators: [newCollaboratorOne, newCollaboratorTwo],
       };
 
       ActivityReport.mockImplementationOnce(() => ({
@@ -762,49 +758,6 @@ describe('Activity Report handlers', () => {
           },
         }
       );
-    });
-
-    it('does not send collaborator-added in-app notifications when there are no newly added collaborators', async () => {
-      const existingCollaborator = {
-        userId: 201,
-        user: { email: 'existing.collaborator@test.gov' },
-      };
-      const existingReport = {
-        ...report,
-        activityReportCollaborators: [existingCollaborator],
-      };
-      const savedReport = {
-        ...report,
-        author: { name: 'Author Name' },
-        activityRecipients: [{ name: 'Recipient A' }],
-        activityReportCollaborators: [existingCollaborator],
-      };
-
-      ActivityReport.mockImplementationOnce(() => ({
-        canUpdate: () => true,
-      }));
-      activityReportAndRecipientsById.mockResolvedValue([
-        {
-          dataValues: existingReport,
-          activityReportCollaborators: existingReport.activityReportCollaborators,
-        },
-        activityRecipients,
-      ]);
-      createOrUpdate.mockResolvedValue(savedReport);
-      userById.mockResolvedValue({ id: mockUser.id });
-      userSettingOverridesById.mockResolvedValue({
-        value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
-      });
-
-      await saveReport(request, mockResponse);
-
-      expect(createNotification).not.toHaveBeenCalledWith(
-        existingCollaborator.userId,
-        savedReport.id,
-        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
-        expect.anything()
-      );
-      expect(createNotification).not.toHaveBeenCalled();
     });
 
     it('handles unauthorized requests', async () => {

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -4,7 +4,7 @@ import { DECIMAL_BASE, REPORT_STATUSES } from '@ttahub/common';
 import _ from 'lodash';
 import moment from 'moment';
 import { Op } from 'sequelize';
-import { REPORTS_PER_PAGE } from '../constants';
+import { ACTIVITY_REPORT_NOTIFICATION_TYPES, REPORTS_PER_PAGE } from '../constants';
 import getGoalsForReport from '../goalServices/getGoalsForReport';
 import { removeRemovedRecipientsGoals } from '../goalServices/goals';
 import { sanitizeActivityReportPageState } from '../lib/activityReportPageState';
@@ -30,6 +30,7 @@ import {
   Grant,
   GrantReplacements,
   NextStep,
+  Notification,
   Objective,
   OtherEntity,
   Program,
@@ -1124,6 +1125,16 @@ export async function handleSoftDeleteReport(report) {
       },
     });
   }
+
+  await Notification.destroy({
+    where: {
+      entityId: report.id,
+      type: {
+        [Op.in]: ACTIVITY_REPORT_NOTIFICATION_TYPES,
+      },
+    },
+  });
+
   return setStatus(report, REPORT_STATUSES.DELETED);
 }
 

--- a/src/services/activityReports.test.js
+++ b/src/services/activityReports.test.js
@@ -1,6 +1,6 @@
 import faker from '@faker-js/faker';
 import { APPROVER_STATUSES, REPORT_STATUSES } from '@ttahub/common';
-import { GOAL_STATUS } from '../constants';
+import { GOAL_STATUS, NOTIFICATION_TYPES } from '../constants';
 import { auditLogger } from '../logger';
 import SCOPES from '../middleware/scopeConstants';
 import db, {
@@ -12,6 +12,7 @@ import db, {
   Goal,
   Grant,
   NextStep,
+  Notification,
   Objective,
   OtherEntity,
   Permission,
@@ -2334,6 +2335,9 @@ describe('Activity report service', () => {
     let goal;
     let alternateGoal;
     let unrelatedGoal;
+    let reportNotification;
+    let reportSystemNotification;
+    let unrelatedReportNotification;
 
     beforeAll(async () => {
       user = await User.create({
@@ -2407,11 +2411,38 @@ describe('Activity report service', () => {
         activityReportId: alternateReport.id,
         goalId: alternateGoal.id,
       });
+      reportNotification = await Notification.create({
+        userId: user.id,
+        entityId: report.id,
+        type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+        text: 'report notification to delete',
+      });
+      reportSystemNotification = await Notification.create({
+        userId: user.id,
+        entityId: report.id,
+        type: NOTIFICATION_TYPES.SYSTEM_PLANNED_OUTAGE,
+        text: 'system notification should remain',
+      });
+      unrelatedReportNotification = await Notification.create({
+        userId: user.id,
+        entityId: unrelatedReport.id,
+        type: NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION,
+        text: 'other report notification should remain',
+      });
     });
 
     afterAll(async () => {
       const reports = [report.id, alternateReport.id, unrelatedReport.id];
       const goals = [goal.id, alternateGoal.id, unrelatedGoal.id];
+      await Notification.destroy({
+        where: {
+          id: [
+            reportNotification?.id,
+            reportSystemNotification?.id,
+            unrelatedReportNotification?.id,
+          ].filter(Boolean),
+        },
+      });
       await ActivityReportGoal.destroy({
         where: {
           activityReportId: reports,
@@ -2454,6 +2485,19 @@ describe('Activity report service', () => {
       const unrelated = await Goal.findByPk(unrelatedGoal.id, { paranoid: false });
       expect(unrelated).not.toBeNull();
       expect(unrelated.deletedAt).toBeNull();
+
+      const remainingNotifications = await Notification.findAll({
+        where: {
+          id: [reportNotification.id, reportSystemNotification.id, unrelatedReportNotification.id],
+        },
+      });
+
+      expect(remainingNotifications.map((notification) => notification.id)).toEqual(
+        expect.arrayContaining([reportSystemNotification.id, unrelatedReportNotification.id])
+      );
+      expect(remainingNotifications.map((notification) => notification.id)).not.toContain(
+        reportNotification.id
+      );
     });
   });
 });

--- a/src/services/notifications/activityReport.test.ts
+++ b/src/services/notifications/activityReport.test.ts
@@ -72,12 +72,7 @@ describe('activityReport notification helpers', () => {
       const reportWithNoRecipients = { ...reportBase, activityRecipients: [] };
       await createApproverSubmittedNotification([{ userId: 1 }], reportWithNoRecipients);
 
-      expect(mockCreateNotification).toHaveBeenCalledWith(
-        1,
-        reportBase.id,
-        NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
-        { metadata: { id: reportBase.id, displayId: reportBase.displayId, recipientName: '' } }
-      );
+      expect(mockCreateNotification).not.toHaveBeenCalled();
     });
 
     it('returns an empty array and makes no calls when passed no approvers', async () => {

--- a/src/services/notifications/activityReport.test.ts
+++ b/src/services/notifications/activityReport.test.ts
@@ -2,6 +2,7 @@ import { NOTIFICATION_TYPES } from '../../constants';
 import {
   createApproverSubmittedNotification,
   createCollaboratorSubmittedNotification,
+  createNotificationForCollaborators,
 } from './activityReport';
 
 jest.mock('./index', () => ({
@@ -132,6 +133,58 @@ describe('activityReport notification helpers', () => {
 
     it('returns an empty array and makes no calls when passed no collaborators', async () => {
       const result = await createCollaboratorSubmittedNotification([], reportWithAuthor);
+      expect(result).toEqual([]);
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createNotificationForCollaborators', () => {
+    const reportWithAuthor = {
+      ...reportBase,
+      author: { name: 'Jane Doe' },
+    };
+
+    it('calls createNotification once per collaborator with the ACTIVITY_REPORT_COLLABORATOR_ADDED type', async () => {
+      const collaborators = [{ userId: 10 }, { userId: 11 }];
+      await createNotificationForCollaborators(collaborators, reportWithAuthor);
+
+      expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+      expect(mockCreateNotification).toHaveBeenNthCalledWith(
+        1,
+        10,
+        reportWithAuthor.id,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        expect.objectContaining({ metadata: expect.any(Object) })
+      );
+      expect(mockCreateNotification).toHaveBeenNthCalledWith(
+        2,
+        11,
+        reportWithAuthor.id,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        expect.objectContaining({ metadata: expect.any(Object) })
+      );
+    });
+
+    it('passes id, displayId, author and recipientName in metadata', async () => {
+      await createNotificationForCollaborators([{ userId: 10 }], reportWithAuthor);
+
+      expect(mockCreateNotification).toHaveBeenCalledWith(
+        10,
+        reportWithAuthor.id,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        {
+          metadata: {
+            id: reportWithAuthor.id,
+            displayId: reportWithAuthor.displayId,
+            author: 'Jane Doe',
+            recipientName: 'Recipient A, Recipient B',
+          },
+        }
+      );
+    });
+
+    it('returns an empty array and makes no calls when passed no collaborators', async () => {
+      const result = await createNotificationForCollaborators([], reportWithAuthor);
       expect(result).toEqual([]);
       expect(mockCreateNotification).not.toHaveBeenCalled();
     });

--- a/src/services/notifications/activityReport.ts
+++ b/src/services/notifications/activityReport.ts
@@ -1,6 +1,13 @@
 import { NOTIFICATION_TYPES } from '../../constants';
 import { createNotification } from './index';
 
+const checkRecipientName = (activityRecipients: { name: string }[]): boolean => {
+  return !!(activityRecipients || [])
+    .map((r) => r.name)
+    .join(', ')
+    .trim();
+};
+
 async function createNotificationForCollaborators(
   currentCollaborators: { userId: number }[],
   savedReport: {
@@ -10,12 +17,7 @@ async function createNotificationForCollaborators(
     author: { name: string };
   }
 ) {
-  if (
-    !(savedReport.activityRecipients || [])
-      .map((r) => r.name)
-      .join(', ')
-      .trim()
-  ) {
+  if (!checkRecipientName(savedReport.activityRecipients)) {
     return Promise.resolve();
   }
 
@@ -46,6 +48,10 @@ async function createApproverSubmittedNotification(
     activityRecipients: { name: string }[];
   }
 ) {
+  if (!checkRecipientName(savedReport.activityRecipients)) {
+    return Promise.resolve();
+  }
+
   return Promise.all(
     currentApprovers.map((approver) =>
       createNotification(

--- a/src/services/notifications/activityReport.ts
+++ b/src/services/notifications/activityReport.ts
@@ -10,6 +10,15 @@ async function createNotificationForCollaborators(
     author: { name: string };
   }
 ) {
+  if (
+    !(savedReport.activityRecipients || [])
+      .map((r) => r.name)
+      .join(', ')
+      .trim()
+  ) {
+    return Promise.resolve();
+  }
+
   return Promise.all(
     currentCollaborators.map((collaborator) =>
       createNotification(

--- a/src/services/notifications/activityReport.ts
+++ b/src/services/notifications/activityReport.ts
@@ -1,6 +1,34 @@
 import { NOTIFICATION_TYPES } from '../../constants';
 import { createNotification } from './index';
 
+async function createNotificationForCollaborators(
+  currentCollaborators: { userId: number }[],
+  savedReport: {
+    id: number;
+    displayId: string;
+    activityRecipients: { name: string }[];
+    author: { name: string };
+  }
+) {
+  return Promise.all(
+    currentCollaborators.map((collaborator) =>
+      createNotification(
+        collaborator.userId,
+        savedReport.id,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_COLLABORATOR_ADDED,
+        {
+          metadata: {
+            id: savedReport.id,
+            displayId: savedReport.displayId,
+            author: savedReport.author.name,
+            recipientName: (savedReport.activityRecipients || []).map((r) => r.name).join(', '),
+          },
+        }
+      )
+    )
+  );
+}
+
 async function createApproverSubmittedNotification(
   currentApprovers: { userId: number }[],
   savedReport: {
@@ -54,4 +82,8 @@ async function createCollaboratorSubmittedNotification(
   );
 }
 
-export { createApproverSubmittedNotification, createCollaboratorSubmittedNotification };
+export {
+  createApproverSubmittedNotification,
+  createCollaboratorSubmittedNotification,
+  createNotificationForCollaborators,
+};

--- a/src/services/notifications/index.test.js
+++ b/src/services/notifications/index.test.js
@@ -205,6 +205,104 @@ describe('Notification service', () => {
       ).rejects.toThrow('No notification configuration found for type invalidType');
     });
 
+    describe('dedupe behavior with notification user state', () => {
+      it('reuses an existing notification when there is no user state row', async () => {
+        const metadata = activityMetadata();
+        await createTrackedActivityReport({ id: metadata.id });
+
+        const existing = await createTrackedNotification({
+          userId: user.id,
+          entityId: metadata.id,
+          type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+        });
+
+        const result = await createNotification(
+          user.id,
+          metadata.id,
+          NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          { metadata }
+        );
+
+        expect(result.id).toBe(existing.id);
+        const count = await Notification.count({
+          where: {
+            userId: user.id,
+            entityId: metadata.id,
+            type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          },
+        });
+        expect(count).toBe(1);
+      });
+
+      it('reuses an existing notification when the user state is unarchived', async () => {
+        const metadata = activityMetadata();
+        await createTrackedActivityReport({ id: metadata.id });
+
+        const existing = await createTrackedNotification({
+          userId: user.id,
+          entityId: metadata.id,
+          type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+        });
+        await NotificationUserState.create({
+          notificationId: existing.id,
+          userId: user.id,
+          archivedAt: null,
+        });
+
+        const result = await createNotification(
+          user.id,
+          metadata.id,
+          NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          { metadata }
+        );
+
+        expect(result.id).toBe(existing.id);
+        const count = await Notification.count({
+          where: {
+            userId: user.id,
+            entityId: metadata.id,
+            type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          },
+        });
+        expect(count).toBe(1);
+      });
+
+      it('creates a new notification when the existing user state is archived', async () => {
+        const metadata = activityMetadata();
+        await createTrackedActivityReport({ id: metadata.id });
+
+        const existing = await createTrackedNotification({
+          userId: user.id,
+          entityId: metadata.id,
+          type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+        });
+        await NotificationUserState.create({
+          notificationId: existing.id,
+          userId: user.id,
+          archivedAt: '2026-01-20',
+        });
+
+        const created = trackNotification(
+          await createNotification(
+            user.id,
+            metadata.id,
+            NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+            { metadata }
+          )
+        );
+
+        expect(created.id).not.toBe(existing.id);
+        const count = await Notification.count({
+          where: {
+            userId: user.id,
+            entityId: metadata.id,
+            type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          },
+        });
+        expect(count).toBe(2);
+      });
+    });
+
     describe('user settings gating', () => {
       let createdOverrideIds = [];
 

--- a/src/services/notifications/index.test.js
+++ b/src/services/notifications/index.test.js
@@ -234,7 +234,7 @@ describe('Notification service', () => {
         expect(count).toBe(1);
       });
 
-      it('reuses an existing notification when the user state is unarchived', async () => {
+      it('reuses an existing notification when it already exists', async () => {
         const metadata = activityMetadata();
         await createTrackedActivityReport({ id: metadata.id });
 
@@ -265,41 +265,6 @@ describe('Notification service', () => {
           },
         });
         expect(count).toBe(1);
-      });
-
-      it('creates a new notification when the existing user state is archived', async () => {
-        const metadata = activityMetadata();
-        await createTrackedActivityReport({ id: metadata.id });
-
-        const existing = await createTrackedNotification({
-          userId: user.id,
-          entityId: metadata.id,
-          type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
-        });
-        await NotificationUserState.create({
-          notificationId: existing.id,
-          userId: user.id,
-          archivedAt: '2026-01-20',
-        });
-
-        const created = trackNotification(
-          await createNotification(
-            user.id,
-            metadata.id,
-            NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
-            { metadata }
-          )
-        );
-
-        expect(created.id).not.toBe(existing.id);
-        const count = await Notification.count({
-          where: {
-            userId: user.id,
-            entityId: metadata.id,
-            type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
-          },
-        });
-        expect(count).toBe(2);
       });
     });
 

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -115,18 +115,7 @@ async function createNotification(
       userId,
       type: notificationType,
       entityId,
-      [Op.or]: [{ '$userStates.archivedAt$': null }, { '$userStates.id$': null }],
     },
-    include: [
-      {
-        model: NotificationUserState,
-        as: 'userStates',
-        required: false,
-        where: { userId },
-        attributes: ['id', 'archivedAt'],
-      },
-    ],
-    subQuery: false,
   });
 
   if (existing) {

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -110,6 +110,29 @@ async function createNotification(
 
   const actionable = Boolean(notificationConfig.actionable);
 
+  const existing = await Notification.findOne({
+    where: {
+      userId,
+      type: notificationType,
+      entityId,
+      [Op.or]: [{ '$userStates.archivedAt$': null }, { '$userStates.id$': null }],
+    },
+    include: [
+      {
+        model: NotificationUserState,
+        as: 'userStates',
+        required: false,
+        where: { userId },
+        attributes: ['id', 'archivedAt'],
+      },
+    ],
+    subQuery: false,
+  });
+
+  if (existing) {
+    return existing;
+  }
+
   return Notification.create({
     userId,
     entityId,


### PR DESCRIPTION
## Description of change

Add an in-app notifications for collaborators when they are added to an AR

## How to test
Prerequisite: user that can see the in-app notification page

- Add that user as a collaborator to an AR
- Confirm fidelity to design
- You may need to repeat the process multiple times to test archiving and whether it is disposed when the report is approved

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5270


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Linked Jira issue
- [ ] JIRA issue status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
