### PR TITLE
[TTAHUB-5736] load staging/prod GTM vars before frontend build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,9 +437,10 @@ jobs:
             ./tools/parse-env-CLI.js "${frontend_env_config}" ./temp.vars
             grep -E '^REACT_APP_(GTM|INCLUDE_ACCESSIBILITY_CSS)' ./temp.vars > ./frontend-build.template.vars
             circleci env subst < ./frontend-build.template.vars > ./frontend-build.vars
-            set -a
-            . ./frontend-build.vars
-            set +a
+            while IFS= read -r line; do
+              [ -z "${line}" ] && continue
+              export "${line}"
+            done < ./frontend-build.vars
             rm -f ./temp.vars ./frontend-build.template.vars ./frontend-build.vars
           fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,8 +420,21 @@ jobs:
     - run:
         name: Build frontend
         command: |
-          if [ "${CIRCLE_BRANCH}" = "production" ] && [ "<< pipeline.parameters.action >>" = "build_test_deploy" ]; then
-            ./tools/parse-env-CLI.js ./deployment_config/prod_vars.yml ./temp.vars
+          frontend_env_config=""
+
+          if [ "<< pipeline.parameters.action >>" = "build_test_deploy" ]; then
+            case "${CIRCLE_BRANCH}" in
+              main)
+                frontend_env_config="./deployment_config/staging_vars.yml"
+                ;;
+              production)
+                frontend_env_config="./deployment_config/prod_vars.yml"
+                ;;
+            esac
+          fi
+
+          if [ -n "${frontend_env_config}" ]; then
+            ./tools/parse-env-CLI.js "${frontend_env_config}" ./temp.vars
             grep -E '^REACT_APP_(GTM|INCLUDE_ACCESSIBILITY_CSS)' ./temp.vars > ./frontend-build.template.vars
             circleci env subst < ./frontend-build.template.vars > ./frontend-build.vars
             set -a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,8 @@ workflows:
             only:
             - main
     jobs:
-    - build_and_lint
+    - build_and_lint:
+        load_deploy_frontend_env: false
     - deploy_job:
         name: reset (dev-blue)
         target_env: "dev-blue"
@@ -336,6 +337,10 @@ jobs:
   build_and_lint:
     executor: docker-executor
     resource_class: large
+    parameters:
+      load_deploy_frontend_env:
+        type: boolean
+        default: true
     steps:
     - checkout
     - run:
@@ -422,15 +427,20 @@ jobs:
         command: |
           frontend_env_config=""
 
-          if [ "<< pipeline.parameters.action >>" = "build_test_deploy" ]; then
-            case "${CIRCLE_BRANCH}" in
-              main)
-                frontend_env_config="./deployment_config/staging_vars.yml"
-                ;;
-              production)
-                frontend_env_config="./deployment_config/prod_vars.yml"
-                ;;
-            esac
+          if [ "<< parameters.load_deploy_frontend_env >>" = "true" ]; then
+            if [ "<< pipeline.parameters.action >>" = "build_test_deploy" ]; then
+              case "${CIRCLE_BRANCH}" in
+                main)
+                  frontend_env_config="./deployment_config/staging_vars.yml"
+                  ;;
+                production)
+                  frontend_env_config="./deployment_config/prod_vars.yml"
+                  ;;
+              esac
+            elif [ "<< pipeline.parameters.action >>" = "deploy_only" ] \
+              && [ "<< pipeline.parameters.target_env >>" = "staging" ]; then
+              frontend_env_config="./deployment_config/staging_vars.yml"
+            fi
           fi
 
           if [ -n "${frontend_env_config}" ]; then
@@ -438,8 +448,19 @@ jobs:
             grep -E '^REACT_APP_(GTM|INCLUDE_ACCESSIBILITY_CSS)' ./temp.vars > ./frontend-build.template.vars
             circleci env subst < ./frontend-build.template.vars > ./frontend-build.vars
             while IFS= read -r line; do
-              [ -z "${line}" ] && continue
-              export "${line}"
+              key="${line%%=*}"
+              value="${line#*=}"
+
+              if [[ ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+                echo "Invalid frontend environment variable name: ${key}"
+                exit 1
+              fi
+
+              if [[ "${value}" == \"*\" ]] || [[ "${value}" == \'*\' ]]; then
+                value="${value:1:${#value}-2}"
+              fi
+
+              export "${key}=${value}"
             done < ./frontend-build.vars
             rm -f ./temp.vars ./frontend-build.template.vars ./frontend-build.vars
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,18 @@ jobs:
           ./tools/run-yarn-audit.js;
     - run:
         name: Build frontend
-        command: yarn --cwd frontend run build
+        command: |
+          if [ "${CIRCLE_BRANCH}" = "production" ] && [ "<< pipeline.parameters.action >>" = "build_test_deploy" ]; then
+            ./tools/parse-env-CLI.js ./deployment_config/prod_vars.yml ./temp.vars
+            grep -E '^REACT_APP_(GTM|INCLUDE_ACCESSIBILITY_CSS)' ./temp.vars > ./frontend-build.template.vars
+            circleci env subst < ./frontend-build.template.vars > ./frontend-build.vars
+            set -a
+            . ./frontend-build.vars
+            set +a
+            rm -f ./temp.vars ./frontend-build.template.vars ./frontend-build.vars
+          fi
+
+          yarn --cwd frontend run build
     - run:
         name: Run lint
         command: |


### PR DESCRIPTION
## Description of change

Fixes staging and production Google Analytics tracking by making each environment's GTM build variables available before the frontend is built.

The deployed sites were not reliably including the Google Tag Manager script in the rendered HTML because the frontend build runs before Cloud.gov deploy-time environment variables are loaded. Vite therefore fell back to the committed frontend default where `REACT_APP_GTM_ENABLED=false`.

This change updates the CircleCI frontend build step for the normal `build_test_deploy` workflow so it:
- uses `deployment_config/staging_vars.yml` when building `main` for staging
- uses `deployment_config/prod_vars.yml` when building `production` for production
- filters to frontend-safe `REACT_APP_GTM*` and accessibility variables
- substitutes CircleCI environment values
- exports those values before `yarn --cwd frontend run build`

This enables the appropriate GTM configuration for staging and production deployment builds without changing feature-branch or local frontend defaults.


## How to test

1. Confirm CI passes for this branch.
2. Confirm `.circleci/config.yml` parses as valid YAML.
3. After merging to `main` and deploying to staging, view the staging page source and confirm the expected `googletagmanager.com` script appears.
4. After promoting the change to `production`, view the production page source at `https://ttahub.ohs.acf.hhs.gov` and confirm the expected GTM script appears.
5. Confirm Google Analytics receives the expected staging and production traffic/events.

Test in a dev environment
<img width="1154" height="814" alt="image" src="https://github.com/user-attachments/assets/d38f7828-cbda-4987-b461-589aa7aac343" />
 


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5736


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [x] JIRA issue status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
