### PR TITLE
[TTAHUB-5516] TR - Alerts table overflowing

### DIFF
--- a/frontend/src/components/TrainingReportAlerts.css
+++ b/frontend/src/components/TrainingReportAlerts.css
@@ -1,10 +1,11 @@
 .ttahub-training-report-alerts-container {
   /* CSS custom properties */
   --half-column-width: 150px;
+}
 
-  /* setup container context and name */
-  container-name: tta-hub-training-report-alerts;
-  container-type: inline-size;
+/* Clip and scroll the table at every width so it never paints outside its card */
+.ttahub-training-report-alerts-scrollable {
+  overflow-x: auto;
 }
 
 .ttahub-training-report-alerts th button {
@@ -30,34 +31,29 @@
   max-width: var(--half-column-width);
 }
 
-@container tta-hub-training-report-alerts (max-width: 1140px) {
-  .ttahub-training-report-alerts-scrollable {
-    overflow-x: scroll;
-  }
+/* Pin the "Action needed" column at every width so the boundary and scroll cue persist */
+.ttahub-training-report-alerts {
+  position: relative;
+}
 
-  .ttahub-training-report-alerts {
-    position: relative;
-  }
+.ttahub-training-report-alerts thead th:last-child {
+  background-color: white;
+}
 
-  .ttahub-training-report-alerts thead th:last-child {
-    background-color: white;
-  }
+.ttahub-training-report-alerts th:last-child,
+.ttahub-training-report-alerts td:last-child {
+  position: sticky;
+  right: 0;
+}
 
-  .ttahub-training-report-alerts th:last-child,
-  .ttahub-training-report-alerts td:last-child {
-    position: sticky;
-    right: 0;
-  }
-
-  .ttahub-training-report-alerts th:last-child::before,
-  .ttahub-training-report-alerts td:last-child::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 1px;
-    background-color: var(--text-ink);
-    pointer-events: none;
-  }
+.ttahub-training-report-alerts th:last-child::before,
+.ttahub-training-report-alerts td:last-child::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background-color: var(--text-ink);
+  pointer-events: none;
 }

--- a/frontend/src/components/TrainingReportAlerts.js
+++ b/frontend/src/components/TrainingReportAlerts.js
@@ -138,7 +138,8 @@ export default function TrainingReportAlerts() {
       loading={false}
     >
       {alertsForTable.length ? (
-        <div className="ttahub-training-report-alerts-scrollable">
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: scroll region needs keyboard focus
+        <div className="ttahub-training-report-alerts-scrollable" tabIndex={0}>
           <SimpleSortableTable
             className="ttahub-training-report-alerts"
             columns={columns}


### PR DESCRIPTION
## Description of change

At certain screen sizes the "My training report alerts" table on the Training Reports landing page painted **outside** its white card instead of being clipped or made scrollable. The alerts scroll wrapper (`.ttahub-training-report-alerts-scrollable`) had no base `overflow-x` rule; clipping/scrolling and the sticky "Action needed" column were gated behind an `@container (max-width: 1140px)` query, so above that threshold the table overflowed its card.

This makes `overflow-x: auto` the base rule on the wrapper (so the table always stays within its card, with a scrollbar only when content actually overflows), pins the "Action needed" column and its divider at every width, removes the now-dead `@container` block and container context, and adds `tabIndex={0}` so the scroll region is keyboard reachable.

## How to test

1. Sign in as a user with training report write permissions and open **Training reports – your region**.
2. Populate the "My training report alerts" widget with long content (long event names, session names, and multiple collaborators), similar to the ticket screenshot.
3. Resize the browser across desktop widths (e.g. ~1280px up to ~1920px). Confirm the table stays inside the white card at every width, with a horizontal scrollbar when the content is wider than the card, and no content painting outside the card.
4. Tab to the alerts table and confirm the scroll region is keyboard focusable.
5. Frontend checks: `cd frontend && yarn lint` and `TZ=America/New_York yarn test --watchAll=false --testPathPattern=TrainingReportAlerts` (23/23 pass).

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5516

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [ ] JIRA issue status updated
- [x] Code is meaningfully tested — existing `TrainingReportAlerts` Jest suite passes (23/23); change is CSS + a11y attribute
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA) — scroll region made keyboard focusable via `tabIndex={0}`
- [ ] API Documentation updated — N/A (frontend-only)
- [ ] Boundary diagram updated — N/A
- [ ] Logical Data Model updated — N/A
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions — N/A
- [ ] UI review complete — **required**: confirm the always-on pinned column + divider at wide widths (see Design note)
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status