### PR TITLE
[TTAHUB-5678] Creator receives collaborator’s resubmission, AR

### DIFF
--- a/docs/email_notifications.md
+++ b/docs/email_notifications.md
@@ -138,7 +138,7 @@ Triggered synchronously by an application event, processed once per job.
 | `COLLABORATOR_ADDED` | `collaboratorAssignedNotification` | `notifyCollaboratorAssigned` | `collaborator_added` |
 | `RECIPIENT_REPORT_APPROVED` | `programSpecialistRecipientReportApprovedNotification` | `notifyRecipientReportApproved` | `recipient_report_approved` |
 | `COLLABORATOR_REPORT_SUBMITTED_FOR_REVIEW` | `collaboratorReportSubmittedForReviewNotification` | `notifyCollaboratorReportSubmittedForReview` | `collaborator_report_submitted_for_review` |
-| `CREATOR_REPORT_SUBMITTED_FOR_REVIEW` | `creatorReportSubmittedForReviewNotification` | `notifyCreatorReportSubmittedForReview` | `creator_report_submitted_for_review` |
+| `CREATOR_REPORT_SUBMITTED_FOR_REVIEW` | `creatorReportSubmittedForReviewNotification` | `notifyCreatorReportSubmittedForReview` | `creator_report_submitted_for_review` (uses "Revised Activity Report ..." wording when resubmitted from `needs_action`) |
 
 All instant handlers share the same shape:
 

--- a/email_templates/creator_report_submitted_for_review/html.pug
+++ b/email_templates/creator_report_submitted_for_review/html.pug
@@ -1,7 +1,7 @@
 style
   include ../email.css
 p Hello,
-p Activity Report #{displayId}, which you created, has been submitted for approval.
+p #{isResubmission ? 'Revised ' : ''}Activity Report #{displayId}, which you created, has been submitted for approval.
 a(href=reportPath) Access this report in the TTA Hub.
 p Best wishes,
   br

--- a/email_templates/creator_report_submitted_for_review/subject.pug
+++ b/email_templates/creator_report_submitted_for_review/subject.pug
@@ -1,1 +1,1 @@
-= `Activity Report ${displayId}: Submitted for approval`
+= `${isResubmission ? 'Revised ' : ''}Activity Report ${displayId}: Submitted for approval`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -120,6 +120,7 @@
     "sass/immutable": ">=5.1.8",
     "filelist": "^2.0.2",
     "node-gyp": "^12.4.0",
+    "postcss-selector-parser": ">=7.1.3",
     "sqlite3": "^5.1.7",
     "test-exclude": "^8.0.0",
     "tar": "^7.5.21",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7165,10 +7165,10 @@ postcss-modules-values@^4.0.0:
   dependencies:
     icss-utils "^5.0.0"
 
-postcss-selector-parser@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
-  integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
+postcss-selector-parser@>=7.1.3, postcss-selector-parser@^7.0.0:
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz#ee7b090724eb60739b530660e5b402200e694a97"
+  integrity sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"

