### PR TITLE
[TTAHUB-5717] Fix production inventory reconciliation collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1091,18 +1091,6 @@ jobs:
             exit 0
           fi
 
-          if ! node ./tools/releaseInventory.js cms-export \
-            --out "${cms_export_path}" \
-            --csv-out "${cms_csv_export_path}" \
-            --release-tag "${BUILD_RELEASE_TAG}" \
-            --release-commit "${CIRCLE_SHA1}" \
-            --pipeline-url "${CIRCLE_BUILD_URL}"; then
-            rm -f "${cms_export_path}" "${cms_csv_export_path}"
-            msg="Production deploy succeeded, but approved CI version CMS export generation failed for ${BUILD_RELEASE_TAG}. Remediate the release record from retained artifacts (TTAHUB-5244): ${CIRCLE_BUILD_URL}"
-            ./bin/notify-slack.sh "${msg}" acf-head-start-alerts "${SLACK_BOT_TOKEN}" || true
-            exit 0
-          fi
-
           inventory_hash=$(sha256sum release/inventory.json | awk '{print $1}')
           cms_export_hash=$(sha256sum "${cms_export_path}" | awk '{print $1}')
           cms_csv_export_hash=$(sha256sum "${cms_csv_export_path}" | awk '{print $1}')

--- a/tools/releaseInventory.js
+++ b/tools/releaseInventory.js
@@ -267,6 +267,14 @@ function fetchPaginatedCfCollection(apiPath, { fetchPage = cfCurl } = {}) {
     visited.add(nextApiPath);
     const page = fetchPage(nextApiPath);
 
+    if (Array.isArray(page?.errors) && page.errors.length > 0) {
+      const details = page.errors
+        .map((error) => [error.code, error.title, error.detail].filter(Boolean).join(' '))
+        .join('; ');
+
+      throw new Error(`Cloud Foundry collection ${nextApiPath} failed: ${details}`);
+    }
+
     if (
       !page ||
       !Array.isArray(page.resources) ||
@@ -320,10 +328,10 @@ function collectSpaceState(spaceName) {
     `/v3/routes?space_guids=${spaceGuid}&per_page=200`
   ).resources;
 
-  // include=service_plan resolves plan names in one call. A plan change alters
+  // fields[service_plan] resolves plan names in one call. A plan change alters
   // the authorized shape of a service, so the plan is part of the record.
   const serviceResponse = fetchPaginatedCfCollection(
-    `/v3/service_instances?space_guids=${spaceGuid}&per_page=200&include=service_plan`
+    `/v3/service_instances?space_guids=${spaceGuid}&per_page=200&fields[service_plan]=guid,name`
   );
   const plansByGuid = new Map(
     (serviceResponse.included?.service_plans || []).map((plan) => [plan.guid, plan.name])

--- a/tools/releaseInventory.test.js
+++ b/tools/releaseInventory.test.js
@@ -439,12 +439,12 @@ describe('fetchPaginatedCfCollection', () => {
       });
 
     const result = fetchPaginatedCfCollection(
-      '/v3/service_instances?space_guids=space-1&per_page=200&include=service_plan',
+      '/v3/service_instances?space_guids=space-1&per_page=200&fields[service_plan]=guid,name',
       { fetchPage }
     );
 
     expect(fetchPage.mock.calls.map(([apiPath]) => apiPath)).toEqual([
-      '/v3/service_instances?space_guids=space-1&per_page=200&include=service_plan',
+      '/v3/service_instances?space_guids=space-1&per_page=200&fields[service_plan]=guid,name',
       '/v3/service_instances?page=2&per_page=200',
     ]);
     expect(result.resources).toEqual([{ guid: 'service-1' }, { guid: 'service-2' }]);
@@ -471,6 +471,24 @@ describe('fetchPaginatedCfCollection', () => {
         fetchPage: () => ({ resources: [], pagination: {} }),
       })
     ).toThrow(/invalid response/);
+  });
+
+  it('reports Cloud Foundry API error details', () => {
+    expect(() =>
+      fetchPaginatedCfCollection('/v3/service_instances', {
+        fetchPage: () => ({
+          errors: [
+            {
+              code: 10005,
+              title: 'CF-InvalidQueryParameter',
+              detail: 'The query parameter is invalid: include',
+            },
+          ],
+        }),
+      })
+    ).toThrow(
+      'Cloud Foundry collection /v3/service_instances failed: 10005 CF-InvalidQueryParameter The query parameter is invalid: include'
+    );
   });
 });
 


### PR DESCRIPTION
## Description of change

Production release inventory reconciliation was failing every deploy because the Cloud Foundry `service_instances` API call used the `include=service_plan` query parameter, which CF's API rejects as invalid. This silently broke the CMS export step and triggered the failure Slack alert on every production run. This PR switches to `fields[service_plan]=guid,name`, which CF accepts, and updates `fetchPaginatedCfCollection` to surface CF API error details in the thrown error message instead of failing opaquely. It also removes the now redundant CMS export failure guard block from the CircleCI production deploy job, since the underlying collection call is fixed and failures now propagate with actionable detail from the script itself.

## How to test

- Verify unit tests pass
- This is a CI/infra fix with no local UI path; validation is confirming the "Reconcile release inventory" CircleCI job succeeds on the next production deploy without triggering the CMS export failure alert.

## Jira Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5717


## Checklists

### Every PR

- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested — `tools/releaseInventory.test.js` updated with new coverage for CF error surfacing
- [n/a] Meets accessibility standards (WCAG 2.1 Levels A, AA) — backend/CI only
- [n/a] API Documentation updated
- [n/a] Boundary diagram updated
- [n/a] Logical Data Model updated
- [n/a] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions — references existing ADR 0029, no new decision introduced
- [n/a] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status