### PR TITLE
[TTAHUB-5552] Stop saving event and approver associations into session report data

### DIFF
--- a/frontend/src/pages/SessionForm/__tests__/index.js
+++ b/frontend/src/pages/SessionForm/__tests__/index.js
@@ -1401,6 +1401,9 @@ describe('SessionReportForm', () => {
       const putBodyJson = JSON.parse(putBody);
       expect(putBodyJson.data.status).toBe(TRAINING_REPORT_STATUSES.COMPLETE);
       expect(putBodyJson.data.approvalStatus).toBeUndefined(); // Should be destructured out
+      // Hydrated associations must not be sent back into the session data column
+      expect(putBodyJson.data.event).toBeUndefined();
+      expect(putBodyJson.data.approver).toBeUndefined();
 
       // Verify navigation with success message
       await waitFor(() => expect(historySpy).toHaveBeenCalled());

--- a/frontend/src/pages/SessionForm/index.js
+++ b/frontend/src/pages/SessionForm/index.js
@@ -590,10 +590,27 @@ export default function SessionForm({ match }) {
         return;
       }
 
+      // Narrow the payload to the fields for this role so hydrated associations
+      // (event, approver) that live on the form state are not persisted back into
+      // the session's JSONB data column. The unfiltered `data` is still used for
+      // the redirect message below.
+      const keyArray = determineKeyArray({
+        isAdminUser,
+        isPoc,
+        eventOrganizer,
+        isCollaborator,
+        isOwner,
+        isApprover,
+        isNcUser,
+        facilitation: data?.facilitation || '',
+        isSubmitted: data?.submitted,
+      });
+      const roleData = reduceDataToMatchKeys(keyArray, data);
+
       // PUT it to the backend
       await updateSession(sessionId, {
         data: {
-          ...data,
+          ...roleData,
           status,
         },
         trainingReportId,

--- a/src/services/sessionReports.test.js
+++ b/src/services/sessionReports.test.js
@@ -65,6 +65,23 @@ describe('session reports service', () => {
         'Event with id 999999 not found'
       );
     });
+
+    it('does not persist hydrated event or approver associations into data', async () => {
+      const created = await createSession({
+        eventId: event.id,
+        data: {
+          card: 'ace',
+          event: { id: event.id, data: { eventId } },
+          approver: { id: 18, name: 'An Approver' },
+        },
+      });
+
+      expect(created.data.card).toBe('ace');
+      expect(created.data.event).toBeUndefined();
+      expect(created.data.approver).toBeUndefined();
+
+      await destroySession(created.id);
+    });
   });
 
   describe('createSession additionalRegions', () => {
@@ -159,6 +176,44 @@ describe('session reports service', () => {
       });
 
       await destroySession(updated.id);
+    });
+
+    it('strips hydrated event and approver associations from incoming data', async () => {
+      const created = await createSession({ eventId: event.id, data: { harry: 'potter' } });
+
+      const updated = await updateSession(created.id, {
+        eventId,
+        data: {
+          harry: 'potter',
+          event: { id: event.id, data: { eventId } },
+          approver: { id: 18, name: 'An Approver' },
+        },
+      });
+
+      expect(updated.data.harry).toBe('potter');
+      expect(updated.data.event).toBeUndefined();
+      expect(updated.data.approver).toBeUndefined();
+
+      await destroySession(created.id);
+    });
+
+    it('removes a previously persisted association when a clean save follows', async () => {
+      const created = await createSession({ eventId: event.id, data: { harry: 'potter' } });
+
+      const dirtied = await updateSession(created.id, {
+        eventId,
+        data: { harry: 'potter', event: { id: event.id, data: { eventId } } },
+      });
+      // the strip runs on write, so even the "dirty" save is clean
+      expect(dirtied.data.event).toBeUndefined();
+
+      const cleaned = await updateSession(created.id, {
+        eventId,
+        data: { harry: 'potter' },
+      });
+      expect(cleaned.data.event).toBeUndefined();
+
+      await destroySession(created.id);
     });
   });
 

--- a/src/services/sessionReports.test.js
+++ b/src/services/sessionReports.test.js
@@ -197,24 +197,6 @@ describe('session reports service', () => {
       await destroySession(created.id);
     });
 
