### PR TITLE
[TTAHUB-5445] Update session objective text to rich text format

### DIFF
--- a/frontend/src/__tests__/utils.test.js
+++ b/frontend/src/__tests__/utils.test.js
@@ -1,6 +1,7 @@
 import { APPROVER_STATUSES, REPORT_STATUSES } from '@ttahub/common';
 import {
   getCollabReportStatusDisplayAndClassnames,
+  getRichTextAsText,
   isEmptyRichText,
   sanitizeRichText,
 } from '../utils';
@@ -62,6 +63,38 @@ describe('isEmptyRichText', () => {
     ['formatted text', '<p><strong>Bold</strong> content</p>'],
   ])('returns false for %s', (_label, value) => {
     expect(isEmptyRichText(value)).toBe(false);
+  });
+});
+
+describe('getRichTextAsText', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['non-string', 123],
+    ['empty string', ''],
+    ['single empty paragraph', '<p></p>'],
+    ['non-breaking space paragraph', '<p>&nbsp;</p>'],
+  ])('returns an empty string for %s', (_label, value) => {
+    expect(getRichTextAsText(value)).toBe('');
+  });
+
+  it('strips a paragraph wrapper', () => {
+    expect(getRichTextAsText('<p>Hello world</p>')).toBe('Hello world');
+  });
+
+  it('strips inline formatting markup', () => {
+    expect(getRichTextAsText('<p>Improve <strong>ERSEA</strong> enrollment</p>')).toBe(
+      'Improve ERSEA enrollment'
+    );
+  });
+
+  it('joins multiple blocks with a single space', () => {
+    expect(getRichTextAsText('<p>First</p><p>Second</p>')).toBe('First Second');
+  });
+
+  it('collapses list items and whitespace entities', () => {
+    expect(getRichTextAsText('<ul><li>One</li><li>Two</li></ul>')).toBe('One Two');
+    expect(getRichTextAsText('<p>a&nbsp;&#160;b</p>')).toBe('a b');
   });
 });
 

