### PR TITLE
[TTAHUB-5720] Warn users when reopening a standard goal on a submitted AR

### DIFF
--- a/frontend/src/components/GoalCards/StandardGoalCard.js
+++ b/frontend/src/components/GoalCards/StandardGoalCard.js
@@ -468,7 +468,6 @@ export default function StandardGoalCard({
           )}
           {/* Alert for invalid status change attempt */}
           <GoalStatusChangeAlert
-            internalLeftMargin="3rem"
             invalidStatusChangeAttempted={invalidStatusChangeAttempted}
             activeActivityReport={statusChangeBlockingReasons.activeActivityReport}
             incompleteObjectives={statusChangeBlockingReasons.incompleteObjectives}

--- a/frontend/src/components/GoalCards/components/GoalStatusChangeAlert.js
+++ b/frontend/src/components/GoalCards/components/GoalStatusChangeAlert.js
@@ -4,7 +4,6 @@ import React from 'react';
 
 export default function GoalStatusChangeAlert({
   invalidStatusChangeAttempted,
-  internalLeftMargin,
   activeActivityReport,
   incompleteObjectives,
 }) {
@@ -19,12 +18,7 @@ export default function GoalStatusChangeAlert({
   const hasMultipleReasons = activeActivityReport && incompleteObjectives;
 
   return (
-    <Alert
-      type="info"
-      role="alert"
-      validation={hasMultipleReasons}
-      className={`${internalLeftMargin} margin-bottom-2`}
-    >
+    <Alert type="info" role="alert" validation={hasMultipleReasons} className="margin-bottom-2">
       {hasMultipleReasons ? (
         <>
           <p className="usa-alert__text">
@@ -48,7 +42,6 @@ export default function GoalStatusChangeAlert({
 }
 
 GoalStatusChangeAlert.propTypes = {
-  internalLeftMargin: PropTypes.string.isRequired,
   invalidStatusChangeAttempted: PropTypes.bool,
   activeActivityReport: PropTypes.bool,
   incompleteObjectives: PropTypes.bool,

--- a/frontend/src/components/SharedGoalComponents/GoalFormUpdateOrRestart.js
+++ b/frontend/src/components/SharedGoalComponents/GoalFormUpdateOrRestart.js
@@ -4,7 +4,11 @@ import { GOAL_STATUS } from '@ttahub/common/src/constants';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormProvider } from 'react-hook-form';
-import { GOAL_FORM_FIELDS } from '../../pages/StandardGoalForm/constants';
+import {
+  DEFAULT_STATUS_CHANGE_BLOCKING_REASONS,
+  GOAL_FORM_FIELDS,
+} from '../../pages/StandardGoalForm/constants';
+import GoalStatusChangeAlert from '../GoalCards/components/GoalStatusChangeAlert';
 import ReadOnlyField from '../ReadOnlyField';
 import GoalFormButtonIterator from './GoalFormButtonIterator';
 import GoalFormContainer from './GoalFormContainer';
@@ -24,6 +28,7 @@ export default function GoalFormUpdateOrRestart({
   onSubmit,
   goalTemplatePrompts,
   isRestart,
+  statusChangeBlockingReasons,
 }) {
   const Objectives = isRestart ? RestartStandardGoalObjectives : ObjectivesSection;
 
@@ -46,6 +51,11 @@ export default function GoalFormUpdateOrRestart({
         <form onSubmit={hookForm.handleSubmit(onSubmit)}>
           <GoalFormTemplatePrompts goalTemplatePrompts={goalTemplatePrompts} />
           <Objectives fieldName={GOAL_FORM_FIELDS.OBJECTIVES} options={goal.objectives} />
+          <GoalStatusChangeAlert
+            invalidStatusChangeAttempted={statusChangeBlockingReasons.invalidStatusChangeAttempted}
+            activeActivityReport={statusChangeBlockingReasons.activeActivityReport}
+            incompleteObjectives={statusChangeBlockingReasons.incompleteObjectives}
+          />
           <GoalFormButtonIterator buttons={standardGoalFormButtons} />
         </form>
       </GoalFormContainer>
@@ -103,9 +113,16 @@ GoalFormUpdateOrRestart.propTypes = {
     })
   ),
   isRestart: PropTypes.bool,
+  statusChangeBlockingReasons: PropTypes.shape({
+    activeActivityReport: PropTypes.bool,
+    incompleteObjectives: PropTypes.bool,
+    fromApi: PropTypes.bool,
+    invalidStatusChangeAttempted: PropTypes.bool,
+  }),
 };
 
 GoalFormUpdateOrRestart.defaultProps = {
   goalTemplatePrompts: null,
   isRestart: false,
+  statusChangeBlockingReasons: DEFAULT_STATUS_CHANGE_BLOCKING_REASONS,
 };

--- a/frontend/src/components/SharedGoalComponents/__tests__/GoalFormUpdateOrRestart.js
+++ b/frontend/src/components/SharedGoalComponents/__tests__/GoalFormUpdateOrRestart.js
@@ -53,7 +53,11 @@ const mockGoalTemplatePrompts = [
 const mockOnSubmit = jest.fn();
 
 describe('GoalFormUpdateOrRestart', () => {
-  const RenderTest = ({ goalTemplatePrompts = null, isRestart = false }) => {
+  const RenderTest = ({
+    goalTemplatePrompts = null,
+    isRestart = false,
+    statusChangeBlockingReasons = undefined,
+  }) => {
     const hookForm = useForm();
     return (
       <MemoryRouter>
@@ -67,6 +71,7 @@ describe('GoalFormUpdateOrRestart', () => {
             onSubmit={mockOnSubmit}
             goalTemplatePrompts={goalTemplatePrompts}
             isRestart={isRestart}
+            statusChangeBlockingReasons={statusChangeBlockingReasons}
           />
         </FormProvider>
       </MemoryRouter>
@@ -94,5 +99,27 @@ describe('GoalFormUpdateOrRestart', () => {
   it('renders RestartStandardGoalObjectives when isRestart is true', () => {
     render(<RenderTest isRestart />);
     expect(screen.getByTestId('restart-standard-goal-objectives')).toBeInTheDocument();
+  });
+
+  it('does not render the status change alert by default', () => {
+    render(<RenderTest />);
+    expect(screen.queryByText(/The goal status cannot be changed/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the status change alert when a blocking reason is present', () => {
+    render(
+      <RenderTest
+        statusChangeBlockingReasons={{
+          activeActivityReport: true,
+          incompleteObjectives: false,
+          fromApi: true,
+          invalidStatusChangeAttempted: true,
+        }}
+      />
+    );
+    expect(screen.getByText(/The goal status cannot be changed because/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/on an activity report that is in a draft status/i)
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/StandardGoalForm/RestartStandardGoalForm.js
+++ b/frontend/src/pages/StandardGoalForm/RestartStandardGoalForm.js
@@ -1,7 +1,7 @@
 import { GOAL_STATUS } from '@ttahub/common/src/constants';
 import { uniqueId } from 'lodash';
 import PropTypes from 'prop-types';
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router';
 import AppLoadingContext from '../../AppLoadingContext';
@@ -12,7 +12,11 @@ import {
 } from '../../components/SharedGoalComponents/constants';
 import GoalFormUpdateOrRestart from '../../components/SharedGoalComponents/GoalFormUpdateOrRestart';
 import { addStandardGoal } from '../../fetchers/standardGoals';
-import { GOAL_FORM_FIELDS, mapObjectivesAndRootCauses } from './constants';
+import {
+  DEFAULT_STATUS_CHANGE_BLOCKING_REASONS,
+  GOAL_FORM_FIELDS,
+  mapObjectivesAndRootCauses,
+} from './constants';
 
 export default function RestartStandardGoalForm({
   goal,
@@ -25,6 +29,10 @@ export default function RestartStandardGoalForm({
 }) {
   const history = useHistory();
   const { setIsAppLoading } = useContext(AppLoadingContext);
+
+  const [statusChangeBlockingReasons, setStatusChangeBlockingReasons] = useState(
+    DEFAULT_STATUS_CHANGE_BLOCKING_REASONS
+  );
 
   const hookForm = useForm({
     defaultValues: {
@@ -65,8 +73,17 @@ export default function RestartStandardGoalForm({
 
       history.push(backLinkTo);
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.log(err);
+      if (err.status === 409 && err.data?.code === 'STANDARD_GOAL_ON_ACTIVITY_REPORT') {
+        setStatusChangeBlockingReasons({
+          activeActivityReport: true,
+          incompleteObjectives: false,
+          fromApi: true,
+          invalidStatusChangeAttempted: true,
+        });
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      }
     } finally {
       setIsAppLoading(false);
     }
@@ -81,6 +98,7 @@ export default function RestartStandardGoalForm({
       goal={goal}
       goalTemplatePrompts={goalTemplatePrompts}
       standardGoalFormButtons={standardGoalFormButtons}
+      statusChangeBlockingReasons={statusChangeBlockingReasons}
       isRestart
     />
   );

--- a/frontend/src/pages/StandardGoalForm/__tests__/RestartStandardGoal.js
+++ b/frontend/src/pages/StandardGoalForm/__tests__/RestartStandardGoal.js
@@ -206,6 +206,27 @@ describe('RestartStandardGoal', () => {
     });
   });
 
+  it('shows a blocking alert when the goal is on an activity report', async () => {
+    fetchMock.post('/api/goal-templates/standard/1/grant/1', {
+      status: 409,
+      body: { code: 'STANDARD_GOAL_ON_ACTIVITY_REPORT' },
+    });
+    renderRestartStandardGoal();
+
+    await waitFor(() => {
+      expect(fetchMock.called('/api/goal-templates/standard/1/grant/1?status=Closed')).toBe(true);
+    });
+
+    const submitButton = await screen.findByRole('button', { name: /Reopen/i });
+    await act(async () => {
+      userEvent.click(submitButton);
+    });
+
+    expect(
+      await screen.findByText(/on an activity report that is in a draft status/i)
+    ).toBeInTheDocument();
+  });
+
   it('navigates to the correct page on cancel', async () => {
     const { history } = renderRestartStandardGoal();
 

--- a/frontend/src/pages/StandardGoalForm/__tests__/RestartStandardGoal.js
+++ b/frontend/src/pages/StandardGoalForm/__tests__/RestartStandardGoal.js
@@ -204,6 +204,9 @@ describe('RestartStandardGoal', () => {
     await waitFor(() => {
       expect(fetchMock.called('/api/goal-templates/standard/1/grant/1')).toBe(true);
     });
+
+    // A generic server error should not surface the conflict guidance alert.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('shows a blocking alert when the goal is on an activity report', async () => {
@@ -211,7 +214,7 @@ describe('RestartStandardGoal', () => {
       status: 409,
       body: { code: 'STANDARD_GOAL_ON_ACTIVITY_REPORT' },
     });
-    renderRestartStandardGoal();
+    const { history } = renderRestartStandardGoal();
 
     await waitFor(() => {
       expect(fetchMock.called('/api/goal-templates/standard/1/grant/1?status=Closed')).toBe(true);
@@ -222,9 +225,15 @@ describe('RestartStandardGoal', () => {
       userEvent.click(submitButton);
     });
 
-    expect(
-      await screen.findByText(/on an activity report that is in a draft status/i)
-    ).toBeInTheDocument();
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(
+      /The goal status cannot be changed because this goal is on an activity report/i
+    );
+
+    // The user should remain on the restart form so they can see the guidance.
+    expect(history.location.pathname).toBe(
+      '/recipient-tta-records/1/region/1/standard-goals/1/grant/1/restart'
+    );
   });
 
   it('navigates to the correct page on cancel', async () => {

--- a/frontend/src/pages/StandardGoalForm/constants.js
+++ b/frontend/src/pages/StandardGoalForm/constants.js
@@ -12,4 +12,11 @@ const mapObjectivesAndRootCauses = (data) => ({
   rootCauses: data.rootCauses ? data.rootCauses.map((r) => r.id) : null,
 });
 
-export { GOAL_FORM_FIELDS, mapObjectivesAndRootCauses };
+const DEFAULT_STATUS_CHANGE_BLOCKING_REASONS = {
+  activeActivityReport: false,
+  incompleteObjectives: false,
+  fromApi: false,
+  invalidStatusChangeAttempted: false,
+};
+
+export { DEFAULT_STATUS_CHANGE_BLOCKING_REASONS, GOAL_FORM_FIELDS, mapObjectivesAndRootCauses };


### PR DESCRIPTION
## Description of change

Users restarting a standard goal that is on a submitted activity report were not warned when the reopen was blocked. This surfaces a blocking info alert (reusing the shared `GoalStatusChangeAlert`) when the API returns a `409 STANDARD_GOAL_ON_ACTIVITY_REPORT` conflict, instead of silently swallowing the error. Also removes the now-unused `internalLeftMargin` prop from `GoalStatusChangeAlert`.

## How to test

Reopen a closed standard goal that is on an activity report in a draft/awaiting-approval/needs-action state and submit. Confirm an info alert appears explaining the status cannot be changed, rather than the form silently failing.

## Jira Issue(s)

* https://jira.acf.gov/browse/TTAHUB-5720


## Checklists

### Every PR

- [x] Linked Jira issue
- [ ] JIRA issue status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
