### PR TITLE
[PROD] Add new Comprehensive Review reviewType

### DIFF
--- a/docs/flow-diagrams/monitoring-goal-create-flow.puml
+++ b/docs/flow-diagrams/monitoring-goal-create-flow.puml
@@ -19,7 +19,7 @@ note right
   Review must have:
   - Status: 'Complete'
   - Delivery Date: Jan 21, 2025 or later
-  - Review Type: FA-1, FA-2, RAN, 'AIAN-DEF', 'Follow-up', 'FA1-FR', 'FA2-CR', 'FA1-PSR', 'FA2-CSR', 'Special'
+  - Review Type: FA-1, FA-2, RAN, 'AIAN-DEF', 'Follow-up', 'FA1-FR', 'FA2-CR', 'FA1-PSR', 'FA2-CSR', 'Special', 'Comprehensive Review'
   - At least one active finding
 end note
 

--- a/docs/monitoring-integration-guide.md
+++ b/docs/monitoring-integration-guide.md
@@ -149,7 +149,7 @@ A: The intent is for citations to be available to select within the time period 
 ## Monitoring Goal Creation Logic (Current)
 Monitoring goals are created only when all of the following are true:
 - Monitoring goal creation is enabled (`ENABLE_MONITORING_GOAL_CREATION=true`).
-- The review type is in the allowlist: `AIAN-DEF`, `RAN`, `Follow-up`, `FA-1`, `FA1-FR`, `FA1-PSR`, `FA-2`, `FA2-CR`, `FA2-CSR`, `Special`.
+- The review type is in the allowlist: `AIAN-DEF`, `RAN`, `Follow-up`, `FA-1`, `FA1-FR`, `FA1-PSR`, `FA-2`, `FA2-CR`, `FA2-CSR`, `Special`, `Comprehensive Review`.
 - The review `reportDeliveryDate` is between the cutoff date (`2025-01-21`) and now.
 - There is at least one open finding linked to the review and grantee. "Open" means either:
   - Finding status is `Active` or `Elevated Deficiency`, or

--- a/docs/monitoring-technical-reference.md
+++ b/docs/monitoring-technical-reference.md
@@ -114,7 +114,7 @@ A new goal is created if:
 * Monitoring goal creation is enabled (`ENABLE_MONITORING_GOAL_CREATION=true`)
 * A monitoring review was delivered between 2025-01-21 and now
 * It is of a type like 'AIAN-DEF', 'RAN', 'FA-1', 'Follow-up', 'FA1-FR',
-          'FA1-PSR', 'FA-2', 'FA2-CR', 'FA2-CSR', 'Special'
+          'FA1-PSR', 'FA-2', 'FA2-CR', 'FA2-CSR', 'Special', 'Comprehensive Review'
 * There is at least one open finding linked to the grant
   * A finding is considered open if it is currently 'Active' or 'Elevated Deficiency', or if its most recent linked review is not yet delivered.
   * A finding is excluded when a Monitoring Goal was closed after that finding's latest delivered review date.

--- a/src/tools/createMonitoringGoals.js
+++ b/src/tools/createMonitoringGoals.js
@@ -74,7 +74,7 @@ const createMonitoringGoals = async () => {
           'Follow-up',
           'FA-1', 'FA1-FR', 'FA1-PSR',
           'FA-2', 'FA2-CR', 'FA2-CSR',
-          'Special'
+          'Special', 'Comprehensive Review'
         )
         AND (clv.last_closed_goal IS NULL
           OR clv.last_closed_goal <= c.latest_report_delivery_date)


### PR DESCRIPTION
## Description of change

This adds to Monitoring Goal creation logic the new "Comprehensive Review" `reviewType` that seems to have replaced the previous "FA2-CR" `reviewType`, and also updates docs in the repo.

## How to test

There's not really a way to test this in staging, but a manual run of the updated SQL shows new Monitoring Goals created for four recipients who have received Comprehensive Review type reviews since May.

## Jira Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5624

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [x] QA review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [x] Staging smoke test completed
- [x] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [x] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