--- a/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/__tests__/sessionSummary.js
@@ -55,6 +55,7 @@ describe('sessionSummary', () => {
       trainers = [],
       otherTrainers = '',
       ttaProvided = 'filled',
+      objective = 'filled',
     } = {}) => ({
       getValues: jest.fn((field) => {
         if (!field) {
@@ -75,6 +76,10 @@ describe('sessionSummary', () => {
 
         if (field === 'ttaProvided') {
           return ttaProvided;
+        }
+
+        if (field === 'objective') {
+          return objective;
         }
 
         return 'filled';
@@ -129,6 +134,31 @@ describe('sessionSummary', () => {
       const hookForm = makeHookForm({
         trainers: [{ id: 1, fullName: 'Regional Trainer 1' }],
         ttaProvided: '<p>Provided coaching on ERSEA.</p>',
+      });
+
+      expect(isPageComplete(hookForm)).toBe(true);
+    });
+
+    it.each([
+      ['empty string', ''],
+      ['single empty paragraph', '<p></p>'],
+      ['empty paragraph with newline', '<p></p>\n'],
+      ['non-breaking space paragraph', '<p>&nbsp;</p>\n'],
+      ['spaces only', '<p>   </p>'],
+      ['multiple empty paragraphs', '<p></p><p></p><p>&nbsp;</p>'],
+    ])('returns false when objective is semantically empty (%s)', (_label, objective) => {
+      const hookForm = makeHookForm({
+        trainers: [{ id: 1, fullName: 'Regional Trainer 1' }],
+        objective,
+      });
+
+      expect(isPageComplete(hookForm)).toBe(false);
+    });
+
+    it('returns true when objective has real rich-text content', () => {
+      const hookForm = makeHookForm({
+        trainers: [{ id: 1, fullName: 'Regional Trainer 1' }],
+        objective: '<p>Improve ERSEA enrollment processes.</p>',
       });
 
       expect(isPageComplete(hookForm)).toBe(true);
@@ -294,11 +324,6 @@ describe('sessionSummary', () => {
         userEvent.type(duration, '1.25');
       });
 
-      const sessionObjective = await screen.findByLabelText(/session objective/i);
-      act(() => {
-        userEvent.type(sessionObjective, 'Session objective');
-      });
-
       await selectEvent.select(document.getElementById('objectiveTopics'), ['Complaint']);
 
       const trainers = await screen.findByLabelText(/Who provided the TTA/i);
@@ -437,9 +462,35 @@ describe('sessionSummary', () => {
 
       // The rich-text editor is present and labeled for assistive technology.
       await waitFor(() => {
-        const editable = document.querySelector('[contenteditable="true"]');
-        expect(editable).not.toBeNull();
+        const editables = Array.from(document.querySelectorAll('[contenteditable="true"]'));
+        const editable = editables.find((node) =>
+          /TTA provided/i.test(node.getAttribute('aria-label') || '')
+        );
+        expect(editable).not.toBeUndefined();
         expect(editable).toHaveAttribute('aria-label', expect.stringMatching(/TTA provided/i));
+      });
+    });
+
+    it('exposes required-field semantics for the session objectives rich-text field', async () => {
+      render(<RenderSessionSummary />);
+
+      // The required field is labeled "Session objectives" with a required indicator,
+      // so screen readers announce it the way the previous native textarea did.
+      const label = await screen.findByText(/Session objectives/i, { selector: 'label' });
+      expect(label).toBeInTheDocument();
+      expect(label.querySelector('.smart-hub--form-required')).not.toBeNull();
+
+      // The rich-text editor is present and labeled for assistive technology.
+      await waitFor(() => {
+        const editables = Array.from(document.querySelectorAll('[contenteditable="true"]'));
+        const editable = editables.find((node) =>
+          /Session objectives/i.test(node.getAttribute('aria-label') || '')
+        );
+        expect(editable).not.toBeUndefined();
+        expect(editable).toHaveAttribute(
+          'aria-label',
+          expect.stringMatching(/Session objectives/i)
+        );
       });
     });
 

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -3,6 +3,7 @@ import {
   Dropdown,
   ErrorMessage,
   Fieldset,
+  FormGroup,
   Label,
   Link,
   Radio,
@@ -28,6 +29,7 @@ import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
 import IpdCourseSelect from '../../../components/ObjectiveCourseSelect';
 import QuestionTooltip from '../../../components/QuestionTooltip';
 import Req from '../../../components/Req';
+import RichEditor from '../../../components/RichEditor';
 import SupportTypeDrawer from '../../../components/SupportTypeDrawer';
 import selectOptionsReset from '../../../components/selectOptionsReset';
 import { deleteSessionObjectiveFile, uploadSessionObjectiveFiles } from '../../../fetchers/session';
@@ -81,6 +83,23 @@ const SessionSummary = ({ datePickerKey, event }) => {
     rules: {
       validate: {
         notEmptyTag: (value) => !isEmptyRichText(value) || 'Describe the tta provided',
+      },
+    },
+    defaultValue: '<p></p>',
+  });
+
+  const {
+    field: {
+      onChange: onChangeObjective,
+      onBlur: onBlurObjective,
+      value: objective,
+      name: objectiveInputName,
+    },
+  } = useController({
+    name: `objective`,
+    rules: {
+      validate: {
+        notEmptyTag: (value) => !isEmptyRichText(value) || 'Describe the session objectives',
       },
     },
     defaultValue: '<p></p>',
@@ -315,16 +334,28 @@ const SessionSummary = ({ datePickerKey, event }) => {
       </FormItem>
 
       <h3 className="margin-top-4 margin-bottom-3">Objective summary</h3>
-      <FormItem label="Session objectives " name="objective" required>
-        <Textarea
-          id="objective"
-          name="objective"
-          inputRef={register({
-            required: 'Describe the session objectives',
-          })}
-          required
-        />
-      </FormItem>
+      <FormGroup error={!!errors.objective}>
+        <Label htmlFor={objectiveInputName}>
+          Session objectives
+          <Req />
+        </Label>
+        {errors.objective ? (
+          <ErrorMessage id={`${objectiveInputName}-error`}>{errors.objective.message}</ErrorMessage>
+        ) : null}
+        <div className="smart-hub--text-area__resize-vertical margin-top-1">
+          <input type="hidden" name={objectiveInputName} value={objective} />
+          <RichEditor
+            ariaLabel="Session objectives"
+            ariaRequired
+            ariaInvalid={!!errors.objective}
+            ariaDescribedBy={errors.objective ? `${objectiveInputName}-error` : undefined}
+            defaultValue={objective}
+            value={objective}
+            onChange={onChangeObjective}
+            onBlur={onBlurObjective}
+          />
+        </div>
+      </FormGroup>
 
       <div>
         <Drawer triggerRef={goalDrawerTriggerRef} stickyHeader stickyFooter title="Goal guidance">
@@ -681,7 +712,12 @@ const ReviewSection = () => {
       title: 'Objectives summary',
       anchor: 'session-objective',
       items: [
-        { label: 'Session objectives', name: 'objective', customValue: { objective } },
+        {
+          label: 'Session objectives',
+          name: 'objective',
+          customValue: { objective: sanitizeRichText(objective) },
+          isRichText: true,
+        },
         { label: 'Supporting goals', name: 'goals', customValue: { goals: supportingGoals } },
         { label: 'Topics', name: 'objectiveTopics', customValue: { objectiveTopics } },
         { label: 'Trainers', name: 'objectiveTrainers', customValue: { objectiveTrainers } },
@@ -737,15 +773,19 @@ export const isPageComplete = (hookForm) => {
     required.push('otherTrainers');
   }
 
-  // ttaProvided is a rich-text field: the generic string check treats any HTML
-  // wrapper (e.g. '<p></p>') as complete, so validate it for actual text content.
-  if (isEmptyRichText(hookForm.getValues('ttaProvided'))) {
+  // ttaProvided and objective are rich-text fields: the generic string check treats
+  // any HTML wrapper (e.g. '<p></p>') as complete, so validate them for actual text
+  // content.
+  if (
+    isEmptyRichText(hookForm.getValues('ttaProvided')) ||
+    isEmptyRichText(hookForm.getValues('objective'))
+  ) {
     return false;
   }
 
   return pageComplete(
     hookForm,
-    required.filter((field) => field !== 'ttaProvided')
+    required.filter((field) => field !== 'ttaProvided' && field !== 'objective')
   );
 };
 

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -343,7 +343,7 @@ const SessionSummary = ({ datePickerKey, event }) => {
           <ErrorMessage id={`${objectiveInputName}-error`}>{errors.objective.message}</ErrorMessage>
         ) : null}
         <div className="smart-hub--text-area__resize-vertical margin-top-1">
-          <input type="hidden" name={objectiveInputName} value={objective} />
+<input type="hidden" id={objectiveInputName} name={objectiveInputName} value={objective} />
           <RichEditor
             ariaLabel="Session objectives"
             ariaRequired

--- a/frontend/src/pages/SessionForm/pages/sessionSummary.js
+++ b/frontend/src/pages/SessionForm/pages/sessionSummary.js
@@ -335,7 +335,7 @@ const SessionSummary = ({ datePickerKey, event }) => {
 
       <h3 className="margin-top-4 margin-bottom-3">Objective summary</h3>
       <FormGroup error={!!errors.objective}>
-        <Label htmlFor={objectiveInputName}>
+        <Label>
           Session objectives
           <Req />
         </Label>
@@ -343,13 +343,11 @@ const SessionSummary = ({ datePickerKey, event }) => {
           <ErrorMessage id={`${objectiveInputName}-error`}>{errors.objective.message}</ErrorMessage>
         ) : null}
         <div className="smart-hub--text-area__resize-vertical margin-top-1">
-<input type="hidden" id={objectiveInputName} name={objectiveInputName} value={objective} />
           <RichEditor
             ariaLabel="Session objectives"
             ariaRequired
             ariaInvalid={!!errors.objective}
             ariaDescribedBy={errors.objective ? `${objectiveInputName}-error` : undefined}
-            defaultValue={objective}
             value={objective}
             onChange={onChangeObjective}
             onBlur={onBlurObjective}

--- a/frontend/src/pages/TrainingReports/components/SessionCard.js
+++ b/frontend/src/pages/TrainingReports/components/SessionCard.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { Closed, InProgress, NoStatus, Pencil, Trash } from '../../../components/icons';
 import Modal from '../../../components/VanillaModal';
 import useSessionCardPermissions from '../../../hooks/useSessionCardPermissions';
+import { getRichTextAsText } from '../../../utils';
 import './SessionCard.scss';
 
 const CardData = ({ label, children }) => (
@@ -143,7 +144,11 @@ function SessionCard({
 
         <CardData label="Session dates">{`${startDate || ''} - ${endDate || ''}`}</CardData>
 
-        <CardData label="Session objective">{objective}</CardData>
+        <CardData label="Session objective">
+          <p className="usa-prose margin-y-0 ttahub-session-card__objective">
+            {getRichTextAsText(objective)}
+          </p>
+        </CardData>
 
         <CardData label="Support type">{objectiveSupportType}</CardData>
 

--- a/frontend/src/pages/TrainingReports/components/SessionCard.scss
+++ b/frontend/src/pages/TrainingReports/components/SessionCard.scss
@@ -4,6 +4,16 @@
     color: $text-link;
 }
 
+// Clamp the session objective to three lines, appending an ellipsis only when
+// the text overflows.
+.ttahub-session-card__objective {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    overflow: hidden;
+}
+
 @container ttahub-event-card (min-width: 800px) {
     .ttahub-session-card__card-data {
         display: flex;

--- a/frontend/src/pages/TrainingReports/components/__tests__/SessionCard.js
+++ b/frontend/src/pages/TrainingReports/components/__tests__/SessionCard.js
@@ -33,7 +33,7 @@ describe('SessionCard', () => {
       sessionName: 'This is my session title',
       startDate: '01/02/2021',
       endDate: '01/03/2021',
-      objective: 'This is my session objective',
+      objective: '<p>This is my session objective</p>',
       objectiveSupportType: SUPPORT_TYPES[2],
       status: 'In progress',
       pocComplete: false,
@@ -81,6 +81,26 @@ describe('SessionCard', () => {
 
     expect(screen.getByText(/trainer 1; trainer 2/i)).toBeInTheDocument();
     expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+  });
+
+  it('strips HTML formatting from the session objective', async () => {
+    const session = {
+      ...defaultSession,
+      data: {
+        ...defaultSession.data,
+        objective: '<p>Improve <strong>ERSEA</strong> enrollment</p>',
+      },
+    };
+    await renderSessionCard(session);
+
+    // The rich-text markup is stripped so the objective displays as clean text.
+    expect(screen.getByText('Improve ERSEA enrollment')).toBeInTheDocument();
+    // No formatting elements are rendered on the card.
+    expect(document.querySelector('strong')).toBeNull();
+    // The objective is clamped to three lines via the dedicated class.
+    expect(screen.getByText('Improve ERSEA enrollment')).toHaveClass(
+      'ttahub-session-card__objective'
+    );
   });
 
   it('owner can both edit and delete (treated as collaborator)', () => {

--- a/frontend/src/pages/ViewTrainingReport/__tests__/TrainingReportV1.js
+++ b/frontend/src/pages/ViewTrainingReport/__tests__/TrainingReportV1.js
@@ -680,6 +680,71 @@ describe('ViewTrainingReport', () => {
     expect(screen.queryAllByText('IST visit').length).toBe(1);
   });
 
+  it('renders the session objective and TTA provided rich text as parsed HTML', async () => {
+    const e = mockEvent();
+    e.sessionReports = [
+      {
+        ...e.sessionReports[0],
+        data: {
+          ...e.sessionReports[0].data,
+          objective: '<p>Improve <strong>ERSEA</strong> enrollment.</p>',
+          ttaProvided: '<p>Provided <strong>coaching</strong>.</p>',
+        },
+      },
+    ];
+
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
+    fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
+    fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
+
+    renderTrainingReport();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Training event report R03-PD-23-1037' })
+    ).toBeInTheDocument();
+
+    // The objective renders as parsed rich text (matching TTA provided), so the bold
+    // markup is preserved rather than shown as raw HTML tags.
+    const objectiveBold = await screen.findByText('ERSEA');
+    expect(objectiveBold.tagName).toBe('STRONG');
+
+    const ttaBold = await screen.findByText('coaching');
+    expect(ttaBold.tagName).toBe('STRONG');
+  });
+
+  it('preserves paragraph and line-break returns in the session objective', async () => {
+    const e = mockEvent();
+    e.sessionReports = [
+      {
+        ...e.sessionReports[0],
+        data: {
+          ...e.sessionReports[0].data,
+          objective: '<p>Paragraph one</p><p>Second line<br />after a break</p>',
+        },
+      },
+    ];
+
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
+    fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
+    fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
+
+    renderTrainingReport();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Training event report R03-PD-23-1037' })
+    ).toBeInTheDocument();
+
+    const objectiveContent = await screen.findByLabelText('Session objective');
+
+    // Hard returns (new paragraphs) render as separate <p> elements.
+    const paragraphs = objectiveContent.querySelectorAll('p');
+    expect(paragraphs.length).toBe(2);
+    expect(paragraphs[0]).toHaveTextContent('Paragraph one');
+
+    // Soft returns (shift+enter) render as a <br> element.
+    expect(objectiveContent.querySelector('br')).not.toBeNull();
+  });
+
   it('display the correct value for Is IST visit if the value isIstVisit is not set and we have no recipients', async () => {
     const e = mockEvent();
     e.sessionReports = [

--- a/frontend/src/pages/ViewTrainingReport/__tests__/index.js
+++ b/frontend/src/pages/ViewTrainingReport/__tests__/index.js
@@ -820,6 +820,71 @@ describe('ViewTrainingReport', () => {
     expect(await screen.findByText('USER 2')).toBeInTheDocument();
   });
 
+  it('renders the session objective and TTA provided rich text as parsed HTML', async () => {
+    const e = mockEvent();
+    e.sessionReports = [
+      {
+        ...e.sessionReports[0],
+        data: {
+          ...e.sessionReports[0].data,
+          objective: '<p>Improve <strong>ERSEA</strong> enrollment.</p>',
+          ttaProvided: '<p>Provided <strong>coaching</strong>.</p>',
+        },
+      },
+    ];
+
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
+    fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
+    fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
+
+    renderTrainingReport();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Training event report R03-PD-23-1037' })
+    ).toBeInTheDocument();
+
+    // The objective renders as parsed rich text (matching TTA provided), so the bold
+    // markup is preserved rather than shown as raw HTML tags.
+    const objectiveBold = await screen.findByText('ERSEA');
+    expect(objectiveBold.tagName).toBe('STRONG');
+
+    const ttaBold = await screen.findByText('coaching');
+    expect(ttaBold.tagName).toBe('STRONG');
+  });
+
+  it('preserves paragraph and line-break returns in the session objective', async () => {
+    const e = mockEvent();
+    e.sessionReports = [
+      {
+        ...e.sessionReports[0],
+        data: {
+          ...e.sessionReports[0].data,
+          objective: '<p>Paragraph one</p><p>Second line<br />after a break</p>',
+        },
+      },
+    ];
+
+    fetchMock.getOnce('/api/events/id/1?readOnly=true', e);
+    fetchMock.getOnce('/api/users/names?ids=1', ['USER 1']);
+    fetchMock.getOnce('/api/users/names?ids=2', ['USER 2']);
+
+    renderTrainingReport();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Training event report R03-PD-23-1037' })
+    ).toBeInTheDocument();
+
+    const objectiveContent = await screen.findByLabelText('Session objective');
+
+    // Hard returns (new paragraphs) render as separate <p> elements.
+    const paragraphs = objectiveContent.querySelectorAll('p');
+    expect(paragraphs.length).toBe(2);
+    expect(paragraphs[0]).toHaveTextContent('Paragraph one');
+
+    // Soft returns (shift+enter) render as a <br> element.
+    expect(objectiveContent.querySelector('br')).not.toBeNull();
+  });
+
   it('displays the delivery method field and the appropriate participants attending', async () => {
     const e = mockEvent();
     e.sessionReports = [

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -75,33 +75,44 @@ export const getEditorState = (name) => {
 };
 
 /**
+ * Convert a rich-text (HTML) value into a clean, human-readable plain-text
+ * string. Strips all tags, decodes the whitespace entities Draft emits, and
+ * collapses remaining whitespace. Useful for compact displays (e.g. cards)
+ * where the formatting itself should not be rendered.
+ *
+ * @param {string} html - rich-text HTML string
+ * @returns {string} plain text ('' for empty or non-string input)
+ */
+export const getRichTextAsText = (html) => {
+  if (!html || typeof html !== 'string') {
+    return '';
+  }
+
+  return (
+    html
+      // replace tags with a space so adjacent blocks don't merge words together
+      .replace(/<[^>]*>/g, ' ')
+      // decode common whitespace entities that Draft emits
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&#160;/g, ' ')
+      // normalize remaining whitespace (including newlines)
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+};
+
+/**
  * Determine whether a rich-text (HTML) value is semantically empty.
  *
  * React Draft emits several "empty" variants beyond a bare `<p></p>` — for
  * example `<p></p>\n`, `<p>&nbsp;</p>`, or multiple empty paragraphs. A naive
- * check against a single sentinel string misses these, so we strip tags,
- * decode non-breaking spaces, collapse whitespace and check for remaining text.
+ * check against a single sentinel string misses these, so we strip the value
+ * down to its visible text (via `getRichTextAsText`) and check for content.
  *
  * @param {string} html - rich-text HTML string
  * @returns {boolean} true when the value contains no visible text content
  */
-export const isEmptyRichText = (html) => {
-  if (!html || typeof html !== 'string') {
-    return true;
-  }
-
-  const textContent = html
-    // drop all HTML tags
-    .replace(/<[^>]*>/g, '')
-    // decode common whitespace entities that Draft emits
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&#160;/g, ' ')
-    // normalize remaining whitespace (including newlines)
-    .replace(/\s+/g, ' ')
-    .trim();
-
-  return textContent.length === 0;
-};
+export const isEmptyRichText = (html) => getRichTextAsText(html).length === 0;
 
 /**
  * Strict allowlist for read-only rich-text rendering. Intentionally excludes

--- a/src/models/hooks/sessionReportPilot.js
+++ b/src/models/hooks/sessionReportPilot.js
@@ -6,7 +6,7 @@ const { TRAINING_REPORT_STATUSES } = require('@ttahub/common');
 const { auditLogger } = require('../../logger');
 const { purifyDataFields } = require('../helpers/purifyFields');
 
-const fieldsToEscape = ['ttaProvided'];
+const fieldsToEscape = ['ttaProvided', 'objective'];
 
 const preventChangesIfEventComplete = async (sequelize, instance, options) => {
   let event;

--- a/src/models/hooks/sessionReportPilot.test.js
+++ b/src/models/hooks/sessionReportPilot.test.js
@@ -179,6 +179,32 @@ describe('sessionReportPilot hooks', () => {
         ttaProvided: '<p>hello</p>',
       });
     });
+
+    it('sanitizes the objective rich text field', async () => {
+      const mockSequelize = {
+        models: {
+          EventReportPilot: {
+            findOne: jest.fn(() => null),
+          },
+        },
+      };
+
+      const setData = jest.fn();
+      const instance = {
+        eventId: 1,
+        changed: jest.fn(() => []),
+        data: {
+          objective: '<p>hello<script>alert("xss")</script></p>',
+        },
+        set: setData,
+      };
+
+      await beforeCreate(mockSequelize, instance, mockOptions);
+
+      expect(setData).toHaveBeenCalledWith('data', {
+        objective: '<p>hello</p>',
+      });
+    });
   });
 
   describe('beforeUpdate', () => {
@@ -217,6 +243,32 @@ describe('sessionReportPilot hooks', () => {
 
       expect(setData).toHaveBeenCalledWith('data', {
         ttaProvided: '<p>hi</p>',
+      });
+    });
+
+    it('sanitizes the objective rich text field', async () => {
+      const mockSequelize = {
+        models: {
+          EventReportPilot: {
+            findOne: jest.fn(() => null),
+          },
+        },
+      };
+
+      const setData = jest.fn();
+      const instance = {
+        eventId: 1,
+        changed: jest.fn(() => []),
+        data: {
+          objective: '<p onclick="evil()">hi</p><script>bad()</script>',
+        },
+        set: setData,
+      };
+
+      await beforeUpdate(mockSequelize, instance, mockOptions);
+
+      expect(setData).toHaveBeenCalledWith('data', {
+        objective: '<p>hi</p>',
       });
     });
   });

--- a/tests/e2e/training-report.spec.ts
+++ b/tests/e2e/training-report.spec.ts
@@ -69,7 +69,11 @@ test('can fill out and complete a training and session report', async ({ page })
   await page.getByLabel('Session end date *mm/dd/yyyy').fill('02/02/2023');
   await page.getByLabel('Duration in hours (round to the nearest quarter hour) *').fill('5');
   await page.getByLabel(/Session context/i).fill('Context');
-  await page.getByLabel('Session objectives *').fill('Objective');
+  await page
+    .getByRole('textbox', { name: /Session objectives/i })
+    .locator('div')
+    .nth(2)
+    .fill('Objective');
 
   await page
     .getByText('Select the goals that this activity supports *Get help selecting a goal')


### PR DESCRIPTION
## Description of change

This updates the objective text on the TR session to be rich text. It also updates the card, review, and standard view screens.

## How to test

- Review the code
- Add rich text to the session.
- Check the event card text (per Kelly limit to 3 lines then ...)
- View the session / event.
- Impersonate the approver ensure it sticks.

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5445


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
