### PR TITLE
[TTAHUB-5053/5561] Add new FEI status indicators to both RTR an Recipient Spotlight (RegionalDash)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "@react-hook/resize-observer": "^1.2.6",
     "@silevis/reactgrid": "3.1",
     "@trussworks/react-uswds": "5.1.0",
-    "@ttahub/common": "2.4.1",
+    "@ttahub/common": "2.4.2",
     "@use-it/interval": "^1.0.0",
     "@uswds/uswds": "3.1.0",
     "async": "^3.2.3",

--- a/frontend/src/components/filter/FilterPriorityIndicator.js
+++ b/frontend/src/components/filter/FilterPriorityIndicator.js
@@ -3,10 +3,10 @@ import React from 'react';
 import FilterSelect from './FilterSelect';
 import { filterSelectProps } from './props';
 
-// Filter out DRS and FEI from the options, but keep them in the constant for future use
-const PRIORITY_INDICATOR_OPTIONS = PRIORITY_INDICATORS.filter(
-  (label) => label !== 'DRS' && label !== 'FEI'
-).map((label, value) => ({ value, label }));
+// Filter out DRS from the options, but keep it in the constant for future use
+const PRIORITY_INDICATOR_OPTIONS = PRIORITY_INDICATORS.filter((label) => label !== 'DRS').map(
+  (label, value) => ({ value, label })
+);
 
 export default function FilterPriorityIndicator({ onApply, inputId, query }) {
   const onApplyClick = (selected) => {

--- a/frontend/src/components/filter/__tests__/FilterPriorityIndicator.js
+++ b/frontend/src/components/filter/__tests__/FilterPriorityIndicator.js
@@ -28,16 +28,17 @@ describe('FilterPriorityIndicator', () => {
     const select = await findByText(/select priority indicator to filter by/i);
     await selectEvent.openMenu(select);
 
-    // Verify all 5 options are present (DRS and FEI are filtered out)
+    // Verify options are present (only DRS is filtered out)
     expect(screen.getByText('Child incidents')).toBeInTheDocument();
     expect(screen.getByText('Deficiency')).toBeInTheDocument();
+    expect(screen.getByText('FEI')).toBeInTheDocument();
     expect(screen.getByText('New recipient')).toBeInTheDocument();
     expect(screen.getByText('New staff')).toBeInTheDocument();
     expect(screen.getByText('No TTA')).toBeInTheDocument();
+    expect(screen.getByText('Underenrolled')).toBeInTheDocument();
 
-    // Verify DRS and FEI are not present
+    // Verify DRS is not present (still hidden)
     expect(screen.queryByText('DRS')).not.toBeInTheDocument();
-    expect(screen.queryByText('FEI')).not.toBeInTheDocument();
   });
 
   it('renders with pre-selected values', async () => {

--- a/frontend/src/pages/RecipientRecord/components/RecipientSpotlight.js
+++ b/frontend/src/pages/RecipientRecord/components/RecipientSpotlight.js
@@ -10,7 +10,7 @@ import { useGrantData } from '../pages/GrantDataContext';
 import IndicatorCounter from './IndicatorCounter';
 import './RecipientSpotlight.scss';
 
-const DISPLAYED_INDICATOR_COUNT = 5;
+const DISPLAYED_INDICATOR_COUNT = 7;
 
 const createRowForEachIndicator = (name, label, value, description) => ({
   name,
@@ -31,7 +31,12 @@ const mappedData = (data) => [
     data.deficiency,
     'Recipient grant has at least one active monitoring deficiency'
   ),
-
+  createRowForEachIndicator(
+    'FEI',
+    'FEI',
+    data.FEI,
+    'Recipient grant is currently in the Full Enrollment Initiative (FEI)'
+  ),
   createRowForEachIndicator(
     'newRecipients',
     'New recipients',
@@ -49,6 +54,12 @@ const mappedData = (data) => [
     'No TTA',
     data.noTTA,
     'Recipient grant does not have any TTA reports in last 12 months'
+  ),
+  createRowForEachIndicator(
+    'underenrolled',
+    'Underenrolled',
+    data.underenrolled,
+    'Recipient grant reports below 97% enrollment but has not reached 4 consecutive months of underenrollment'
   ),
 ];
 

--- a/frontend/src/pages/RecipientRecord/components/RecipientSpotlight.js
+++ b/frontend/src/pages/RecipientRecord/components/RecipientSpotlight.js
@@ -35,7 +35,7 @@ const mappedData = (data) => [
     'FEI',
     'FEI',
     data.FEI,
-    'Recipient grant is currently in the Full Enrollment Initiative (FEI)'
+    'Recipient grant is currently in the Full Enrollment Initiative (FEI) including 6-month evaluation and designated chronically underenrolled (DCU) periods'
   ),
   createRowForEachIndicator(
     'newRecipients',

--- a/frontend/src/pages/RecipientRecord/components/__tests__/RecipientSpotlight.js
+++ b/frontend/src/pages/RecipientRecord/components/__tests__/RecipientSpotlight.js
@@ -20,6 +20,7 @@ const mockSpotlightData = {
       noTTA: true,
       DRS: false,
       FEI: false,
+      underenrolled: false,
     },
   ],
   overview: {
@@ -44,6 +45,7 @@ const noIndicatorsMockData = {
       noTTA: false,
       DRS: false,
       FEI: false,
+      underenrolled: false,
     },
   ],
   overview: {
@@ -107,7 +109,7 @@ describe('RecipientSpotlight', () => {
       expect(
         screen.getByText(/Recipient grant may need prioritized attention/i)
       ).toBeInTheDocument();
-      expect(screen.getByText(/3 of 5 priority indicators/i)).toBeInTheDocument();
+      expect(screen.getByText(/3 of 7 priority indicators/i)).toBeInTheDocument();
     });
   });
 
@@ -121,7 +123,7 @@ describe('RecipientSpotlight', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/No priority indicators identified/i)).toBeInTheDocument();
-      expect(screen.getByText(/0 of 5 priority indicators/i)).toBeInTheDocument();
+      expect(screen.getByText(/0 of 7 priority indicators/i)).toBeInTheDocument();
     });
   });
 