--- a/src/lib/mailer/index.js
+++ b/src/lib/mailer/index.js
@@ -397,7 +397,7 @@ export const collaboratorReportSubmittedForReviewNotification = (report, collabo
 export const notifyCreatorReportSubmittedForReview = (job, transport = defaultTransport) => {
   if (process.env.SEND_NOTIFICATIONS !== 'true') return null;
 
-  const { report, creator } = job.data;
+  const { report, creator, isResubmission = false } = job.data;
   const { id, displayId } = report;
   logger.debug(
     `MAILER: Attempting to notify ${creator.email} that report ${displayId} was submitted for approval`
@@ -411,15 +411,20 @@ export const notifyCreatorReportSubmittedForReview = (job, transport = defaultTr
     return createEmailSender(transport).send({
       template: path.resolve(emailTemplatePath, 'creator_report_submitted_for_review'),
       message: { to: toEmails },
-      locals: { reportPath, displayId },
+      locals: { reportPath, displayId, isResubmission },
     });
   });
 };
 
-export const creatorReportSubmittedForReviewNotification = (report, creator) => {
+export const creatorReportSubmittedForReviewNotification = (
+  report,
+  creator,
+  isResubmission = false
+) => {
   enqueueNotification(EMAIL_ACTIONS.CREATOR_REPORT_SUBMITTED_FOR_REVIEW, {
     report,
     creator,
+    isResubmission,
   });
 };
 

--- a/src/lib/mailer/index.test.js
+++ b/src/lib/mailer/index.test.js
@@ -777,6 +777,23 @@ describe('mailer tests', () => {
       expect(message.text).toContain(reportPath);
     });
 
+    it('uses Revised wording for resubmissions', async () => {
+      process.env.SEND_NOTIFICATIONS = 'true';
+      const email = await notifyCreatorReportSubmittedForReview(
+        {
+          data: { report: mockReport, creator: mockAuthor, isResubmission: true },
+        },
+        jsonTransport
+      );
+      const message = JSON.parse(email.message);
+      expect(message.subject).toBe(
+        `Revised Activity Report ${mockReport.displayId}: Submitted for approval`
+      );
+      expect(message.text).toContain(
+        `Revised Activity Report ${mockReport.displayId}, which you created, has been submitted for approval.`
+      );
+    });
+
     it('Tests that emails are not sent without SEND_NOTIFICATIONS', async () => {
       process.env.SEND_NOTIFICATIONS = 'false';
       const email = await notifyCreatorReportSubmittedForReview(
@@ -805,7 +822,16 @@ describe('mailer tests', () => {
       expect(notificationQueueMock.add).toHaveBeenCalledTimes(1);
       expect(notificationQueueMock.add).toHaveBeenCalledWith(
         EMAIL_ACTIONS.CREATOR_REPORT_SUBMITTED_FOR_REVIEW,
-        expect.objectContaining({ report: mockReport, creator: mockAuthor })
+        expect.objectContaining({ report: mockReport, creator: mockAuthor, isResubmission: false })
+      );
+    });
+
+    it('enqueues the creator job with the resubmission flag', () => {
+      jest.spyOn(notificationQueueMock, 'add').mockClear();
+      creatorReportSubmittedForReviewNotification(mockReport, mockAuthor, true);
+      expect(notificationQueueMock.add).toHaveBeenCalledWith(
+        EMAIL_ACTIONS.CREATOR_REPORT_SUBMITTED_FOR_REVIEW,
+        expect.objectContaining({ report: mockReport, creator: mockAuthor, isResubmission: true })
       );
     });
   });

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -796,7 +796,7 @@ export async function submitReport(req, res) {
         EMAIL_ACTIONS.CREATOR_REPORT_SUBMITTED_FOR_REVIEW
       );
       if (creatorSetting && creatorSetting.value === USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY) {
-        creatorReportSubmittedForReviewNotification(savedReport, report.author);
+        creatorReportSubmittedForReviewNotification(savedReport, report.author, isResubmission);
       }
     }
 

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -815,7 +815,7 @@ export async function submitReport(req, res) {
         EMAIL_ACTIONS.CREATOR_REPORT_SUBMITTED_FOR_REVIEW
       );
       if (creatorSetting && creatorSetting.value === USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY) {
-        creatorReportSubmittedForReviewNotification(savedReport, report.author);
+        creatorReportSubmittedForReviewNotification(savedReport, report.author, isResubmission);
       }
     }
 

--- a/src/routes/activityReports/handlers.js
+++ b/src/routes/activityReports/handlers.js
@@ -792,7 +792,7 @@ export async function submitReport(req, res) {
         EMAIL_ACTIONS.CREATOR_REPORT_SUBMITTED_FOR_REVIEW
       );
       if (creatorSetting && creatorSetting.value === USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY) {
-        creatorReportSubmittedForReviewNotification(savedReport, report.author);
+        creatorReportSubmittedForReviewNotification(savedReport, report.author, isResubmission);
       }
     }
 

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -1873,11 +1873,48 @@ describe('Activity Report handlers', () => {
 
         await submitReport(request, mockResponse);
 
-        expect(creatorNotification).toHaveBeenCalledWith(savedReport, {
-          id: 99,
-          name: 'Creator User',
-          email: 'creator@test.gov',
+        expect(creatorNotification).toHaveBeenCalledWith(
+          savedReport,
+          {
+            id: 99,
+            name: 'Creator User',
+            email: 'creator@test.gov',
+          },
+          false
+        );
+      });
+
+      it('marks the creator email as a resubmission when the report was previously needs_action', async () => {
+        userSettingOverridesById.mockResolvedValue({
+          value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
         });
+        activityReportAndRecipientsById.mockResolvedValue([
+          {
+            displayId: report.displayId,
+            dataValues: report,
+            objectivesWithoutGoals: [],
+            activityReportCollaborators: [],
+            author: { id: 99, name: 'Creator User', email: 'creator@test.gov' },
+            calculatedStatus: REPORT_STATUSES.NEEDS_ACTION,
+          },
+          undefined,
+          undefined,
+        ]);
+        const creatorNotification = jest
+          .spyOn(mailer, 'creatorReportSubmittedForReviewNotification')
+          .mockImplementation();
+
+        await submitReport(request, mockResponse);
+
+        expect(creatorNotification).toHaveBeenCalledWith(
+          savedReport,
+          {
+            id: 99,
+            name: 'Creator User',
+            email: 'creator@test.gov',
+          },
+          true
+        );
       });
 
       it('does not email the creator when they are not opted into IMMEDIATELY', async () => {

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -1674,11 +1674,48 @@ describe('Activity Report handlers', () => {
 
         await submitReport(request, mockResponse);
 
-        expect(creatorNotification).toHaveBeenCalledWith(savedReport, {
-          id: 99,
-          name: 'Creator User',
-          email: 'creator@test.gov',
+        expect(creatorNotification).toHaveBeenCalledWith(
+          savedReport,
+          {
+            id: 99,
+            name: 'Creator User',
+            email: 'creator@test.gov',
+          },
+          false
+        );
+      });
+
+      it('marks the creator email as a resubmission when the report was previously needs_action', async () => {
+        userSettingOverridesById.mockResolvedValue({
+          value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
         });
+        activityReportAndRecipientsById.mockResolvedValue([
+          {
+            displayId: report.displayId,
+            dataValues: report,
+            objectivesWithoutGoals: [],
+            activityReportCollaborators: [],
+            author: { id: 99, name: 'Creator User', email: 'creator@test.gov' },
+            calculatedStatus: REPORT_STATUSES.NEEDS_ACTION,
+          },
+          undefined,
+          undefined,
+        ]);
+        const creatorNotification = jest
+          .spyOn(mailer, 'creatorReportSubmittedForReviewNotification')
+          .mockImplementation();
+
+        await submitReport(request, mockResponse);
+
+        expect(creatorNotification).toHaveBeenCalledWith(
+          savedReport,
+          {
+            id: 99,
+            name: 'Creator User',
+            email: 'creator@test.gov',
+          },
+          true
+        );
       });
 
       it('does not email the creator when they are not opted into IMMEDIATELY', async () => {

--- a/src/routes/activityReports/handlers.test.js
+++ b/src/routes/activityReports/handlers.test.js
@@ -1616,11 +1616,48 @@ describe('Activity Report handlers', () => {
 
         await submitReport(request, mockResponse);
 
-        expect(creatorNotification).toHaveBeenCalledWith(savedReport, {
-          id: 99,
-          name: 'Creator User',
-          email: 'creator@test.gov',
+        expect(creatorNotification).toHaveBeenCalledWith(
+          savedReport,
+          {
+            id: 99,
+            name: 'Creator User',
+            email: 'creator@test.gov',
+          },
+          false
+        );
+      });
+
+      it('marks the creator email as a resubmission when the report was previously needs_action', async () => {
+        userSettingOverridesById.mockResolvedValue({
+          value: USER_SETTINGS.EMAIL.VALUES.IMMEDIATELY,
         });
+        activityReportAndRecipientsById.mockResolvedValue([
+          {
+            displayId: report.displayId,
+            dataValues: report,
+            objectivesWithoutGoals: [],
+            activityReportCollaborators: [],
+            author: { id: 99, name: 'Creator User', email: 'creator@test.gov' },
+            calculatedStatus: REPORT_STATUSES.NEEDS_ACTION,
+          },
+          undefined,
+          undefined,
+        ]);
+        const creatorNotification = jest
+          .spyOn(mailer, 'creatorReportSubmittedForReviewNotification')
+          .mockImplementation();
+
+        await submitReport(request, mockResponse);
+
+        expect(creatorNotification).toHaveBeenCalledWith(
+          savedReport,
+          {
+            id: 99,
+            name: 'Creator User',
+            email: 'creator@test.gov',
+          },
+          true
+        );
       });
 
       it('does not email the creator when they are not opted into IMMEDIATELY', async () => {


### PR DESCRIPTION
## Description of change

Adds the "Revised" resubmission wording to the immediate email a report creator receives when a collaborator resubmits an Activity Report for approval. When the AR was previously in `needs_action`, the subject and body are prefixed with "Revised" to signal a resubmission. Stacks on the TTAHUB-5676 approver-assigned work, reusing its `isResubmission` flag (derived in `submitReport`).

## How to test

As a collaborator (not the creator) on an AR, request changes then resubmit the report while the creator is opted into the immediate "submitted for review" email. Confirm the creator receives an email with subject `Revised Activity Report <displayId>: Submitted for approval` and body beginning `Revised Activity Report ...`. On a first-time submission, confirm the wording has no "Revised" prefix. Automated: `yarn jest src/lib/mailer/index.test.js src/routes/activityReports/handlers.test.js`.

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5678

## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [ ] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status