### PR TITLE
[TTAHUB-5553] QA dash data inconsistencies

### DIFF
--- a/src/queries/api/dashboards/qa/dashboard.sql
+++ b/src/queries/api/dashboards/qa/dashboard.sql
@@ -433,7 +433,16 @@ BEGIN
         AND (
           program_type_filter IS NULL
           OR (
-            COALESCE(program_type_filter, '[]')::jsonb @> to_jsonb(p."programType") != program_type_not_filter
+            EXISTS (
+              SELECT 1
+              FROM json_array_elements_text(COALESCE(program_type_filter, '[]')::json) AS value
+              WHERE (
+                value::text = 'EHS' AND p."programType" IN ('EHS', 'AIAN EHS', 'Migrant EHS')
+              )
+              OR (
+                value::text = 'HS' AND p."programType" IN ('HS', 'AIAN HS', 'Migrant HS')
+              )
+            ) != program_type_not_filter
           )
         )
         WHERE 1 = 1
@@ -577,8 +586,7 @@ BEGIN
 -- Step 2.2 If grant filters active, delete from filtered_goals for any goals filtered, delete from filtered_grants using filtered_goals
 
     IF
-        goal_name_filter IS NOT NULL OR
-        activity_report_goal_response_filter IS NOT NULL
+        goal_name_filter IS NOT NULL
     THEN
     WITH
       applied_filtered_goals AS (
@@ -600,25 +608,7 @@ BEGIN
           ) != goal_name_not_filter
           )
         )
-        LEFT JOIN "GoalFieldResponses" gfr
-        ON g.id = gfr."goalId"
-        -- Real FEI goal is in the production DATABASE with an id of 19017 in the GoalTemplates table
-        AND g."goalTemplateId" = 19017
-        -- Filter for activityReportGoalResponse if ssdi.activityReportGoalResponse is defined, for array columns
-        AND (
-          activity_report_goal_response_filter IS NULL
-          OR (
-          (gfr."response" && ARRAY(
-            SELECT value::text
-            FROM json_array_elements_text(
-            COALESCE(activity_report_goal_response_filter, '[]')::json
-            )
-          )) != activity_report_goal_response_not_filter
-          )
-        )
         WHERE 1 = 1
-        -- Continued Filter for activityReportGoalResponse if ssdi.activityReportGoalResponse is defined, for array columns
-        AND (activity_report_goal_response_filter IS NULL OR gfr.id IS NOT NULL)
         GROUP BY 1
         ORDER BY 1
       ),
@@ -702,6 +692,7 @@ BEGIN
         report_id_filter IS NOT NULL OR
         start_date_filter IS NOT NULL OR
         end_date_filter IS NOT NULL OR
+        activity_report_goal_response_filter IS NOT NULL OR
         reason_filter IS NOT NULL OR
         target_populations_filter IS NOT NULL OR
         tta_type_filter IS NOT NULL
@@ -720,38 +711,95 @@ BEGIN
           OR (
             EXISTS (
               SELECT 1
-              FROM json_array_elements_text(COALESCE(report_text_filter, '[]')::json) AS value
+              FROM json_array_elements_text(COALESCE(report_id_filter, '[]')::json) AS value
               WHERE CONCAT('R', LPAD(a."regionId"::text, 2, '0'), '-AR-', a.id) ~* value::text
               OR COALESCE(a."legacyId",'') ~* value::text
-            ) != report_text_not_filter
+            ) != report_id_not_filter
           )
         )
         -- Filter for startDate dates between two values if ssdi.startDate is defined
         AND (
           start_date_filter IS NULL
           OR (
-          a."startDate"::date <@ (
-            SELECT CONCAT(
-            '[', MIN(value::timestamp), ',',
-            COALESCE(NULLIF(MAX(value::timestamp), MIN(value::timestamp)), NOW()::timestamp), ')'
-            )::daterange
-            FROM json_array_elements_text(
-            COALESCE(start_date_filter, '[]')::json
-            ) AS value
-          ) != start_date_not_filter
+            CASE
+              WHEN json_array_length(COALESCE(start_date_filter, '[]')::json) <= 1 THEN
+                CASE
+                  WHEN start_date_not_filter THEN
+                    a."startDate"::date <= (
+                      SELECT MIN(value::date)
+                      FROM json_array_elements_text(COALESCE(start_date_filter, '[]')::json) AS value
+                    )
+                  ELSE
+                    a."startDate"::date >= (
+                      SELECT MIN(value::date)
+                      FROM json_array_elements_text(COALESCE(start_date_filter, '[]')::json) AS value
+                    )
+                END
+              ELSE
+                (
+                  a."startDate"::date >= (
+                    SELECT MIN(value::date)
+                    FROM json_array_elements_text(COALESCE(start_date_filter, '[]')::json) AS value
+                  )
+                  AND a."startDate"::date <= (
+                    SELECT MAX(value::date)
+                    FROM json_array_elements_text(COALESCE(start_date_filter, '[]')::json) AS value
+                  )
+                ) != start_date_not_filter
+            END
           )
         )
         -- Filter for endDate dates between two values if ssdi.endDate is defined
         AND (
           end_date_filter IS NULL
           OR (
-          a."endDate"::date <@ (
-            SELECT CONCAT(
-            '[', MIN(value::timestamp), ',',
-            COALESCE(NULLIF(MAX(value::timestamp), MIN(value::timestamp)), NOW()::timestamp), ')'
-            )::daterange
-            FROM json_array_elements_text(COALESCE(end_date_filter, '[]')::json) AS value
-          ) != end_date_not_filter
+            CASE
+              WHEN json_array_length(COALESCE(end_date_filter, '[]')::json) <= 1 THEN
+                CASE
+                  WHEN end_date_not_filter THEN
+                    a."endDate"::date <= (
+                      SELECT MIN(value::date)
+                      FROM json_array_elements_text(COALESCE(end_date_filter, '[]')::json) AS value
+                    )
+                  ELSE
+                    a."endDate"::date >= (
+                      SELECT MIN(value::date)
+                      FROM json_array_elements_text(COALESCE(end_date_filter, '[]')::json) AS value
+                    )
+                END
+              ELSE
+                (
+                  a."endDate"::date >= (
+                    SELECT MIN(value::date)
+                    FROM json_array_elements_text(COALESCE(end_date_filter, '[]')::json) AS value
+                  )
+                  AND a."endDate"::date <= (
+                    SELECT MAX(value::date)
+                    FROM json_array_elements_text(COALESCE(end_date_filter, '[]')::json) AS value
+                  )
+                ) != end_date_not_filter
+            END
+          )
+        )
+        -- Filter for activityReportGoalResponse if ssdi.activityReportGoalResponse is defined
+        AND (
+          activity_report_goal_response_filter IS NULL
+          OR (
+            EXISTS (
+              SELECT 1
+              FROM "ActivityReportGoals" arg
+              JOIN "ActivityReportGoalFieldResponses" argfr
+              ON arg.id = argfr."activityReportGoalId"
+              WHERE arg."activityReportId" = a.id
+              AND (
+                argfr."response"::TEXT[] && ARRAY(
+                  SELECT value::text
+                  FROM json_array_elements_text(
+                    COALESCE(activity_report_goal_response_filter, '[]')::json
+                  ) AS value
+                )
+              )
+            ) != activity_report_goal_response_not_filter
           )
         )
         -- Filter for reason if ssdi.reason is defined, for array columns
