### PR TITLE
[TTAHUB-5654] Add TTA Timeline BE API

### DIFF
--- a/docs/openapi/paths/index.yaml
+++ b/docs/openapi/paths/index.yaml
@@ -48,6 +48,8 @@
   $ref: './files.yaml'
 '/recipient/{recipientId}':
   $ref: './recipient/recipient-id.yaml'
+'/recipient/{recipientId}/region/{regionId}/timeline':
+  $ref: './recipient/recipient-timeline.yaml'
 '/recipient/search':
   $ref: './recipient/recipient-search.yaml'
 '/recipient/goals/{recipientId}':

--- a/docs/openapi/paths/recipient/recipient-timeline.yaml
+++ b/docs/openapi/paths/recipient/recipient-timeline.yaml
@@ -1,0 +1,89 @@
+get:
+  tags:
+    - recipient
+  summary: Retrieve timeline events for a recipient in a region
+  operationId: getRecipientTimeline
+  parameters:
+    - in: path
+      name: recipientId
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+    - in: path
+      name: regionId
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+    - in: query
+      name: limit
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    - in: query
+      name: offset
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    - in: query
+      name: sortBy
+      required: false
+      schema:
+        type: string
+        enum:
+          - date
+        default: date
+    - in: query
+      name: direction
+      required: false
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+        default: desc
+    - in: query
+      name: filters
+      required: false
+      schema:
+        type: array
+        maxItems: 20
+        items:
+          type: string
+          minLength: 1
+          maxLength: 100
+  responses:
+    200:
+      description: Timeline events for the recipient
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - count
+              - events
+            properties:
+              count:
+                type: integer
+                minimum: 0
+              events:
+                type: array
+                items:
+                  type: object
+          example:
+            count: 0
+            events: []
+    400:
+      description: Invalid path or query parameters
+    401:
+      description: Authentication is required
+    403:
+      description: User does not have access to the requested region
+    404:
+      description: Recipient was not found

--- a/docs/openapi/paths/recipient/recipient-timeline.yaml
+++ b/docs/openapi/paths/recipient/recipient-timeline.yaml
@@ -57,7 +57,15 @@ get:
         items:
           type: string
           minLength: 1
-          maxLength: 100
+          maxLength: 2000
+          description: Serialized timeline filter JSON with topic, condition, and query fields.
+    - in: query
+      name: excludeMultiRecipientCommunications
+      required: false
+      schema:
+        type: boolean
+        default: false
+      description: Exclude communications associated with more than one recipient.
   responses:
     200:
       description: Timeline events for the recipient