@@ -141,11 +143,11 @@ describe('RecipientSpotlight', () => {
       expect(badIndicators).toHaveLength(3);
 
       // Find all indicators with good-indicator class (false)
-      // FEI and DRS are now hidden, so only 2 good indicators remain (deficiency and newStaff)
+      // DRS is hidden; the 4 falsy indicators are deficiency, FEI, newStaff, and underenrolled
       const goodIndicators = document.querySelectorAll(
         '.ttahub-recipient-spotlight-content-cell-good-indicator'
       );
-      expect(goodIndicators).toHaveLength(2);
+      expect(goodIndicators).toHaveLength(4);
     });
 
     // Verify specific indicators from our mock data
@@ -334,8 +336,8 @@ describe('RecipientSpotlight', () => {
 
     await waitFor(() => {
       // In our mockSpotlightData, we have:
-      // childIncidents: true, deficiency: false, newRecipients: true,
-      // newStaff: false, noTTA: true
+      // childIncidents: true, deficiency: false, FEI: false, newRecipients: true,
+      // newStaff: false, noTTA: true, underenrolled: false
 
       // Check that cells with true values get the bad-indicator class
       const trueIndicatorCells = document.querySelectorAll(
@@ -344,10 +346,11 @@ describe('RecipientSpotlight', () => {
       expect(trueIndicatorCells).toHaveLength(3);
 
       // Check that cells with false values get the good-indicator class
+      // (deficiency, FEI, newStaff, underenrolled)
       const falseIndicatorCells = document.querySelectorAll(
         '.ttahub-recipient-spotlight-content-cell-good-indicator'
       );
-      expect(falseIndicatorCells).toHaveLength(2);
+      expect(falseIndicatorCells).toHaveLength(4);
     });
   });
 });

--- a/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
+++ b/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
@@ -22,7 +22,7 @@ const INDICATOR_DETAILS = {
   },
   FEI: {
     label: 'FEI',
-    description: 'Recipient is currently in the Full Enrollment Initiative (FEI)',
+    description: 'Recipient is currently in the Full Enrollment Initiative (FEI) including 6-month evaluation and designated chronically underenrolled (DCU) periods',
   },
   // Temporarily hidden - will be added back later
   // DRS: {

--- a/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
+++ b/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
@@ -7,8 +7,8 @@ import ExpanderButton from '../../../components/ExpanderButton';
 import IndicatorCounter from '../../RecipientRecord/components/IndicatorCounter';
 import './RecipientSpotlightCard.scss';
 
-// Number of priority indicators currently shown (DRS and FEI temporarily hidden)
-const DISPLAYED_INDICATOR_COUNT = 5;
+// Number of priority indicators currently shown (DRS temporarily hidden)
+const DISPLAYED_INDICATOR_COUNT = 7;
 
 const INDICATOR_DETAILS = {
   childIncidents: {
@@ -20,14 +20,14 @@ const INDICATOR_DETAILS = {
     label: 'Deficiency',
     description: 'Recipient has at least one active monitoring deficiency',
   },
+  FEI: {
+    label: 'FEI',
+    description: 'Recipient is currently in the Full Enrollment Initiative (FEI)',
+  },
   // Temporarily hidden - will be added back later
   // DRS: {
   //   label: 'DRS',
   //   description: 'Recipient meets the conditions for the Designation Renewal System (DRS)',
-  // },
-  // FEI: {
-  //   label: 'FEI',
-  //   description: 'Recipient is currently in the Full Enrollment Initiative (FEI)',
   // },
   newRecipients: {
     label: 'New recipient',
@@ -43,6 +43,11 @@ const INDICATOR_DETAILS = {
     label: 'No TTA',
     description: 'Recipient does not have any TTA reports in last 12 months',
   },
+  underenrolled: {
+    label: 'Underenrolled',
+    description:
+      'Recipient reports below 97% enrollment but has not reached 4 consecutive months of underenrollment',
+  },
 };
 
 export default function RecipientSpotlightCard({ recipient }) {
@@ -56,12 +61,13 @@ export default function RecipientSpotlightCard({ recipient }) {
     const indicators = [
       recip.childIncidents,
       recip.deficiency,
+      recip.FEI,
       recip.newRecipients,
       recip.newStaff,
       recip.noTTA,
+      recip.underenrolled,
       // Temporarily hidden - will be added back later
       // recip.DRS,
-      // recip.FEI,
     ];
     return indicators.filter(Boolean).length;
   };

--- a/frontend/src/pages/RegionalDashboard/components/__tests__/RecipientSpotlightCard.js
+++ b/frontend/src/pages/RegionalDashboard/components/__tests__/RecipientSpotlightCard.js
@@ -17,6 +17,7 @@ const mockRecipient = {
   noTTA: false,
   DRS: false,
   FEI: false,
+  underenrolled: false,
 };
 
 describe('RecipientSpotlightCard', () => {
@@ -65,7 +66,7 @@ describe('RecipientSpotlightCard', () => {
   it('displays indicator count text inline with counter', () => {
     renderCard();
     // The text is now rendered inline within the IndicatorCounter component
-    expect(screen.getByText(/2\s+of\s+5/)).toBeInTheDocument();
+    expect(screen.getByText(/2\s+of\s+7/)).toBeInTheDocument();
   });
 
   it('renders ExpanderButton with "View" text initially', () => {
@@ -119,12 +120,14 @@ describe('RecipientSpotlightCard', () => {
     const expandButton = screen.getByRole('button', { name: /indicators for recipient/i });
     fireEvent.click(expandButton);
 
-    // Should show all indicators (FEI and DRS are temporarily hidden)
+    // Should show all displayed indicators (DRS is temporarily hidden)
     expect(screen.getByText('Child incidents')).toBeInTheDocument();
     expect(screen.getByText('New recipient')).toBeInTheDocument();
     expect(screen.getByText('Deficiency')).toBeInTheDocument();
+    expect(screen.getByText('FEI')).toBeInTheDocument();
     expect(screen.getByText('New staff')).toBeInTheDocument();
     expect(screen.getByText('No TTA')).toBeInTheDocument();
+    expect(screen.getByText('Underenrolled')).toBeInTheDocument();
   });
 
   it('handles recipient with all indicators active', () => {
@@ -137,6 +140,7 @@ describe('RecipientSpotlightCard', () => {
       noTTA: true,
       DRS: true,
       FEI: true,
+      underenrolled: true,
     };
 
     const { container } = render(
@@ -145,9 +149,9 @@ describe('RecipientSpotlightCard', () => {
       </BrowserRouter>
     );
 
-    // Only 5 indicators are shown (FEI and DRS are temporarily hidden)
+    // 7 indicators are shown (DRS is temporarily hidden)
     const filledBoxes = container.querySelectorAll('.ttahub--indicator-box-filled');
-    expect(filledBoxes.length).toBe(5);
+    expect(filledBoxes.length).toBe(7);
   });
 
   it('handles recipient with no active indicators', () => {
@@ -211,7 +215,7 @@ describe('RecipientSpotlightCard', () => {
     expect(filledBoxes.length).toBe(0);
   });
 
-  it('renders all 5 indicator types when all are active', () => {
+  it('renders all 7 indicator types when all are active', () => {
     const allActiveRecipient = {
       ...mockRecipient,
       childIncidents: true,
@@ -221,6 +225,7 @@ describe('RecipientSpotlightCard', () => {
       noTTA: true,
       DRS: true,
       FEI: true,
+      underenrolled: true,
     };
 
     render(
@@ -232,12 +237,14 @@ describe('RecipientSpotlightCard', () => {
     const expandButton = screen.getByRole('button', { name: /indicators for recipient/i });
     fireEvent.click(expandButton);
 
-    // FEI and DRS are temporarily hidden
+    // DRS is temporarily hidden
     expect(screen.getByText('Child incidents')).toBeInTheDocument();
     expect(screen.getByText('Deficiency')).toBeInTheDocument();
+    expect(screen.getByText('FEI')).toBeInTheDocument();
     expect(screen.getByText('New recipient')).toBeInTheDocument();
     expect(screen.getByText('New staff')).toBeInTheDocument();
     expect(screen.getByText('No TTA')).toBeInTheDocument();
+    expect(screen.getByText('Underenrolled')).toBeInTheDocument();
   });
 
   it('assigns correct test id to DataCard', () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2403,10 +2403,10 @@
   resolved "https://registry.yarnpkg.com/@trussworks/react-uswds/-/react-uswds-5.1.0.tgz#3f8cb9cc31660933f75fbc3b0aa17d4f7ae21f4e"
   integrity sha512-XREY9vIQxgZHsa5Vwf8exTwsTCPIr9Au3/TDm76mjnq+hNnHUiGt1qWAaI9Yj7oUU+F4lg0TNuzKLNZLf3tXVw==
 
-"@ttahub/common@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@ttahub/common/-/common-2.4.1.tgz#5cb774b38e6620987b07a3efbd3fb5afb186d1ff"
-  integrity sha512-AmNDalBN50rIbDlxQr9QfLIxw07qDDeP8fnpP0AXRBBSINYMrnU3YhOseXPAREnpch0FQI4tbQyjP990g9F2Xw==
+"@ttahub/common@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@ttahub/common/-/common-2.4.2.tgz#2b1a68ab83b118d1201f8589136fd05517764031"
+  integrity sha512-P3a6nYsKiokSKU0husSSlMBx8kaEMM5wdOGX92BW/k9RhC288e5M0kKK0mmBxFF2j81vEZw/ItZ0V1I+d66B9Q==
 
 "@turf/area@^7.1.0":
   version "7.3.5"

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@braintree/sanitize-url": "^7.1.1",
     "@faker-js/faker": "^6.3.1",
     "@mesh-kit/core": "^1.0.160",
-    "@ttahub/common": "2.3.8",
+    "@ttahub/common": "2.4.1",
     "@types/ioredis-mock": "^8.2.6",
     "adm-zip": "^0.6.0",
     "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@braintree/sanitize-url": "^7.1.1",
     "@faker-js/faker": "^6.3.1",
     "@mesh-kit/core": "^1.0.160",
-    "@ttahub/common": "2.4.1",
+    "@ttahub/common": "2.4.2",
     "@types/ioredis-mock": "^8.2.6",
     "adm-zip": "^0.6.0",
     "ajv": "^8.18.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ttahub/common",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The purpose of this package is to reduce code duplication between the frontend and backend projects.",
   "main": "src/index.js",
   "author": "",

--- a/packages/common/src/constants.js
+++ b/packages/common/src/constants.js
@@ -113,6 +113,7 @@ const PRIORITY_INDICATORS = [
   'New recipient',
   'New staff',
   'No TTA',
+  'Underenrolled',
 ];
 
 exports.PRIORITY_INDICATORS = PRIORITY_INDICATORS;

--- a/src/services/recipientSpotlight.js
+++ b/src/services/recipientSpotlight.js
@@ -1,6 +1,31 @@
 /* eslint-disable max-len */
+
+import { FEI_HS_STATUSES } from '@ttahub/common';
 import { Op, QueryTypes } from 'sequelize';
 import { Grant, Recipient, sequelize } from '../models';
+
+// Of the possible imported FEI statuses (FEI_HS_STATUSES), these indicate the
+// grant is currently in the Full Enrollment Initiative (including the 6-month
+// evaluation and designated chronically underenrolled (DCU) periods). We filter
+// the canonical list so the exact strings live in one place and any drift in
+// FEI_HS_STATUSES is reflected here automatically. This membership may change
+// going forward, so it is kept in one spot.
+const FEI_IN_INITIATIVE_STATUSES = FEI_HS_STATUSES.filter((status) =>
+  [
+    'Notified of 12 Month Period',
+    'Month X of 12 Month Period',
+    'DCU Month X of 6 Month DCU Evaluation',
+    'Central Office Review',
+    'DCU + OHS Initiated Reduction + Month X of 6 Month DCU Evaluation',
+    'DCU + Grantee Initiated Reduction/Conversion + Month X of 6 Month DCU Evaluation',
+  ].includes(status)
+);
+
+// FEI statuses that indicate a grant reports below 97% enrollment but has not
+// reached 4 consecutive months of underenrollment.
+const FEI_UNDERENROLLED_STATUSES = FEI_HS_STATUSES.filter(
+  (status) => status === 'Underenrolled less than 4 Months'
+);
 
 // Map from indicator label (as shown in UI) to column name in SQL
 const INDICATOR_LABEL_TO_COLUMN = {
@@ -11,6 +36,7 @@ const INDICATOR_LABEL_TO_COLUMN = {
   'No TTA': 'noTTA',
   DRS: 'DRS',
   FEI: 'FEI',
+  Underenrolled: 'underenrolled',
 };
 
 // Whitelist of allowed sortBy column names to prevent SQL injection
@@ -26,6 +52,7 @@ const ALLOWED_SORT_COLUMNS = [
   'noTTA',
   'DRS',
   'FEI',
+  'underenrolled',
   'indicatorCount',
 ];
 
@@ -97,19 +124,17 @@ export async function getRecipientSpotlightIndicators(
 
   /*
     Create the spotlight query using the grant ids and other params.
-    At the time of writing this comment, there will be a total of seven spotlight indicators.
-    For the MVP we will only implement 5 of them. Based on the grant ids we will create the
-    raw sql query and return an array of objects. Each row is a recipient the recipient object
-    should have the following properties
+    At the time of writing this comment, there will be a total of eight spotlight indicators.
+    Based on the grant ids we will create the raw sql query and return an array of objects.
+    Each row is a recipient the recipient object should have the following properties
     recipientId, regionId, grantIds, childIncidents, deficiency, newRecipients,
-    newStaff, noTTA, DRS, FEI
-    with a true or false for each of the seven indicators. We want to handle pagination,
-    sorting
-    given the parameters. For now for DRS and FEI we will return false.
+    newStaff, noTTA, DRS, FEI, underenrolled
+    with a true or false for each of the indicators. We want to handle pagination,
+    sorting given the parameters. DRS is not yet implemented and will return false.
 
     Note: LTM = Last Twelve Months
 
-    Description of the seven indicators:
+    Description of the indicators:
     1. Child Incidents (monitoring data): Grants that have at least one child incident
     (RAN) monitoring citation in LTM (MonitoringReviews.ReviewType).
     2. Deficiency (monitoring data): Grants that have at least one review > finding > standard
@@ -120,7 +145,10 @@ export async function getRecipientSpotlightIndicators(
     which matches recipientLeadership() in src/services/recipient.js
     5. No TTA: There are no approved reports (AR) for this recipient in the LTM.
     6. DRS: TBD
-    7. FEI: TBD
+    7. FEI: Grant is currently in the Full Enrollment Initiative based on its FEI HS
+    or FEI EHS status (see FEI_IN_INITIATIVE_STATUSES above).
+    8. Underenrolled: Grant reports below 97% enrollment but has not reached 4 consecutive
+    months of underenrollment (see FEI_UNDERENROLLED_STATUSES above).
 */
   const grantIdList = grantIds.map((g) => g.id);
   const hasGrantIds = grantIdList.length > 0;
@@ -243,7 +271,9 @@ export async function getRecipientSpotlightIndicators(
       gr.id grid,
       gr."startDate" grstart,
       gr.number grnumber,
-      gr.status grstatus
+      gr.status grstatus,
+      gr."feiHsStatus" fei_hs_status,
+      gr."feiEhsStatus" fei_ehs_status
     FROM recipients r
     JOIN grant_recipients g
       ON r.rid = g.rid
@@ -370,6 +400,35 @@ export async function getRecipientSpotlightIndicators(
         region no_tta_region
       FROM grants_without_tta
     ),
+    -- 7. FEI: Grants currently in the Full Enrollment Initiative
+    --    (based on the grant's FEI HS or FEI EHS status).
+    --    The applicable statuses may change going forward, so they are
+    --    sourced from a derived constant (FEI_IN_INITIATIVE_STATUSES).
+    fei AS (
+      SELECT DISTINCT
+        rid fei_rid,
+        region fei_region
+      FROM all_grants
+      WHERE grstatus = 'Active'
+        AND (
+          fei_hs_status IN (:feiInitiativeStatuses)
+          OR fei_ehs_status IN (:feiInitiativeStatuses)
+        )
+    ),
+    -- 8. Underenrolled: Grants that report below 97% enrollment but have not
+    --    reached 4 consecutive months of underenrollment
+    --    (FEI HS or FEI EHS status of "Underenrolled less than 4 Months").
+    underenrolled AS (
+      SELECT DISTINCT
+        rid underenrolled_rid,
+        region underenrolled_region
+      FROM all_grants
+      WHERE grstatus = 'Active'
+        AND (
+          fei_hs_status IN (:feiUnderenrolledStatuses)
+          OR fei_ehs_status IN (:feiUnderenrolledStatuses)
+        )
+    ),
     -- Combine all indicators into one result set
     combined_indicators AS (
       SELECT
@@ -384,12 +443,15 @@ export async function getRecipientSpotlightIndicators(
         new_staff_rid IS NOT NULL "newStaff",
         no_tta_rid IS NOT NULL "noTTA",
         FALSE AS "DRS",  -- Placeholder for future implementation
-        FALSE AS "FEI",   -- Placeholder for future implementation
+        fei_rid IS NOT NULL "FEI",
+        underenrolled_rid IS NOT NULL "underenrolled",
         (incident_rid IS NOT NULL)::int +
         (deficiency_rid IS NOT NULL)::int +
         (new_recip_rid IS NOT NULL)::int +
         (new_staff_rid IS NOT NULL)::int +
-        (no_tta_rid IS NOT NULL)::int "indicatorCount"
+        (no_tta_rid IS NOT NULL)::int +
+        (fei_rid IS NOT NULL)::int +
+        (underenrolled_rid IS NOT NULL)::int "indicatorCount"
       FROM recipients
       LEFT JOIN child_incidents ci
         ON rid = incident_rid
@@ -406,6 +468,12 @@ export async function getRecipientSpotlightIndicators(
       LEFT JOIN no_tta nt
         ON rid = no_tta_rid
         AND region = no_tta_region
+      LEFT JOIN fei f
+        ON rid = fei_rid
+        AND region = fei_region
+      LEFT JOIN underenrolled ue
+        ON rid = underenrolled_rid
+        AND region = underenrolled_region
     )
 
     SELECT
@@ -422,6 +490,10 @@ export async function getRecipientSpotlightIndicators(
 
   // Execute the raw SQL query to get the recipient spotlight indicators.
   const spotlightSqlData = await sequelize.query(spotLightSql, {
+    replacements: {
+      feiInitiativeStatuses: FEI_IN_INITIATIVE_STATUSES,
+      feiUnderenrolledStatuses: FEI_UNDERENROLLED_STATUSES,
+    },
     type: QueryTypes.SELECT,
   });
 

--- a/src/services/recipientSpotlight.js
+++ b/src/services/recipientSpotlight.js
@@ -5,11 +5,14 @@ import { Op, QueryTypes } from 'sequelize';
 import { Grant, Recipient, sequelize } from '../models';
 
 // Of the possible imported FEI statuses (FEI_HS_STATUSES), these indicate the
-// grant is currently in the Full Enrollment Initiative (including the 6-month
-// evaluation and designated chronically underenrolled (DCU) periods). We filter
-// the canonical list so the exact strings live in one place and any drift in
-// FEI_HS_STATUSES is reflected here automatically. This membership may change
-// going forward, so it is kept in one spot.
+// grant is currently in the Full Enrollment Initiative — covering the 12-month
+// period, Central Office Review, and the designated chronically underenrolled
+// (DCU) 6-month evaluation statuses.
+// Note: the standalone "Month X of 6 Month Evaluation Period" status is
+// intentionally NOT part of the initiative and is excluded here on purpose.
+// We filter the canonical list so the exact strings live in one place and any
+// drift in FEI_HS_STATUSES is reflected here automatically. This membership may
+// change going forward, so it is kept in one spot.
 const FEI_IN_INITIATIVE_STATUSES = FEI_HS_STATUSES.filter((status) =>
   [
     'Notified of 12 Month Period',

--- a/src/services/recipientSpotlight.test.js
+++ b/src/services/recipientSpotlight.test.js
@@ -749,6 +749,7 @@ describe('recipientSpotlight service', () => {
       expect(result.recipients[0]).toHaveProperty('noTTA');
       expect(result.recipients[0]).toHaveProperty('DRS');
       expect(result.recipients[0]).toHaveProperty('FEI');
+      expect(result.recipients[0]).toHaveProperty('underenrolled');
       expect(result.overview).toHaveProperty('numRecipients');
       expect(result.overview).toHaveProperty('totalRecipients');
       expect(result.overview).toHaveProperty('recipientPercentage');
@@ -1199,7 +1200,7 @@ describe('recipientSpotlight service', () => {
       }
     });
 
-    it('confirms DRS and FEI are set to false for MVP', async () => {
+    it('confirms DRS is set to false (not yet implemented)', async () => {
       // Use a recipient with an indicator since we filter out 0-indicator recipients
       const scopes = createScopesWithRecipientAndRegion(childIncidentsRecipient.id, REGION_ID);
       const result = await getRecipientSpotlightIndicators(scopes, 'recipientName', 'ASC', 0, 10, [
@@ -1210,7 +1211,308 @@ describe('recipientSpotlight service', () => {
       expect(result.recipients).toBeDefined();
       expect(Array.isArray(result.recipients)).toBe(true);
       expect(result.recipients[0].DRS).toBe(false);
+      // childIncidentsGrant has no FEI status, so FEI and underenrolled are false
       expect(result.recipients[0].FEI).toBe(false);
+      expect(result.recipients[0].underenrolled).toBe(false);
+    });
+
+    // Helper to create a recipient with one or more grants that carry FEI statuses.
+    // Returns the created recipient, grants, and a cleanup function.
+    const createFeiRecipient = async (name, grantConfigs) => {
+      const recipient = await Recipient.create({
+        id: faker.unique(() => faker.datatype.number({ min: 30001, max: 49999 })),
+        name,
+        regionId: REGION_ID,
+      });
+      await db.MonitoringGranteeLink.create({ granteeId: recipient.id.toString() });
+
+      const grantNumbers = grantConfigs.map(
+        (_, index) => `G-FEI-${faker.datatype.number({ min: 100000, max: 999999 })}-${index}`
+      );
+      await db.GrantNumberLink.bulkCreate(grantNumbers.map((grantNumber) => ({ grantNumber })));
+
+      const grants = await Promise.all(
+        grantConfigs.map((config, index) =>
+          Grant.create({
+            id: faker.unique(() => faker.datatype.number({ min: 30001, max: 49999 })),
+            number: grantNumbers[index],
+            recipientId: recipient.id,
+            regionId: REGION_ID,
+            status: config.status || 'Active',
+            startDate: pastFiveYears,
+            endDate: createDate,
+            feiHsStatus: config.feiHsStatus || null,
+            feiEhsStatus: config.feiEhsStatus || null,
+            cdi: false,
+          })
+        )
+      );
+
+      const cleanup = async () => {
+        await Grant.destroy({
+          where: { id: grants.map((g) => g.id) },
+          force: true,
+          individualHooks: true,
+        });
+        await db.MonitoringGranteeLink.destroy({
+          where: { granteeId: recipient.id.toString() },
+          force: true,
+        });
+        await Recipient.destroy({ where: { id: recipient.id }, force: true });
+        await db.GrantNumberLink.destroy({ where: { grantNumber: grantNumbers }, force: true });
+      };
+
+      return { recipient, grants, cleanup };
+    };
+
+    it('identifies FEI via feiHsStatus', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('FEI HS Recipient', [
+        { feiHsStatus: 'Month X of 12 Month Period' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID]
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].FEI).toBe(true);
+        expect(result.recipients[0].underenrolled).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('identifies FEI via feiEhsStatus', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('FEI EHS Recipient', [
+        { feiEhsStatus: 'Central Office Review' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID]
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].FEI).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('flags FEI for DCU evaluation-period statuses', async () => {
+      const dcuStatuses = [
+        'DCU + OHS Initiated Reduction + Month X of 6 Month DCU Evaluation',
+        'DCU + Grantee Initiated Reduction/Conversion + Month X of 6 Month DCU Evaluation',
+      ];
+      // eslint-disable-next-line no-restricted-syntax
+      for (const status of dcuStatuses) {
+        // eslint-disable-next-line no-await-in-loop
+        const { recipient, cleanup } = await createFeiRecipient(`DCU FEI Recipient ${status}`, [
+          { feiHsStatus: status },
+        ]);
+        try {
+          const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+          // eslint-disable-next-line no-await-in-loop
+          const result = await getRecipientSpotlightIndicators(
+            scopes,
+            'recipientName',
+            'ASC',
+            0,
+            10,
+            [REGION_ID]
+          );
+          expect(result.recipients.length).toBe(1);
+          expect(result.recipients[0].FEI).toBe(true);
+        } finally {
+          // eslint-disable-next-line no-await-in-loop
+          await cleanup();
+        }
+      }
+    });
+
+    it('does not flag FEI for a non-initiative FEI status', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('Fully Enrolled Recipient', [
+        { feiHsStatus: 'Fully Enrolled' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID]
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].FEI).toBe(false);
+        expect(result.recipients[0].underenrolled).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('flags FEI at the recipient level when at least one grant is in FEI', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('Mixed FEI Recipient', [
+        { feiHsStatus: 'Fully Enrolled' },
+        { feiEhsStatus: 'Notified of 12 Month Period' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID]
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].FEI).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('scopes FEI to the specific grant in grant mode', async () => {
+      const { recipient, grants, cleanup } = await createFeiRecipient('Grant Mode FEI Recipient', [
+        { feiHsStatus: 'Central Office Review' },
+        { feiHsStatus: 'Fully Enrolled' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+
+        // Grant mode on the in-FEI grant -> FEI true
+        const inFeiResult = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID],
+          [],
+          [],
+          grants[0].id
+        );
+        expect(inFeiResult.recipients.length).toBe(1);
+        expect(inFeiResult.recipients[0].FEI).toBe(true);
+
+        // Grant mode on the fully-enrolled grant -> FEI false
+        const notInFeiResult = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID],
+          [],
+          [],
+          grants[1].id
+        );
+        expect(notInFeiResult.recipients.length).toBe(1);
+        expect(notInFeiResult.recipients[0].FEI).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('identifies underenrolled via feiHsStatus', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('Underenrolled HS Recipient', [
+        { feiHsStatus: 'Underenrolled less than 4 Months' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID]
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].underenrolled).toBe(true);
+        // "Underenrolled less than 4 Months" is not an in-FEI status
+        expect(result.recipients[0].FEI).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('identifies underenrolled via feiEhsStatus', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('Underenrolled EHS Recipient', [
+        { feiEhsStatus: 'Underenrolled less than 4 Months' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID]
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].underenrolled).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('filters recipients by the FEI priority indicator', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('FEI Filter Recipient', [
+        { feiHsStatus: 'DCU Month X of 6 Month DCU Evaluation' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID],
+          ['FEI']
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].recipientId).toBe(recipient.id);
+        expect(result.recipients[0].FEI).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('filters recipients by the Underenrolled priority indicator', async () => {
+      const { recipient, cleanup } = await createFeiRecipient('Underenrolled Filter Recipient', [
+        { feiHsStatus: 'Underenrolled less than 4 Months' },
+      ]);
+      try {
+        const scopes = createScopesWithRecipientAndRegion(recipient.id, REGION_ID);
+        const result = await getRecipientSpotlightIndicators(
+          scopes,
+          'recipientName',
+          'ASC',
+          0,
+          10,
+          [REGION_ID],
+          ['Underenrolled']
+        );
+        expect(result.recipients.length).toBe(1);
+        expect(result.recipients[0].recipientId).toBe(recipient.id);
+        expect(result.recipients[0].underenrolled).toBe(true);
+      } finally {
+        await cleanup();
+      }
     });
 
     it('filters by singleGrantId correctly', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,10 +3606,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
-"@ttahub/common@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@ttahub/common/-/common-2.4.1.tgz#5cb774b38e6620987b07a3efbd3fb5afb186d1ff"
-  integrity sha512-AmNDalBN50rIbDlxQr9QfLIxw07qDDeP8fnpP0AXRBBSINYMrnU3YhOseXPAREnpch0FQI4tbQyjP990g9F2Xw==
+"@ttahub/common@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@ttahub/common/-/common-2.4.2.tgz#2b1a68ab83b118d1201f8589136fd05517764031"
+  integrity sha512-P3a6nYsKiokSKU0husSSlMBx8kaEMM5wdOGX92BW/k9RhC288e5M0kKK0mmBxFF2j81vEZw/ItZ0V1I+d66B9Q==
 
 "@types/argparse@1.0.38":
   version "1.0.38"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,10 +3606,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
-"@ttahub/common@2.3.8":
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/@ttahub/common/-/common-2.3.8.tgz#487e6903d36e85e276e79b231dc6bbfa4a416163"
-  integrity sha512-EfGKtAALEOo/uzNYVv/7hVneoa5ZhzK8a206Tj2j6Zm8zv/TqNlNosU/h+BEcIjWYO+UWys7r7Euqjh4v6ikYA==
+"@ttahub/common@2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@ttahub/common/-/common-2.4.1.tgz#5cb774b38e6620987b07a3efbd3fb5afb186d1ff"
+  integrity sha512-AmNDalBN50rIbDlxQr9QfLIxw07qDDeP8fnpP0AXRBBSINYMrnU3YhOseXPAREnpch0FQI4tbQyjP990g9F2Xw==
 
 "@types/argparse@1.0.38":
   version "1.0.38"


### PR DESCRIPTION
## Description of change

There are two tickets in this PR 5053 and 5561:

5053: Adds the FEI indicator based on the new FEI statuses we bring in to both the RTR and Recipient Spotlight tab. It also adds the indicator to the filter.

5561: This adds the new Underenrollment indicator based on the new FEI status to both RTR and Recipient Spotlight. It also adds the filter. 

## How to test

- Review the code
- Note that there are 6 Indicators for FEI
- Note that there is only 1 indicator for Underenrollement

The following query adds some dummy data to test with on our test db:

```
-- Populate FEI status columns on 3 active grants to exercise the spotlight indicators.
-- Case 1: FEI only (in-initiative via feiHsStatus)
-- Case 2: Underenrolled only (via feiEhsStatus)
-- Case 3: Both FEI and Underenrolled (HS in-initiative + EHS underenrolled)
WITH picks AS (
  SELECT
    id,
    ROW_NUMBER() OVER (ORDER BY id) AS rn
  FROM "Grants"
  WHERE status = 'Active'
    AND "regionId" = 1          -- change region as needed
  LIMIT 3
)
UPDATE "Grants" g
SET
  "feiHsStatus" = CASE p.rn
    WHEN 1 THEN 'Central Office Review'            -- FEI true
    WHEN 2 THEN NULL                               -- underenrolled comes from EHS
    WHEN 3 THEN 'Month X of 12 Month Period'       -- FEI true
  END,
  "feiEhsStatus" = CASE p.rn
    WHEN 1 THEN NULL
    WHEN 2 THEN 'Underenrolled less than 4 Months' -- underenrolled true
    WHEN 3 THEN 'Underenrolled less than 4 Months' -- underenrolled true (both)
  END,
  "updatedAt" = NOW()
FROM picks p
WHERE g.id = p.id
RETURNING g.id, g."regionId", g."recipientId", g."feiHsStatus", g."feiEhsStatus";
```

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5053
* https://jira.acf.gov/browse/TTAHUB-5561



## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`elainaparrish` is the authorized approver under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