@@ -872,38 +920,62 @@ BEGIN
         FROM filtered_activity_reports fa
         JOIN "ActivityReports" a
         ON fa.id = a.id
-        JOIN "ActivityReportGoals" arg
-        ON a.id = arg."activityReportId"
-        JOIN filtered_goals fg
-        ON arg."goalId" = fg.id
-        JOIN "ActivityReportObjectives" aro
-        ON a.id = aro."activityReportId"
-        JOIN "Objectives" o
-        ON aro."objectiveId" = o.id
-        AND arg."goalId" = o."goalId"
-        JOIN "ActivityReportObjectiveTopics" arot
-        ON aro.id = arot."activityReportObjectiveId"
-        JOIN "Topics" t
-        ON arot."topicId" = t.id
-        JOIN "NextSteps" ns
-        ON a.id = ns."activityReportId"
         WHERE 1 = 1
         -- Filter for reportText if ssdi.reportText is defined
         AND (
           report_text_filter IS NULL
           OR (
-          EXISTS (
-            SELECT 1
-            FROM json_array_elements_text(COALESCE(report_text_filter, '[]')::json) AS value
-            WHERE CONCAT(a.context, '\n', arg.name, '\n', aro.title, '\n', aro."ttaProvided", '\n', ns.note) ~* value::text
-          ) != report_text_not_filter
+            EXISTS (
+              SELECT 1
+              FROM json_array_elements_text(COALESCE(report_text_filter, '[]')::json) AS value
+              WHERE COALESCE(a.context, '') ~* value::text
+              OR COALESCE(a."additionalNotes", '') ~* value::text
+              OR EXISTS (
+                SELECT 1
+                FROM "ActivityReportGoals" arg
+                WHERE arg."activityReportId" = a.id
+                AND COALESCE(arg.name, '') ~* value::text
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM "ActivityReportObjectives" aro
+                WHERE aro."activityReportId" = a.id
+                AND (
+                  COALESCE(aro.title, '') ~* value::text
+                  OR COALESCE(aro."ttaProvided", '') ~* value::text
+                )
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM "NextSteps" ns
+                WHERE ns."activityReportId" = a.id
+                AND COALESCE(ns.note, '') ~* value::text
+              )
+            ) != report_text_not_filter
           )
         )
         -- Filter for topic if ssdi.topic is defined
         AND (
           topic_filter IS NULL
           OR (
-            COALESCE(topic_filter, '[]')::jsonb @> to_jsonb(t.name) != topic_not_filter
+            (
+              (
+                COALESCE(a."topics", ARRAY[]::TEXT[]) && ARRAY(
+                  SELECT value::text
+                  FROM json_array_elements_text(COALESCE(topic_filter, '[]')::json) AS value
+                )
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM "ActivityReportObjectives" aro
+                JOIN "ActivityReportObjectiveTopics" arot
+                ON aro.id = arot."activityReportObjectiveId"
+                JOIN "Topics" t
+                ON arot."topicId" = t.id
+                WHERE aro."activityReportId" = a.id
+                AND COALESCE(topic_filter, '[]')::jsonb @> to_jsonb(t.name)
+              )
+            ) != topic_not_filter
           )
         )
         GROUP BY 1
@@ -1084,23 +1156,33 @@ BEGIN
         FROM filtered_activity_reports fa
         JOIN "ActivityReports" a
         ON fa.id = a.id
-        JOIN "ActivityReportCollaborators" arc
-        ON a.id = arc."activityReportId"
-        JOIN "UserRoles" ur1
-        ON arc."userId" = ur1."userId"
-        JOIN "Roles" r1
-        ON ur1."roleId" = r1.id
-        JOIN "UserRoles" ur2
-        ON a."userId" = ur2."userId"
-        JOIN "Roles" r2
-        ON ur2."roleId" = r2.id
         WHERE 1 = 1
         -- Filter for roles if ssdi.roles is defined
         AND (
           roles_filter IS NULL
           OR (
-            COALESCE(roles_filter, '[]')::jsonb @> to_jsonb(r1."fullName")
-            OR COALESCE(roles_filter, '[]')::jsonb @> to_jsonb(r2."fullName")
+            EXISTS (
+              SELECT 1
+              FROM json_array_elements_text(COALESCE(roles_filter, '[]')::json) AS value
+              WHERE EXISTS (
+                SELECT 1
+                FROM "UserRoles" ur
+                JOIN "Roles" r
+                ON ur."roleId" = r.id
+                WHERE ur."userId" = a."userId"
+                AND r."fullName" = value::text
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM "ActivityReportCollaborators" arc
+                JOIN "UserRoles" ur
+                ON arc."userId" = ur."userId"
+                JOIN "Roles" r
+                ON ur."roleId" = r.id
+                WHERE arc."activityReportId" = a.id
+                AND r."fullName" = value::text
+              )
+            )
           ) != roles_not_filter
         )
         GROUP BY 1

