### PR TITLE
[TTAHUB-5555] Fix tagname in active noncompliant citations drawer

### DIFF
--- a/frontend/src/widgets/ActiveNoncompliantCitationsWithTtaSupport.js
+++ b/frontend/src/widgets/ActiveNoncompliantCitationsWithTtaSupport.js
@@ -67,7 +67,7 @@ export function ActiveNoncompliantCitationsWithTtaSupportWidget({ data, loading 
   return (
     <>
       <Drawer triggerRef={drawerTriggerRef} title="Active noncompliant citations with TTA support">
-        <ContentFromFeedByTag tagName="ttahub-active-noncompliant-citation" />
+        <ContentFromFeedByTag tagName="ttahub-active-anc-citation" />
       </Drawer>
 
       <LineGraphWidget

--- a/frontend/src/widgets/__tests__/ActiveNoncompliantCitationsWithTtaSupport.js
+++ b/frontend/src/widgets/__tests__/ActiveNoncompliantCitationsWithTtaSupport.js
@@ -1,7 +1,9 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
 import React from 'react';
 import AppLoadingContext from '../../AppLoadingContext';
+import { mockRSSData } from '../../testHelpers';
 import { ActiveNoncompliantCitationsWithTtaSupportWidget } from '../ActiveNoncompliantCitationsWithTtaSupport';
 
 jest.mock('plotly.js-basic-dist', () => ({
@@ -28,6 +30,18 @@ const TEST_DATA = [
 ];
 
 describe('ActiveNoncompliantCitationsWithTtaSupportWidget', () => {
+  it('calls the correct help drawer', () => {
+    fetchMock.get('/api/feeds/item?tag=ttahub-active-anc-citation', mockRSSData());
+
+    render(
+      <AppLoadingContext.Provider value={{ setIsAppLoading: jest.fn() }}>
+        <ActiveNoncompliantCitationsWithTtaSupportWidget data={TEST_DATA} />
+      </AppLoadingContext.Provider>
+    );
+
+    expect(fetchMock.called('/api/feeds/item?tag=ttahub-active-anc-citation')).toBe(true);
+  });
+
   it('derives legend labels from trace data', async () => {
     render(
       <AppLoadingContext.Provider value={{ setIsAppLoading: jest.fn() }}>

--- a/frontend/src/widgets/__tests__/ActiveNoncompliantCitationsWithTtaSupport.js
+++ b/frontend/src/widgets/__tests__/ActiveNoncompliantCitationsWithTtaSupport.js
@@ -30,6 +30,10 @@ const TEST_DATA = [
 ];
 
 describe('ActiveNoncompliantCitationsWithTtaSupportWidget', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
   it('calls the correct help drawer', () => {
     fetchMock.get('/api/feeds/item?tag=ttahub-active-anc-citation', mockRSSData());
 


### PR DESCRIPTION
## Description of change

A jira tag was implemented incorrectly on the "Active noncompliant citations with TTA support" "about this data" drawer


## How to test
Click the link and confirm that data is correctly loaded

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5555


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Linked Jira issue
- [ ] JIRA issue status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
