### PR TITLE
[TTAHUB-5353] Fix display of suspended reason

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/__tests__/index.js
@@ -597,7 +597,7 @@ describe('ViewGoalDetails', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('renders the most recent suspended reason when there are multiple suspensions', async () => {
+  test('renders the most recent suspended reason regardless of statusChanges order', async () => {
     const suspendedGoal = {
       id: 8,
       name: 'Repeatedly Suspended Goal',
@@ -610,9 +610,21 @@ describe('ViewGoalDetails', () => {
       goalCollaborators: [],
       objectives: [],
       reason: 'Goal created',
-      // Ordered by createdAt ASC (as the backend returns them). The goal was suspended,
-      // resumed, then suspended again with a different reason.
+      // Intentionally NOT ordered by createdAt to prove the FE sorts independently
+      // of whatever order the backend returns the status changes in. The goal was
+      // suspended, resumed, then suspended again with a different (later) reason.
       statusChanges: [
+        {
+          id: 83,
+          goalId: 8,
+          userId: 2,
+          oldStatus: GOAL_STATUS.IN_PROGRESS,
+          newStatus: GOAL_STATUS.SUSPENDED,
+          reason: 'Key staff turnover / vacancies',
+          createdAt: '2025-03-15T00:00:00.000Z',
+          performedAt: '2025-03-15T00:00:00.000Z',
+          user: { name: 'Another User', roles: [{ name: 'Program Manager' }] },
+        },
         {
           id: 80,
           goalId: 8,
@@ -644,17 +656,6 @@ describe('ViewGoalDetails', () => {
           reason: 'Unknown',
           createdAt: '2025-03-10T00:00:00.000Z',
           performedAt: '2025-03-10T00:00:00.000Z',
-          user: { name: 'Another User', roles: [{ name: 'Program Manager' }] },
-        },
-        {
-          id: 83,
-          goalId: 8,
-          userId: 2,
-          oldStatus: GOAL_STATUS.IN_PROGRESS,
-          newStatus: GOAL_STATUS.SUSPENDED,
-          reason: 'Key staff turnover / vacancies',
-          createdAt: '2025-03-15T00:00:00.000Z',
-          performedAt: '2025-03-15T00:00:00.000Z',
           user: { name: 'Another User', roles: [{ name: 'Program Manager' }] },
         },
       ],

--- a/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/__tests__/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/__tests__/index.js
@@ -539,6 +539,151 @@ describe('ViewGoalDetails', () => {
     );
   });
 
+  test('renders the suspended reason (not the goal-created reason) for a suspended goal', async () => {
+    const suspendedGoal = {
+      id: 7,
+      name: 'Suspended Standard Goal',
+      status: GOAL_STATUS.SUSPENDED,
+      createdAt: '2025-02-01T00:00:00.000Z',
+      goalTemplateId: 1,
+      grantId: 1,
+      goalTemplate: { id: 1, templateName: 'Improve Child Development' },
+      grant: { id: 1, number: '012345 HS', numberWithProgramTypes: '012345 HS - EHS, HS' },
+      goalCollaborators: [],
+      objectives: [],
+      // Reproduces the bug: backend attaches an arbitrary status change reason.
+      reason: 'Goal created',
+      statusChanges: [
+        {
+          id: 70,
+          goalId: 7,
+          userId: 1,
+          oldStatus: null,
+          newStatus: GOAL_STATUS.NOT_STARTED,
+          reason: 'Goal created',
+          createdAt: '2025-02-01T00:00:00.000Z',
+          performedAt: '2025-02-01T00:00:00.000Z',
+          user: { name: 'Test User', roles: [{ name: 'Program Specialist' }] },
+        },
+        {
+          id: 71,
+          goalId: 7,
+          userId: 2,
+          oldStatus: GOAL_STATUS.NOT_STARTED,
+          newStatus: GOAL_STATUS.SUSPENDED,
+          reason: 'Recipient request',
+          createdAt: '2025-02-05T00:00:00.000Z',
+          performedAt: '2025-02-05T00:00:00.000Z',
+          user: { name: 'Another User', roles: [{ name: 'Program Manager' }] },
+        },
+      ],
+      responses: null,
+    };
+
+    fetchMock.get(goalHistoryUrl, { goals: [suspendedGoal], overview: mockOverview });
+    await act(async () => {
+      renderViewGoalDetails();
+    });
+
+    const accordionButton = await screen.findByRole('button', { name: /G-7 \| Suspended/i });
+    await waitFor(() => expect(accordionButton).toHaveAttribute('aria-expanded', 'true'));
+    const accordionContent = document.getElementById(
+      accordionButton.getAttribute('aria-controls')
+    );
+
+    expect(within(accordionContent).getByText('Suspended - Recipient request')).toBeInTheDocument();
+    expect(
+      within(accordionContent).queryByText('Suspended - Goal created')
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the most recent suspended reason when there are multiple suspensions', async () => {
+    const suspendedGoal = {
+      id: 8,
+      name: 'Repeatedly Suspended Goal',
+      status: GOAL_STATUS.SUSPENDED,
+      createdAt: '2025-03-01T00:00:00.000Z',
+      goalTemplateId: 1,
+      grantId: 1,
+      goalTemplate: { id: 1, templateName: 'Improve Child Development' },
+      grant: { id: 1, number: '012345 HS', numberWithProgramTypes: '012345 HS - EHS, HS' },
+      goalCollaborators: [],
+      objectives: [],
+      reason: 'Goal created',
+      // Ordered by createdAt ASC (as the backend returns them). The goal was suspended,
+      // resumed, then suspended again with a different reason.
+      statusChanges: [
+        {
+          id: 80,
+          goalId: 8,
+          userId: 1,
+          oldStatus: null,
+          newStatus: GOAL_STATUS.NOT_STARTED,
+          reason: 'Goal created',
+          createdAt: '2025-03-01T00:00:00.000Z',
+          performedAt: '2025-03-01T00:00:00.000Z',
+          user: { name: 'Test User', roles: [{ name: 'Program Specialist' }] },
+        },
+        {
+          id: 81,
+          goalId: 8,
+          userId: 2,
+          oldStatus: GOAL_STATUS.NOT_STARTED,
+          newStatus: GOAL_STATUS.SUSPENDED,
+          reason: 'Recipient request',
+          createdAt: '2025-03-05T00:00:00.000Z',
+          performedAt: '2025-03-05T00:00:00.000Z',
+          user: { name: 'Another User', roles: [{ name: 'Program Manager' }] },
+        },
+        {
+          id: 82,
+          goalId: 8,
+          userId: 2,
+          oldStatus: GOAL_STATUS.SUSPENDED,
+          newStatus: GOAL_STATUS.IN_PROGRESS,
+          reason: 'Unknown',
+          createdAt: '2025-03-10T00:00:00.000Z',
+          performedAt: '2025-03-10T00:00:00.000Z',
+          user: { name: 'Another User', roles: [{ name: 'Program Manager' }] },
+        },
+        {
+          id: 83,
+          goalId: 8,
+          userId: 2,
+          oldStatus: GOAL_STATUS.IN_PROGRESS,
+          newStatus: GOAL_STATUS.SUSPENDED,
+          reason: 'Key staff turnover / vacancies',
+          createdAt: '2025-03-15T00:00:00.000Z',
+          performedAt: '2025-03-15T00:00:00.000Z',
+          user: { name: 'Another User', roles: [{ name: 'Program Manager' }] },
+        },
+      ],
+      responses: null,
+    };
+
+    fetchMock.get(goalHistoryUrl, { goals: [suspendedGoal], overview: mockOverview });
+    await act(async () => {
+      renderViewGoalDetails();
+    });
+
+    const accordionButton = await screen.findByRole('button', { name: /G-8 \| Suspended/i });
+    await waitFor(() => expect(accordionButton).toHaveAttribute('aria-expanded', 'true'));
+    const accordionContent = document.getElementById(
+      accordionButton.getAttribute('aria-controls')
+    );
+
+    // Should show the most recent suspension reason, not the earlier one.
+    expect(
+      within(accordionContent).getByText('Suspended - Key staff turnover / vacancies')
+    ).toBeInTheDocument();
+    expect(
+      within(accordionContent).queryByText('Suspended - Recipient request')
+    ).not.toBeInTheDocument();
+    expect(
+      within(accordionContent).queryByText('Suspended - Goal created')
+    ).not.toBeInTheDocument();
+  });
+
   test('renders objective information including reports, topics, and resources', async () => {
     fetchMock.get(goalHistoryUrl, { goals: mockGoalHistory, overview: mockOverview });
     await act(async () => {

--- a/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/index.js
@@ -299,12 +299,19 @@ export default function ViewGoalDetails({ recipient, regionId }) {
     // When the goal is currently suspended, the reason must come from the most recent
     // status change that transitioned the goal to Suspended. The backend-provided
     // `goal.reason` is derived from an arbitrary joined status change row (the earliest),
-    // which yields incorrect values like "Goal created".
+    // which yields incorrect values like "Goal created". We sort explicitly by timestamp
+    // (using the raw statusChanges so the original ISO timestamps are preserved) rather
+    // than relying on the order the backend returns the status changes in.
     const suspendedReason =
       goal.status === GOAL_STATUS.SUSPENDED
-        ? statusUpdates
+        ? [...(goal.statusChanges || [])]
             .filter((u) => u.newStatus === GOAL_STATUS.SUSPENDED)
-            .reduce((latest, u) => u, null)?.reason
+            .sort(
+              (a, b) =>
+                moment.utc(a.performedAt || a.createdAt).valueOf() -
+                moment.utc(b.performedAt || b.createdAt).valueOf()
+            )
+            .at(-1)?.reason
         : null;
 
     const rootCauseItems = (goal.responses || []).reduce((items, response) => {

--- a/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/index.js
+++ b/frontend/src/pages/RecipientRecord/pages/ViewStandardGoals/index.js
@@ -295,6 +295,18 @@ export default function ViewGoalDetails({ recipient, regionId }) {
     }
 
     const objectives = goal.objectives || [];
+
+    // When the goal is currently suspended, the reason must come from the most recent
+    // status change that transitioned the goal to Suspended. The backend-provided
+    // `goal.reason` is derived from an arbitrary joined status change row (the earliest),
+    // which yields incorrect values like "Goal created".
+    const suspendedReason =
+      goal.status === GOAL_STATUS.SUSPENDED
+        ? statusUpdates
+            .filter((u) => u.newStatus === GOAL_STATUS.SUSPENDED)
+            .reduce((latest, u) => u, null)?.reason
+        : null;
+
     const rootCauseItems = (goal.responses || []).reduce((items, response) => {
       if (Array.isArray(response.response)) {
         response.response.filter(Boolean).forEach((value, valueIndex) => {
@@ -387,7 +399,11 @@ export default function ViewGoalDetails({ recipient, regionId }) {
           <div className="goal-status-section margin-bottom-3">
             <ReadOnlyField label="Goal status">
               {goal.status}
-              {goal.status === GOAL_STATUS.SUSPENDED ? <> - {goal.reason}</> : <></>}
+              {goal.status === GOAL_STATUS.SUSPENDED && suspendedReason ? (
+                <> - {suspendedReason}</>
+              ) : (
+                <></>
+              )}
             </ReadOnlyField>
           </div>
 


### PR DESCRIPTION
## Description of change

On the RTR goal history when the goal is currently suspended we were selecting the wrong status. So suspended would show something like 'Suspended - Goal created'. This fixes the issue on the FE by selecting the correct status and corresponding reason.

## How to test

- Review the change
- Make sure it correctly shows when both the current and past status is suspended.


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5353


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