--- a/src/lib/parsePositiveInteger.ts
+++ b/src/lib/parsePositiveInteger.ts
@@ -1,0 +1,12 @@
+export default function parsePositiveInteger(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+
+  if (typeof value !== 'string' || !/^[0-9]+$/.test(value)) {
+    return null;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isSafeInteger(parsedValue) && parsedValue > 0 ? parsedValue : null;
+}

--- a/src/middleware/checkIdParamMiddleware.js
+++ b/src/middleware/checkIdParamMiddleware.js
@@ -1,10 +1,11 @@
 import httpCodes from 'http-codes';
+import parsePositiveInteger from '../lib/parsePositiveInteger';
 import { auditLogger } from '../logger';
 
 const errorMessage = 'Received malformed request params';
 
 function canBeInt(str) {
-  return Number.isInteger(Number(str)) && Number(str) > 0;
+  return parsePositiveInteger(str) !== null;
 }
 
 /**
@@ -202,7 +203,13 @@ export function checkGoalTemplateIdParam(req, res, next) {
 }
 
 export function checkIdParam(req, res, next, paramName) {
-  if (req.params && req.params[paramName] && canBeInt(req.params[paramName])) {
+  const parsedParam = parsePositiveInteger(req.params?.[paramName]);
+  if (parsedParam !== null) {
+    res.locals = res.locals || {};
+    res.locals.validatedParams = {
+      ...res.locals.validatedParams,
+      [paramName]: parsedParam,
+    };
     return next();
   }
 
@@ -273,8 +280,8 @@ export function checkGrantIdQueryParam(req, res, next) {
     return next();
   }
 
-  const parsed = Number(grantId);
-  if (!Number.isInteger(parsed) || parsed < 1) {
+  const parsed = parsePositiveInteger(grantId);
+  if (parsed === null) {
     const msg = `${errorMessage}: grantId ${String(grantId)}`;
     auditLogger.error(msg);
     return res.status(httpCodes.BAD_REQUEST).send(msg);

--- a/src/middleware/checkIdParamMiddleware.test.js
+++ b/src/middleware/checkIdParamMiddleware.test.js
@@ -567,7 +567,21 @@ describe('checkIdParamMiddleware', () => {
 
       checkRecipientIdParam(mockRequest, mockResponse, mockNext);
       expect(mockResponse.status).not.toHaveBeenCalled();
+      expect(mockResponse.locals.validatedParams.recipientId).toBe(2);
       expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('throws 400 if param exceeds the safe integer range', () => {
+      const mockRequest = {
+        path: '/api/endpoint',
+        params: {
+          recipientId: '9007199254740992',
+        },
+      };
+
+      checkRecipientIdParam(mockRequest, mockResponse, mockNext);
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockNext).not.toHaveBeenCalled();
     });
 
     it('throw 400 if param is not string or integer', () => {
@@ -608,7 +622,21 @@ describe('checkIdParamMiddleware', () => {
 
       checkRegionIdParam(mockRequest, mockResponse, mockNext);
       expect(mockResponse.status).not.toHaveBeenCalled();
+      expect(mockResponse.locals.validatedParams.regionId).toBe(2);
       expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('throws 400 if param uses scientific notation', () => {
+      const mockRequest = {
+        path: '/api/endpoint',
+        params: {
+          regionId: '1e1',
+        },
+      };
+
+      checkRegionIdParam(mockRequest, mockResponse, mockNext);
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockNext).not.toHaveBeenCalled();
     });
 
     it('throw 400 if param is not string or integer', () => {

--- a/src/routes/monitoring/handlers.test.js
+++ b/src/routes/monitoring/handlers.test.js
@@ -50,6 +50,11 @@ jest.mock('csv-stringify', () => {
 });
 
 describe('monintoring handlers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRecipientAccessAndExistence.mockResolvedValue(true);
+  });
+
   describe('getMonitoringData', () => {
     let req;
     let res;
@@ -88,6 +93,16 @@ describe('monintoring handlers', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(data);
+    });
+
+    it('does not call monitoringData when recipient access fails', async () => {
+      checkRecipientAccessAndExistence.mockResolvedValue(false);
+
+      await getMonitoringData(req, res);
+
+      expect(monitoringData).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
     });
 
     it('should call handleErrors if an error is thrown', async () => {
@@ -137,6 +152,16 @@ describe('monintoring handlers', () => {
       expect(res.json).toHaveBeenCalledWith(data);
     });
 
+    it('does not call ttaByReviews when recipient access fails', async () => {
+      checkRecipientAccessAndExistence.mockResolvedValue(false);
+
+      await getTtaByReview(req, res);
+
+      expect(ttaByReviews).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
     it('should call handleErrors if an error is thrown', async () => {
       const error = new Error('Test error');
       ttaByReviews.mockRejectedValue(error);
@@ -184,6 +209,16 @@ describe('monintoring handlers', () => {
       expect(res.json).toHaveBeenCalledWith(data);
     });
 
+    it('does not call ttaByCitations when recipient access fails', async () => {
+      checkRecipientAccessAndExistence.mockResolvedValue(false);
+
+      await getTtaByCitation(req, res);
+
+      expect(ttaByCitations).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
     it('should call handleErrors if an error is thrown', async () => {
       const error = new Error('Test error');
       ttaByCitations.mockRejectedValue(error);
@@ -229,6 +264,16 @@ describe('monintoring handlers', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(data);
+    });
+
+    it('does not call classScore when recipient access fails', async () => {
+      checkRecipientAccessAndExistence.mockResolvedValue(false);
+
+      await getClassScore(req, res);
+
+      expect(classScore).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
     });
 
     it('should call handleErrors if an error is thrown', async () => {

--- a/src/routes/monitoring/handlers.ts
+++ b/src/routes/monitoring/handlers.ts
@@ -320,7 +320,11 @@ export async function getTtaByReview(req: Request, res: Response) {
   const { recipientId, regionId } = req.params;
 
   try {
-    await checkRecipientAccessAndExistence(req, res);
+    const canAccessRecipient = await checkRecipientAccessAndExistence(req, res);
+    if (!canAccessRecipient) {
+      return;
+    }
+
     const data = await ttaByReviews(Number(recipientId), Number(regionId));
 
     res.status(200).json(data);
@@ -333,7 +337,11 @@ export async function getTtaByCitation(req: Request, res: Response) {
   const { recipientId, regionId } = req.params;
 
   try {
-    await checkRecipientAccessAndExistence(req, res);
+    const canAccessRecipient = await checkRecipientAccessAndExistence(req, res);
+    if (!canAccessRecipient) {
+      return;
+    }
+
     const data = await ttaByCitations(Number(recipientId), Number(regionId));
 
     res.status(200).json(data);
@@ -346,7 +354,11 @@ export async function getMonitoringData(req: Request, res: Response) {
   const { recipientId, grantNumber, regionId } = req.params;
 
   try {
-    await checkRecipientAccessAndExistence(req, res);
+    const canAccessRecipient = await checkRecipientAccessAndExistence(req, res);
+    if (!canAccessRecipient) {
+      return;
+    }
+
     const data = await monitoringData({
       recipientId: Number(recipientId),
       grantNumber: String(grantNumber),
@@ -363,7 +375,11 @@ export async function getClassScore(req: Request, res: Response) {
   const { recipientId, grantNumber, regionId } = req.params;
 
   try {
-    await checkRecipientAccessAndExistence(req, res);
+    const canAccessRecipient = await checkRecipientAccessAndExistence(req, res);
+    if (!canAccessRecipient) {
+      return;
+    }
+
     const data = await classScore({
       recipientId: Number(recipientId),
       grantNumber: String(grantNumber),

--- a/src/routes/recipient/handlers.js
+++ b/src/routes/recipient/handlers.js
@@ -14,6 +14,7 @@ import {
   recipientsByName,
   recipientsByUserId,
 } from '../../services/recipient';
+import { getRecipientTimeline as getRecipientTimelineService } from '../../services/recipientTimeline';
 import { standardGoalsForRecipient } from '../../services/standardGoals';
 import { userById } from '../../services/users';
 import { checkRecipientAccessAndExistence as checkAccessAndExistence } from '../utils';
@@ -149,6 +150,25 @@ export async function getRecipientLeadership(req, res) {
     // Get goals for recipient.
     const leadership = await recipientLeadership(recipientId, regionId);
     res.json(leadership);
+  } catch (error) {
+    await handleErrors(req, res, error, logContext);
+  }
+}
+
+export async function getRecipientTimeline(req, res) {
+  try {
+    const canAccessRecipient = await checkAccessAndExistence(req, res);
+
+    if (!canAccessRecipient) {
+      return;
+    }
+
+    const timeline = await getRecipientTimelineService({
+      ...res.locals.validatedParams,
+      ...res.locals.recipientTimelineQuery,
+    });
+
+    res.json(timeline);
   } catch (error) {
     await handleErrors(req, res, error, logContext);
   }

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -209,6 +209,12 @@ describe('getGoalsByActivityRecipient', () => {
       end: jest.fn(),
     })),
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResponse.locals = {};
+  });
+
   it('retrieves goals by recipient', async () => {
     const req = {
       params: {
@@ -227,7 +233,7 @@ describe('getGoalsByActivityRecipient', () => {
     expect(mockResponse.json).toHaveBeenCalledWith(recipientWhere);
   });
 
-  it("returns a 404 when a recipient can't be found", async () => {
+  it('returns a 404 when the recipient has no grant in the requested region', async () => {
     const req = {
       params: {
         recipientId: 14565,
@@ -246,6 +252,10 @@ describe('getGoalsByActivityRecipient', () => {
     standardGoalsForRecipient.mockResolvedValue(null);
     await getGoalsByRecipient(req, mockResponse);
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(NOT_FOUND);
+    expect(recipientById).toHaveBeenCalledWith(14565, {
+      where: { regionId: 1 },
+    });
+    expect(standardGoalsForRecipient).not.toHaveBeenCalled();
   });
 
   it('returns a 500 on error', async () => {
@@ -285,6 +295,12 @@ describe('getRecipientLeadership', () => {
       end: jest.fn(),
     })),
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResponse.locals = {};
+  });
+
   it('retrieves goals by recipient', async () => {
     const req = {
       params: {
@@ -302,7 +318,7 @@ describe('getRecipientLeadership', () => {
     expect(mockResponse.json).toHaveBeenCalledWith([]);
   });
 
-  it("returns a 404 when a recipient can't be found", async () => {
+  it('returns a 404 when the recipient has no grant in the requested region', async () => {
     const req = {
       params: {
         recipientId: 14565,
@@ -321,6 +337,10 @@ describe('getRecipientLeadership', () => {
     recipientLeadership.mockResolvedValue(null);
     await getRecipientLeadership(req, mockResponse);
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(NOT_FOUND);
+    expect(recipientById).toHaveBeenCalledWith(14565, {
+      where: { regionId: 1 },
+    });
+    expect(recipientLeadership).not.toHaveBeenCalled();
   });
 
   it('returns a 500 on error', async () => {

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -12,6 +12,7 @@ import {
   recipientsByName,
   recipientsByUserId,
 } from '../../services/recipient';
+import { getRecipientTimeline as getRecipientTimelineService } from '../../services/recipientTimeline';
 import { standardGoalsForRecipient } from '../../services/standardGoals';
 import {
   getGoalsByIdandRecipient,
@@ -19,6 +20,7 @@ import {
   getRecipient,
   getRecipientAndGrantsByUser,
   getRecipientLeadership,
+  getRecipientTimeline,
   searchRecipients,
 } from './handlers';
 
@@ -43,6 +45,8 @@ jest.mock('../../services/recipient', () => ({
 }));
 
 jest.mock('../../goalServices/goalsByIdAndRecipient');
+
+jest.mock('../../services/recipientTimeline');
 
 jest.mock('../../services/accessValidation');
 
@@ -343,6 +347,73 @@ describe('getRecipientLeadership', () => {
     getUserReadRegions.mockResolvedValue([2]);
     await getRecipientLeadership(req, mockResponse);
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
+  });
+});
+
+describe('getRecipientTimeline', () => {
+  const responseBody = {
+    count: 0,
+    events: [],
+  };
+
+  const timelineQuery = {
+    limit: 25,
+    offset: 10,
+    sortBy: 'date',
+    direction: 'asc',
+    filters: ['example'],
+  };
+
+  const req = {
+    params: {
+      recipientId: '100000',
+      regionId: '1',
+    },
+    session: {
+      userId: 1000,
+    },
+  };
+
+  const mockResponse = {
+    json: jest.fn(),
+    sendStatus: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    locals: {
+      validatedParams: {
+        recipientId: 100000,
+        regionId: 1,
+      },
+      recipientTimelineQuery: timelineQuery,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentUserId.mockResolvedValue(1000);
+    recipientById.mockResolvedValue({ id: 100000 });
+    getUserReadRegions.mockResolvedValue([1]);
+    getRecipientTimelineService.mockResolvedValue(responseBody);
+  });
+
+  it('returns the stable empty timeline contract for an authorized user', async () => {
+    await getRecipientTimeline(req, mockResponse);
+
+    expect(getRecipientTimelineService).toHaveBeenCalledWith({
+      recipientId: 100000,
+      regionId: 1,
+      ...timelineQuery,
+    });
+    expect(mockResponse.json).toHaveBeenCalledWith(responseBody);
+  });
+
+  it('rejects users without access to the requested region', async () => {
+    getUserReadRegions.mockResolvedValue([2]);
+
+    await getRecipientTimeline(req, mockResponse);
+
+    expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
+    expect(getRecipientTimelineService).not.toHaveBeenCalled();
+    expect(mockResponse.json).not.toHaveBeenCalled();
   });
 });
 

--- a/src/routes/recipient/handlers.test.js
+++ b/src/routes/recipient/handlers.test.js
@@ -361,7 +361,8 @@ describe('getRecipientTimeline', () => {
     offset: 10,
     sortBy: 'date',
     direction: 'asc',
-    filters: ['example'],
+    filters: [{ topic: 'date', condition: 'is within', query: '08/01/2025-08/01/2026' }],
+    excludeMultiRecipientCommunications: true,
   };
 
   const req = {

--- a/src/routes/recipient/index.js
+++ b/src/routes/recipient/index.js
@@ -7,8 +7,10 @@ import {
   getRecipient,
   getRecipientAndGrantsByUser,
   getRecipientLeadership,
+  getRecipientTimeline,
   searchRecipients,
 } from './handlers';
+import { checkRecipientTimelineQuery } from './middleware';
 
 const router = express.Router();
 router.get('/search', transactionWrapper(searchRecipients));
@@ -29,6 +31,13 @@ router.get(
   '/:recipientId/region/:regionId/leadership',
   checkRecipientIdParam,
   transactionWrapper(getRecipientLeadership)
+);
+router.get(
+  '/:recipientId/region/:regionId/timeline',
+  checkRecipientIdParam,
+  checkRegionIdParam,
+  checkRecipientTimelineQuery,
+  transactionWrapper(getRecipientTimeline)
 );
 
 export default router;

--- a/src/routes/recipient/index.test.js
+++ b/src/routes/recipient/index.test.js
@@ -1,0 +1,69 @@
+import express from 'express';
+import request from 'supertest';
+import { checkRecipientAccessAndExistence } from '../utils';
+import router from './index';
+
+jest.mock('../transactionWrapper', () =>
+  jest.fn(
+    (handler) =>
+      async function wrapper(req, res, next) {
+        return handler(req, res, next);
+      }
+  )
+);
+jest.mock('../utils');
+
+describe('recipient routes', () => {
+  const app = express();
+  app.use('/recipient', router);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkRecipientAccessAndExistence.mockResolvedValue(true);
+  });
+
+  it('wires the timeline handler behind recipient, region, and query validation', () => {
+    const timelineRoute = router.stack.find(
+      (layer) => layer.route?.path === '/:recipientId/region/:regionId/timeline'
+    );
+
+    expect(timelineRoute).toBeDefined();
+    expect(timelineRoute.route.methods.get).toBe(true);
+    expect(timelineRoute.route.stack.map((layer) => layer.name)).toEqual([
+      'checkRecipientIdParam',
+      'checkRegionIdParam',
+      'checkRecipientTimelineQuery',
+      'wrapper',
+    ]);
+  });
+
+  it('returns the empty contract through the timeline route', async () => {
+    const response = await request(app)
+      .get('/recipient/100000/region/1/timeline')
+      .query({ limit: 25, offset: 10, sortBy: 'date', direction: 'asc' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      count: 0,
+      events: [],
+    });
+  });
+
+  it.each([
+    '/recipient/not-a-number/region/1/timeline',
+    '/recipient/100000/region/not-a-number/timeline',
+    '/recipient/100000/region/1e1/timeline',
+  ])('rejects invalid path parameters for %s', async (path) => {
+    const response = await request(app).get(path);
+
+    expect(response.status).toBe(400);
+    expect(checkRecipientAccessAndExistence).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid query parameters before calling the handler', async () => {
+    const response = await request(app).get('/recipient/100000/region/1/timeline?limit=0');
+
+    expect(response.status).toBe(400);
+    expect(checkRecipientAccessAndExistence).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/recipient/index.test.js
+++ b/src/routes/recipient/index.test.js
@@ -49,6 +49,23 @@ describe('recipient routes', () => {
     });
   });
 
+  it('accepts the multi-select event-type filter used by the timeline UI', async () => {
+    const filters = JSON.stringify({
+      topic: 'eventType',
+      condition: 'is',
+      query: ['Email communication', 'Phone communication', 'In person communication'],
+    });
+
+    expect(filters).toHaveLength(118);
+
+    const response = await request(app)
+      .get('/recipient/100000/region/1/timeline')
+      .query({ filters });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ count: 0, events: [] });
+  });
+
   it.each([
     '/recipient/not-a-number/region/1/timeline',
     '/recipient/100000/region/not-a-number/timeline',

--- a/src/routes/recipient/middleware.test.js
+++ b/src/routes/recipient/middleware.test.js
@@ -1,0 +1,89 @@
+import httpCodes from 'http-codes';
+import { auditLogger } from '../../logger';
+import { checkRecipientTimelineQuery } from './middleware';
+
+jest.mock('../../logger', () => ({
+  auditLogger: {
+    error: jest.fn(),
+  },
+}));
+
+const mockResponse = () => {
+  const res = {
+    locals: {},
+    send: jest.fn(),
+    status: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+describe('checkRecipientTimelineQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies conservative defaults when query parameters are omitted', () => {
+    const req = { query: {} };
+    const res = mockResponse();
+    const next = jest.fn();
+
+    checkRecipientTimelineQuery(req, res, next);
+
+    expect(res.locals.recipientTimelineQuery).toEqual({
+      limit: 20,
+      offset: 0,
+      sortBy: 'date',
+      direction: 'desc',
+      filters: [],
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('parses valid pagination and filter values', () => {
+    const req = {
+      query: {
+        limit: '25',
+        offset: '10',
+        sortBy: 'date',
+        direction: 'asc',
+        filters: ['one', 'two'],
+      },
+    };
+    const res = mockResponse();
+    const next = jest.fn();
+
+    checkRecipientTimelineQuery(req, res, next);
+
+    expect(res.locals.recipientTimelineQuery).toEqual({
+      limit: 25,
+      offset: 10,
+      sortBy: 'date',
+      direction: 'asc',
+      filters: ['one', 'two'],
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['non-positive limit', { limit: '0' }],
+    ['negative offset', { offset: '-1' }],
+    ['unsupported sort field', { sortBy: 'title' }],
+    ['unsupported direction', { direction: 'sideways' }],
+    ['structured filters', { filters: { key: 'value' } }],
+    ['unknown query parameter', { extra: 'value' }],
+  ])('rejects %s', (_description, query) => {
+    const req = { query };
+    const res = mockResponse();
+    const next = jest.fn();
+
+    checkRecipientTimelineQuery(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(httpCodes.BAD_REQUEST);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.stringContaining('Received malformed request query')
+    );
+    expect(auditLogger.error).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/recipient/middleware.test.js
+++ b/src/routes/recipient/middleware.test.js
@@ -36,18 +36,25 @@ describe('checkRecipientTimelineQuery', () => {
       sortBy: 'date',
       direction: 'desc',
       filters: [],
+      excludeMultiRecipientCommunications: false,
     });
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it('parses valid pagination and filter values', () => {
+  it('parses valid pagination, structured filters, and the multi-recipient switch', () => {
+    const filter = JSON.stringify({
+      topic: 'eventType',
+      condition: 'is',
+      query: ['Email communication', 'Phone communication', 'In person communication'],
+    });
     const req = {
       query: {
         limit: '25',
         offset: '10',
         sortBy: 'date',
         direction: 'asc',
-        filters: ['one', 'two'],
+        filters: filter,
+        excludeMultiRecipientCommunications: 'true',
       },
     };
     const res = mockResponse();
@@ -60,7 +67,14 @@ describe('checkRecipientTimelineQuery', () => {
       offset: 10,
       sortBy: 'date',
       direction: 'asc',
-      filters: ['one', 'two'],
+      filters: [
+        {
+          topic: 'eventType',
+          condition: 'is',
+          query: ['Email communication', 'Phone communication', 'In person communication'],
+        },
+      ],
+      excludeMultiRecipientCommunications: true,
     });
     expect(next).toHaveBeenCalledTimes(1);
   });
@@ -70,7 +84,12 @@ describe('checkRecipientTimelineQuery', () => {
     ['negative offset', { offset: '-1' }],
     ['unsupported sort field', { sortBy: 'title' }],
     ['unsupported direction', { direction: 'sideways' }],
-    ['structured filters', { filters: { key: 'value' } }],
+    ['non-serialized filters', { filters: { key: 'value' } }],
+    ['malformed serialized filter', { filters: '{' }],
+    [
+      'serialized filter with an unsupported topic',
+      { filters: JSON.stringify({ topic: 'recipient', condition: 'is', query: ['1'] }) },
+    ],
     ['unknown query parameter', { extra: 'value' }],
   ])('rejects %s', (_description, query) => {
     const req = { query };

--- a/src/routes/recipient/middleware.ts
+++ b/src/routes/recipient/middleware.ts
@@ -5,12 +5,65 @@ import { auditLogger } from '../../logger';
 
 const errorMessage = 'Received malformed request query';
 
+const TIMELINE_FILTER_TOPICS = ['date', 'purpose', 'standard', 'eventType'];
+const DATE_FILTER_CONDITIONS = ['is', 'is within', 'is on or after', 'is on or before'];
+const SELECT_FILTER_CONDITIONS = ['is', 'is not'];
+
+const timelineFilterSchema = Joi.object({
+  topic: Joi.string()
+    .valid(...TIMELINE_FILTER_TOPICS)
+    .required(),
+  condition: Joi.string().required(),
+  query: Joi.alternatives()
+    .try(
+      Joi.string().trim().allow('').max(500),
+      Joi.array().items(Joi.string().trim().min(1).max(100)).min(1).max(20)
+    )
+    .required(),
+})
+  .custom((filter, helpers) => {
+    const isDateFilter = filter.topic === 'date';
+    const allowedConditions = isDateFilter ? DATE_FILTER_CONDITIONS : SELECT_FILTER_CONDITIONS;
+
+    if (!allowedConditions.includes(filter.condition)) {
+      return helpers.error('any.invalid');
+    }
+
+    if (
+      (isDateFilter && typeof filter.query !== 'string') ||
+      (!isDateFilter && !Array.isArray(filter.query))
+    ) {
+      return helpers.error('any.invalid');
+    }
+
+    return filter;
+  })
+  .unknown(false);
+
+const serializedTimelineFilter = Joi.string()
+  .trim()
+  .min(1)
+  .max(2000)
+  .custom((value, helpers) => {
+    let filter;
+
+    try {
+      filter = JSON.parse(value);
+    } catch {
+      return helpers.error('any.invalid');
+    }
+
+    const { error, value: validatedFilter } = timelineFilterSchema.validate(filter);
+    return error ? helpers.error('any.invalid') : validatedFilter;
+  });
+
 const recipientTimelineQuerySchema = Joi.object({
   limit: Joi.number().integer().min(1).max(100).default(20),
   offset: Joi.number().integer().min(0).default(0),
   sortBy: Joi.string().valid('date').default('date'),
   direction: Joi.string().valid('asc', 'desc').default('desc'),
-  filters: Joi.array().items(Joi.string().trim().min(1).max(100)).max(20).single().default([]),
+  filters: Joi.array().items(serializedTimelineFilter).max(20).single().default([]),
+  excludeMultiRecipientCommunications: Joi.boolean().default(false),
 }).unknown(false);
 
 export function checkRecipientTimelineQuery(req: Request, res: Response, next: NextFunction) {

--- a/src/routes/recipient/middleware.ts
+++ b/src/routes/recipient/middleware.ts
@@ -1,0 +1,29 @@
+import type { NextFunction, Request, Response } from 'express';
+import httpCodes from 'http-codes';
+import Joi from 'joi';
+import { auditLogger } from '../../logger';
+
+const errorMessage = 'Received malformed request query';
+
+const recipientTimelineQuerySchema = Joi.object({
+  limit: Joi.number().integer().min(1).max(100).default(20),
+  offset: Joi.number().integer().min(0).default(0),
+  sortBy: Joi.string().valid('date').default('date'),
+  direction: Joi.string().valid('asc', 'desc').default('desc'),
+  filters: Joi.array().items(Joi.string().trim().min(1).max(100)).max(20).single().default([]),
+}).unknown(false);
+
+export function checkRecipientTimelineQuery(req: Request, res: Response, next: NextFunction) {
+  const { error, value } = recipientTimelineQuerySchema.validate(req.query, {
+    abortEarly: false,
+  });
+
+  if (error) {
+    const message = `${errorMessage}: ${error.message}`;
+    auditLogger.error(message);
+    return res.status(httpCodes.BAD_REQUEST).send(message);
+  }
+
+  res.locals.recipientTimelineQuery = value;
+  return next();
+}

--- a/src/routes/utils.test.js
+++ b/src/routes/utils.test.js
@@ -1,4 +1,3 @@
-import { DECIMAL_BASE } from '@ttahub/common';
 import httpCodes from 'http-codes';
 import { getUserReadRegions } from '../services/accessValidation';
 import { currentUserId } from '../services/currentUser';
@@ -12,7 +11,7 @@ jest.mock('../services/recipient');
 jest.mock('../services/users');
 
 const mockResponse = () => {
-  const res = {};
+  const res = { locals: {} };
   res.sendStatus = jest.fn().mockReturnValue(res);
   res.status = jest.fn().mockReturnValue(res);
   res.json = jest.fn().mockReturnValue(res);
@@ -63,6 +62,19 @@ describe('Route Utils', () => {
       const result = await checkRecipientAccessAndExistence(req, res);
       expect(result).toBe(true);
       expect(res.sendStatus).not.toHaveBeenCalled();
+      expect(res.locals.validatedParams).toEqual({ recipientId: 10, regionId: 1 });
+      expect(recipientById).toHaveBeenCalledWith(10, []);
+    });
+
+    it('returns false and 400 for a scientific-notation region', async () => {
+      req = mockRequest({ recipientId: '10', regionId: '1e1' });
+
+      const result = await checkRecipientAccessAndExistence(req, res);
+
+      expect(result).toBe(false);
+      expect(res.sendStatus).toHaveBeenCalledWith(httpCodes.BAD_REQUEST);
+      expect(getUserReadRegions).not.toHaveBeenCalled();
+      expect(recipientById).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/routes/utils.test.js
+++ b/src/routes/utils.test.js
@@ -49,12 +49,13 @@ describe('Route Utils', () => {
       expect(res.sendStatus).toHaveBeenCalledWith(httpCodes.FORBIDDEN);
     });
 
-    it('returns false and 404 if recipient not found', async () => {
+    it('returns false and 404 if the recipient has no grant in the requested region', async () => {
       recipientById.mockResolvedValue(null);
-      req = mockRequest({ recipientId: '99', regionId: '1' }); // User can access region 1
+      req = mockRequest({ recipientId: '10', regionId: '1' }); // User can access region 1
       const result = await checkRecipientAccessAndExistence(req, res);
       expect(result).toBe(false);
       expect(res.sendStatus).toHaveBeenCalledWith(httpCodes.NOT_FOUND);
+      expect(recipientById).toHaveBeenCalledWith(10, { where: { regionId: 1 } });
     });
 
     it('returns true if user has access and recipient exists', async () => {
@@ -63,7 +64,7 @@ describe('Route Utils', () => {
       expect(result).toBe(true);
       expect(res.sendStatus).not.toHaveBeenCalled();
       expect(res.locals.validatedParams).toEqual({ recipientId: 10, regionId: 1 });
-      expect(recipientById).toHaveBeenCalledWith(10, []);
+      expect(recipientById).toHaveBeenCalledWith(10, { where: { regionId: 1 } });
     });
 
     it('returns false and 400 for a scientific-notation region', async () => {

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -31,8 +31,11 @@ const checkRecipientAccessAndExistence = async (req: Request, res: Response) => 
     return false;
   }
 
-  // Check recipient exists.
-  const recipient = await recipientById(validatedRecipientId, []);
+  // Verify that the recipient has a grant in the requested region. This avoids
+  // revealing recipient existence outside the requested region.
+  const recipient = await recipientById(validatedRecipientId, {
+    where: { regionId: validatedRegionId },
+  });
   if (!recipient) {
     res.sendStatus(httpCodes.NOT_FOUND);
     return false;

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -1,22 +1,38 @@
-import { DECIMAL_BASE } from '@ttahub/common';
 import type { Request, Response } from 'express';
 import httpCodes from 'http-codes';
+import parsePositiveInteger from '../lib/parsePositiveInteger';
 import { getUserReadRegions } from '../services/accessValidation';
 import { currentUserId } from '../services/currentUser';
 import { recipientById } from '../services/recipient';
 
 const checkRecipientAccessAndExistence = async (req: Request, res: Response) => {
   const { recipientId, regionId } = req.params;
+  res.locals = res.locals || {};
+  const validatedRecipientId =
+    res.locals.validatedParams?.recipientId ?? parsePositiveInteger(recipientId);
+  const validatedRegionId = res.locals.validatedParams?.regionId ?? parsePositiveInteger(regionId);
+
+  if (validatedRecipientId === null || validatedRegionId === null) {
+    res.sendStatus(httpCodes.BAD_REQUEST);
+    return false;
+  }
+
+  res.locals.validatedParams = {
+    ...res.locals.validatedParams,
+    recipientId: validatedRecipientId,
+    regionId: validatedRegionId,
+  };
+
   // Check if user has access to this region.
   const userId = await currentUserId(req, res);
   const readRegions = await getUserReadRegions(userId);
-  if (!readRegions.includes(parseInt(regionId, DECIMAL_BASE))) {
+  if (!readRegions.includes(validatedRegionId)) {
     res.sendStatus(httpCodes.FORBIDDEN);
     return false;
   }
 
   // Check recipient exists.
-  const recipient = await recipientById(recipientId, []);
+  const recipient = await recipientById(validatedRecipientId, []);
   if (!recipient) {
     res.sendStatus(httpCodes.NOT_FOUND);
     return false;

--- a/src/services/recipientTimeline.test.ts
+++ b/src/services/recipientTimeline.test.ts
@@ -1,0 +1,20 @@
+import { getRecipientTimeline } from './recipientTimeline';
+
+describe('getRecipientTimeline', () => {
+  it('returns the empty timeline contract', async () => {
+    const result = await getRecipientTimeline({
+      recipientId: 100000,
+      regionId: 1,
+      limit: 20,
+      offset: 0,
+      sortBy: 'date',
+      direction: 'desc',
+      filters: [],
+    });
+
+    expect(result).toEqual({
+      count: 0,
+      events: [],
+    });
+  });
+});

--- a/src/services/recipientTimeline.test.ts
+++ b/src/services/recipientTimeline.test.ts
@@ -10,6 +10,7 @@ describe('getRecipientTimeline', () => {
       sortBy: 'date',
       direction: 'desc',
       filters: [],
+      excludeMultiRecipientCommunications: false,
     });
 
     expect(result).toEqual({

--- a/src/services/recipientTimeline.ts
+++ b/src/services/recipientTimeline.ts
@@ -1,3 +1,9 @@
+interface RecipientTimelineFilter {
+  topic: 'date' | 'purpose' | 'standard' | 'eventType';
+  condition: string;
+  query: string | string[];
+}
+
 interface RecipientTimelineParams {
   recipientId: number;
   regionId: number;
@@ -5,7 +11,8 @@ interface RecipientTimelineParams {
   offset: number;
   sortBy: 'date';
   direction: 'asc' | 'desc';
-  filters: string[];
+  filters: RecipientTimelineFilter[];
+  excludeMultiRecipientCommunications: boolean;
 }
 
 interface RecipientTimelineResponse {

--- a/src/services/recipientTimeline.ts
+++ b/src/services/recipientTimeline.ts
@@ -1,0 +1,23 @@
+interface RecipientTimelineParams {
+  recipientId: number;
+  regionId: number;
+  limit: number;
+  offset: number;
+  sortBy: 'date';
+  direction: 'asc' | 'desc';
+  filters: string[];
+}
+
+interface RecipientTimelineResponse {
+  count: number;
+  events: unknown[];
+}
+
+export async function getRecipientTimeline(
+  _params: RecipientTimelineParams
+): Promise<RecipientTimelineResponse> {
+  return {
+    count: 0,
+    events: [],
+  };
+}

--- a/tests/api/recipient.spec.ts
+++ b/tests/api/recipient.spec.ts
@@ -292,4 +292,32 @@ test.describe('get /recipient', () => {
 
     await validateSchema(response, schema, expect);
   });
+
+  test('/:recipientId/region/:regionId/timeline, authorized', async ({ request }) => {
+    const response = await request.get(`${root}/recipient/2/region/14/timeline`, {
+      headers: { 'playwright-user-id': '1' },
+    });
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({
+      count: 0,
+      events: [],
+    });
+  });
+
+  test('/:recipientId/region/:regionId/timeline, forbidden region', async ({ request }) => {
+    const response = await request.get(`${root}/recipient/2/region/14/timeline`, {
+      headers: { 'playwright-user-id': '4' },
+    });
+
+    expect(response.status()).toBe(403);
+  });
+
+  test('/:recipientId/region/:regionId/timeline, invalid region', async ({ request }) => {
+    const response = await request.get(`${root}/recipient/2/region/1e1/timeline`, {
+      headers: { 'playwright-user-id': '1' },
+    });
+
+    expect(response.status()).toBe(400);
+  });
 });


### PR DESCRIPTION
## Description of change

Adds a new backend endpoint, `GET /recipient/:recipientId/region/:regionId/timeline`, that will back the upcoming TTA Timeline feature. The route is wired through the existing recipient/region access check (`checkRecipientAccessAndExistence`), a new Joi validated query middleware (`checkRecipientTimelineQuery`) for `limit`, `offset`, `sortBy`, `direction`, and `filters`, and a new `recipientTimeline` service. The service currently returns an empty `{ count: 0, events: [] }` stub; timeline data is follow-up work.

Along the way, `checkIdParam`/`checkGrantIdQueryParam` and `checkRecipientAccessAndExistence` are refactored to share a single `parsePositiveInteger` helper and to stash validated, parsed path params on `res.locals.validatedParams` instead of re-parsing strings in handlers. The new endpoint is documented in `docs/openapi/paths/recipient/recipient-timeline.yaml`.

## How to test

* Verify unit tests pass
* Manually: call `GET /api/recipient/:recipientId/region/:regionId/timeline` as a user with region access, confirm `200` with `{ count: 0, events: [] }`; call it for a region you cannot access and confirm `403`; call it with an invalid query param (e.g. `sortBy=foo`) and confirm `400`.

## Jira Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5654


## Checklists

### Every PR

- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [n/a] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status