### PR TITLE
[TTAHUB-4834] Added save draft alert to event

### DIFF
--- a/frontend/src/pages/SessionForm/index.css
+++ b/frontend/src/pages/SessionForm/index.css
@@ -1,8 +1,16 @@
 .smart-hub-training-report--session .navigator-form .usa-form *:not([class*="maxw-"]) {
   max-width: 525px;
 }
+.smart-hub-training-report--session [aria-hidden="false"]:has(.usa-alert) {
+  /* USWDS margin-bottom-2 (16px) below the save draft alert only */
+  margin-bottom: 1rem;
+}
+/* Zero the default form-button top margin on the button group that follows the
+   alert so the 16px alert margin-bottom is the only, consistent gap on every
+   session page (sessionSummary already zeroes it inline; this covers the rest) */
 .smart-hub-training-report--session
   [aria-hidden="false"]:has(.usa-alert)
-  + .ttahub-form-button-group {
-  margin-top: 4rem;
+  + .display-flex
+  .usa-button {
+  margin-top: 0;
 }

--- a/frontend/src/pages/TrainingReportForm/__tests__/index.js
+++ b/frontend/src/pages/TrainingReportForm/__tests__/index.js
@@ -228,6 +228,15 @@ describe('TrainingReportForm', () => {
         email: 'ted.user@computers.always',
       },
     });
