### PR TITLE
[Prod] Fix bug with goal display, new email and in-app notifications

### DIFF
--- a/docs/email_notifications.md
+++ b/docs/email_notifications.md
@@ -132,7 +132,7 @@ Triggered synchronously by an application event, processed once per job.
 
 | `EMAIL_ACTIONS` key | Trigger helper | Handler | Template |
 |---------------------|----------------|---------|----------|
-| `NEEDS_ACTION` | `changesRequestedNotification` | `notifyChangesRequested` | `changes_requested_by_manager` |
+| `NEEDS_ACTION` | `changesRequestedNotification` | `notifyChangesRequested` | `changes_requested_by_manager` (author/collaborators), `changes_requested_by_manager_approver` (other approvers) |
 | `SUBMITTED` | `approverAssignedNotification` | `notifyApproverAssigned` | `manager_approval_requested` |
 | `APPROVED` | `reportApprovedNotification` | `notifyReportApproved` | `report_approved` |
 | `COLLABORATOR_ADDED` | `collaboratorAssignedNotification` | `notifyCollaboratorAssigned` | `collaborator_added` |
@@ -261,6 +261,7 @@ Templates are Pug files located in `email_templates/` (repo root). Each template
 ```
 email_templates/
 ├── changes_requested_by_manager/
+├── changes_requested_by_manager_approver/
 ├── collaborator_added/
 ├── digest/
 ├── digest_empty/

--- a/email_templates/changes_requested_by_manager_approver/html.pug
+++ b/email_templates/changes_requested_by_manager_approver/html.pug
@@ -1,0 +1,12 @@
+style
+  include ../email.css
+p Hello,
+p 
+p #{managerName} requested changes to report #{displayId}. 
+if comments
+  p #{managerName} provided the following comments:
+  blockquote !{comments} 
+a(href=reportPath) Approve this report in the TTA Hub.
+p Best wishes,
+  br
+  | The TTA Hub team

--- a/email_templates/changes_requested_by_manager_approver/subject.pug
+++ b/email_templates/changes_requested_by_manager_approver/subject.pug
@@ -1,0 +1,1 @@
+= `Activity Report ${displayId}: Changes requested by ${managerName}`

--- a/frontend/src/components/GoalForm/ObjectiveFiles.js
+++ b/frontend/src/components/GoalForm/ObjectiveFiles.js
@@ -182,7 +182,10 @@ ObjectiveFiles.propTypes = {
   onBlur: PropTypes.func,
   reportId: PropTypes.number,
   forceObjectiveSave: PropTypes.bool,
-  selectedObjectiveId: PropTypes.number,
+  // A newly created (not yet saved) objective has a client-side uuid string id, while a
+  // persisted objective has a numeric id. The showSaveDraftInfo logic already guards on
+  // `typeof selectedObjectiveId === 'number'`, so accept both to avoid a spurious warning.
+  selectedObjectiveId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   useFiles: PropTypes.bool,
   onChangeUseFiles: PropTypes.func,
 };

--- a/frontend/src/components/HeaderUserMenu.js
+++ b/frontend/src/components/HeaderUserMenu.js
@@ -259,7 +259,7 @@ function HeaderUserMenu({
   const stopImpersonating = () => {
     setIsImpersonating(false);
     window.sessionStorage.removeItem(SESSION_STORAGE_IMPERSONATION_KEY);
-    window.location.href = '/';
+    window.location.href = '/admin/users';
   };
 
   return (

--- a/frontend/src/components/Navigator/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/ActivityReportNavigator.js
@@ -487,22 +487,66 @@ const ActivityReportNavigator = ({
 
       // Update RHF with saved data
       if (savedData) {
+        // "Save goal" finalizes the goal and CLOSES the edit form. The read-only
+        // goals list renders from the `goals` array, so the just-saved goal must
+        // live there.
+        //
+        // However, the backend still reports the goal as actively edited (its
+        // isActivelyEdited flag was set when the user opened it for editing and is
+        // not cleared by this report save). As a result convertGoalsToFormData
+        // (run inside onSave) splits that goal out into `goalForEditing`, leaving
+        // `goals` empty. If we then close the form, nothing renders: the read-only
+        // list is empty and the edit form (which shows goalForEditing) is hidden.
+        // That is exactly the "blank goals after save" bug — a page refresh only
+        // "works" because the form re-initializes OPEN when goalForEditing is set.
+        //
+        // Since we are explicitly closing the form here, fold any split-out
+        // goalForEditing back into the goals array at its original position so the
+        // read-only list renders every goal in one pass.
+        const editingGoal = savedData.goalForEditing;
+        let mergedGoals = Array.isArray(savedData.goals) ? [...savedData.goals] : [];
+        if (editingGoal && typeof editingGoal === 'object' && editingGoal.id) {
+          const insertIndex =
+            typeof editingGoal.originalIndex === 'number'
+              ? Math.min(editingGoal.originalIndex, mergedGoals.length)
+              : mergedGoals.length;
+          mergedGoals.splice(insertIndex, 0, editingGoal);
+        }
+
+        // Clear the goal form fields as part of the SAME reset payload rather than
+        // mutating them with setValue() calls AFTER reset(). Calling
+        // setValue('goalForEditing.objectives', []) on a goalForEditing that reset()
+        // just set to '' re-creates goalForEditing as a truthy { objectives: [] }
+        // object and leaves the read-only goals list rendering against a stale/empty
+        // snapshot until the next full reload. Folding the clears into a single reset
+        // keeps the form state consistent in one render pass.
         const normalizedSavedData = {
           ...savedData,
-          goalForEditing: savedData.goalForEditing || '',
+          goals: mergedGoals,
+          goalForEditing: '',
+          goalName: '',
+          goalEndDate: '',
+          goalPrompts: [],
         };
 
         reset(normalizedSavedData);
 
-        // On save goal re-evaluate page status.
-        updateGoalsObjectivesPageState(normalizedSavedData);
-
-        // clear out the goal form after a successful save
-        setValue('goalForEditing.objectives', []);
+        // reset() alone does NOT reliably update the `goals` field that the goals
+        // page renders from — that field is bound with useController() in the
+        // child, and in this react-hook-form v6 setup the controller value does
+        // not pick up the reset. The working draft-save handler (onSaveDraftGoal)
+        // updates the read-only list via explicit setValue('goals', ...), so we do
+        // the same here to force the controlled field (and therefore the read-only
+        // list) to reflect the just-saved goals. Without this the list stays blank
+        // until a full page reload re-initializes the form.
+        setValue('goals', mergedGoals);
         setValue('goalForEditing', '');
         setValue('goalName', '');
         setValue('goalEndDate', '');
         setValue('goalPrompts', []);
+
+        // On save goal re-evaluate page status.
+        updateGoalsObjectivesPageState(normalizedSavedData);
 
         // close the goal form
         toggleGoalForm(true);

--- a/frontend/src/components/Navigator/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/ActivityReportNavigator.js
@@ -504,7 +504,7 @@ const ActivityReportNavigator = ({
         // goalForEditing back into the goals array at its original position so the
         // read-only list renders every goal in one pass.
         const editingGoal = savedData.goalForEditing;
-        let mergedGoals = Array.isArray(savedData.goals) ? [...savedData.goals] : [];
+        const mergedGoals = Array.isArray(savedData.goals) ? [...savedData.goals] : [];
         if (editingGoal && typeof editingGoal === 'object' && editingGoal.id) {
           const insertIndex =
             typeof editingGoal.originalIndex === 'number'

--- a/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.js
+++ b/frontend/src/components/Navigator/__tests__/ActivityReportNavigator.js
@@ -900,10 +900,56 @@ describe('ActivityReportNavigator goals page saves', () => {
       expect(defaultProps.onSave).toHaveBeenCalled();
     });
 
+    // The goal form fields are cleared as part of the single reset() payload
+    // (not via post-reset setValue calls) so the read-only goals list renders
+    // consistently in one pass.
     await waitFor(() => {
-      expect(hookForm.setValue).toHaveBeenCalledWith('goalName', '');
+      expect(hookForm.reset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          goalForEditing: '',
+          goalName: '',
+          goalEndDate: '',
+          goalPrompts: [],
+        })
+      );
+    });
+  });
+
+  it('folds a backend-split goalForEditing into the goals list when closing the form', async () => {
+    const hookForm = createMockHookForm({
+      goalForEditing: { id: 7, name: 'Goal', originalIndex: 1 },
+      values: { goalPrompts: [] },
+      formState: { isDirty: true, errors: {} },
+    });
+
+    // Backend still reports the just-saved goal as actively edited, so onSave
+    // returns it split out into goalForEditing with the goals array missing it.
+    // Because "Save goal" closes the form, the goal must be folded back into
+    // goals at its original index so the read-only list renders it.
+    defaultProps.onSave.mockResolvedValue({
+      id: 1,
+      goals: [{ id: 5, name: 'Existing goal' }],
+      goalForEditing: { id: 7, name: 'Goal', originalIndex: 1 },
+    });
+
+    renderWithContext(hookForm);
+
+    const continueBtn = document.getElementById('draft-goals-objectives-save-continue');
+    fireEvent.click(continueBtn);
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalled();
+    });
+
+    // reset() alone does not propagate to the useController-bound `goals` field,
+    // so the handler also calls setValue('goals', ...) with the folded goal at its
+    // original index to force the read-only list to render it.
+    await waitFor(() => {
+      expect(hookForm.setValue).toHaveBeenCalledWith('goals', [
+        { id: 5, name: 'Existing goal' },
+        { id: 7, name: 'Goal', originalIndex: 1 },
+      ]);
       expect(hookForm.setValue).toHaveBeenCalledWith('goalForEditing', '');
-      expect(hookForm.reset).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
+++ b/frontend/src/pages/ActivityReport/__tests__/formDataHelpers.js
@@ -529,6 +529,36 @@ describe('FormDataHelpers', () => {
       });
     });
 
+    it('keeps an actively-edited goal in the goals list when the report status does not allow goal editing', () => {
+      // Regression: when an approved report is re-saved, the goal's isActivelyEdited
+      // flag can still be set. If we default the status to DRAFT (an allowed editing
+      // status), the goal is wrongly routed into goalForEditing, leaving the goals
+      // array empty and the read-only list blank until a full refresh. Passing the
+      // real (non-editing) status keeps the goal in the read-only goals list.
+      const { goals, goalForEditing } = convertGoalsToFormData(
+        [
+          {
+            id: 1,
+            objectives: [],
+            activityReportGoals: [{ id: 1, isActivelyEdited: true }],
+          },
+        ],
+        [1],
+        REPORT_STATUSES.APPROVED
+      );
+
+      expect(goalForEditing).toBeNull();
+      expect(goals).toEqual([
+        {
+          id: 1,
+          grantIds: [1],
+          prompts: [],
+          objectives: [],
+          activityReportGoals: [{ id: 1, isActivelyEdited: true }],
+        },
+      ]);
+    });
+
     it('keeps useIpdCourses true even when there are no courses', () => {
       const { goalForEditing } = convertGoalsToFormData(
         [

--- a/frontend/src/pages/ActivityReport/index.js
+++ b/frontend/src/pages/ActivityReport/index.js
@@ -559,10 +559,21 @@ function ActivityReport({ match, location, region }) {
       let reportData = updatedReport;
 
       // format the goals and objectives appropriately, as well as divide them
-      // by which one is open and which one is not
+      // by which one is open and which one is not.
+      //
+      // We must pass calculatedStatus and goalOrder here (matching the new-report
+      // branch above and convertReportToFormData used on page refresh). Without
+      // calculatedStatus, it defaults to DRAFT, which is an allowed
+      // goal-editing status. A just-saved goal whose isActivelyEdited flag is still
+      // set then gets routed into goalForEditing (leaving the goals array empty),
+      // so the read-only goals list renders blank until a full page refresh runs
+      // the conversion with the real status. Passing the real status/order makes
+      // the post-save state identical to the refreshed state.
       const { goalForEditing, goals } = convertGoalsToFormData(
         updatedReport.goalsAndObjectives,
-        updatedReport.activityRecipients.map((r) => r.activityRecipientId)
+        updatedReport.activityRecipients.map((r) => r.activityRecipientId),
+        updatedReport.calculatedStatus,
+        updatedReport.goalOrder
       );
 
       reportData = {

--- a/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
+++ b/frontend/src/pages/RegionalDashboard/components/RecipientSpotlightCard.js
@@ -22,7 +22,8 @@ const INDICATOR_DETAILS = {
   },
   FEI: {
     label: 'FEI',
-    description: 'Recipient is currently in the Full Enrollment Initiative (FEI) including 6-month evaluation and designated chronically underenrolled (DCU) periods',
+    description:
+      'Recipient is currently in the Full Enrollment Initiative (FEI) including 6-month evaluation and designated chronically underenrolled (DCU) periods',
   },
   // Temporarily hidden - will be added back later
   // DRS: {

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -62,6 +62,7 @@ const createEmailSender = (transport = defaultTransport) => {
     send,
     transport,
     htmlToText: { wordwrap: 120 },
+    preview: false,
   });
 };
 
@@ -169,8 +170,13 @@ export const onCompletedNotification = (job, result) => {
 export const notifyChangesRequested = (job, transport = defaultTransport) => {
   if (process.env.SEND_NOTIFICATIONS !== 'true') return null;
 
-  const addresses = [];
-  const { report, approver, authorWithSetting, collabsWithSettings } = job.data;
+  const {
+    report,
+    approver,
+    authorWithSetting,
+    collabsWithSettings = [],
+    approversWithSettings = [],
+  } = job.data;
   const { id, displayId } = report;
   const approverEmail = approver.user.email;
   const approverName = approver.user.name;
@@ -180,28 +186,46 @@ export const notifyChangesRequested = (job, transport = defaultTransport) => {
   );
 
   const collabArray = collabsWithSettings.map((c) => c.user.email);
+  const approverArray = approversWithSettings.map((a) => a.user.email);
   const reportPath = `${process.env.TTA_SMART_HUB_URI}/activity-reports/${id}`;
+
+  const locals = {
+    managerName: approverName,
+    reportPath,
+    displayId,
+    comments: approverNote,
+  };
+
+  // The author and collaborators need to make changes and resubmit, while the
+  // remaining approvers need to review/approve, so each group gets its own template.
+  const authorCollabAddresses = [];
   if (authorWithSetting) {
-    addresses.push(authorWithSetting.email);
+    authorCollabAddresses.push(authorWithSetting.email);
   }
   if (collabArray && collabArray.length > 0) {
-    addresses.push(collabArray);
+    authorCollabAddresses.push(collabArray);
   }
 
-  return sendIfEnabled(addresses, (toEmails) =>
-    createEmailSender(transport).send({
-      template: path.resolve(emailTemplatePath, 'changes_requested_by_manager'),
-      message: {
-        to: toEmails,
-      },
-      locals: {
-        managerName: approverName,
-        reportPath,
-        displayId,
-        comments: approverNote,
-      },
-    })
-  );
+  return Promise.all([
+    sendIfEnabled(authorCollabAddresses, (toEmails) =>
+      createEmailSender(transport).send({
+        template: path.resolve(emailTemplatePath, 'changes_requested_by_manager'),
+        message: {
+          to: toEmails,
+        },
+        locals,
+      })
+    ),
+    sendIfEnabled(approverArray, (toEmails) =>
+      createEmailSender(transport).send({
+        template: path.resolve(emailTemplatePath, 'changes_requested_by_manager_approver'),
+        message: {
+          to: toEmails,
+        },
+        locals,
+      })
+    ),
+  ]);
 };
 
 /**
@@ -625,13 +649,15 @@ export const changesRequestedNotification = (
   report,
   approver,
   authorWithSetting,
-  collabsWithSettings
+  collabsWithSettings,
+  approversWithSettings
 ) => {
   enqueueNotification(EMAIL_ACTIONS.NEEDS_ACTION, {
     report,
     approver,
     authorWithSetting,
     collabsWithSettings,
+    approversWithSettings,
   });
 };
 

--- a/src/lib/mailer/index.test.js
+++ b/src/lib/mailer/index.test.js
@@ -374,47 +374,86 @@ describe('mailer tests', () => {
   });
 
   describe('Changes requested by manager', () => {
-    it('Tests that an email is sent', async () => {
+    it('Tests that separate emails are sent to author/collaborators and approvers', async () => {
       process.env.SEND_NOTIFICATIONS = 'true';
-      const email = await notifyChangesRequested(
+      const [authorCollabEmail, approverEmail] = await notifyChangesRequested(
         {
           data: {
             report: mockReport,
             approver: mockApprover,
             authorWithSetting: mockReport.author,
             collabsWithSettings: [mockCollaborator1, mockCollaborator2],
+            approversWithSettings: [mockApprover],
           },
         },
         jsonTransport
       );
-      expect(email.envelope.from).toBe(process.env.FROM_EMAIL_ADDRESS);
-      expect(email.envelope.to).toStrictEqual([
+
+      // Author and collaborators get the "make changes and resubmit" template.
+      expect(authorCollabEmail.envelope.from).toBe(process.env.FROM_EMAIL_ADDRESS);
+      expect(authorCollabEmail.envelope.to).toStrictEqual([
         mockAuthor.email,
         mockCollaborator1.user.email,
         mockCollaborator2.user.email,
       ]);
-      const message = JSON.parse(email.message);
-      expect(message.subject).toBe(`Activity Report ${mockReport.displayId}: Changes requested`);
-      expect(message.text).toContain(
+      const authorCollabMessage = JSON.parse(authorCollabEmail.message);
+      expect(authorCollabMessage.subject).toBe(
+        `Activity Report ${mockReport.displayId}: Changes requested`
+      );
+      expect(authorCollabMessage.text).toContain(
         `${mockManager.name} requested changes to report ${mockReport.displayId}.`
       );
-      expect(message.text).toContain(mockApprover.note);
-      expect(message.text).toContain(reportPath);
+      expect(authorCollabMessage.text).toContain('Make changes and resubmit this report');
+      expect(authorCollabMessage.text).toContain(mockApprover.note);
+      expect(authorCollabMessage.text).toContain(reportPath);
+
+      // Approvers get the separate "approve this report" template.
+      expect(approverEmail.envelope.to).toStrictEqual([mockApprover.user.email]);
+      const approverMessage = JSON.parse(approverEmail.message);
+      expect(approverMessage.subject).toBe(
+        `Activity Report ${mockReport.displayId}: Changes requested by ${mockManager.name}`
+      );
+      expect(approverMessage.text).toContain(
+        `${mockManager.name} requested changes to report ${mockReport.displayId}.`
+      );
+      expect(approverMessage.text).toContain('Approve this report');
+      expect(approverMessage.text).toContain(mockApprover.note);
+      expect(approverMessage.text).toContain(reportPath);
     });
     it('Tests that an email is not sent if no recipients', async () => {
       process.env.SEND_NOTIFICATIONS = 'true';
-      const email = await notifyChangesRequested(
+      const [authorCollabEmail, approverEmail] = await notifyChangesRequested(
         {
           data: {
             report: mockReport,
             approver: mockApprover,
             authorWithSetting: null,
             collabsWithSettings: [],
+            approversWithSettings: [],
           },
         },
         jsonTransport
       );
-      expect(email).toBe(null);
+      expect(authorCollabEmail).toBe(null);
+      expect(approverEmail).toBe(null);
+    });
+    it('Tests that an email is sent to approvers if no author or collaborators are recipients', async () => {
+      process.env.SEND_NOTIFICATIONS = 'true';
+      const [authorCollabEmail, approverEmail] = await notifyChangesRequested(
+        {
+          data: {
+            report: mockReport,
+            approver: mockApprover,
+            authorWithSetting: null,
+            collabsWithSettings: [],
+            approversWithSettings: [mockApprover],
+          },
+        },
+        jsonTransport
+      );
+
+      expect(authorCollabEmail).toBe(null);
+      expect(approverEmail.envelope.to).toStrictEqual([mockApprover.user.email]);
     });
     it('Tests that emails are not sent without SEND_NOTIFICATIONS', async () => {
       process.env.SEND_NOTIFICATIONS = 'false';
@@ -1558,8 +1597,17 @@ describe('mailer tests', () => {
     it('"changes requested" on the notificationQueue', async () => {
       const report = await ActivityReport.create(reportObject);
 
-      changesRequestedNotification(report, mockApprover, null, []);
-      expect(notificationQueueMock.add).toHaveBeenCalled();
+      changesRequestedNotification(report, mockApprover, null, [], [mockApprover]);
+      expect(notificationQueueMock.add).toHaveBeenCalledWith(
+        EMAIL_ACTIONS.NEEDS_ACTION,
+        expect.objectContaining({
+          report,
+          approver: mockApprover,
+          authorWithSetting: null,
+          collabsWithSettings: [],
+          approversWithSettings: [mockApprover],
+        })
+      );
     });
 
     it('"changes requested" which logs on error', async () => {

--- a/src/lib/mailer/logNotifications.js
+++ b/src/lib/mailer/logNotifications.js
@@ -21,11 +21,12 @@ export default async function logEmailNotification(job, success, result) {
   let newCollaborator;
   let newApprover;
   let collabArray;
+  let approverArray;
   let programSpecialists;
   let collaboratorEmailAddresses;
   const { data } = job;
-  const { report } = data;
-  const { author, activityReportCollaborators } = report;
+  const { report, approversWithSettings: approvers = [] } = data;
+  const { author, activityReportCollaborators = [] } = report;
 
   try {
     switch (job.name) {
@@ -41,7 +42,8 @@ export default async function logEmailNotification(job, success, result) {
         break;
       case EMAIL_ACTIONS.NEEDS_ACTION:
         collabArray = activityReportCollaborators.map((c) => c.user.email);
-        emailTo = [author ? author.email : '', ...collabArray];
+        approverArray = approvers.map((a) => a.user.email);
+        emailTo = [author ? author.email : '', ...collabArray, ...approverArray];
         template = path.resolve(emailTemplatePath, 'changes_requested_by_manager', 'subject.pug');
         break;
       case EMAIL_ACTIONS.APPROVED:

--- a/src/lib/mailer/logNotifications.test.js
+++ b/src/lib/mailer/logNotifications.test.js
@@ -31,6 +31,14 @@ describe('Email Notifications', () => {
           },
         ],
       },
+      approversWithSettings: [
+        {
+          user: {
+            email: 'mockApprover@test.gov',
+            name: 'Mock Approver',
+          },
+        },
+      ],
       newCollaborator: {
         email: 'mockNewCollaborator@test.gov',
         name: 'Mock New Collaborator',
@@ -174,6 +182,7 @@ describe('Email Notifications', () => {
         emailTo: [
           mockJob.data.report.author.email,
           mockJob.data.report.activityReportCollaborators[0].user.email,
+          mockJob.data.approversWithSettings[0].user.email,
         ],
         action: mockJob.name,
         subject: 'Activity Report AR-04-1235: Changes requested',
@@ -183,9 +192,10 @@ describe('Email Notifications', () => {
       });
       const mailerLog = await logEmailNotification(mockJob, success, result);
       expect(mailerLog).not.toBeNull();
-      expect(mailerLog.emailTo.length).toEqual(2);
+      expect(mailerLog.emailTo.length).toEqual(3);
       expect(mailerLog.emailTo[0]).toEqual('mockAuthor@test.gov');
       expect(mailerLog.emailTo[1]).toEqual('mockCollaborator@test.gov');
+      expect(mailerLog.emailTo[2]).toEqual('mockApprover@test.gov');
       expect(mailerLog.subject).toEqual('Activity Report AR-04-1235: Changes requested');
       expect(mailerLog.success).toEqual(false);
       expect(mailerLog.result).toEqual(result);
@@ -196,7 +206,11 @@ describe('Email Notifications', () => {
       mockJob.name = EMAIL_ACTIONS.NEEDS_ACTION;
       createMailerLogMock.mockResolvedValueOnce({
         jobId: mockJob.id,
-        emailTo: ['', mockJob.data.report.activityReportCollaborators[0].user.email],
+        emailTo: [
+          '',
+          mockJob.data.report.activityReportCollaborators[0].user.email,
+          mockJob.data.approversWithSettings[0].user.email,
+        ],
         action: mockJob.name,
         subject: 'Activity Report AR-04-1235: Changes requested',
         activityReports: [mockJob.data.report.id],
@@ -205,13 +219,72 @@ describe('Email Notifications', () => {
       });
       const mailerLog = await logEmailNotification(mockJob, success, result);
       expect(mailerLog).not.toBeNull();
-      expect(mailerLog.emailTo.length).toEqual(2);
+      expect(mailerLog.emailTo.length).toEqual(3);
       expect(mailerLog.emailTo[0]).toEqual('');
       expect(mailerLog.emailTo[1]).toEqual('mockCollaborator@test.gov');
+      expect(mailerLog.emailTo[2]).toEqual('mockApprover@test.gov');
       expect(mailerLog.subject).toEqual('Activity Report AR-04-1235: Changes requested');
       expect(mailerLog.success).toEqual(false);
       expect(mailerLog.result).toEqual(result);
       mockJob.data.report.author = auth;
+    });
+    it('orders needs action mailer log recipients as author, collaborators, then approvers', async () => {
+      mockJob.name = EMAIL_ACTIONS.NEEDS_ACTION;
+      const orderedJob = {
+        ...mockJob,
+        data: {
+          ...mockJob.data,
+          approversWithSettings: [
+            ...mockJob.data.approversWithSettings,
+            {
+              user: {
+                email: 'mockApprover2@test.gov',
+                name: 'Mock Approver 2',
+              },
+            },
+          ],
+          report: {
+            ...mockJob.data.report,
+            activityReportCollaborators: [
+              ...mockJob.data.report.activityReportCollaborators,
+              {
+                user: {
+                  email: 'mockCollaborator2@test.gov',
+                  name: 'Mock Collaborator 2',
+                },
+              },
+            ],
+          },
+        },
+      };
+      createMailerLogMock.mockResolvedValueOnce({
+        jobId: orderedJob.id,
+        emailTo: [
+          orderedJob.data.report.author.email,
+          orderedJob.data.report.activityReportCollaborators[0].user.email,
+          orderedJob.data.report.activityReportCollaborators[1].user.email,
+          orderedJob.data.approversWithSettings[0].user.email,
+          orderedJob.data.approversWithSettings[1].user.email,
+        ],
+        action: orderedJob.name,
+        subject: 'Activity Report AR-04-1235: Changes requested',
+        activityReports: [orderedJob.data.report.id],
+        success,
+        result,
+      });
+      const mailerLog = await logEmailNotification(orderedJob, success, result);
+      expect(mailerLog).not.toBeNull();
+      expect(createMailerLogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailTo: [
+            'mockAuthor@test.gov',
+            'mockCollaborator@test.gov',
+            'mockCollaborator2@test.gov',
+            'mockApprover@test.gov',
+            'mockApprover2@test.gov',
+          ],
+        })
+      );
     });
     it('create a mailer log entry for an approved report', async () => {
       mockJob.name = EMAIL_ACTIONS.APPROVED;

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -397,7 +397,8 @@ export async function getGroups(req, res) {
  * @returns {Promise<Array>} - an array containing an author and collaborators that subscribe
  */
 async function checkEmailSettings(report, setting) {
-  const { author, activityReportCollaborators } = report;
+  const { author, activityReportCollaborators, approvers } = report;
+  const shouldCheckApprovers = setting === USER_SETTINGS.EMAIL.KEYS.CHANGE_REQUESTED;
 
   const settingForAuthor = author ? await userSettingOverridesById(author.id, setting) : null;
 
@@ -420,6 +421,21 @@ async function checkEmailSettings(report, setting) {
         return settingsForAllCollabs[index].value === USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY;
       })
     : [];
+
+  const settingForApprovers =
+    shouldCheckApprovers && approvers
+      ? await Promise.all(approvers.map((a) => userSettingOverridesById(a.user.id, setting)))
+      : [];
+
+  const approversWithSettings =
+    shouldCheckApprovers && approvers
+      ? approvers.filter((_value, index) => {
+          if (!settingForApprovers[index]) {
+            return false;
+          }
+          return settingForApprovers[index].value === USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY;
+        })
+      : [];
 
   // FIXME: This should be temporary until we have a solid relationship between
   // program specialists and grants.
@@ -460,7 +476,12 @@ async function checkEmailSettings(report, setting) {
     programSpecialistsToNotify.map(async (ps) => userById(ps.id))
   );
 
-  return [authorWithSetting, collabsWithSettings, programSpecialistsToNotify];
+  return [
+    authorWithSetting,
+    collabsWithSettings,
+    programSpecialistsToNotify,
+    approversWithSettings,
+  ];
 }
 /**
  * Review a report, setting Approver status to approved or needs action
@@ -517,15 +538,16 @@ export async function reviewReport(req, res) {
     }
 
     if (reviewedReport.calculatedStatus === REPORT_STATUSES.NEEDS_ACTION) {
-      const [authorWithSetting, collabsWithSettings] = await checkEmailSettings(
-        reviewedReport,
-        USER_SETTINGS.EMAIL.KEYS.CHANGE_REQUESTED
-      );
+      const [authorWithSetting, collabsWithSettings, , approversWithSettings] =
+        await checkEmailSettings(reviewedReport, USER_SETTINGS.EMAIL.KEYS.CHANGE_REQUESTED);
+
       changesRequestedNotification(
         reviewedReport,
         savedApprover,
         authorWithSetting,
-        collabsWithSettings
+        collabsWithSettings,
+        // approvers, minus the approver whose review triggered this workflow
+        approversWithSettings.filter((a) => a.user.id !== userId)
       );
     }
 

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -1,5 +1,6 @@
 import { APPROVER_STATUSES, DECIMAL_BASE, REPORT_STATUSES } from '@ttahub/common';
 import stringify from 'csv-stringify/lib/sync';
+import { uniq } from 'lodash';
 import { QueryTypes } from 'sequelize';
 import { EMAIL_ACTIONS, USER_SETTINGS } from '../../constants';
 import { goalsForGrants, setActivityReportGoalAsActivelyEdited } from '../../goalServices/goals';
@@ -552,11 +553,7 @@ export async function reviewReport(req, res) {
     }
 
     if (status === REPORT_STATUSES.NEEDS_ACTION) {
-      const {
-        author,
-        // activityReportCollaborators,
-        // approvers
-      } = reviewedReport;
+      const { author, activityReportCollaborators, approvers } = reviewedReport;
 
       // add in-app notification
       // - for creator
@@ -566,29 +563,22 @@ export async function reviewReport(req, res) {
         approver: savedApprover,
       });
 
-      // - for collaborators
-      // await Promise.all(
-      //   activityReportCollaborators.map((collab) =>
-      //     createChangesRequestedNotification({ userId: collab.user.id }, 'collaborator', {
-      //       ...reviewedReport.toJSON(),
-      //       activityRecipients,
-      //       approver: savedApprover,
-      //     })
-      //   )
-      // );
-
-      // - for approvers, excluding the one who just reviewed
-      // await Promise.all(
-      //   approvers
-      //     .filter((approver) => approver.user.id !== userId)
-      //     .map((approver) =>
-      //       createChangesRequestedNotification({ userId: approver.user.id }, 'approver', {
-      //         ...reviewedReport.toJSON(),
-      //         activityRecipients,
-      //         approver: savedApprover,
-      //       })
-      //     )
-      // );
+      await Promise.all(
+        uniq([
+          // - for approvers, excluding the one who just reviewed
+          ...approvers.map((approver) => approver.user.id),
+          // - for collaborators
+          ...activityReportCollaborators.map((collab) => collab.user.id),
+        ])
+          .filter((id) => id !== userId)
+          .map((id) =>
+            createChangesRequestedNotification({ userId: id }, 'approver', {
+              ...reviewedReport.toJSON(),
+              activityRecipients,
+              approver: savedApprover,
+            })
+          )
+      );
     }
 
     res.json(savedApprover);

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -372,6 +372,20 @@ describe('Activity Report handlers', () => {
               },
             },
           ],
+          approvers: [
+            {
+              user: {
+                id: mockRequest.session.userId,
+                email: 'reviewing.approver@tta.gov',
+              },
+            },
+            {
+              user: {
+                id: secondMockManager.id,
+                email: 'other.approver@tta.gov',
+              },
+            },
+          ],
           id: 999999,
           toJSON: () => ({
             id: 999999,
@@ -405,6 +419,20 @@ describe('Activity Report handlers', () => {
       await reviewReport(needsActionReportRequest, mockResponse);
       expect(mockResponse.json).toHaveBeenCalledWith(mockApproverRecord);
       expect(changesRequestedNotification).toHaveBeenCalled();
+      expect(changesRequestedNotification).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        [
+          {
+            user: {
+              id: secondMockManager.id,
+              email: 'other.approver@tta.gov',
+            },
+          },
+        ]
+      );
       expect(createNotification).toHaveBeenCalledTimes(1);
       expect(createNotification).toHaveBeenNthCalledWith(
         1,
@@ -420,6 +448,89 @@ describe('Activity Report handlers', () => {
           },
           skipExisting: 'archived',
         }
+      );
+    });
+    it('excludes approvers with non-immediate change requested email settings', async () => {
+      const mockApproverRecord = {
+        id: 1,
+        userId: needsActionReportRequest.session.userId,
+        activityReportId: needsActionReportRequest.params.activityReportId,
+        status: needsActionReportRequest.body.status,
+        note: needsActionReportRequest.body.note,
+        user: {
+          name: 'Approver Name',
+        },
+      };
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          calculatedStatus: REPORT_STATUSES.NEEDS_ACTION,
+          activityRecipientType: 'recipient',
+          displayId: 'R01-AR-999999',
+          author: {
+            id: 777,
+          },
+          activityReportCollaborators: [],
+          approvers: [
+            {
+              user: {
+                id: mockRequest.session.userId,
+                email: 'reviewing.approver@tta.gov',
+              },
+            },
+            {
+              user: {
+                id: secondMockManager.id,
+                email: 'other.approver@tta.gov',
+              },
+            },
+          ],
+          id: 999999,
+          toJSON: () => ({
+            id: 999999,
+            displayId: 'R01-AR-999999',
+          }),
+        },
+        [
+          {
+            name: 'Recipient A',
+          },
+          {
+            name: 'Recipient B',
+          },
+        ],
+      ]);
+
+      ActivityReport.mockImplementationOnce(() => ({
+        canReview: () => true,
+      }));
+
+      upsertApprover.mockResolvedValue(mockApproverRecord);
+      const changesRequestedNotification = jest
+        .spyOn(mailer, 'changesRequestedNotification')
+        .mockImplementation();
+
+      userSettingOverridesById.mockImplementation((userId, key) => {
+        if (key === USER_SETTINGS.EMAIL.KEYS.CHANGE_REQUESTED && userId === secondMockManager.id) {
+          return Promise.resolve({
+            key: USER_SETTINGS.EMAIL.KEYS.CHANGE_REQUESTED,
+            value: USER_SETTINGS.EMAIL.VALUES.NEVER,
+          });
+        }
+        return Promise.resolve({
+          key,
+          value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
+        });
+      });
+
+      await reviewReport(needsActionReportRequest, mockResponse);
+
+      expect(mockResponse.json).toHaveBeenCalledWith(mockApproverRecord);
+      expect(changesRequestedNotification).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        []
       );
     });
     it('sends the in-app needs action notification when an approver requests changes but the report is not yet in needs action status', async () => {

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -419,6 +419,7 @@ describe('Activity Report handlers', () => {
       await reviewReport(needsActionReportRequest, mockResponse);
       expect(mockResponse.json).toHaveBeenCalledWith(mockApproverRecord);
       expect(changesRequestedNotification).toHaveBeenCalled();
+      expect(createNotification).toHaveBeenCalledTimes(4);
       expect(changesRequestedNotification).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
@@ -433,12 +434,146 @@ describe('Activity Report handlers', () => {
           },
         ]
       );
-      expect(createNotification).toHaveBeenCalledTimes(1);
       expect(createNotification).toHaveBeenNthCalledWith(
         1,
         777,
         999999,
         NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+      expect(createNotification).toHaveBeenNthCalledWith(
+        2,
+        secondMockManager.id,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+      expect(createNotification).toHaveBeenNthCalledWith(
+        3,
+        888,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+      expect(createNotification).toHaveBeenNthCalledWith(
+        4,
+        889,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+    });
+    it('deduplicates the in-app needs-action notification for a user who is both an approver and a collaborator', async () => {
+      const mockApproverRecord = {
+        id: 1,
+        userId: needsActionReportRequest.session.userId,
+        activityReportId: needsActionReportRequest.params.activityReportId,
+        status: needsActionReportRequest.body.status,
+        note: needsActionReportRequest.body.note,
+        user: {
+          name: 'Approver Name',
+        },
+      };
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          calculatedStatus: REPORT_STATUSES.NEEDS_ACTION,
+          activityRecipientType: 'recipient',
+          displayId: 'R01-AR-999999',
+          author: {
+            id: 777,
+          },
+          // 888 is both a collaborator and a (non-reviewing) approver.
+          activityReportCollaborators: [
+            {
+              user: {
+                id: 888,
+              },
+            },
+          ],
+          approvers: [
+            {
+              user: {
+                id: 1,
+              },
+            },
+            {
+              user: {
+                id: 888,
+              },
+            },
+          ],
+          id: 999999,
+          toJSON: () => ({
+            id: 999999,
+            displayId: 'R01-AR-999999',
+          }),
+        },
+        [
+          {
+            name: 'Recipient A',
+          },
+          {
+            name: 'Recipient B',
+          },
+        ],
+      ]);
+
+      ActivityReport.mockImplementationOnce(() => ({
+        canReview: () => true,
+      }));
+
+      upsertApprover.mockResolvedValue(mockApproverRecord);
+      jest.spyOn(mailer, 'changesRequestedNotification').mockImplementation();
+
+      userSettingOverridesById.mockResolvedValue({
+        key: USER_SETTINGS.EMAIL.KEYS.NEEDS_ACTION,
+        value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
+      });
+
+      await reviewReport(needsActionReportRequest, mockResponse);
+
+      // creator (777) + a single notification for user 888 (deduped), reviewer (1) excluded.
+      expect(createNotification).toHaveBeenCalledTimes(2);
+      const notificationsFor888 = createNotification.mock.calls.filter(
+        ([recipientId]) => recipientId === 888
+      );
+      expect(notificationsFor888).toHaveLength(1);
+      expect(createNotification).toHaveBeenCalledWith(
+        888,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
         {
           metadata: {
             id: 999999,
@@ -557,6 +692,18 @@ describe('Activity Report handlers', () => {
             id: 777,
           },
           activityReportCollaborators: [],
+          approvers: [
+            {
+              user: {
+                id: 1,
+              },
+            },
+            {
+              user: {
+                id: 890,
+              },
+            },
+          ],
           id: 999999,
           toJSON: () => ({
             id: 999999,
@@ -592,8 +739,8 @@ describe('Activity Report handlers', () => {
       expect(mockResponse.json).toHaveBeenCalledWith(mockApproverRecord);
       // Email keyed off calculatedStatus (SUBMITTED) should not fire.
       expect(changesRequestedNotification).not.toHaveBeenCalled();
-      // In-app notification keyed off the approver's status should fire.
-      expect(createNotification).toHaveBeenCalledTimes(1);
+      // In-app notifications keyed off the approver's status should fire.
+      expect(createNotification).toHaveBeenCalledTimes(2);
       expect(createNotification).toHaveBeenNthCalledWith(
         1,
         777,
@@ -609,6 +756,251 @@ describe('Activity Report handlers', () => {
           skipExisting: 'archived',
         }
       );
+      expect(createNotification).toHaveBeenNthCalledWith(
+        2,
+        890,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+    });
+    it('sends collaborator-type in-app needs-action notifications to collaborators', async () => {
+      const mockApproverRecord = {
+        id: 1,
+        userId: needsActionReportRequest.session.userId,
+        activityReportId: needsActionReportRequest.params.activityReportId,
+        status: needsActionReportRequest.body.status,
+        note: needsActionReportRequest.body.note,
+        user: {
+          name: 'Approver Name',
+        },
+      };
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          calculatedStatus: REPORT_STATUSES.NEEDS_ACTION,
+          activityRecipientType: 'recipient',
+          displayId: 'R01-AR-999999',
+          author: {
+            id: 777,
+          },
+          activityReportCollaborators: [
+            {
+              user: {
+                id: 888,
+              },
+            },
+            {
+              user: {
+                id: 889,
+              },
+            },
+          ],
+          approvers: [
+            {
+              user: {
+                id: 1,
+              },
+            },
+          ],
+          id: 999999,
+          toJSON: () => ({
+            id: 999999,
+            displayId: 'R01-AR-999999',
+          }),
+        },
+        [
+          {
+            name: 'Recipient A',
+          },
+          {
+            name: 'Recipient B',
+          },
+        ],
+      ]);
+
+      ActivityReport.mockImplementationOnce(() => ({
+        canReview: () => true,
+      }));
+
+      upsertApprover.mockResolvedValue(mockApproverRecord);
+      userSettingOverridesById.mockResolvedValue({
+        key: USER_SETTINGS.EMAIL.KEYS.NEEDS_ACTION,
+        value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
+      });
+
+      await reviewReport(needsActionReportRequest, mockResponse);
+
+      expect(createNotification).toHaveBeenCalledTimes(3);
+      expect(createNotification).toHaveBeenCalledWith(
+        888,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+      expect(createNotification).toHaveBeenCalledWith(
+        889,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+    });
+    it('sends collaborator-type in-app needs-action notifications to non-reviewing approvers', async () => {
+      const mockApproverRecord = {
+        id: 1,
+        userId: needsActionReportRequest.session.userId,
+        activityReportId: needsActionReportRequest.params.activityReportId,
+        status: needsActionReportRequest.body.status,
+        note: needsActionReportRequest.body.note,
+        user: {
+          name: 'Approver Name',
+        },
+      };
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          calculatedStatus: REPORT_STATUSES.SUBMITTED,
+          activityRecipientType: 'recipient',
+          displayId: 'R01-AR-999999',
+          author: {
+            id: 777,
+          },
+          activityReportCollaborators: [],
+          approvers: [{ user: { id: 1 } }, { user: { id: 890 } }],
+          id: 999999,
+          toJSON: () => ({
+            id: 999999,
+            displayId: 'R01-AR-999999',
+          }),
+        },
+        [{ name: 'Recipient A' }, { name: 'Recipient B' }],
+      ]);
+      ActivityReport.mockImplementationOnce(() => ({
+        canReview: () => true,
+      }));
+      upsertApprover.mockResolvedValue(mockApproverRecord);
+
+      await reviewReport(needsActionReportRequest, mockResponse);
+
+      expect(createNotification).toHaveBeenCalledWith(
+        890,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        {
+          metadata: {
+            id: 999999,
+            displayId: 'R01-AR-999999',
+            recipientName: 'Recipient A, Recipient B',
+            approver: 'Approver Name',
+          },
+          skipExisting: 'archived',
+        }
+      );
+    });
+    it('excludes the reviewing approver (userId 1) from needs-action in-app notifications', async () => {
+      const mockApproverRecord = {
+        id: 1,
+        userId: needsActionReportRequest.session.userId,
+        activityReportId: needsActionReportRequest.params.activityReportId,
+        status: needsActionReportRequest.body.status,
+        note: needsActionReportRequest.body.note,
+        user: {
+          name: 'Approver Name',
+        },
+      };
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          calculatedStatus: REPORT_STATUSES.SUBMITTED,
+          activityRecipientType: 'recipient',
+          displayId: 'R01-AR-999999',
+          author: {
+            id: 777,
+          },
+          activityReportCollaborators: [],
+          approvers: [{ user: { id: 1 } }],
+          id: 999999,
+          toJSON: () => ({
+            id: 999999,
+            displayId: 'R01-AR-999999',
+          }),
+        },
+        [{ name: 'Recipient A' }],
+      ]);
+      ActivityReport.mockImplementationOnce(() => ({
+        canReview: () => true,
+      }));
+      upsertApprover.mockResolvedValue(mockApproverRecord);
+
+      await reviewReport(needsActionReportRequest, mockResponse);
+
+      expect(createNotification).toHaveBeenCalledTimes(1);
+      expect(createNotification).not.toHaveBeenCalledWith(
+        1,
+        999999,
+        NOTIFICATION_TYPES.ACTIVITY_REPORT_NEEDS_ACTION_COLLABORATOR,
+        expect.anything()
+      );
+    });
+    it('does not create in-app needs-action notifications when activity recipients are empty', async () => {
+      const mockApproverRecord = {
+        id: 1,
+        userId: needsActionReportRequest.session.userId,
+        activityReportId: needsActionReportRequest.params.activityReportId,
+        status: needsActionReportRequest.body.status,
+        note: needsActionReportRequest.body.note,
+        user: {
+          name: 'Approver Name',
+        },
+      };
+      activityReportAndRecipientsById.mockResolvedValue([
+        {
+          calculatedStatus: REPORT_STATUSES.SUBMITTED,
+          activityRecipientType: 'recipient',
+          displayId: 'R01-AR-999999',
+          author: {
+            id: 777,
+          },
+          activityReportCollaborators: [{ user: { id: 888 } }],
+          approvers: [{ user: { id: 889 } }],
+          id: 999999,
+          toJSON: () => ({
+            id: 999999,
+            displayId: 'R01-AR-999999',
+          }),
+        },
+        [],
+      ]);
+      ActivityReport.mockImplementationOnce(() => ({
+        canReview: () => true,
+      }));
+      upsertApprover.mockResolvedValue(mockApproverRecord);
+
+      await reviewReport(needsActionReportRequest, mockResponse);
+
+      expect(mockResponse.json).toHaveBeenCalledWith(mockApproverRecord);
+      expect(createNotification).not.toHaveBeenCalled();
     });
     it('handles unauthorizedRequests', async () => {
       activityReportAndRecipientsById.mockResolvedValue([

--- a/src/services/activityReports.js
+++ b/src/services/activityReports.js
@@ -453,7 +453,7 @@ export async function activityReportAndRecipientsById(activityReportId) {
           {
             model: User,
             as: 'user',
-            attributes: ['id', 'name', 'fullName'],
+            attributes: ['id', 'name', 'fullName', 'email'],
             include: [
               {
                 model: Role,

--- a/src/services/notifications/index.test.js
+++ b/src/services/notifications/index.test.js
@@ -1,5 +1,9 @@
 import faker from '@faker-js/faker';
-import { ACTIVITY_REPORT_NOTIFICATION_TYPES, NOTIFICATION_TYPES } from '../../constants';
+import {
+  ACTIVITY_REPORT_NOTIFICATION_TYPES,
+  NOTIFICATION_CONFIGURATION,
+  NOTIFICATION_TYPES,
+} from '../../constants';
 import db from '../../models';
 import {
   archiveNotificationsByEntityAndType,
@@ -40,6 +44,10 @@ describe('Notification service', () => {
     userName: faker.name.findName(),
     date: '01/15/2026 12:00 PM ET',
   };
+
+  // Derives the exact text createNotification will generate for a given type/metadata,
+  // so seeded "existing" notifications match the text qualifier used by the dedup lookup.
+  const notificationTextFor = (type, metadata) => NOTIFICATION_CONFIGURATION[type].textFn(metadata);
 
   const trackNotification = (notification) => {
     createdNotificationIds.push(notification.id);
@@ -217,6 +225,7 @@ describe('Notification service', () => {
           userId: user.id,
           entityId: metadata.id,
           type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          text: notificationTextFor(NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED, metadata),
         });
 
         const result = await createNotification(
@@ -245,6 +254,7 @@ describe('Notification service', () => {
           userId: user.id,
           entityId: metadata.id,
           type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          text: notificationTextFor(NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED, metadata),
         });
         await NotificationUserState.create({
           notificationId: existing.id,
@@ -268,6 +278,40 @@ describe('Notification service', () => {
           },
         });
         expect(count).toBe(1);
+      });
+
+      it('creates a new notification when an existing one has different text', async () => {
+        const metadata = activityMetadata();
+        await createTrackedActivityReport({ id: metadata.id });
+
+        const existing = await createTrackedNotification({
+          userId: user.id,
+          entityId: metadata.id,
+          type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          text: 'Some stale, mismatched notification text.',
+        });
+
+        const result = trackNotification(
+          await createNotification(
+            user.id,
+            metadata.id,
+            NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+            { metadata }
+          )
+        );
+
+        expect(result.id).not.toBe(existing.id);
+        expect(result.text).toBe(
+          notificationTextFor(NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED, metadata)
+        );
+        const count = await Notification.count({
+          where: {
+            userId: user.id,
+            entityId: metadata.id,
+            type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+          },
+        });
+        expect(count).toBe(2);
       });
 
       describe('skipExisting option', () => {
@@ -314,6 +358,7 @@ describe('Notification service', () => {
             userId: user.id,
             entityId: metadata.id,
             type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+            text: notificationTextFor(NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED, metadata),
           });
           await NotificationUserState.create({
             notificationId: existing.id,
@@ -347,6 +392,7 @@ describe('Notification service', () => {
             userId: user.id,
             entityId: metadata.id,
             type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+            text: notificationTextFor(NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED, metadata),
           });
 
           const result = await createNotification(
@@ -375,6 +421,7 @@ describe('Notification service', () => {
             userId: user.id,
             entityId: metadata.id,
             type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+            text: notificationTextFor(NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED, metadata),
           });
           await NotificationUserState.create({
             notificationId: existing.id,
@@ -398,6 +445,45 @@ describe('Notification service', () => {
             },
           });
           expect(count).toBe(1);
+        });
+
+        it('creates a new notification when an existing non-archived one has different text', async () => {
+          const metadata = activityMetadata();
+          await createTrackedActivityReport({ id: metadata.id });
+
+          const existing = await createTrackedNotification({
+            userId: user.id,
+            entityId: metadata.id,
+            type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+            text: 'Some stale, mismatched notification text.',
+          });
+          await NotificationUserState.create({
+            notificationId: existing.id,
+            userId: user.id,
+            archivedAt: null,
+          });
+
+          const result = trackNotification(
+            await createNotification(
+              user.id,
+              metadata.id,
+              NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+              { metadata, skipExisting: 'archived' }
+            )
+          );
+
+          expect(result.id).not.toBe(existing.id);
+          expect(result.text).toBe(
+            notificationTextFor(NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED, metadata)
+          );
+          const count = await Notification.count({
+            where: {
+              userId: user.id,
+              entityId: metadata.id,
+              type: NOTIFICATION_TYPES.ACTIVITY_REPORT_SUBMITTED,
+            },
+          });
+          expect(count).toBe(2);
         });
       });
     });

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -124,6 +124,7 @@ async function createNotification(
         [Op.and]: [
           {
             userId,
+            text: notificationText,
             type: notificationType,
             entityId,
           },
@@ -146,6 +147,7 @@ async function createNotification(
     existing = await Notification.findOne({
       where: {
         userId,
+        text: notificationText,
         type: notificationType,
         entityId,
       },

--- a/tests/e2e/activity-report.spec.ts
+++ b/tests/e2e/activity-report.spec.ts
@@ -250,6 +250,13 @@ test.describe('Activity Report', () => {
 
     expect(arNumber).toBeTruthy();
 
+    // Regression guard (PR #3099): after clicking "Save goal" the read-only goal
+    // view must render immediately, without needing a page refresh. Assert the
+    // saved goal card and its objective are visible before adding another goal.
+    await expect(page.getByRole('heading', { name: 'Recipient TTA goal' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Objective summary' })).toBeVisible();
+    await expect(page.getByText('g1o1', { exact: true })).toBeVisible();
+
     // create the second goal
     await page.getByRole('button', { name: 'Add new goal' }).click();
 


### PR DESCRIPTION
## Description of change

Fix bug where read only goals were not displaying on an AR when the goal is new
Add in-app "Approver has requested changes" notification for collaborators and other approvers
Add an email notification matching existing ones for collaborators, authors of activity reports when a report is marked needs action

## How to test

Test that a new goal appears in the grey box on the activity report (instead of an empty section)
Use impersonation to confirm the notification is sent when a report is set to needs action
Make sure it is disposed of properly via report lifecycle events (resubmission, approval)

Create a report with two approvers
Make sure that one approver can receive emails and has the notification preference set to deliver immediately (use the -new notification preferences screen)
Submit the report as needs action as the other approver
The approver who did not review, the one who is set up to receive emails, should receive the notification

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5569
* https://jira.acf.gov/browse/TTAHUB-5567
* https://jira.acf.gov/browse/TTAHUB-5570
* https://jira.acf.gov/browse/TTAHUB-5510

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [x] UI review complete
- [x] QA review complete

### Before merge to main

- [x] OHS demo complete
- [x] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [x] Staging smoke test completed
- [x] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [x] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