-    it('removes a previously persisted association when a clean save follows', async () => {
-      const created = await createSession({ eventId: event.id, data: { harry: 'potter' } });
-
-      const dirtied = await updateSession(created.id, {
-        eventId,
-        data: { harry: 'potter', event: { id: event.id, data: { eventId } } },
-      });
-      // the strip runs on write, so even the "dirty" save is clean
-      expect(dirtied.data.event).toBeUndefined();
-
-      const cleaned = await updateSession(created.id, {
-        eventId,
-        data: { harry: 'potter' },
-      });
-      expect(cleaned.data.event).toBeUndefined();
-
-      await destroySession(created.id);
-    });
   });
 
   describe('destroySession', () => {

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -28,6 +28,25 @@ type WhereOptions = {
   data?: unknown;
 };
 
+// Hydrated associations (the parent event record and the approver user record)
+// are returned to the client as separate associations and must never be persisted
+// back into the session's JSONB `data` column. Storing them creates a stale,
+// duplicate source of truth. This is a server-side backstop so no client payload
+// can reintroduce the duplication regardless of how the form serializes its state.
+export const SESSION_ASSOCIATION_KEYS = ['approver', 'event'] as const;
+
+export const removeAssociationsFromData = <T extends Record<string, unknown>>(data: T): T => {
+  if (!data || typeof data !== 'object') {
+    return data;
+  }
+
+  const cleaned = { ...data };
+  SESSION_ASSOCIATION_KEYS.forEach((key) => {
+    delete cleaned[key];
+  });
+  return cleaned;
+};
+
 const normalizeStates = (states: string[] | undefined): string[] => {
   return (states || [])
     .map((state: string) => {
@@ -211,12 +230,14 @@ export async function createSession(request) {
     throw new Error(`Event with id ${eventId} not found`);
   }
 
+  const cleanData = removeAssociationsFromData(data);
+
   const created = await SessionReportPilot.create(
     {
       eventId: event.id,
       data: cast(
         JSON.stringify({
-          ...data,
+          ...cleanData,
           reviewStatus: REPORT_STATUSES.DRAFT,
           additionalStates: event.data.additionalStates || [],
           additionalRegions: event.data.additionalRegions || [],
@@ -250,7 +271,7 @@ export async function updateSession(id: number, request) {
 
   // Combine existing session data with new data.
   const existingData = session.data;
-  const newData = { ...existingData, ...data };
+  const newData = { ...existingData, ...removeAssociationsFromData(data) };
 
   const event = await findEventBySmartsheetId(eventId);
 

--- a/src/services/sessionReports.ts
+++ b/src/services/sessionReports.ts
@@ -35,15 +35,15 @@ type WhereOptions = {
 // can reintroduce the duplication regardless of how the form serializes its state.
 export const SESSION_ASSOCIATION_KEYS = ['approver', 'event'] as const;
 
-export const removeAssociationsFromData = <T extends Record<string, unknown>>(data: T): T => {
-  if (!data || typeof data !== 'object') {
-    return data;
+export const removeAssociationsFromData = (data: unknown): Record<string, unknown> => {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return {};
   }
 
-  const cleaned = { ...data };
-  SESSION_ASSOCIATION_KEYS.forEach((key) => {
+  const cleaned: Record<string, unknown> = { ...(data as Record<string, unknown>) };
+  for (const key of SESSION_ASSOCIATION_KEYS) {
     delete cleaned[key];
-  });
+  }
   return cleaned;
 };
 


### PR DESCRIPTION
## Description of change

The `SessionReportPilots.data` JSONB column was accumulating full copies of the parent event (`data->'event'`) and approver (`data->'approver'`) records that already exist as separate associations, creating a stale, duplicate source of truth. Two layers combined to cause it: the approver review handler (`onReview`) sent raw form values (including the hydrated `event`/`approver` associations) to the update endpoint, and `updateSession`/`createSession` merged incoming data additively with no allowlist, so once a key landed it was never removed. This fixes both layers — `onReview` now filters its payload like its sibling handlers, and the service strips `event`/`approver` from incoming data as a backstop. A one-time purge of existing rows is intentionally deferred to a separate ticket that must run *after* this deploys (otherwise rows re-dirty on the next review submit, which is what happened after the Oct 2024 cleanup).

## How to test

1. As an approver, open a submitted session report and submit a review (approve or needs-action).
2. Confirm the review saves and redirects normally, and that `SELECT data->'event' IS NULL, data->'approver' IS NULL FROM "SessionReportPilots" WHERE id = <id>` returns true for the updated row.
3. Automated: `TZ=America/New_York yarn --cwd frontend test --watchAll=false -t "onReview approval workflow"` and the `createSession`/`updateSession` cases in `src/services/sessionReports.test.js`.

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5552

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [ ] JIRA issue status updated
- [x] Code is meaningfully tested <!-- FE onReview payload assertions + BE service tests on create/update paths -->
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA) <!-- no UI change -->
- [ ] API Documentation updated <!-- N/A: no API shape change -->
- [ ] Boundary diagram updated <!-- N/A -->
- [ ] Logical Data Model updated <!-- N/A: no schema change -->
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions <!-- N/A -->
- [ ] UI review complete <!-- N/A: no visible UI change -->
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status

---

### Follow-ups (separate tickets)
- Purge migration removing `event`/`approver` from existing rows — schedule **after** this deploys.
- `files`, `supportingAttachments`, `submitter` are still written into the same JSON column (same defect class, smaller blobs; read paths need analysis first).
- The session update endpoint applies no allowlist to `data`.