--- a/src/queries/api/dashboards/qa/dashboard.sql
+++ b/src/queries/api/dashboards/qa/dashboard.sql
@@ -666,15 +666,29 @@ BEGIN
     SELECT
         a.id
     FROM "ActivityReports" a
-    JOIN "ActivityRecipients" ar
+    LEFT JOIN "ActivityRecipients" ar
         ON a.id = ar."activityReportId"
-    JOIN filtered_grants fgr
+    LEFT JOIN filtered_grants fgr
         ON ar."grantId" = fgr.id
-    JOIN "ActivityReportGoals" arg
-        ON a.id = arg."activityReportId"
-    JOIN filtered_goals fg
-        ON arg."goalId" = fg.id
     WHERE a."calculatedStatus" = 'approved'
+    AND (
+      fgr.id IS NOT NULL
+      OR (
+        recipient_filter IS NULL
+        AND program_type_filter IS NULL
+        AND grant_numbers_filter IS NULL
+        AND state_code_filter IS NULL
+        AND group_filter IS NULL
+        AND current_user_id_filter IS NULL
+        AND goal_name_filter IS NULL
+        AND (
+          region_ids_filter IS NULL
+          OR (
+            COALESCE(region_ids_filter, '[]')::jsonb @> to_jsonb(a."regionId")::jsonb
+          ) != region_ids_not_filter
+        )
+      )
+    )
     GROUP BY 1
     ORDER BY 1
     RETURNING

--- a/src/queries/api/dashboards/qa/dashboard.sql
+++ b/src/queries/api/dashboards/qa/dashboard.sql
@@ -341,6 +341,7 @@ DECLARE
     reason_filter TEXT := NULLIF(current_setting('ssdi.reason', true), '');
     target_populations_filter TEXT := NULLIF(current_setting('ssdi.targetPopulations', true), '');
     tta_type_filter TEXT := NULLIF(current_setting('ssdi.ttaType', true), '');
+    tta_type_filter_normalized TEXT := NULL;
     report_text_filter TEXT := NULLIF(current_setting('ssdi.reportText', true), '');
     topic_filter TEXT := NULLIF(current_setting('ssdi.topic', true), '');
     recipient_single_or_multi_filter TEXT := NULLIF(current_setting('ssdi.singleOrMultiRecipients', true), '');
@@ -368,6 +369,19 @@ DECLARE
     roles_not_filter BOOLEAN := COALESCE(current_setting('ssdi.role.not', true), 'false') = 'true';
 
 BEGIN
+  IF tta_type_filter IS NOT NULL THEN
+    SELECT
+      string_agg(v.value, ',' ORDER BY v.first_position)
+    INTO tta_type_filter_normalized
+    FROM (
+      SELECT
+        value::text AS value,
+        MIN(ordinality) AS first_position
+      FROM json_array_elements_text(COALESCE(tta_type_filter, '[]')::json) WITH ORDINALITY AS t(value, ordinality)
+      WHERE value::text IN ('technical-assistance', 'training', 'training,technical-assistance')
+      GROUP BY value::text
+    ) v;
+  END IF;
 ---------------------------------------------------------------------------------------------------
 -- Step 0.1: make a table to hold applied filters
   DROP TABLE IF EXISTS process_log;
@@ -386,7 +400,7 @@ BEGIN
     SELECT
       id
     FROM "Grants"
-    WHERE COALESCE(deleted, false) = false
+    -- WHERE COALESCE(deleted, false) = false
     GROUP BY 1
     ORDER BY 1
     RETURNING id
@@ -414,38 +428,44 @@ BEGIN
         FROM filtered_grants fgr
         JOIN "Grants" gr
         ON fgr.id = gr.id
-        JOIN "Recipients" r
-        ON gr."recipientId" = r.id
+        WHERE 1 = 1
         -- Filter for recipients if ssdi.recipients is defined
         AND (
           recipient_filter IS NULL
           OR (
-          EXISTS (
-            SELECT 1
-            FROM json_array_elements_text(COALESCE(recipient_filter, '[]')::json) AS value
-            WHERE r.name ~* value::text
-          ) != recipient_not_filter
+            EXISTS (
+              SELECT 1
+              FROM "Recipients" r
+              WHERE r.id = gr."recipientId"
+              AND EXISTS (
+                SELECT 1
+                FROM json_array_elements_text(COALESCE(recipient_filter, '[]')::json) AS value
+                WHERE r.name ~* value::text
+              )
+            ) != recipient_not_filter
           )
         )
