### PR TITLE
[TTAHUB-5404 ] Add filter guidance help drawer to TTA History tab

### DIFF
--- a/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/TTAHistory.js
@@ -1,9 +1,14 @@
 import { Grid } from '@trussworks/react-uswds';
 import PropTypes from 'prop-types';
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, {
+  useCallback, useContext, useMemo, useRef, useState,
+} from 'react';
 import { Helmet } from 'react-helmet';
 import { v4 as uuidv4 } from 'uuid';
 import ActivityReportsTable from '../../../components/ActivityReportsTable';
+import ContentFromFeedByTag from '../../../components/ContentFromFeedByTag';
+import Drawer from '../../../components/Drawer';
+import DrawerTriggerButton from '../../../components/DrawerTriggerButton';
 import FilterPanel from '../../../components/filter/FilterPanel';
 import FilterContext from '../../../FilterContext';
 import useSanitizedFilters from '../../../hooks/useSanitizedFilters';
@@ -24,6 +29,7 @@ const defaultDate = formatDateRange({
 const VALID_TOPICS = new Set(TTAHISTORY_FILTER_CONFIG.map((f) => f.id));
 
 export default function TTAHistory({ recipientName, recipientId, regionId }) {
+  const pageDrawerRef = useRef(null);
   const [resetPagination, setResetPagination] = useState(false);
   // Bump the version suffix whenever filters are added or removed from the
   // config so that stale filters saved in a browser tab's session storage are
@@ -103,6 +109,14 @@ export default function TTAHistory({ recipientName, recipientId, regionId }) {
             applyButtonAria="Apply filters to recipient record data"
             allUserRegions={regions}
           />
+        </div>
+        <div className="margin-bottom-3">
+          <DrawerTriggerButton drawerTriggerRef={pageDrawerRef}>
+            Learn how filters impact the data displayed
+          </DrawerTriggerButton>
+          <Drawer title="Filter guidance" triggerRef={pageDrawerRef}>
+            <ContentFromFeedByTag tagName="ttahub-tta-history-filters" />
+          </Drawer>
         </div>
         <TTAHistoryOverview
           fields={['Activity reports', 'Training report sessions', 'Hours of TTA', 'Participants', 'In person activities']}

--- a/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
+++ b/frontend/src/pages/RecipientRecord/pages/__tests__/TTAHistory.js
@@ -74,6 +74,12 @@ describe('Recipient Record - TTA History', () => {
       `/api/widgets/approvedARAndTRByGoalCategory?startDate.win=${yearToDate}&region.in[]=1&recipientId.ctn[]=401`,
       []
     );
+
+    fetchMock.get(
+      '/api/feeds/item?tag=ttahub-tta-history-filters',
+      '<feed><entry><summary>Filter guidance</summary></entry></feed>',
+      { overwriteRoutes: false }
+    );
   });
 
   afterEach(() => {

--- a/frontend/src/pages/RecipientRecord/pages/constants.js
+++ b/frontend/src/pages/RecipientRecord/pages/constants.js
@@ -1,8 +1,6 @@
 import { DECIMAL_BASE } from '@ttahub/common';
 import {
-  activityReportGoalResponseFilter,
   endDateFilter,
-  specialistRoleFilter,
   startDateFilter,
   ttaHistoryMyReportsFilter,
 } from '../../../components/filter/activityReportFilters';
@@ -30,9 +28,7 @@ export const getGoalsAndObjectivesFilterConfig = (grantNumberParams) =>
 const TTAHISTORY_FILTER_CONFIG = [
   { ...startDateFilter, display: 'Date started' },
   { ...endDateFilter, display: 'Date ended' },
-  activityReportGoalResponseFilter,
   ttaHistoryMyReportsFilter,
-  specialistRoleFilter,
 ];
 
 TTAHISTORY_FILTER_CONFIG.sort((a, b) => a.display.localeCompare(b.display));


### PR DESCRIPTION
## Description of change

This add a filter help drawer to the TTA History tab.

## How to test

- Review changes
- Make sure the drawer works and shows


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5404


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