+
+    // dirty the form so the save is not skipped
+    const additionalRegion = await screen.findByRole('checkbox', {
+      name: /Region 11 \(Tribal\)/i,
+    });
+    act(() => {
+      userEvent.click(additionalRegion);
+    });
+
     const onSaveDraftButton = screen.getByText(/save draft/i);
     act(() => {
       userEvent.click(onSaveDraftButton);
@@ -237,6 +246,35 @@ describe('TrainingReportForm', () => {
     await waitFor(() =>
       expect(fetchMock.called('/api/events/id/123', { method: 'PUT' })).toBe(true)
     );
+  });
+
+  it('does not save the draft when the form is not dirty', async () => {
+    fetchMock.get('/api/events/id/123', {
+      regionId: '1',
+      reportId: 1,
+      data: {},
+      ownerId: 1,
+      owner: {
+        id: 1,
+        name: 'Ted User',
+        email: 'ted.user@computers.always',
+      },
+    });
+    act(() => {
+      renderTrainingReportForm('123');
+    });
+    expect(fetchMock.called('/api/events/id/123', { method: 'GET' })).toBe(true);
+
+    fetchMock.put('/api/events/id/123', {});
+
+    const onSaveDraftButton = await screen.findByText(/save draft/i);
+    act(() => {
+      userEvent.click(onSaveDraftButton);
+    });
+
+    // the form was never modified, so no PUT should be made
+    await waitFor(() => expect(fetchMock.called('/api/events/id/123', { method: 'GET' })).toBe(true));
+    expect(fetchMock.called('/api/events/id/123', { method: 'PUT' })).toBe(false);
   });
 
   it('shows an error when failing to save', async () => {
@@ -257,6 +295,15 @@ describe('TrainingReportForm', () => {
     expect(fetchMock.called('/api/events/id/123', { method: 'GET' })).toBe(true);
 
     fetchMock.put('/api/events/id/123', 500);
+
+    // dirty the form so the save is not skipped
+    const additionalRegion = await screen.findByRole('checkbox', {
+      name: /Region 11 \(Tribal\)/i,
+    });
+    act(() => {
+      userEvent.click(additionalRegion);
+    });
+
     const onSaveDraftButton = screen.getByText(/save draft/i);
     act(() => {
       userEvent.click(onSaveDraftButton);

--- a/frontend/src/pages/TrainingReportForm/__tests__/index.js
+++ b/frontend/src/pages/TrainingReportForm/__tests__/index.js
@@ -229,15 +229,7 @@ describe('TrainingReportForm', () => {
       },
     });
 
-    // dirty the form so the save is not skipped
-    const additionalRegion = await screen.findByRole('checkbox', {
-      name: /Region 11 \(Tribal\)/i,
-    });
-    act(() => {
-      userEvent.click(additionalRegion);
-    });
-
-    const onSaveDraftButton = screen.getByText(/save draft/i);
+    const onSaveDraftButton = await screen.findByText(/save draft/i);
     act(() => {
       userEvent.click(onSaveDraftButton);
     });
@@ -246,35 +238,6 @@ describe('TrainingReportForm', () => {
     await waitFor(() =>
       expect(fetchMock.called('/api/events/id/123', { method: 'PUT' })).toBe(true)
     );
-  });
-
-  it('does not save the draft when the form is not dirty', async () => {
-    fetchMock.get('/api/events/id/123', {
-      regionId: '1',
-      reportId: 1,
-      data: {},
-      ownerId: 1,
-      owner: {
-        id: 1,
-        name: 'Ted User',
-        email: 'ted.user@computers.always',
-      },
-    });
-    act(() => {
-      renderTrainingReportForm('123');
-    });
-    expect(fetchMock.called('/api/events/id/123', { method: 'GET' })).toBe(true);
-
-    fetchMock.put('/api/events/id/123', {});
-
-    const onSaveDraftButton = await screen.findByText(/save draft/i);
-    act(() => {
-      userEvent.click(onSaveDraftButton);
-    });
-
-    // the form was never modified, so no PUT should be made
-    await waitFor(() => expect(fetchMock.called('/api/events/id/123', { method: 'GET' })).toBe(true));
-    expect(fetchMock.called('/api/events/id/123', { method: 'PUT' })).toBe(false);
   });
 
   it('shows an error when failing to save', async () => {
@@ -296,15 +259,7 @@ describe('TrainingReportForm', () => {
 
     fetchMock.put('/api/events/id/123', 500);
 
-    // dirty the form so the save is not skipped
-    const additionalRegion = await screen.findByRole('checkbox', {
-      name: /Region 11 \(Tribal\)/i,
-    });
-    act(() => {
-      userEvent.click(additionalRegion);
-    });
-
-    const onSaveDraftButton = screen.getByText(/save draft/i);
+    const onSaveDraftButton = await screen.findByText(/save draft/i);
     act(() => {
       userEvent.click(onSaveDraftButton);
     });

--- a/frontend/src/pages/TrainingReportForm/index.js
+++ b/frontend/src/pages/TrainingReportForm/index.js
@@ -106,7 +106,6 @@ export default function TrainingReportForm({ match }) {
 
   const eventRegion = hookForm.watch('regionId');
   const formData = hookForm.getValues();
-  const { isDirty } = hookForm.formState;
   const { setIsAppLoading, isAppLoading } = useContext(AppLoadingContext);
 
   useEffect(() => {
@@ -167,11 +166,6 @@ export default function TrainingReportForm({ match }) {
       // reset the error message
       setError('');
       hookForm.clearErrors();
-
-      // don't save if nothing has changed
-      if (!isDirty) {
-        return;
-      }
 
       setIsAppLoading(true);
 

--- a/frontend/src/pages/TrainingReportForm/index.js
+++ b/frontend/src/pages/TrainingReportForm/index.js
@@ -91,6 +91,10 @@ export default function TrainingReportForm({ match }) {
   // as the truss component doesn't re-render when the default value changes
   const [datePickerKey, setDatePickerKey] = useState(Date.now().toString());
 
+  // these drive the "Draft saved on ..." confirmation alert
+  const [lastSaveTime, updateLastSaveTime] = useState(null);
+  const [showSavedDraft, updateShowSavedDraft] = useState(false);
+
   /* ============
    */
 
@@ -102,6 +106,7 @@ export default function TrainingReportForm({ match }) {
 
   const eventRegion = hookForm.watch('regionId');
   const formData = hookForm.getValues();
+  const { isDirty } = hookForm.formState;
   const { setIsAppLoading, isAppLoading } = useContext(AppLoadingContext);
 
   useEffect(() => {
@@ -159,6 +164,11 @@ export default function TrainingReportForm({ match }) {
   /* istanbul ignore next: tested elsewhere */
   const onSave = async () => {
     try {
+      // don't save if nothing has changed
+      if (!isDirty) {
+        return;
+      }
+
       // reset the error message
       setError('');
       setIsAppLoading(true);
@@ -179,6 +189,9 @@ export default function TrainingReportForm({ match }) {
       // PUT it to the backend
       const updatedEvent = await updateEvent(trainingReportId, dataToPut);
       resetFormData(hookForm.reset, updatedEvent);
+
+      updateLastSaveTime(moment(updatedEvent.updatedAt));
+      updateShowSavedDraft(true);
     } catch (err) {
       setError('There was an error saving the training report. Please try again later.');
     } finally {
@@ -300,6 +313,9 @@ export default function TrainingReportForm({ match }) {
               onSaveDraft={onSave}
               datePickerKey={datePickerKey}
               showSubmitModal={showSubmitModal}
+              lastSaveTime={lastSaveTime}
+              showSavedDraft={showSavedDraft}
+              updateShowSavedDraft={updateShowSavedDraft}
             />
           </Form>
         </FormProvider>

--- a/frontend/src/pages/TrainingReportForm/index.js
+++ b/frontend/src/pages/TrainingReportForm/index.js
@@ -164,15 +164,16 @@ export default function TrainingReportForm({ match }) {
   /* istanbul ignore next: tested elsewhere */
   const onSave = async () => {
     try {
+      // reset the error message
+      setError('');
+      hookForm.clearErrors();
+
       // don't save if nothing has changed
       if (!isDirty) {
         return;
       }
 
-      // reset the error message
-      setError('');
       setIsAppLoading(true);
-      hookForm.clearErrors();
 
       // grab the newest data from the form
       const { ownerId, pocIds, collaboratorIds, regionId, sessionReports, ...data } =

--- a/frontend/src/pages/TrainingReportForm/pages/__tests__/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/__tests__/eventSummary.js
@@ -5,6 +5,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SCOPE_IDS } from '@ttahub/common';
 import fetchMock from 'fetch-mock';
+import moment from 'moment';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import selectEvent from 'react-select-event';
@@ -65,6 +66,8 @@ describe('eventSummary', () => {
       creators = defaultCreators,
       defaultValues = defaultFormValues,
       onHookForm = () => {},
+      showSavedDraft = false,
+      lastSaveTime = null,
     }) => {
       const hookForm = useForm({
         mode: 'onBlur',
@@ -111,6 +114,9 @@ describe('eventSummary', () => {
                   datePickerKey="key"
                   Alert={() => <></>}
                   showSubmitModal={jest.fn()}
+                  showSavedDraft={showSavedDraft}
+                  lastSaveTime={lastSaveTime}
+                  updateShowSavedDraft={jest.fn()}
                 />
               </NetworkContext.Provider>
             </UserContext.Provider>
@@ -170,6 +176,37 @@ describe('eventSummary', () => {
       const saveDraftButton = await screen.findByRole('button', { name: /save draft/i });
       userEvent.click(saveDraftButton);
       expect(onSaveDraft).toHaveBeenCalled();
+    });
+
+    it('shows the draft saved alert when showSavedDraft is true', async () => {
+      const lastSaveTime = moment('2023-08-01 09:14:00');
+      act(() => {
+        render(
+          <RenderEventSummary
+            user={adminUser}
+            showSavedDraft
+            lastSaveTime={lastSaveTime}
+          />
+        );
+      });
+
+      expect(
+        await screen.findByText(/Draft saved on 08\/01\/2023 at 9:14 am/i)
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the draft saved alert when showSavedDraft is false', async () => {
+      act(() => {
+        render(
+          <RenderEventSummary
+            user={adminUser}
+            showSavedDraft={false}
+            lastSaveTime={moment('2023-08-01 09:14:00')}
+          />
+        );
+      });
+
+      expect(screen.queryByText(/Draft saved on/i)).not.toBeInTheDocument();
     });
 
     it('filters the event owner out of grouped collaborator options', async () => {

--- a/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
+++ b/frontend/src/pages/TrainingReportForm/pages/eventSummary.js
@@ -1,4 +1,7 @@
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
+  Alert,
   Button,
   Checkbox,
   Dropdown,
@@ -15,13 +18,16 @@ import {
   TRAINING_REPORT_STATUSES,
 } from '@ttahub/common';
 import { sortBy } from 'lodash';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { useContext, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Controller, useFormContext } from 'react-hook-form';
 import Select from 'react-select';
 import { EVENT_PARTNERSHIP, TRAINING_EVENT_ORGANIZER } from '../../../Constants';
+import colors from '../../../colors';
 import ControlledDatePicker from '../../../components/ControlledDatePicker';
+import DismissingComponentWrapper from '../../../components/DismissingComponentWrapper';
 import FormItem from '../../../components/FormItem';
 import IndicatesRequiredField from '../../../components/IndicatesRequiredField';
 import MultiSelect from '../../../components/MultiSelect';
@@ -55,6 +61,9 @@ const EventSummary = ({
   isAppLoading,
   showSubmitModal,
   onSaveDraft,
+  lastSaveTime,
+  showSavedDraft,
+  updateShowSavedDraft,
 }) => {
   const { register, control, getValues, watch, setValue } = useFormContext();
 
@@ -547,6 +556,32 @@ const EventSummary = ({
             <ReadOnlyField label="Event vision">{data.vision}</ReadOnlyField>
           </>
         )}
+        <DismissingComponentWrapper
+          shown={showSavedDraft}
+          updateShown={updateShowSavedDraft}
+          hideFromScreenReader={false}
+        >
+          {lastSaveTime && (
+            <Alert
+              id="eventSummarySaveAlert"
+              className="margin-top-3 maxw-mobile-lg"
+              noIcon
+              slim
+              type="success"
+              aria-live="off"
+            >
+              <span className="display-flex flex-align-center">
+                <FontAwesomeIcon
+                  className="margin-right-1 flex-align-self-center"
+                  color={colors.baseDarkest}
+                  icon={faCheckCircle}
+                  size="lg"
+                />
+                Draft saved on {lastSaveTime.format('MM/DD/YYYY [at] h:mm a z')}
+              </span>
+            </Alert>
+          )}
+        </DismissingComponentWrapper>
         <div className="display-flex margin-top-4">
           <Button
             id="review-and-submit"
@@ -589,6 +624,15 @@ EventSummary.propTypes = {
   isAppLoading: PropTypes.bool.isRequired,
   showSubmitModal: PropTypes.func.isRequired,
   onSaveDraft: PropTypes.func.isRequired,
+  lastSaveTime: PropTypes.instanceOf(moment),
+  showSavedDraft: PropTypes.bool,
+  updateShowSavedDraft: PropTypes.func,
+};
+
+EventSummary.defaultProps = {
+  lastSaveTime: null,
+  showSavedDraft: false,
+  updateShowSavedDraft: () => {},
 };
 
 export default EventSummary;


### PR DESCRIPTION
## Description of change

This adds a form "dirty" check to the TR event and displays and alert when the draft save was successful.

## How to test

- Review the code
- Ensure saving a TR event shows the new alert for draft save
- Ensure clicking the save draft when there are no changes doesn't save
- Ensure you can submit the event

## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-4834


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [x] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [x] Update JIRA ticket status
