### PR TITLE
[TTAHUB-5737] Fix backup_prod_db failure

### DIFF
--- a/automation/common/scripts/postgrescli_install.sh
+++ b/automation/common/scripts/postgrescli_install.sh
@@ -221,9 +221,11 @@ function cleanup() {
 
 # Main function to control workflow
 function main() {
-    local deb_url="https://security.debian.org/debian-security/pool/updates/main/p/postgresql-15/postgresql-client-15_15.18-0+deb12u1_amd64.deb"
+    # snapshot.debian.org is used instead of security.debian.org because it retains all historical
+    # package builds permanently; security.debian.org prunes older point releases once superseded.
+    local deb_url="https://snapshot.debian.org/archive/debian-security/20260813T182349Z/pool/updates/main/p/postgresql-15/postgresql-client-15_15.19-0+deb12u1_amd64.deb"
     local deb_file="/tmp/postgresql.deb"
-    local deb_sha256="fc98076d378231baac95d6eae09a3e01730cd706f4d00bbcda6ba580d38355a1"
+    local deb_sha256="73eea2d8ca54ecf025b820832712e4852b50f57b83b3216fe6061884761c8d0d"
     local bin_dir="/tmp/local/bin"
     local tools=("pg_dump" "pg_isready" "pg_restore" "psql" "reindexdb" "vacuumdb")
 


### PR DESCRIPTION

## Description of change

* Bumps the pinned version to the current release, `postgresql-client-15_15.19-0+deb12u1`, with a freshly verified sha256 hash.
* Switches the download source from `security.debian.org` to `snapshot.debian.org`, which retains all historical package builds permanently, so this won't silently break again on the next Debian security point release.

## How to test
* Confirmed locally that the new snapshot.debian.org URL downloads successfully and the file's sha256 matches the hash in the script, and that the .deb extracts all required tools (pg_dump, pg_isready, pg_restore, psql, reindexdb, vacuumdb) correctly.

* To validate in CI before merging: trigger a CircleCI pipeline manually on this branch with pipeline parameter action = backup_prod (runs the backup_prod_manual workflow, which isn't restricted to main and will exercise backup_prod_db → restore_prod_to_temp → process_temp_db → backup_temp_db using this branch's version of the script). Confirm the backup_prod_db job passes.


## Jira Issue(s)

<!-- Link a Jira issue for this PR. Replace TTAHUB-0 before requesting review. -->
<!-- Maintenance, dependency, docs, and CI/CD changes still require a dedicated Jira issue. -->
* https://jira.acf.gov/browse/TTAHUB-5737


## Checklists

### Every PR

<!-- Add details to each completed item -->
- [x] Linked Jira issue
- [ ] JIRA issue status updated
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
- [ ] UI review complete
- [ ] QA review complete

### Before merge to main

- [ ] OHS demo complete
- [ ] Ready to create production PR

### Production Deploy

- [ ] PR created as **Draft**
- [ ] Staging smoke test completed
- [ ] PR transitioned to **Open** _(this `ready_for_review` transition triggers the Slack/Jira automation)_
- [ ] Reviewer added after the PR is **Open** _(`seyandiangov` and `elainaparrish` are the authorized approvers under normal circumstances)_
  - _Sequence: Draft PR → Smoke test → Open PR (automation runs) → Add reviewer_
  - _Confirm that the Slack notification was sent after the PR was opened_
  - _Confirm that linked Jira ticket(s) transitioned as expected; if not, review the GitHub Actions workflow logs_

### After merge/deploy

- [ ] Update JIRA ticket status
