### PR TITLE
[TTAHUB-5672] Protect recipient goal fetches by goal region access

### DIFF
--- a/src/goalServices/goalsByIdAndRecipient.test.ts
+++ b/src/goalServices/goalsByIdAndRecipient.test.ts
@@ -1,0 +1,102 @@
+import { GOAL_STATUS } from '../constants';
+import db from '../models';
+import { createGoal, createGrant, createRecipient } from '../testUtils';
+import { goalRegionIdsByIdAndRecipient } from './goalsByIdAndRecipient';
+
+const { Goal, Grant, Recipient, sequelize } = db;
+
+describe('goalRegionIdsByIdAndRecipient', () => {
+  let firstRecipient;
+  let secondRecipient;
+  let firstGrant;
+  let secondGrant;
+  let firstGoal;
+  let secondGoal;
+  let otherRecipientGoal;
+
+  beforeAll(async () => {
+    firstRecipient = await createRecipient({});
+    secondRecipient = await createRecipient({});
+
+    firstGrant = await createGrant({
+      recipientId: firstRecipient.id,
+      regionId: 1,
+    });
+
+    secondGrant = await createGrant({
+      recipientId: firstRecipient.id,
+      regionId: 2,
+    });
+
+    const otherRecipientGrant = await createGrant({
+      recipientId: secondRecipient.id,
+      regionId: 3,
+    });
+
+    firstGoal = await createGoal({
+      grantId: firstGrant.id,
+      status: GOAL_STATUS.IN_PROGRESS,
+    });
+
+    secondGoal = await createGoal({
+      grantId: secondGrant.id,
+      status: GOAL_STATUS.IN_PROGRESS,
+    });
+
+    otherRecipientGoal = await createGoal({
+      grantId: otherRecipientGrant.id,
+      status: GOAL_STATUS.IN_PROGRESS,
+    });
+  });
+
+  afterAll(async () => {
+    await Goal.destroy({
+      where: {
+        id: [firstGoal.id, secondGoal.id, otherRecipientGoal.id],
+      },
+      force: true,
+      individualHooks: true,
+    });
+
+    await Grant.destroy({
+      where: {
+        id: [firstGrant.id, secondGrant.id, otherRecipientGoal.grantId],
+      },
+      individualHooks: true,
+    });
+
+    await Recipient.destroy({
+      where: {
+        id: [firstRecipient.id, secondRecipient.id],
+      },
+      individualHooks: true,
+    });
+
+    await sequelize.close();
+  });
+
+  it('returns region ids only for matching goals owned by the requested recipient', async () => {
+    const regionIds = await goalRegionIdsByIdAndRecipient(
+      [firstGoal.id, secondGoal.id, otherRecipientGoal.id],
+      firstRecipient.id
+    );
+
+    expect(regionIds.sort()).toEqual([1, 2]);
+  });
+
+  it('accepts a single goal id', async () => {
+    const regionIds = await goalRegionIdsByIdAndRecipient(firstGoal.id, firstRecipient.id);
+
+    expect(regionIds).toEqual([1]);
+  });
+
+  it('returns an empty array without querying when no goal ids are provided', async () => {
+    const findAllSpy = jest.spyOn(Goal, 'findAll');
+
+    const regionIds = await goalRegionIdsByIdAndRecipient([], firstRecipient.id);
+
+    expect(regionIds).toEqual([]);
+    expect(findAllSpy).not.toHaveBeenCalled();
+    findAllSpy.mockRestore();
+  });
+});