-        JOIN "Programs" p
-        ON gr.id = p."grantId"
         -- Filter for programType if ssdi.programType is defined
         AND (
           program_type_filter IS NULL
           OR (
             EXISTS (
               SELECT 1
-              FROM json_array_elements_text(COALESCE(program_type_filter, '[]')::json) AS value
-              WHERE (
-                value::text = 'EHS' AND p."programType" IN ('EHS', 'AIAN EHS', 'Migrant EHS')
-              )
-              OR (
-                value::text = 'HS' AND p."programType" IN ('HS', 'AIAN HS', 'Migrant HS')
+              FROM "Programs" p
+              WHERE p."grantId" = gr.id
+              AND EXISTS (
+                SELECT 1
+                FROM json_array_elements_text(COALESCE(program_type_filter, '[]')::json) AS value
+                WHERE (
+                  value::text = 'EHS' AND p."programType" IN ('EHS', 'AIAN EHS', 'Migrant EHS')
+                )
+                OR (
+                  value::text = 'HS' AND p."programType" IN ('HS', 'AIAN HS', 'Migrant HS')
+                )
               )
             ) != program_type_not_filter
           )
         )
-        WHERE 1 = 1
         -- Filter for grantNumbers if ssdi.grantNumbers is defined
         AND (
           grant_numbers_filter IS NULL
@@ -499,8 +519,7 @@ BEGIN
 ---------------------------------------------------------------------------------------------------
 -- Step 1.3: If grant filters active, delete from filtered_grants any grarnts filtered grants
   IF
-    group_filter IS NOT NULL OR
-    current_user_id_filter IS NOT NULL
+    group_filter IS NOT NULL
   THEN
     WITH
       applied_filtered_grants AS (
@@ -674,12 +693,19 @@ BEGIN
     AND (
       fgr.id IS NOT NULL
       OR (
+        EXISTS (
+          SELECT 1
+          FROM "ActivityRecipients" ar_scope
+          JOIN "Grants" gr_scope
+            ON ar_scope."grantId" = gr_scope.id
+          WHERE ar_scope."activityReportId" = a.id
+        )
+        AND
         recipient_filter IS NULL
         AND program_type_filter IS NULL
         AND grant_numbers_filter IS NULL
         AND state_code_filter IS NULL
         AND group_filter IS NULL
-        AND current_user_id_filter IS NULL
         AND goal_name_filter IS NULL
         AND (
           region_ids_filter IS NULL
@@ -836,20 +862,14 @@ BEGIN
           )) != target_populations_not_filter
           )
         )
-        -- Filter for ttaType where both column and filter are jsonb arrays and compare them ignoring order
+        -- Filter for ttaType using the same normalized, case-insensitive comparison semantics as AR scopes
         AND (
           tta_type_filter IS NULL
           OR (
-          (
-            a."ttaType"::TEXT[] @> ARRAY(
-            SELECT value::text
-            FROM json_array_elements_text(COALESCE(tta_type_filter, '[]')::json)
-            )
-            AND a."ttaType"::TEXT[] <@ ARRAY(
-            SELECT value::text
-            FROM json_array_elements_text(COALESCE(tta_type_filter, '[]')::json)
-            )
-          ) != tta_type_not_filter
+            tta_type_filter_normalized IS NOT NULL
+            AND (
+              COALESCE(ARRAY_TO_STRING(a."ttaType", ','), '') ILIKE tta_type_filter_normalized
+            ) != tta_type_not_filter
           )
         )
         GROUP BY 1
@@ -928,45 +948,67 @@ BEGIN
     topic_filter IS NOT NULL
     THEN
     WITH
+      report_text_search AS (
+        SELECT
+          '%' || LOWER(STRING_AGG(value, ',' ORDER BY position)) || '%' AS search_pattern
+        FROM json_array_elements_text(COALESCE(report_text_filter, '[]')::json)
+          WITH ORDINALITY AS terms(value, position)
+        HAVING report_text_filter IS NOT NULL
+      ),
+      report_text_matching_reports AS (
+        SELECT
+          fa.id
+        FROM filtered_activity_reports fa
+        JOIN "ActivityReports" a ON fa.id = a.id
+        CROSS JOIN report_text_search rts
+        WHERE
+          LOWER(COALESCE(a.context, '')) LIKE rts.search_pattern
+          OR LOWER(COALESCE(a."additionalNotes", '')) LIKE rts.search_pattern
+
+        UNION
+
+        SELECT
+          fa.id
+        FROM "ActivityReportGoals" arg
+        JOIN filtered_activity_reports fa ON fa.id = arg."activityReportId"
+        CROSS JOIN report_text_search rts
+        GROUP BY fa.id, rts.search_pattern
+        HAVING LOWER(STRING_AGG(arg.name, CHR(10))) LIKE rts.search_pattern
+
+        UNION
+
+        SELECT
+          fa.id
+        FROM "ActivityReportObjectives" aro
+        JOIN filtered_activity_reports fa ON fa.id = aro."activityReportId"
+        CROSS JOIN report_text_search rts
+        GROUP BY fa.id, rts.search_pattern
+        HAVING LOWER(
+          STRING_AGG(CONCAT_WS(CHR(10), aro.title, aro."ttaProvided"), CHR(10))
+        ) LIKE rts.search_pattern
+
+        UNION
+
+        SELECT
+          fa.id
+        FROM "NextSteps" ns
+        JOIN filtered_activity_reports fa ON fa.id = ns."activityReportId"
+        CROSS JOIN report_text_search rts
+        GROUP BY fa.id, rts.search_pattern
+        HAVING LOWER(STRING_AGG(ns.note, CHR(10))) LIKE rts.search_pattern
+      ),
       applied_filtered_activity_reports AS (
         SELECT
           a.id "activityReportId"
         FROM filtered_activity_reports fa
         JOIN "ActivityReports" a
         ON fa.id = a.id
+        LEFT JOIN report_text_matching_reports rtmr ON a.id = rtmr.id
         WHERE 1 = 1
         -- Filter for reportText if ssdi.reportText is defined
         AND (
           report_text_filter IS NULL
-          OR (
-            EXISTS (
-              SELECT 1
-              FROM json_array_elements_text(COALESCE(report_text_filter, '[]')::json) AS value
-              WHERE COALESCE(a.context, '') ~* value::text
-              OR COALESCE(a."additionalNotes", '') ~* value::text
-              OR EXISTS (
-                SELECT 1
-                FROM "ActivityReportGoals" arg
-                WHERE arg."activityReportId" = a.id
-                AND COALESCE(arg.name, '') ~* value::text
-              )
-              OR EXISTS (
-                SELECT 1
-                FROM "ActivityReportObjectives" aro
-                WHERE aro."activityReportId" = a.id
-                AND (
-                  COALESCE(aro.title, '') ~* value::text
-                  OR COALESCE(aro."ttaProvided", '') ~* value::text
-                )
-              )
-              OR EXISTS (
-                SELECT 1
-                FROM "NextSteps" ns
-                WHERE ns."activityReportId" = a.id
-                AND COALESCE(ns.note, '') ~* value::text
-              )
-            ) != report_text_not_filter
-          )
+          OR (rtmr.id IS NOT NULL) != report_text_not_filter
         )
         -- Filter for topic if ssdi.topic is defined
         AND (
@@ -975,7 +1017,7 @@ BEGIN
             (
               (
                 COALESCE(a."topics", ARRAY[]::TEXT[]) && ARRAY(
-                  SELECT value::text
+                  SELECT value::varchar
                   FROM json_array_elements_text(COALESCE(topic_filter, '[]')::json) AS value
                 )
               )

--- a/src/queries/api/dashboards/qa/dashboard.sql
+++ b/src/queries/api/dashboards/qa/dashboard.sql
@@ -400,7 +400,7 @@ BEGIN
     SELECT
       id
     FROM "Grants"
-    -- WHERE COALESCE(deleted, false) = false
+    WHERE COALESCE(deleted, false) = false
     GROUP BY 1
     ORDER BY 1
     RETURNING id

--- a/src/queries/api/dashboards/qa/dashboard.test.js
+++ b/src/queries/api/dashboards/qa/dashboard.test.js
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('QA dashboard SQL parity guards', () => {
+  const sql = readFileSync(path.join(__dirname, 'dashboard.sql'), 'utf8');
+
+  it('uses reportId filter variables for report ID matching', () => {
+    expect(sql).toContain("COALESCE(report_id_filter, '[]')::json");
+    expect(sql).toContain('!= report_id_not_filter');
+    expect(sql).not.toMatch(
+      /json_array_elements_text\(COALESCE\(report_text_filter, '\[\]'\)::json\)\s+AS value[\s\S]*CONCAT\('R', LPAD\(a\."regionId"::text, 2, '0'\), '-AR-', a\.id\) ~\* value::text/
+    );
+  });
+
+  it('uses inclusive date boundary logic for start/end date filters', () => {
+    expect(sql).toContain('a."startDate"::date <= (');
+    expect(sql).toContain('a."startDate"::date >= (');
+    expect(sql).toContain('a."endDate"::date <= (');
+    expect(sql).toContain('a."endDate"::date >= (');
+  });
+
+  it('does not require inner-join chain for reportText/topic filtering', () => {
+    expect(sql).toContain('COALESCE(a."additionalNotes", \'\') ~* value::text');
+    expect(sql).toContain('FROM "ActivityReportGoals" arg');
+    expect(sql).toContain('FROM "ActivityReportObjectives" aro');
+    expect(sql).toContain('FROM "NextSteps" ns');
+  });
+
+  it('matches specialist roles from author OR collaborators', () => {
+    expect(sql).toContain('WHERE ur."userId" = a."userId"');
+    expect(sql).toContain('WHERE arc."activityReportId" = a.id');
+  });
+
+  it('expands grouped program types like the activity report API', () => {
+    expect(sql).toContain(
+      "value::text = 'EHS' AND p.\"programType\" IN ('EHS', 'AIAN EHS', 'Migrant EHS')"
+    );
+    expect(sql).toContain(
+      "value::text = 'HS' AND p.\"programType\" IN ('HS', 'AIAN HS', 'Migrant HS')"
+    );
+  });
+
+  it('filters FEI root cause from activity report goal field responses at report level', () => {
+    expect(sql).toContain('JOIN "ActivityReportGoalFieldResponses" argfr');
+    expect(sql).toContain('arg.id = argfr."activityReportGoalId"');
+    expect(sql).toContain('arg."activityReportId" = a.id');
+  });
+});

--- a/src/queries/api/dashboards/qa/dashboard.test.js
+++ b/src/queries/api/dashboards/qa/dashboard.test.js
@@ -45,4 +45,16 @@ describe('QA dashboard SQL parity guards', () => {
     expect(sql).toContain('arg.id = argfr."activityReportGoalId"');
     expect(sql).toContain('arg."activityReportId" = a.id');
   });
+
+  it('seeds filtered_activity_reports without requiring goal links', () => {
+    const seedStep = sql.match(/seed_filtered_activity_reports AS \([\s\S]*?RETURNING/);
+
+    expect(seedStep?.[0]).toContain('LEFT JOIN "ActivityRecipients" ar');
+    expect(seedStep?.[0]).toContain('LEFT JOIN filtered_grants fgr');
+    expect(seedStep?.[0]).not.toContain('JOIN "ActivityReportGoals" arg');
+    expect(seedStep?.[0]).not.toContain('JOIN filtered_goals fg');
+    expect(seedStep?.[0]).toContain('fgr.id IS NOT NULL');
+    expect(seedStep?.[0]).toContain('to_jsonb(a."regionId")::jsonb');
+    expect(seedStep?.[0]).toContain('goal_name_filter IS NULL');
+  });
 });

--- a/src/queries/api/dashboards/qa/dashboard.test.js
+++ b/src/queries/api/dashboards/qa/dashboard.test.js
@@ -19,11 +19,20 @@ describe('QA dashboard SQL parity guards', () => {
     expect(sql).toContain('a."endDate"::date >= (');
   });
 
-  it('does not require inner-join chain for reportText/topic filtering', () => {
-    expect(sql).toContain('COALESCE(a."additionalNotes", \'\') ~* value::text');
-    expect(sql).toContain('FROM "ActivityReportGoals" arg');
-    expect(sql).toContain('FROM "ActivityReportObjectives" aro');
-    expect(sql).toContain('FROM "NextSteps" ns');
+  it('matches report text with set-based LIKE queries instead of correlated regex scans', () => {
+    expect(sql).toContain('report_text_search AS (');
+    expect(sql).toContain('report_text_matching_reports AS (');
+    expect(sql).toContain("LOWER(COALESCE(a.context, '')) LIKE rts.search_pattern");
+    expect(sql).toContain('JOIN filtered_activity_reports fa ON fa.id = arg."activityReportId"');
+    expect(sql).toContain('JOIN filtered_activity_reports fa ON fa.id = aro."activityReportId"');
+    expect(sql).toContain('JOIN filtered_activity_reports fa ON fa.id = ns."activityReportId"');
+    expect(sql).not.toMatch(/COALESCE\([^)]+, ''\) ~\* value::text/);
+  });
+
+  it('uses matching array types in the shared reportText/topic filter block', () => {
+    expect(sql).toMatch(
+      /COALESCE\(a\."topics", ARRAY\[\]::TEXT\[\]\) && ARRAY\(\s+SELECT value::varchar/
+    );
   });
 
   it('matches specialist roles from author OR collaborators', () => {
@@ -46,6 +55,25 @@ describe('QA dashboard SQL parity guards', () => {
     expect(sql).toContain('arg."activityReportId" = a.id');
   });
 
+  it('normalizes and applies TTA type filtering with AR-style case-insensitive matching', () => {
+    expect(sql).toContain('tta_type_filter_normalized TEXT := NULL;');
+    expect(sql).toContain(
+      "WHERE value::text IN ('technical-assistance', 'training', 'training,technical-assistance')"
+    );
+    expect(sql).toContain("string_agg(v.value, ',' ORDER BY v.first_position)");
+    expect(sql).toContain(
+      "COALESCE(ARRAY_TO_STRING(a.\"ttaType\", ','), '') ILIKE tta_type_filter_normalized"
+    );
+  });
+
+  it('returns an AR-equivalent TTA type set-difference debug dataset', () => {
+    expect(sql).toContain('"name": "tta_type_count_debug"');
+    expect(sql).toContain('CREATE TEMP TABLE tta_type_count_debug');
+    expect(sql).toContain('missing_from_qa');
+    expect(sql).toContain('extra_in_qa');
+    expect(sql).toContain('ARRAY(SELECT id FROM missing_reports ORDER BY id LIMIT 100)');
+  });
+
   it('seeds filtered_activity_reports without requiring goal links', () => {
     const seedStep = sql.match(/seed_filtered_activity_reports AS \([\s\S]*?RETURNING/);
 
@@ -54,7 +82,33 @@ describe('QA dashboard SQL parity guards', () => {
     expect(seedStep?.[0]).not.toContain('JOIN "ActivityReportGoals" arg');
     expect(seedStep?.[0]).not.toContain('JOIN filtered_goals fg');
     expect(seedStep?.[0]).toContain('fgr.id IS NOT NULL');
+    expect(seedStep?.[0]).toContain('FROM "ActivityRecipients" ar_scope');
+    expect(seedStep?.[0]).toContain('JOIN "Grants" gr_scope');
     expect(seedStep?.[0]).toContain('to_jsonb(a."regionId")::jsonb');
     expect(seedStep?.[0]).toContain('goal_name_filter IS NULL');
+    expect(seedStep?.[0]).not.toContain('current_user_id_filter IS NULL');
+  });
+
+  it('only applies current-user grant filtering when a group filter is active', () => {
+    expect(sql).toMatch(/IF\s+group_filter IS NOT NULL\s+THEN[\s\S]*?GroupCollaborators/);
+    expect(sql).not.toMatch(
+      /IF\s+group_filter IS NOT NULL OR\s+current_user_id_filter IS NOT NULL\s+THEN/
+    );
+  });
+
+  it('does not require recipient or program rows for unrelated grant filters', () => {
+    const grantFilterStep = sql.match(/-- Step 1\.2:[\s\S]*?-- Step 1\.3:/);
+
+    expect(grantFilterStep?.[0]).not.toContain('JOIN "Recipients" r');
+    expect(grantFilterStep?.[0]).not.toContain('JOIN "Programs" p');
+    expect(grantFilterStep?.[0]).toContain('FROM "Recipients" r');
+    expect(grantFilterStep?.[0]).toContain('FROM "Programs" p');
+  });
+
+  it('applies state filtering to the AR-equivalent debug report set', () => {
+    const debugStep = sql.match(/ar_scope_reports AS \([\s\S]*?qa_reports AS \(/);
+
+    expect(debugStep?.[0]).toContain('state_code_filter IS NULL');
+    expect(debugStep?.[0]).toContain('gr."stateCode"');
   });
 });

--- a/src/queries/api/dashboards/qa/dashboard.test.js
+++ b/src/queries/api/dashboards/qa/dashboard.test.js
@@ -29,10 +29,24 @@ describe('QA dashboard SQL parity guards', () => {
     expect(sql).not.toMatch(/COALESCE\([^)]+, ''\) ~\* value::text/);
   });
 
+  it('joins multiple report_text_filter terms into a single ordered LIKE search pattern', () => {
+    expect(sql).toMatch(
+      /'%'\s+\|\|\s+LOWER\(STRING_AGG\(value, ',' ORDER BY position\)\)\s+\|\|\s+'%'/
+    );
+    expect(sql).toContain('WITH ORDINALITY AS terms(value, position)');
+  });
+
   it('uses matching array types in the shared reportText/topic filter block', () => {
     expect(sql).toMatch(
       /COALESCE\(a\."topics", ARRAY\[\]::TEXT\[\]\) && ARRAY\(\s+SELECT value::varchar/
     );
+  });
+
+  it('applies topic.not to the combined report-topic and objective-topic match block', () => {
+    expect(sql).toContain('COALESCE(a."topics", ARRAY[]::TEXT[]) && ARRAY(');
+    expect(sql).toContain('OR EXISTS (');
+    expect(sql).toContain("AND COALESCE(topic_filter, '[]')::jsonb @> to_jsonb(t.name)");
+    expect(sql).toContain(') != topic_not_filter');
   });
 
   it('matches specialist roles from author OR collaborators', () => {
@@ -66,12 +80,13 @@ describe('QA dashboard SQL parity guards', () => {
     );
   });
 
-  it('returns an AR-equivalent TTA type set-difference debug dataset', () => {
-    expect(sql).toContain('"name": "tta_type_count_debug"');
-    expect(sql).toContain('CREATE TEMP TABLE tta_type_count_debug');
-    expect(sql).toContain('missing_from_qa');
-    expect(sql).toContain('extra_in_qa');
-    expect(sql).toContain('ARRAY(SELECT id FROM missing_reports ORDER BY id LIMIT 100)');
+  it('normalizes TTA type filters by preserving first-seen ordering for allowed values', () => {
+    expect(sql).toContain('WITH ORDINALITY AS t(value, ordinality)');
+    expect(sql).toContain('MIN(ordinality) AS first_position');
+    expect(sql).toContain(
+      "WHERE value::text IN ('technical-assistance', 'training', 'training,technical-assistance')"
+    );
+    expect(sql).toContain("string_agg(v.value, ',' ORDER BY v.first_position)");
   });
 
   it('seeds filtered_activity_reports without requiring goal links', () => {
@@ -105,10 +120,9 @@ describe('QA dashboard SQL parity guards', () => {
     expect(grantFilterStep?.[0]).toContain('FROM "Programs" p');
   });
 
-  it('applies state filtering to the AR-equivalent debug report set', () => {
-    const debugStep = sql.match(/ar_scope_reports AS \([\s\S]*?qa_reports AS \(/);
-
-    expect(debugStep?.[0]).toContain('state_code_filter IS NULL');
-    expect(debugStep?.[0]).toContain('gr."stateCode"');
+  it('applies state filtering to grants and the seeded report set', () => {
+    expect(sql).toContain('state_code_filter IS NULL');
+    expect(sql).toContain('COALESCE(state_code_filter, \'[]\')::jsonb @> to_jsonb(gr."stateCode")');
+    expect(sql).toContain('AND state_code_filter IS NULL');
   });
 });

--- a/src/routes/ssdi/handlers.ts
+++ b/src/routes/ssdi/handlers.ts
@@ -7,7 +7,6 @@ import {
   checkFolderPermissions,
   executeQuery,
   type FilterValues,
-  generateFilterString,
   isFile,
   listQueryFiles,
   preprocessAndValidateFilters,
@@ -84,7 +83,7 @@ const listQueries = async (req: Request, res: Response) => {
     // Use the validated internal scriptPath for listing queries
     const queryFiles = await listQueryFiles(scriptPath, user);
     res.json(queryFiles);
-  } catch (error) {
+  } catch (_error) {
     res.status(500).send('Error listing query files');
   }
 };

--- a/src/services/ssdi.test.js
+++ b/src/services/ssdi.test.js
@@ -1,10 +1,11 @@
+import path from 'node:path';
 import fs from 'fs';
-import path from 'path';
 import { QueryTypes } from 'sequelize';
 import db from '../models';
 import UserPolicy from '../policies/user';
 import {
   applyFilterOptions,
+  BASE_DIRECTORY,
   cache,
   checkDirectoryExists,
   checkFolderPermissions,
@@ -73,7 +74,7 @@ describe('ssdi', () => {
   describe('safeResolvePath', () => {
     it('should resolve the path safely within BASE_DIRECTORY', () => {
       const result = safeResolvePath('test/path.sql');
-      expect(result.endsWith('/app/src/queries/test/path.sql')).toBe(true);
+      expect(result).toBe(path.resolve(BASE_DIRECTORY, 'test/path.sql'));
     });
 
     it('should throw an error if the resolved path is outside BASE_DIRECTORY', () => {
@@ -735,9 +736,7 @@ describe('ssdi', () => {
     SELECT * FROM test;`);
 
       // Mock the permission check to always return true
-      const checkFolderPermissionsMock = jest
-        .spyOn(UserPolicy.prototype, 'checkPermissions')
-        .mockResolvedValue(true);
+      jest.spyOn(UserPolicy.prototype, 'checkPermissions').mockResolvedValue(true);
 
       const result = await readFiltersFromFile('file1.sql', 1);
       expect(result).toEqual({
@@ -802,7 +801,7 @@ describe('ssdi', () => {
 
     it('should return errors for invalid filters and types', () => {
       const input = { flag1: [1, 'two', 3], invalidFlag: [1, 2, 3] };
-      const { result, errors } = preprocessAndValidateFilters(filters, input);
+      const { errors } = preprocessAndValidateFilters(filters, input);
       expect(errors.invalidFilters).toEqual(['Invalid filter: invalidFlag']);
       expect(errors.invalidTypes).toEqual([
         'Invalid type for filter flag1: expected integer[] received 1,two,3',
@@ -914,21 +913,12 @@ describe('ssdi', () => {
 
   describe('executeQuery', () => {
     const mockQuery = jest.fn();
-    let pathResolveSpy;
-    let fsReadFileSpy;
-    let fsStatSpy;
+    const resolvedPathFor = (fileName) => path.resolve(BASE_DIRECTORY, fileName);
 
     beforeEach(() => {
       jest.clearAllMocks();
       db.sequelize.query = mockQuery;
       cache.clear();
-    });
-
-    afterEach(() => {
-      // Restore the original implementations after each test
-      if (pathResolveSpy) pathResolveSpy.mockRestore();
-      if (fsReadFileSpy) fsReadFileSpy.mockRestore();
-      if (fsStatSpy) fsStatSpy.mockRestore();
     });
 
     it('should throw an error if the file path is not a string', async () => {
@@ -938,9 +928,7 @@ describe('ssdi', () => {
     });
 
     it('should resolve the file path correctly using safeResolvePath', async () => {
-      const mockResolvedPath = '/app/src/queries/resolved/path/to/test.sql';
-      // Spy on path.resolve to mock it only for this test
-      pathResolveSpy = jest.spyOn(path, 'resolve').mockReturnValue(mockResolvedPath);
+      const mockResolvedPath = resolvedPathFor('test.sql');
 
       const mockStat = { mtime: new Date() };
       fs.promises.stat.mockResolvedValue(mockStat);
@@ -950,15 +938,13 @@ describe('ssdi', () => {
 
       await executeQuery('test.sql');
 
-      expect(path.resolve).toHaveBeenCalledWith(expect.anything(), 'test.sql');
       const cachedFile = cache.get(mockResolvedPath);
       expect(cachedFile).toBeDefined();
       expect(cachedFile?.query).toEqual('SELECT * FROM test;');
     });
 
     it('should cache the query after reading the file', async () => {
-      const mockResolvedPath = '/app/src/queries/resolved/path/to/test.sql';
-      pathResolveSpy = jest.spyOn(path, 'resolve').mockReturnValue(mockResolvedPath);
+      const mockResolvedPath = resolvedPathFor('test.sql');
 
       const mockStat = { mtime: new Date() };
       fs.promises.stat.mockResolvedValue(mockStat);
@@ -973,8 +959,7 @@ describe('ssdi', () => {
     });
 
     it('should throw an error if the JSON header cannot be read from the file', async () => {
-      const mockResolvedPath = '/app/src/queries/resolved/path/to/invalid.sql';
-      pathResolveSpy = jest.spyOn(path, 'resolve').mockReturnValue(mockResolvedPath);
+      const mockResolvedPath = resolvedPathFor('invalid.sql');
 
       const mockStat = { mtime: new Date() };
       fs.promises.stat.mockResolvedValue(mockStat);
@@ -986,9 +971,6 @@ describe('ssdi', () => {
     });
 
     it('should execute the query and return the result', async () => {
-      const mockResolvedPath = '/app/src/queries/resolved/path/to/valid.sql';
-      pathResolveSpy = jest.spyOn(path, 'resolve').mockReturnValue(mockResolvedPath);
-
       const mockStat = { mtime: new Date() };
       fs.promises.stat.mockResolvedValue(mockStat);
       fs.promises.readFile.mockResolvedValue(
@@ -1003,9 +985,6 @@ describe('ssdi', () => {
     });
 
     it('should throw an error if the query execution fails', async () => {
-      const mockResolvedPath = '/app/src/queries/resolved/path/to/valid.sql';
-      pathResolveSpy = jest.spyOn(path, 'resolve').mockReturnValue(mockResolvedPath);
-
       const mockStat = { mtime: new Date() };
       fs.promises.stat.mockResolvedValue(mockStat);
       fs.promises.readFile.mockResolvedValue(
@@ -1017,8 +996,7 @@ describe('ssdi', () => {
     });
 
     it('should use the cached result if the file has been cached', async () => {
-      const mockResolvedPath = '/app/src/queries/resolved/path/to/cached.sql';
-      pathResolveSpy = jest.spyOn(path, 'resolve').mockReturnValue(mockResolvedPath);
+      const mockResolvedPath = resolvedPathFor('cached.sql');
 
       cache.set(mockResolvedPath, {
         jsonHeader: { name: 'test', filters: [] },

--- a/src/services/ssdi.ts
+++ b/src/services/ssdi.ts
@@ -137,11 +137,7 @@ interface CachedFilters {
 }
 
 // Base directory for file operations
-const isWindows = process.platform === 'win32';
-const BASE_DIRECTORY = path.resolve(
-  process.cwd(),
-  isWindows ? 'src/queries/' : '/app/src/queries/'
-);
+const BASE_DIRECTORY = path.resolve(process.cwd(), 'src/queries');
 
 // Cache to store parsed JSON headers and queries
 const cache: Map<string, CachedFile> = new Map();

--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -110,8 +110,10 @@ export default async function overview(scopes) {
     1
   ).toString();
 
-  const numParticipants = duration
-    .reduce((prev, report) => prev + getActivityReportParticipantCount(report), 0);
+  const numParticipants = duration.reduce(
+    (prev, report) => prev + getActivityReportParticipantCount(report),
+    0
+  );
 
   // our final query, it stands on its own as explained in the comment for the last one
   const [res] = await ActivityReport.findAll({
@@ -146,13 +148,13 @@ export default async function overview(scopes) {
         model: ActivityRecipient,
         as: 'activityRecipients',
         attributes: [],
-        required: false,
+        required: true,
         include: [
           {
             model: Grant,
             as: 'grant',
             attributes: [],
-            required: false,
+            required: true,
             include: [
               {
                 model: Recipient,
@@ -162,12 +164,12 @@ export default async function overview(scopes) {
               },
             ],
           },
-          {
-            model: OtherEntity,
-            attributes: [],
-            as: 'otherEntity',
-            required: false,
-          },
+          // {
+          //   model: OtherEntity,
+          //   attributes: [],
+          //   as: 'otherEntity',
+          //   required: false,
+          // },
         ],
       },
     ],

--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -1,4 +1,5 @@
 import { REPORT_STATUSES } from '@ttahub/common';
+import { stubFalse } from 'lodash';
 import { Op } from 'sequelize';
 import { getActivityReportParticipantCount } from '../lib/activityReportParticipantCount';
 import {
@@ -148,13 +149,13 @@ export default async function overview(scopes) {
         model: ActivityRecipient,
         as: 'activityRecipients',
         attributes: [],
-        required: true,
+        required: false,
         include: [
           {
             model: Grant,
             as: 'grant',
             attributes: [],
-            required: true,
+            required: false,
             include: [
               {
                 model: Recipient,
@@ -164,12 +165,12 @@ export default async function overview(scopes) {
               },
             ],
           },
-          // {
-          //   model: OtherEntity,
-          //   attributes: [],
-          //   as: 'otherEntity',
-          //   required: false,
-          // },
+          {
+            model: OtherEntity,
+            attributes: [],
+            as: 'otherEntity',
+            required: false,
+          },
         ],
       },
     ],

--- a/src/widgets/overview.js
+++ b/src/widgets/overview.js
@@ -1,5 +1,4 @@
 import { REPORT_STATUSES } from '@ttahub/common';
-import { stubFalse } from 'lodash';
 import { Op } from 'sequelize';
 import { getActivityReportParticipantCount } from '../lib/activityReportParticipantCount';
 import {


### PR DESCRIPTION
## Description of change

A few bugs with the QA dash implementation. This results in discrepancies between totals shown on the QA dash versus other pages/widgets. Where discrepancies existed, I deferred to the scopes/implementation more widely used

1. Program type filtering did not match the grouped HS/EHS implementation used by Activity Reports.
2. Date filters were not inclusive of their boundary dates.
3.  currentUserId  was applied to every request, causing unintended grant filtering when no group filter was selected.
4. Report ID filtering referenced the report-text filter variables instead of the report ID variables.
5. Activity Reports were incorrectly required to have linked goals.
6. Report-level filters were unnecessarily constrained by the filtered goal and grant sets.
7. FEI root-cause filtering used goal-level responses instead of the responses associated with each Activity Report goal.
8. TTA type filtering required exact array equality instead of using the normalized matching behavior used by Activity Reports.
9. Report-text filtering required several optional associations, omitted additional notes, and used expensive correlated regular-expression queries.
10. Topic filtering required objective topics and did not include topics stored directly on the Activity Report.
11. Topic filtering compared incompatible PostgreSQL array types, causing report-text requests to fail because the filters share a query block.
12. Specialist-role filtering required both creator and collaborator role associations instead of matching either source.
13. State and territory filtering unnecessarily required related recipient and program records, excluding otherwise valid reports.
14. Grant filtering now uses filter-specific association checks so unrelated filters do not impose additional recipient or program requirements.
15. Reports are still required to have an associated grant, matching the Activity Report overview, without requiring that grant to survive unrelated QA grant filters.

## How to test

Make sure my changes make sense; make sure the filters producing matching results in totals of activity reports across AR landing/QA dash/regional dash

Note!! The QA dash excludes other entity reports, seemingly by design, so there will still be discrepancy. This PR is only intended to close the gap between the different implementations

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5553


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [ ] Linked Jira issue
- [ ] JIRA issue status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