--- a/src/goalServices/goalsByIdAndRecipient.ts
+++ b/src/goalServices/goalsByIdAndRecipient.ts
@@ -41,6 +41,10 @@ export const OBJECTIVE_ATTRIBUTES_TO_QUERY_ON_RTR = [
 ];
 
 export async function goalRegionIdsByIdAndRecipient(ids: number | number[], recipientId: number) {
+  if (Array.isArray(ids) && !ids.length) {
+    return [];
+  }
+
   const goals = await Goal.findAll({
     attributes: ['id'],
     where: {

--- a/src/goalServices/goalsByIdAndRecipient.ts
+++ b/src/goalServices/goalsByIdAndRecipient.ts
@@ -40,6 +40,28 @@ export const OBJECTIVE_ATTRIBUTES_TO_QUERY_ON_RTR = [
   'rtrOrder',
 ];
 
+export async function goalRegionIdsByIdAndRecipient(ids: number | number[], recipientId: number) {
+  const goals = await Goal.findAll({
+    attributes: ['id'],
+    where: {
+      id: ids,
+    },
+    include: [
+      {
+        model: Grant,
+        as: 'grant',
+        attributes: ['regionId'],
+        required: true,
+        where: {
+          recipientId,
+        },
+      },
+    ],
+  });
+
+  return goals.map((goal) => Number(goal.grant.regionId));
+}
+
 const OPTIONS_FOR_GOAL_FORM_QUERY = (id: number[] | number, recipientId: number) => ({
   attributes: [
     'name',

--- a/src/routes/recipient/handlers.js
+++ b/src/routes/recipient/handlers.js
@@ -1,5 +1,7 @@
 import httpCodes from 'http-codes';
-import goalsByIdAndRecipient from '../../goalServices/goalsByIdAndRecipient';
+import goalsByIdAndRecipient, {
+  goalRegionIdsByIdAndRecipient,
+} from '../../goalServices/goalsByIdAndRecipient';
 import handleErrors from '../../lib/apiErrorHandler';
 import Recipient from '../../policies/recipient';
 import Users from '../../policies/user';
@@ -16,7 +18,10 @@ import {
 } from '../../services/recipient';
 import { standardGoalsForRecipient } from '../../services/standardGoals';
 import { userById } from '../../services/users';
-import { checkRecipientAccessAndExistence as checkAccessAndExistence } from '../utils';
+import {
+  checkRecipientAccessAndExistence as checkAccessAndExistence,
+  checkUserRegionAccess,
+} from '../utils';
 
 const namespace = 'SERVICE:RECIPIENT';
 
@@ -29,10 +34,24 @@ export async function getGoalsByIdandRecipient(req, res) {
     const { recipientId } = req.params;
     const { goalIds } = req.query;
 
+    const regionIds = await goalRegionIdsByIdAndRecipient(goalIds, recipientId);
+
+    if (!regionIds.length) {
+      res.sendStatus(404);
+      return;
+    }
+
+    const proceedQuestionMark = await checkUserRegionAccess(req, res, regionIds);
+
+    if (!proceedQuestionMark) {
+      return;
+    }
+
     const goals = await goalsByIdAndRecipient(goalIds, recipientId);
 
     if (!goals.length) {
       res.sendStatus(404);
+      return;
     }
 
     res.json(goals);

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -1,5 +1,7 @@
-import { INTERNAL_SERVER_ERROR, NOT_FOUND, UNAUTHORIZED } from 'http-codes';
-import goalsByIdAndRecipient from '../../goalServices/goalsByIdAndRecipient';
+import { FORBIDDEN, INTERNAL_SERVER_ERROR, NOT_FOUND, UNAUTHORIZED } from 'http-codes';
+import goalsByIdAndRecipient, {
+  goalRegionIdsByIdAndRecipient,
+} from '../../goalServices/goalsByIdAndRecipient';
 import SCOPES from '../../middleware/scopeConstants';
 import db from '../../models';
 import Users from '../../policies/user';
@@ -445,6 +447,13 @@ describe('getRecipientAndGrantsByUser', () => {
 });
 
 describe('getGoalsByIdAndRecipient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentUserId.mockResolvedValue(1000);
+    getUserReadRegions.mockResolvedValue([1]);
+    goalRegionIdsByIdAndRecipient.mockResolvedValue([1]);
+  });
+
   it('handles errors', async () => {
     const req = {
       params: {
@@ -494,11 +503,41 @@ describe('getGoalsByIdAndRecipient', () => {
       })),
     };
 
-    goalsByIdAndRecipient.mockResolvedValueOnce([]);
+    goalRegionIdsByIdAndRecipient.mockResolvedValueOnce([]);
 
     await getGoalsByIdandRecipient(req, mockResponse);
 
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(NOT_FOUND);
+    expect(goalsByIdAndRecipient).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when any matching goal belongs to a region the user cannot access', async () => {
+    const req = {
+      params: {
+        recipientId: 100000,
+      },
+      query: {
+        goalIds: [1, 2],
+      },
+    };
+
+    const mockResponse = {
+      attachment: jest.fn(),
+      json: jest.fn(),
+      send: jest.fn(),
+      sendStatus: jest.fn(),
+      status: jest.fn(() => ({
+        end: jest.fn(),
+      })),
+    };
+
+    goalRegionIdsByIdAndRecipient.mockResolvedValueOnce([1, 2]);
+    getUserReadRegions.mockResolvedValueOnce([1]);
+
+    await getGoalsByIdandRecipient(req, mockResponse);
+
+    expect(mockResponse.sendStatus).toHaveBeenCalledWith(FORBIDDEN);
+    expect(goalsByIdAndRecipient).not.toHaveBeenCalled();
   });
 
   it('return goals successfully', async () => {
@@ -525,6 +564,8 @@ describe('getGoalsByIdAndRecipient', () => {
 
     await getGoalsByIdandRecipient(req, mockResponse);
 
+    expect(goalRegionIdsByIdAndRecipient).toHaveBeenCalledWith([1], 100000);
+    expect(getUserReadRegions).toHaveBeenCalledWith(1000);
     expect(mockResponse.json).toHaveBeenCalledWith([{ name: 'goal' }]);
   });
 });

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -511,6 +511,34 @@ describe('getGoalsByIdAndRecipient', () => {
     expect(goalsByIdAndRecipient).not.toHaveBeenCalled();
   });
 
+  it('handles no goals after region access succeeds', async () => {
+    const req = {
+      params: {
+        recipientId: 100000,
+      },
+      query: {
+        goalIds: [1],
+      },
+    };
+
+    const mockResponse = {
+      attachment: jest.fn(),
+      json: jest.fn(),
+      send: jest.fn(),
+      sendStatus: jest.fn(),
+      status: jest.fn(() => ({
+        end: jest.fn(),
+      })),
+    };
+
+    goalsByIdAndRecipient.mockResolvedValueOnce([]);
+
+    await getGoalsByIdandRecipient(req, mockResponse);
+
+    expect(mockResponse.sendStatus).toHaveBeenCalledWith(NOT_FOUND);
+    expect(mockResponse.json).not.toHaveBeenCalled();
+  });
+
   it('returns 403 when any matching goal belongs to a region the user cannot access', async () => {
     const req = {
       params: {

--- a/src/routes/utils.test.js
+++ b/src/routes/utils.test.js
@@ -67,6 +67,22 @@ describe('Route Utils', () => {
   });
 
   describe('checkUserRegionAccess', () => {
+    it('returns false and 400 if no regions are provided', async () => {
+      req = mockRequest();
+      const result = await checkUserRegionAccess(req, res, []);
+      expect(result).toBe(false);
+      expect(res.sendStatus).toHaveBeenCalledWith(httpCodes.BAD_REQUEST);
+      expect(getUserReadRegions).not.toHaveBeenCalled();
+    });
+
+    it('returns false and 400 if any region is invalid', async () => {
+      req = mockRequest();
+      const result = await checkUserRegionAccess(req, res, [1, Number.NaN]);
+      expect(result).toBe(false);
+      expect(res.sendStatus).toHaveBeenCalledWith(httpCodes.BAD_REQUEST);
+      expect(getUserReadRegions).not.toHaveBeenCalled();
+    });
+
     it('returns false and 403 if user cannot access all requested regions', async () => {
       getUserReadRegions.mockResolvedValue([1]);
       req = mockRequest();

--- a/src/routes/utils.test.js
+++ b/src/routes/utils.test.js
@@ -4,7 +4,7 @@ import { getUserReadRegions } from '../services/accessValidation';
 import { currentUserId } from '../services/currentUser';
 import { allArUserIdsByRecipientAndRegion, recipientById } from '../services/recipient';
 import { userById } from '../services/users';
-import { checkRecipientAccessAndExistence } from './utils';
+import { checkRecipientAccessAndExistence, checkUserRegionAccess } from './utils';
 
 jest.mock('../services/accessValidation');
 jest.mock('../services/currentUser');
@@ -61,6 +61,24 @@ describe('Route Utils', () => {
     it('returns true if user has access and recipient exists', async () => {
       req = mockRequest({ recipientId: '10', regionId: '1' });
       const result = await checkRecipientAccessAndExistence(req, res);
+      expect(result).toBe(true);
+      expect(res.sendStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkUserRegionAccess', () => {
+    it('returns false and 403 if user cannot access all requested regions', async () => {
+      getUserReadRegions.mockResolvedValue([1]);
+      req = mockRequest();
+      const result = await checkUserRegionAccess(req, res, [1, 2]);
+      expect(result).toBe(false);
+      expect(res.sendStatus).toHaveBeenCalledWith(httpCodes.FORBIDDEN);
+    });
+
+    it('returns true if user can access all requested regions', async () => {
+      getUserReadRegions.mockResolvedValue([1, 2]);
+      req = mockRequest();
+      const result = await checkUserRegionAccess(req, res, [1, 2]);
       expect(result).toBe(true);
       expect(res.sendStatus).not.toHaveBeenCalled();
     });

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -25,5 +25,19 @@ const checkRecipientAccessAndExistence = async (req: Request, res: Response) => 
   return true;
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export { checkRecipientAccessAndExistence };
+const checkUserRegionAccess = async (req: Request, res: Response, regionIds: number[]) => {
+  const userId = await currentUserId(req, res);
+  const readRegions = await getUserReadRegions(userId);
+  const hasAccessToAllRegions = regionIds.every((regionId) =>
+    readRegions.includes(Number(regionId))
+  );
+
+  if (!hasAccessToAllRegions) {
+    res.sendStatus(httpCodes.FORBIDDEN);
+    return false;
+  }
+
+  return true;
+};
+
+export { checkRecipientAccessAndExistence, checkUserRegionAccess };

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -26,6 +26,16 @@ const checkRecipientAccessAndExistence = async (req: Request, res: Response) => 
 };
 
 const checkUserRegionAccess = async (req: Request, res: Response, regionIds: number[]) => {
+  const validRegionIds =
+    Array.isArray(regionIds) &&
+    regionIds.length > 0 &&
+    regionIds.every((regionId) => Number.isInteger(Number(regionId)) && Number(regionId) > 0);
+
+  if (!validRegionIds) {
+    res.sendStatus(httpCodes.BAD_REQUEST);
+    return false;
+  }
+
   const userId = await currentUserId(req, res);
   const readRegions = await getUserReadRegions(userId);
   const hasAccessToAllRegions = regionIds.every((regionId) =>


### PR DESCRIPTION
## Description of change

`getGoalsByIdandRecipient` (`GET /recipient/:recipientId/goals`) only checked that the recipient existed, not that the requesting user had read access to the regions the requested goals actually belong to. A new `goalRegionIdsByIdAndRecipient` helper looks up the region for each requested goal id under the given recipient, and a new `checkUserRegionAccess` util in `src/routes/utils.ts` verifies the user has read access to every one of those regions before the goals are fetched and returned. Requests for goals in a region the user cannot read now get a 403 instead of goal data; requests for goal ids with no match now return 404 before any region check runs.

## How to test

* Verify the tests pass
* Manually: as a user with read access limited to certain regions, call `GET /api/recipient/:recipientId/goals?goalIds[]=<id>` with a goal id belonging to a region you can access (expect 200 with goal data) and one belonging to a region you cannot access (expect 403).

## Jira Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5672


## Checklists

### Every PR

- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status